### PR TITLE
fix(core): ensure core attributes initialized without rich library

### DIFF
--- a/src/agents/solve/utils/display_manager.py
+++ b/src/agents/solve/utils/display_manager.py
@@ -55,41 +55,20 @@ class DisplayManager:
             "cost": 0.0,
         }
         
+        
+        # Log buffer
+        self.log_buffer = []
+        self.max_log_lines = 20
+        
         # Early return if rich not available (but after initializing core attributes)
         if not self.rich_available:
             self.console = None
-            self.log_buffer = []
-            self.max_log_lines = 20
             self.layout = None
             self.live = None
             return
 
         # Explicitly use raw stdout, bypass logger redirection
         self.console = Console(file=sys.__stdout__)
-
-        # Status data
-        self.agents_status = {
-            "InvestigateAgent": "pending",
-            "NoteAgent": "pending",
-            "ManagerAgent": "pending",
-            "SolveAgent": "pending",
-            "ToolAgent": "pending",
-            "ResponseAgent": "pending",
-            "PrecisionAnswerAgent": "pending",
-        }
-
-        self.stats = {
-            "model": "Unknown",
-            "calls": 0,
-            "tokens": 0,
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "cost": 0.0,
-        }
-
-        # Log buffer
-        self.log_buffer = []
-        self.max_log_lines = 20
 
         # Layout
         self.layout = self._make_layout()


### PR DESCRIPTION
## Description

Fixed AttributeError when rich library is not installed. DisplayManager.__init__ 
was returning early when rich was unavailable, skipping initialization of 
agents_status and stats attributes required by solve router.

## Related Issues
NA

## Changes Made

- Move agents_status and stats initialization before rich check
- Initialize console, log_buffer, layout, and live as None when rich unavailable
- Ensure graceful fallback to basic text output without rich dependency

## Bug Reproduction

Smart Solver crashed because:
- The developer had `rich` library installed locally
- `rich` was missing from `requirements.txt` 
- As an optional dev dependency for UI enhancements, its absence should not break core functionality

Screenshots below show the error state and successful resolution.

<img width="1082" height="369" alt="Screenshot 2025-12-31 at 11 42 16 PM" src="https://github.com/user-attachments/assets/40216067-2f61-45ba-82d3-bde3ab4e76ab" />
<img width="1440" height="772" alt="Screenshot 2025-12-31 at 11 41 53 PM" src="https://github.com/user-attachments/assets/14bd78a2-4573-4b54-a01b-410f2f581edf" />

## Module(s) Affected

- [ ] Dashboard
- [ ] Knowledge Base Management
- [x] Smart Solver
- [ ] Question Generator
- [ ] Deep Research
- [ ] Co-Writer
- [ ] Notebook
- [ ] Guided Learning
- [ ] Idea Generation
- [ ] API/Backend
- [ ] Frontend/Web
- [ ] Configuration
- [ ] Documentation
- [ ] Other: ___________

## Checklist

- [x] Changes tested locally
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] No new warnings generated
- [ ] Tests added/updated (if applicable)

## Additional Notes

Fixes: Solver crash with 'DisplayManager' object has no attribute 'agents_status'
Impact: Critical - Solver is now functional without optional rich library

Modified: src/core/display_manager.py