### PR TITLE
fix: replace 16 bare excepts with except Exception across 9 files

### DIFF
--- a/scripts/generate_roster.py
+++ b/scripts/generate_roster.py
@@ -84,7 +84,7 @@ def fetch_github_api(url: str, token: str = None, count_only: bool = False) -> t
                                 total_count += len(more_data)
                                 if len(more_data) < per_page:
                                     break
-                        except:
+                        except Exception:
                             break
                     break
         except Exception as e:

--- a/scripts/start_web.py
+++ b/scripts/start_web.py
@@ -467,7 +467,7 @@ if __name__ == "__main__":
                 if result == 0:
                     print_flush(f"✅ Backend is running on port {backend_port}!")
                     break
-            except:
+            except Exception:
                 pass
 
         if backend.poll() is not None:

--- a/src/agents/research/agents/reporting_agent.py
+++ b/src/agents/research/agents/reporting_agent.py
@@ -573,7 +573,7 @@ class ReportingAgent(BaseAgent):
                 parts_list = cit_id.replace("CIT-", "").split("-")
                 if len(parts_list) == 2:
                     return (1, int(parts_list[0]), int(parts_list[1]))
-            except:
+            except Exception:
                 pass
             return (999, 999, 999)
 
@@ -947,7 +947,7 @@ class ReportingAgent(BaseAgent):
                 parts_list = cit_id.replace("CIT-", "").split("-")
                 if len(parts_list) == 2:
                     return (1, int(parts_list[0]), int(parts_list[1]))
-            except:
+            except Exception:
                 pass
             return (999, 999, 999)
 

--- a/src/api/routers/knowledge.py
+++ b/src/api/routers/knowledge.py
@@ -700,7 +700,7 @@ async def websocket_progress(websocket: WebSocket, kb_name: str):
                     age_seconds = (now - progress_time).total_seconds()
                     if age_seconds < 300:  # 5 minutes
                         should_send = True
-                except:
+                except Exception:
                     pass
 
             if should_send:
@@ -738,13 +738,13 @@ async def websocket_progress(websocket: WebSocket, kb_name: str):
         logger.debug(f"Progress WS error: {e}")
         try:
             await websocket.send_json({"type": "error", "message": str(e)})
-        except:
+        except Exception:
             pass
     finally:
         await broadcaster.disconnect(kb_name, websocket)
         try:
             await websocket.close()
-        except:
+        except Exception:
             pass
 
 

--- a/src/api/utils/task_id_manager.py
+++ b/src/api/utils/task_id_manager.py
@@ -90,7 +90,7 @@ class TaskIDManager:
                             finished_time = datetime.fromisoformat(finished_at)
                             if finished_time < cutoff:
                                 to_remove.append(task_id)
-                        except:
+                        except Exception:
                             pass
 
             for task_id in to_remove:

--- a/src/knowledge/start_kb.py
+++ b/src/knowledge/start_kb.py
@@ -60,7 +60,7 @@ def list_knowledge_bases():
                 print(
                     f"    - RAG: {'Initialized' if stats.get('rag_initialized') else 'Not initialized'}"
                 )
-            except:
+            except Exception:
                 pass
 
     print("=" * 60 + "\n")

--- a/src/logging/adapters/lightrag.py
+++ b/src/logging/adapters/lightrag.py
@@ -123,7 +123,7 @@ def LightRAGLogContext(logger_name: Optional[str] = None, scene: Optional[str] =
         debug_logger.debug(
             f"Setting up LightRAG log forwarding (scene={scene}, logger_name={logger_name})"
         )
-    except:
+    except Exception:
         pass  # Ignore if logger setup fails
 
     # Determine logger name
@@ -174,7 +174,7 @@ def LightRAGLogContext(logger_name: Optional[str] = None, scene: Optional[str] =
     try:
         test_msg = "LightRAG log forwarding enabled"
         lightrag_logger.info(test_msg)
-    except:
+    except Exception:
         pass  # Ignore test log errors
 
     try:

--- a/src/logging/logger.py
+++ b/src/logging/logger.py
@@ -458,7 +458,7 @@ class Logger:
                     else str(tool_input)
                 )
                 self.debug(f"Tool Input: {input_str[:500]}...")
-            except:
+            except Exception:
                 pass
         if tool_output is not None:
             try:
@@ -468,7 +468,7 @@ class Logger:
                     else str(tool_output)
                 )
                 self.debug(f"Tool Output: {output_str[:500]}...")
-            except:
+            except Exception:
                 pass
 
     def log_llm_input(

--- a/src/tools/tex_downloader.py
+++ b/src/tools/tex_downloader.py
@@ -141,7 +141,7 @@ class TexDownloader:
         try:
             with tarfile.open(file_path, "r:*") as tar:
                 return True
-        except:
+        except Exception:
             return False
 
     def _is_zip_file(self, file_path: Path) -> bool:
@@ -149,7 +149,7 @@ class TexDownloader:
         try:
             with zipfile.ZipFile(file_path, "r") as zip_file:
                 return True
-        except:
+        except Exception:
             return False
 
     def _extract_tar(self, tar_path: Path, extract_dir: Path):
@@ -204,7 +204,7 @@ class TexDownloader:
                 content = tex_file.read_text(encoding="utf-8", errors="ignore")
                 if r"\documentclass" in content:
                     return tex_file
-            except:
+            except Exception:
                 continue
 
         # 3. Return largest tex file


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` across 9 files (16 sites).

**Why:** Bare `except:` catches `BaseException` including `KeyboardInterrupt` and `SystemExit`, which can prevent clean shutdown and mask critical errors. Using `except Exception:` preserves all existing fallback behavior while allowing system exceptions to propagate.

**Files changed:**
- `scripts/generate_roster.py` — pagination fallback
- `scripts/start_web.py` — port check fallback
- `src/agents/research/agents/reporting_agent.py` — citation parsing (2 sites)
- `src/api/routers/knowledge.py` — progress tracking (3 sites)
- `src/api/utils/task_id_manager.py` — task cleanup
- `src/knowledge/start_kb.py` — service startup
- `src/logging/adapters/lightrag.py` — logger setup (2 sites)
- `src/logging/logger.py` — log formatting (2 sites)
- `src/tools/tex_downloader.py` — file extraction (3 sites)