### PR TITLE
fix(ui): knowledge base modal backdrop and positioning

### DIFF
--- a/web/app/knowledge/page.tsx
+++ b/web/app/knowledge/page.tsx
@@ -845,7 +845,7 @@ export default function KnowledgePage() {
 
       {/* Create KB Modal */}
       {createModalOpen && (
-        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 mt-40">
           <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-2xl w-full max-w-md p-6 animate-in zoom-in-95">
             <div className="flex justify-between items-center mb-4">
               <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100">


### PR DESCRIPTION
## Description

Fixed the Knowledge Base modal positioning and backdrop display issue. Removed backdrop blur effect and adjusted modal vertical positioning for better visibility.

## Related Issues

N/A

## Changes Made

- Modified modal container styling in `knowledge/page.tsx`:
  ```tsx
  // Before
  <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">

  // After
  <div className="fixed inset-0 z-50 flex items-center justify-center p-4 mt-40">
  ```
- Removed `bg-black/50 backdrop-blur-sm` classes from modal container
- Added `mt-40` margin-top for proper modal positioning

**Before/After Screenshots:**

### Before
<img width="1440" height="791" alt="before" src="https://github.com/user-attachments/assets/8d6f5271-dbfc-4dc2-8eb8-20ca1ac4e282" />

### After  
<img width="1440" height="772" alt="after" src="https://github.com/user-attachments/assets/b38cd853-02ed-42bd-9aea-ff7d602d5b01" />

## Module(s) Affected

- [ ] Dashboard
- [x] Knowledge Base Management
- [ ] Smart Solver
- [ ] Question Generator
- [ ] Deep Research
- [ ] Co-Writer
- [ ] Notebook
- [ ] Guided Learning
- [ ] Idea Generation
- [ ] API/Backend
- [x] Frontend/Web
- [ ] Configuration
- [ ] Documentation
- [ ] Other: ___________

## Checklist

- [x] Changes tested locally
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] No new warnings generated
- [ ] Tests added/updated (if applicable)

## Additional Notes

Simplified modal overlay by removing backdrop blur and adjusted vertical positioning with margin-top for improved modal visibility and user experience. This is a CSS-only change with no functional impact.
