### PR TITLE
fix: resolve double decoration in embedding functions for OpenRouter …

### DIFF
--- a/src/knowledge/initializer.py
+++ b/src/knowledge/initializer.py
@@ -281,10 +281,14 @@ class KnowledgeBaseInitializer:
         embedding_cfg = self.embedding_cfg
         embedding_api_key = embedding_cfg["api_key"] or self.api_key
         embedding_base_url = embedding_cfg["base_url"] or self.base_url
+
+        # CRITICAL: Use openai_embed.func to avoid double decoration
+        # openai_embed is already decorated with @wrap_embedding_func_with_attrs
+        # We need to access the unwrapped function to prevent dimension mismatch
         embedding_func = EmbeddingFunc(
             embedding_dim=embedding_cfg["dim"],
             max_token_size=embedding_cfg["max_tokens"],
-            func=lambda texts: openai_embed(
+            func=lambda texts: openai_embed.func(
                 texts,
                 model=embedding_cfg["model"],
                 api_key=embedding_api_key,

--- a/src/tools/rag_tool.py
+++ b/src/tools/rag_tool.py
@@ -199,10 +199,13 @@ async def rag_search(
         return llm_model_func(prompt, system_prompt, history_messages, **kwargs)
 
     # Define embedding function
+    # CRITICAL: Use openai_embed.func to avoid double decoration
+    # openai_embed is already decorated with @wrap_embedding_func_with_attrs
+    # We need to access the unwrapped function to prevent dimension mismatch
     embedding_func = EmbeddingFunc(
         embedding_dim=embedding_dim,
         max_token_size=embedding_max_tokens,
-        func=lambda texts: openai_embed(
+        func=lambda texts: openai_embed.func(
             texts,
             model=embedding_model,
             api_key=embedding_api_key,


### PR DESCRIPTION
…compatibility

Fixes embedding dimension validation errors when using OpenRouter or other OpenAI-compatible providers with custom embedding dimensions.

Problem:
- The openai_embed function is decorated with @wrap_embedding_func_with_attrs
- Creating another EmbeddingFunc wrapper around it caused double decoration
- This resulted in 'Vector count mismatch' errors during RAG queries
- Citations failed to generate due to embedding validation failures

Solution:
- Use openai_embed.func to access the unwrapped function
- Prevents double decoration and dimension mismatch errors
- Follows LightRAG's documented pattern for composing decorated functions

Impact:
- Enables OpenRouter and other providers to work correctly
- Fixes citation generation in RAG queries
- Resolves 'expected X vectors but got Y vectors' errors

Tested with:
- OpenRouter (text-embedding-3-large, 3072 dimensions)
- Multiple test cases including comma-separated keywords
- Both knowledge base initialization and RAG queries

Related to issue #59 (embedding provider compatibility)

<!--
Thank you for contributing to AI-Tutor!

Please make sure your pull request is ready for review before submitting.

About this template

This template assists contributors in providing a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

[Briefly describe the changes made in this pull request.]

## Related Issues

[Reference any related issues or tasks addressed by this pull request.]
- Closes #
- Related to #

## Changes Made

[List the specific changes made in this pull request.]

## Module(s) Affected

- [ ] Dashboard
- [ ] Knowledge Base Management
- [ ] Smart Solver
- [ ] Question Generator
- [ ] Deep Research
- [ ] Co-Writer
- [ ] Notebook
- [ ] Guided Learning
- [ ] Idea Generation
- [ ] API/Backend
- [ ] Frontend/Web
- [ ] Configuration
- [ ] Documentation
- [ ] Other: ___________

## Checklist

- [ ] ✅ Ran `pre-commit run --all-files` (required — CI will fail otherwise)
- [ ] Changes tested locally
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] No new warnings generated
- [ ] Tests added/updated (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
