### PR TITLE
fix(api): resolve HTTP 413 on file uploads larger than 1 MB

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -147,6 +147,36 @@ async def lifespan(app: FastAPI):
     logger.info("Application shutdown")
 
 
+# ---------------------------------------------------------------------------
+# Starlette multipart upload size limit
+#
+# By default Starlette's ``MultiPartParser`` caps each individual file part at
+# 1 MB (the class-level ``max_file_size`` / ``max_part_size`` attribute).
+# Files that exceed this limit are rejected at the middleware layer *before*
+# the route handler runs, resulting in an HTTP 413 "Request Entity Too Large"
+# response — even when the file is well within DocumentValidator.MAX_FILE_SIZE
+# (100 MB).
+#
+# We raise the Starlette limit here to match the application-level cap so that
+# the framework streams larger uploads through to the route handler, which then
+# applies the real per-file size check via DocumentValidator.
+#
+# References:
+#   https://github.com/HKUDS/DeepTutor/issues/170
+#   https://github.com/encode/starlette/blob/master/starlette/formparsers.py
+# ---------------------------------------------------------------------------
+try:
+    from starlette.formparsers import MultiPartParser as _MultiPartParser
+
+    _UPLOAD_LIMIT_BYTES = 100 * 1024 * 1024  # 100 MB — matches DocumentValidator.MAX_FILE_SIZE
+    # Starlette ≥ 0.31 exposes ``max_file_size`` as a class attribute used as
+    # the default value for ``max_part_size`` in MultiPartParser.__init__().
+    _MultiPartParser.max_file_size = _UPLOAD_LIMIT_BYTES
+except (ImportError, AttributeError):
+    # Older Starlette versions do not enforce a part-level size limit;
+    # no patching is required.
+    pass
+
 app = FastAPI(
     title="DeepTutor API",
     version="1.0.0",


### PR DESCRIPTION
## Summary

Fixes #170

Uploading a PDF (≥ 1 MB) to an existing knowledge base raised HTTP 413 **Request Entity Too Large** even though the file was well within the application-level 100 MB cap configured in `DocumentValidator.MAX_FILE_SIZE`.

## Root cause

Starlette's `MultiPartParser` (≥ 0.31) enforces its own per-part size limit via the class attribute `max_file_size`, which defaults to **1 MB**.  Files exceeding this limit are rejected at the framework layer — before the route handler runs — so `DocumentValidator`'s streaming size check never gets a chance to act, and the server returns 413.

This explains why a 32-byte `.txt` file succeeds while a 2 MB `.pdf` fails.

## Fix

In `src/api/main.py`, we patch `MultiPartParser.max_file_size` to **100 MB** (matching `DocumentValidator.MAX_FILE_SIZE`) at application startup, before the FastAPI instance is created.  The existing `DocumentValidator` streaming check then applies the real per-file limit as intended.

A `try/except (ImportError, AttributeError)` guard keeps full compatibility with older Starlette versions that do not expose this attribute.

## Changes

`src/api/main.py`
- Added 30-line block that patches `starlette.formparsers.MultiPartParser.max_file_size` to 100 MB with full inline explanation and reference to this issue.

## Verification

1. Start DeepTutor with default configuration
2. Create a knowledge base
3. Attempt to upload a PDF ≥ 1 MB to that knowledge base
4. Confirm upload succeeds (previously returned 413)
5. Confirm files > 100 MB are still rejected (via `DocumentValidator`)