### PR TITLE
fix(deps): gate oauth-cli-kit to Python 3.11+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ deeptutor = "deeptutor_cli.main:main"
 anthropic = ["anthropic>=0.30.0"]
 dashscope = ["dashscope>=1.14.0"]
 search = ["perplexityai>=0.1.0"]
-oauth = ["oauth-cli-kit>=0.2.0"]
+oauth = ["oauth-cli-kit>=0.2.0; python_version >= '3.11'"]
 server = [
     "fastapi>=0.100.0",
     "uvicorn[standard]>=0.24.0",
@@ -52,7 +52,7 @@ all = [
     "anthropic>=0.30.0",
     "dashscope>=1.14.0",
     "perplexityai>=0.1.0",
-    "oauth-cli-kit>=0.2.0",
+    "oauth-cli-kit>=0.2.0; python_version >= '3.11'",
     "fastapi>=0.100.0",
     "uvicorn[standard]>=0.24.0",
     "websockets>=12.0",

--- a/requirements/cli.txt
+++ b/requirements/cli.txt
@@ -18,7 +18,7 @@ tiktoken>=0.5.0
 anthropic>=0.30.0
 dashscope>=1.14.0
 perplexityai>=0.1.0
-oauth-cli-kit>=0.1.1
+oauth-cli-kit>=0.1.1; python_version >= "3.11"
 
 # --- HTTP clients ---
 aiohttp>=3.9.4


### PR DESCRIPTION
## Summary
- add a Python version marker to oauth-cli-kit in requirements/cli.txt
- add the same Python version marker to the oauth and all extras in pyproject.toml
- keep Python 3.10 installs from failing during the import-check dependency step

## Why
The current Tests workflow runs an import check on Python 3.10, 3.11, and 3.12. However, oauth-cli-kit currently requires Python 3.11+, so the Python 3.10 job fails during dependency installation before any imports are checked.

This is already visible on upstream dev runs, so this PR keeps the dependency optional on Python 3.10 while preserving it for Python 3.11+.

## Verification
- confirmed on Python 3.10 that pip skips the marked oauth-cli-kit requirement instead of erroring
- confirmed provider_cmd.py still compiles locally

Related: this should unblock the existing red import-check state affecting PR #250.