### PR TITLE
docs: implement reasoning and safety checklist #199

### DIFF
--- a/docs/deep_tutor_reasoning_and_safety_checklist.md
+++ b/docs/deep_tutor_reasoning_and_safety_checklist.md
@@ -1,0 +1,19 @@
+# DeepTutor Reasoning & Safety Checklist
+
+This checklist aims to ensure pedagogical safety and reasoning robustness during multi-turn tutoring sessions.
+
+## 1. Typical Failure Modes
+- **Constraint Loss**: Forgetting earlier pedagogical boundaries (e.g., "don't give the answer yet").
+- **Retrieval Drift**: Using low-quality or off-topic knowledge base snippets.
+- **Overconfidence**: Asserting facts without clear grounding in the retrieved material.
+
+## 2. Debugging Steps
+- [ ] Check prompt logs for lost context.
+- [ ] Verify RAG retrieval scores and snippet relevance.
+- [ ] Ensure model output includes citations from the Knowledge Base.
+
+## 3. Issue Reporting
+When opening an issue, please include:
+- Tools used during the failure.
+- Anonymized conversation trace.
+- Retrieved snippets that led to the error.


### PR DESCRIPTION
This PR adds the `deep_tutor_reasoning_and_safety_checklist.md` to the documentation, providing users and maintainers with a framework for talking about and debugging reasoning failures (#199).

### Changes:
- Added pedagogical safety checklist.
- Included failure mode symptoms and likely causes.
- Standardized issue reporting requirements for reasoning bugs.

/claim #199