### PR TITLE
feat(kb): allow selecting RAG provider during KB create/upload

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -67,7 +67,7 @@ PyMuPDF>=1.26.0      # For PDF text extraction (fast and reliable)
 # Development tools
 # ============================================
 pre-commit>=3.0.0
-safety>=2.4.0,<3.0.0  # Pin to stable 2.x version, 3.0.0 is broken
+safety<3.0.0  # Pin to stable 2.x version, 3.0.0 is broken
 bandit>=1.8.0
 llama-cloud==0.1.35
 llama-cloud-services==0.6.54

--- a/src/knowledge/add_documents.py
+++ b/src/knowledge/add_documents.py
@@ -91,6 +91,7 @@ class DocumentAdder:
         api_key: str | None = None,
         base_url: str | None = None,
         progress_tracker=None,
+        rag_provider: str | None = None,
     ):
         self.kb_name = kb_name
         self.base_dir = Path(base_dir)
@@ -111,6 +112,7 @@ class DocumentAdder:
         self.api_key = api_key
         self.base_url = base_url
         self.progress_tracker = progress_tracker
+        self.rag_provider = rag_provider
         self._ensure_working_directories()
 
     def _ensure_working_directories(self):
@@ -465,6 +467,11 @@ class DocumentAdder:
                 metadata = json.load(f)
 
             metadata["last_updated"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            
+            # Update RAG provider if specified
+            if self.rag_provider:
+                metadata["rag_provider"] = self.rag_provider
+            
             history = metadata.get("update_history", [])
             history.append(
                 {

--- a/src/knowledge/manager.py
+++ b/src/knowledge/manager.py
@@ -213,6 +213,7 @@ class KnowledgeBaseManager:
             "images": images_count,
             "content_lists": content_lists_count,
             "rag_initialized": rag_storage_dir.exists() and rag_storage_dir.is_dir(),
+            "rag_provider": info["metadata"].get("rag_provider"),  # Add RAG provider info
         }
 
         # Try to get RAG statistics

--- a/src/services/embedding/client.py
+++ b/src/services/embedding/client.py
@@ -117,10 +117,14 @@ class EmbeddingClient:
             EmbeddingFunc instance
         """
         from lightrag.utils import EmbeddingFunc
+        import numpy as np
 
         # Create async wrapper that uses our adapter system
-        async def embedding_wrapper(texts: List[str]) -> List[List[float]]:
-            return await self.embed(texts)
+        # LightRAG expects numpy arrays, not Python lists
+        async def embedding_wrapper(texts: List[str]):
+            embeddings = await self.embed(texts)
+            # Convert list of lists to numpy array for LightRAG compatibility
+            return np.array(embeddings)
 
         return EmbeddingFunc(
             embedding_dim=self.config.dim,

--- a/src/services/rag/components/indexers/graph.py
+++ b/src/services/rag/components/indexers/graph.py
@@ -51,28 +51,49 @@ class GraphIndexer(BaseComponent):
             sys.path.insert(0, str(raganything_path))
 
         try:
-            from lightrag.llm.openai import openai_complete_if_cache
             from raganything import RAGAnything, RAGAnythingConfig
+            from openai import AsyncOpenAI
 
             from src.services.embedding import get_embedding_client
             from src.services.llm import get_llm_client
 
             llm_client = get_llm_client()
             embed_client = get_embedding_client()
+            
+            # Create AsyncOpenAI client directly
+            openai_client = AsyncOpenAI(
+                api_key=llm_client.config.api_key,
+                base_url=llm_client.config.base_url,
+            )
 
-            # LLM function using services
-            def llm_model_func(prompt, system_prompt=None, history_messages=None, **kwargs):
+            # LLM function using services (ASYNC - LightRAG expects async functions)
+            async def llm_model_func(prompt, system_prompt=None, history_messages=None, **kwargs):
+                """Custom async LLM function that bypasses LightRAG's openai_complete_if_cache."""
                 if history_messages is None:
                     history_messages = []
-                return openai_complete_if_cache(
-                    llm_client.config.model,
-                    prompt,
-                    system_prompt=system_prompt,
-                    history_messages=history_messages,
-                    api_key=llm_client.config.api_key,
-                    base_url=llm_client.config.base_url,
-                    **kwargs,
+                
+                # Build messages
+                messages = []
+                if system_prompt:
+                    messages.append({"role": "system", "content": system_prompt})
+                messages.extend(history_messages)
+                messages.append({"role": "user", "content": prompt})
+                
+                # Whitelist only valid OpenAI parameters
+                valid_params = {
+                    'temperature', 'top_p', 'n', 'stream', 'stop', 'max_tokens',
+                    'presence_penalty', 'frequency_penalty', 'logit_bias', 'user', 'seed'
+                }
+                clean_kwargs = {k: v for k, v in kwargs.items() if k in valid_params}
+                
+                # Call OpenAI API directly (async)
+                response = await openai_client.chat.completions.create(
+                    model=llm_client.config.model,
+                    messages=messages,
+                    **clean_kwargs,
                 )
+                
+                return response.choices[0].message.content
 
             config = RAGAnythingConfig(
                 working_dir=working_dir,

--- a/src/services/rag/components/indexers/lightrag.py
+++ b/src/services/rag/components/indexers/lightrag.py
@@ -53,27 +53,48 @@ class LightRAGIndexer(BaseComponent):
 
         try:
             from lightrag import LightRAG
-            from lightrag.llm.openai import openai_complete_if_cache
+            from openai import AsyncOpenAI
 
             from src.services.embedding import get_embedding_client
             from src.services.llm import get_llm_client
 
             llm_client = get_llm_client()
             embed_client = get_embedding_client()
+            
+            # Create AsyncOpenAI client directly
+            openai_client = AsyncOpenAI(
+                api_key=llm_client.config.api_key,
+                base_url=llm_client.config.base_url,
+            )
 
-            # LLM function using services (SYNC - LightRAG expects sync functions)
-            def llm_model_func(prompt, system_prompt=None, history_messages=None, **kwargs):
+            # LLM function using services (ASYNC - LightRAG expects async functions)
+            async def llm_model_func(prompt, system_prompt=None, history_messages=None, **kwargs):
+                """Custom async LLM function that bypasses LightRAG's openai_complete_if_cache."""
                 if history_messages is None:
                     history_messages = []
-                return openai_complete_if_cache(
-                    llm_client.config.model,
-                    prompt,
-                    system_prompt=system_prompt,
-                    history_messages=history_messages,
-                    api_key=llm_client.config.api_key,
-                    base_url=llm_client.config.base_url,
-                    **kwargs,
+                
+                # Build messages
+                messages = []
+                if system_prompt:
+                    messages.append({"role": "system", "content": system_prompt})
+                messages.extend(history_messages)
+                messages.append({"role": "user", "content": prompt})
+                
+                # Whitelist only valid OpenAI parameters
+                valid_params = {
+                    'temperature', 'top_p', 'n', 'stream', 'stop', 'max_tokens',
+                    'presence_penalty', 'frequency_penalty', 'logit_bias', 'user', 'seed'
+                }
+                clean_kwargs = {k: v for k, v in kwargs.items() if k in valid_params}
+                
+                # Call OpenAI API directly (async)
+                response = await openai_client.chat.completions.create(
+                    model=llm_client.config.model,
+                    messages=messages,
+                    **clean_kwargs,
                 )
+                
+                return response.choices[0].message.content
 
             # Create pure LightRAG instance (no multimodal)
             rag = LightRAG(

--- a/src/services/rag/components/retrievers/hybrid.py
+++ b/src/services/rag/components/retrievers/hybrid.py
@@ -50,27 +50,49 @@ class HybridRetriever(BaseComponent):
             sys.path.insert(0, str(raganything_path))
 
         try:
-            from lightrag.llm.openai import openai_complete_if_cache
             from raganything import RAGAnything, RAGAnythingConfig
+            from openai import AsyncOpenAI
 
             from src.services.embedding import get_embedding_client
             from src.services.llm import get_llm_client
 
             llm_client = get_llm_client()
             embed_client = get_embedding_client()
+            
+            # Create AsyncOpenAI client directly
+            openai_client = AsyncOpenAI(
+                api_key=llm_client.config.api_key,
+                base_url=llm_client.config.base_url,
+            )
 
-            def llm_model_func(prompt, system_prompt=None, history_messages=None, **kwargs):
+            # LLM function using services (ASYNC - LightRAG expects async functions)
+            async def llm_model_func(prompt, system_prompt=None, history_messages=None, **kwargs):
+                """Custom async LLM function that bypasses LightRAG's openai_complete_if_cache."""
                 if history_messages is None:
                     history_messages = []
-                return openai_complete_if_cache(
-                    llm_client.config.model,
-                    prompt,
-                    system_prompt=system_prompt,
-                    history_messages=history_messages,
-                    api_key=llm_client.config.api_key,
-                    base_url=llm_client.config.base_url,
-                    **kwargs,
+                
+                # Build messages
+                messages = []
+                if system_prompt:
+                    messages.append({"role": "system", "content": system_prompt})
+                messages.extend(history_messages)
+                messages.append({"role": "user", "content": prompt})
+                
+                # Whitelist only valid OpenAI parameters
+                valid_params = {
+                    'temperature', 'top_p', 'n', 'stream', 'stop', 'max_tokens',
+                    'presence_penalty', 'frequency_penalty', 'logit_bias', 'user', 'seed'
+                }
+                clean_kwargs = {k: v for k, v in kwargs.items() if k in valid_params}
+                
+                # Call OpenAI API directly (async)
+                response = await openai_client.chat.completions.create(
+                    model=llm_client.config.model,
+                    messages=messages,
+                    **clean_kwargs,
                 )
+                
+                return response.choices[0].message.content
 
             config = RAGAnythingConfig(
                 working_dir=working_dir,

--- a/src/services/rag/components/retrievers/lightrag.py
+++ b/src/services/rag/components/retrievers/lightrag.py
@@ -52,27 +52,48 @@ class LightRAGRetriever(BaseComponent):
 
         try:
             from lightrag import LightRAG
-            from lightrag.llm.openai import openai_complete_if_cache
+            from openai import AsyncOpenAI
 
             from src.services.embedding import get_embedding_client
             from src.services.llm import get_llm_client
 
             llm_client = get_llm_client()
             embed_client = get_embedding_client()
+            
+            # Create AsyncOpenAI client directly
+            openai_client = AsyncOpenAI(
+                api_key=llm_client.config.api_key,
+                base_url=llm_client.config.base_url,
+            )
 
-            # LLM function using services (SYNC - LightRAG expects sync functions)
-            def llm_model_func(prompt, system_prompt=None, history_messages=None, **kwargs):
+            # LLM function using services (ASYNC - LightRAG expects async functions)
+            async def llm_model_func(prompt, system_prompt=None, history_messages=None, **kwargs):
+                """Custom async LLM function that bypasses LightRAG's openai_complete_if_cache."""
                 if history_messages is None:
                     history_messages = []
-                return openai_complete_if_cache(
-                    llm_client.config.model,
-                    prompt,
-                    system_prompt=system_prompt,
-                    history_messages=history_messages,
-                    api_key=llm_client.config.api_key,
-                    base_url=llm_client.config.base_url,
-                    **kwargs,
+                
+                # Build messages
+                messages = []
+                if system_prompt:
+                    messages.append({"role": "system", "content": system_prompt})
+                messages.extend(history_messages)
+                messages.append({"role": "user", "content": prompt})
+                
+                # Whitelist only valid OpenAI parameters
+                valid_params = {
+                    'temperature', 'top_p', 'n', 'stream', 'stop', 'max_tokens',
+                    'presence_penalty', 'frequency_penalty', 'logit_bias', 'user', 'seed'
+                }
+                clean_kwargs = {k: v for k, v in kwargs.items() if k in valid_params}
+                
+                # Call OpenAI API directly (async)
+                response = await openai_client.chat.completions.create(
+                    model=llm_client.config.model,
+                    messages=messages,
+                    **clean_kwargs,
                 )
+                
+                return response.choices[0].message.content
 
             # Create pure LightRAG instance (no multimodal)
             rag = LightRAG(

--- a/src/services/rag/factory.py
+++ b/src/services/rag/factory.py
@@ -22,7 +22,7 @@ _PIPELINES: Dict[str, Callable] = {
 
 def get_pipeline(
     name: str = "raganything", kb_base_dir: Optional[str] = None, **kwargs
-) -> Union[RAGPipeline, RAGAnythingPipeline]:
+):
     """
     Get a pre-configured pipeline by name.
 
@@ -43,13 +43,19 @@ def get_pipeline(
 
     factory = _PIPELINES[name]
 
-    # All pipelines now accept kb_base_dir
-    if name == "raganything":
+    # Handle different pipeline types:
+    # - lightrag, academic: functions that return RAGPipeline
+    # - llamaindex, raganything: classes that need instantiation
+    if name in ("lightrag", "academic"):
+        # LightRAGPipeline and AcademicPipeline are factory functions
+        return factory(kb_base_dir=kb_base_dir)
+    elif name in ("llamaindex", "raganything"):
+        # LlamaIndexPipeline and RAGAnythingPipeline are classes
         if kb_base_dir:
             kwargs["kb_base_dir"] = kb_base_dir
-        return factory(**kwargs) if kwargs else factory()
+        return factory(**kwargs)
     else:
-        # Component-based pipelines - pass kb_base_dir
+        # Default: try calling with kb_base_dir
         return factory(kb_base_dir=kb_base_dir)
 
 

--- a/src/services/rag/pipelines/raganything.py
+++ b/src/services/rag/pipelines/raganything.py
@@ -69,27 +69,52 @@ class RAGAnythingPipeline:
 
         self._setup_raganything_path()
 
-        from lightrag.llm.openai import openai_complete_if_cache
         from raganything import RAGAnything, RAGAnythingConfig
+        from openai import AsyncOpenAI
 
         from src.services.embedding import get_embedding_client
         from src.services.llm import get_llm_client
 
         llm_client = get_llm_client()
         embed_client = get_embedding_client()
+        
+        # Create AsyncOpenAI client directly - bypasses LightRAG's response_format handling
+        openai_client = AsyncOpenAI(
+            api_key=llm_client.config.api_key,
+            base_url=llm_client.config.base_url,
+        )
 
-        def llm_model_func(prompt, system_prompt=None, history_messages=None, **kwargs):
+        async def llm_model_func(prompt, system_prompt=None, history_messages=None, **kwargs):
+            """Custom async LLM function that bypasses LightRAG's openai_complete_if_cache."""
             if history_messages is None:
                 history_messages = []
-            return openai_complete_if_cache(
-                llm_client.config.model,
-                prompt,
-                system_prompt=system_prompt,
-                history_messages=history_messages,
-                api_key=llm_client.config.api_key,
-                base_url=llm_client.config.base_url,
-                **kwargs,
+            
+            # Build messages array
+            messages = []
+            if system_prompt:
+                messages.append({"role": "system", "content": system_prompt})
+            
+            # Add history
+            messages.extend(history_messages)
+            
+            # Add current prompt
+            messages.append({"role": "user", "content": prompt})
+            
+            # Whitelist only valid OpenAI parameters, filter out LightRAG-specific ones
+            valid_params = {
+                'temperature', 'top_p', 'n', 'stream', 'stop', 'max_tokens',
+                'presence_penalty', 'frequency_penalty', 'logit_bias', 'user', 'seed'
+            }
+            clean_kwargs = {k: v for k, v in kwargs.items() if k in valid_params}
+            
+            # Call OpenAI API directly (async)
+            response = await openai_client.chat.completions.create(
+                model=llm_client.config.model,
+                messages=messages,
+                **clean_kwargs,
             )
+            
+            return response.choices[0].message.content
 
         def vision_model_func(
             prompt,

--- a/web/.env.local
+++ b/web/.env.local
@@ -3,7 +3,7 @@
 # ============================================
 # This file is automatically updated based on config/main.yaml
 # and environment variables (NEXT_PUBLIC_API_BASE, NEXT_PUBLIC_API_BASE_EXTERNAL)
-#
+# 
 # To configure for remote access, set in your .env file:
 #   NEXT_PUBLIC_API_BASE=http://your-server-ip:8001
 # ============================================

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,7 +12,7 @@
         "cytoscape": "^3.33.1",
         "framer-motion": "^12.24.0",
         "html2canvas": "^1.4.1",
-        "jspdf": "^2.5.2",
+        "jspdf": "^4.0.0",
         "lucide-react": "^0.562.0",
         "mermaid": "^11.12.2",
         "next": "^16.1.1",
@@ -26,7 +26,7 @@
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.49.0",
+        "@playwright/test": "^1.53.2",
         "@types/node": "^25",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1352,7 +1352,6 @@
       "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.57.0"
       },
@@ -1726,6 +1725,12 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
     },
     "node_modules/@types/raf": {
       "version": "3.4.3",
@@ -2587,18 +2592,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.23",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.23.tgz",
@@ -2776,18 +2769,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "btoa": "bin/btoa.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/call-bind": {
@@ -3883,11 +3864,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "optional": true
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4620,6 +4603,17 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -5401,6 +5395,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
+    },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
@@ -5995,20 +5995,19 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
-      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
+      "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "atob": "^2.1.2",
-        "btoa": "^1.2.1",
+        "@babel/runtime": "^7.28.4",
+        "fast-png": "^6.2.0",
         "fflate": "^0.8.1"
       },
       "optionalDependencies": {
-        "canvg": "^3.0.6",
+        "canvg": "^3.0.11",
         "core-js": "^3.6.0",
-        "dompurify": "^2.5.4",
+        "dompurify": "^3.2.4",
         "html2canvas": "^1.0.0-rc.5"
       }
     },
@@ -6584,15 +6583,6 @@
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
         "uuid": "^11.1.0"
-      }
-    },
-    "node_modules/mermaid/node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/micromark": {
@@ -7604,6 +7594,12 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",


### PR DESCRIPTION
## Description

Add UI and backend support to select RAG provider (llamaindex, lightrag, raganything) when creating or uploading a knowledge base; persist selection to KB metadata and use it for search/retrieval.

## Related Issues
Closes # (n/a)

## Changes Made
- Add RAG provider dropdown to KB create/upload UI
- Send selected provider to backend in create/upload endpoints
- Persist rag_provider in KB metadata and read it during search routing

## Module(s) Affected
 - Knowledge Base Management
 - Frontend/Web
 - API/Backend