### PR TITLE
fix: add missing imports for mimic websocket router

### DIFF
--- a/deeptutor/api/routers/question.py
+++ b/deeptutor/api/routers/question.py
@@ -1,7 +1,9 @@
 import asyncio
 import base64
 from datetime import datetime
+from pathlib import Path
 import re
+import sys
 import traceback
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
@@ -9,15 +11,14 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from deeptutor.agents.question import AgentCoordinator
 from deeptutor.api.utils.log_interceptor import LogInterceptor
 from deeptutor.api.utils.task_id_manager import TaskIDManager
-from deeptutor.services.path_service import get_path_service
-from deeptutor.tools.question import mimic_exam_questions
-from deeptutor.utils.document_validator import DocumentValidator
-from deeptutor.utils.error_utils import format_exception_message
-
 from deeptutor.logging import get_logger
 from deeptutor.services.config import PROJECT_ROOT, load_config_with_main
 from deeptutor.services.llm.config import get_llm_config
+from deeptutor.services.path_service import get_path_service
 from deeptutor.services.settings.interface_settings import get_ui_language
+from deeptutor.tools.question import mimic_exam_questions
+from deeptutor.utils.document_validator import DocumentValidator
+from deeptutor.utils.error_utils import format_exception_message
 
 # Setup module logger with unified logging system (from config)
 config = load_config_with_main("main.yaml", PROJECT_ROOT)
@@ -418,12 +419,24 @@ async def websocket_question_generate(websocket: WebSocket):
                     return
 
                 # Extract fields from requirement dict
-                user_topic = requirement.get("knowledge_point", "") if isinstance(requirement, dict) else str(requirement)
-                preference = requirement.get("preference", "") if isinstance(requirement, dict) else ""
-                difficulty = requirement.get("difficulty", "") if isinstance(requirement, dict) else ""
-                question_type = requirement.get("question_type", "") if isinstance(requirement, dict) else ""
+                user_topic = (
+                    requirement.get("knowledge_point", "")
+                    if isinstance(requirement, dict)
+                    else str(requirement)
+                )
+                preference = (
+                    requirement.get("preference", "") if isinstance(requirement, dict) else ""
+                )
+                difficulty = (
+                    requirement.get("difficulty", "") if isinstance(requirement, dict) else ""
+                )
+                question_type = (
+                    requirement.get("question_type", "") if isinstance(requirement, dict) else ""
+                )
 
-                logger.info(f"Starting question generation for {count} question(s), topic: {user_topic}")
+                logger.info(
+                    f"Starting question generation for {count} question(s), topic: {user_topic}"
+                )
 
                 batch_result = await coordinator.generate_from_topic(
                     user_topic=user_topic,

--- a/tests/api/test_question_router.py
+++ b/tests/api/test_question_router.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+FastAPI = pytest.importorskip("fastapi").FastAPI
+TestClient = pytest.importorskip("fastapi.testclient").TestClient
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_question_router_module():
+    yield
+    sys.modules.pop("deeptutor.api.routers.question", None)
+
+
+class _DummyLogger:
+    def debug(self, *_args, **_kwargs) -> None:
+        pass
+
+    def error(self, *_args, **_kwargs) -> None:
+        pass
+
+    def exception(self, *_args, **_kwargs) -> None:
+        pass
+
+    def info(self, *_args, **_kwargs) -> None:
+        pass
+
+    def success(self, *_args, **_kwargs) -> None:
+        pass
+
+    def warning(self, *_args, **_kwargs) -> None:
+        pass
+
+
+class _DummyLogInterceptor:
+    def __init__(self, *_args, **_kwargs) -> None:
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args) -> None:
+        return None
+
+
+def _package(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    module.__path__ = []
+    return module
+
+
+def _load_question_router_module(monkeypatch: pytest.MonkeyPatch):
+    sys.modules.pop("deeptutor.api.routers.question", None)
+
+    fake_agents = _package("deeptutor.agents")
+    fake_agents_question = types.ModuleType("deeptutor.agents.question")
+    fake_agents_question.AgentCoordinator = object
+    fake_agents.question = fake_agents_question
+    monkeypatch.setitem(sys.modules, "deeptutor.agents", fake_agents)
+    monkeypatch.setitem(sys.modules, "deeptutor.agents.question", fake_agents_question)
+
+    fake_logging = _package("deeptutor.logging")
+    fake_logging.get_logger = lambda *_args, **_kwargs: _DummyLogger()
+    fake_logging_handlers = types.ModuleType("deeptutor.logging.handlers")
+    fake_logging_handlers.JSONFileHandler = object
+    fake_logging_handlers.LogInterceptor = _DummyLogInterceptor
+    fake_logging_handlers.WebSocketLogHandler = object
+    fake_logging_handlers.create_task_logger = lambda *_args, **_kwargs: None
+    fake_logging.handlers = fake_logging_handlers
+    monkeypatch.setitem(sys.modules, "deeptutor.logging", fake_logging)
+    monkeypatch.setitem(sys.modules, "deeptutor.logging.handlers", fake_logging_handlers)
+
+    fake_config = types.ModuleType("deeptutor.services.config")
+    fake_config.PROJECT_ROOT = Path.cwd()
+    fake_config.load_config_with_main = lambda *_args, **_kwargs: {}
+    monkeypatch.setitem(sys.modules, "deeptutor.services.config", fake_config)
+
+    fake_llm_package = _package("deeptutor.services.llm")
+    fake_llm_config = types.ModuleType("deeptutor.services.llm.config")
+    fake_llm_config.get_llm_config = lambda: None
+    fake_llm_package.config = fake_llm_config
+    monkeypatch.setitem(sys.modules, "deeptutor.services.llm", fake_llm_package)
+    monkeypatch.setitem(sys.modules, "deeptutor.services.llm.config", fake_llm_config)
+
+    fake_settings_package = _package("deeptutor.services.settings")
+    fake_interface_settings = types.ModuleType("deeptutor.services.settings.interface_settings")
+    fake_interface_settings.get_ui_language = lambda default="en": default
+    fake_settings_package.interface_settings = fake_interface_settings
+    monkeypatch.setitem(sys.modules, "deeptutor.services.settings", fake_settings_package)
+    monkeypatch.setitem(
+        sys.modules,
+        "deeptutor.services.settings.interface_settings",
+        fake_interface_settings,
+    )
+
+    fake_tools = _package("deeptutor.tools")
+    fake_tools_question = types.ModuleType("deeptutor.tools.question")
+
+    async def _default_mimic_exam_questions(*_args, **_kwargs):
+        return {"success": True}
+
+    fake_tools_question.mimic_exam_questions = _default_mimic_exam_questions
+    fake_tools.question = fake_tools_question
+    monkeypatch.setitem(sys.modules, "deeptutor.tools", fake_tools)
+    monkeypatch.setitem(sys.modules, "deeptutor.tools.question", fake_tools_question)
+
+    return importlib.import_module("deeptutor.api.routers.question")
+
+
+def _build_app(router_module) -> FastAPI:
+    app = FastAPI()
+    app.include_router(router_module.router, prefix="/api/v1/question")
+    return app
+
+
+def test_mimic_websocket_accepts_config_and_returns_messages(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    question_router_module = _load_question_router_module(monkeypatch)
+
+    async def _fake_mimic_exam_questions(*_args, **_kwargs):
+        return {"success": False, "error": "stub mimic failure"}
+
+    monkeypatch.setattr(question_router_module, "mimic_exam_questions", _fake_mimic_exam_questions)
+    monkeypatch.setattr(question_router_module, "MIMIC_OUTPUT_DIR", tmp_path / "mimic_papers")
+
+    with TestClient(_build_app(question_router_module)) as client:
+        with client.websocket_connect("/api/v1/question/mimic") as websocket:
+            websocket.send_json(
+                {
+                    "mode": "parsed",
+                    "paper_path": str(tmp_path / "paper"),
+                    "kb_name": "demo-kb",
+                    "max_questions": 3,
+                }
+            )
+            messages = [websocket.receive_json() for _ in range(3)]
+
+    assert [message["type"] for message in messages] == ["status", "status", "error"]
+    assert messages[0]["stage"] == "init"
+    assert messages[1]["stage"] == "processing"
+    assert messages[2]["content"] == "stub mimic failure"


### PR DESCRIPTION
### Description

Fixes #255 

The `/mimic` WebSocket endpoint in `question.py` uses `sys.path` and `Path` but neither `sys` nor `pathlib.Path` were imported. This causes a `NameError` as soon as a client connects to the mimic endpoint.

Added the two missing imports and a minimal WebSocket regression test that verifies the endpoint accepts a config message and returns the expected status/error sequence.

### Related Issues
- #255 

### Module(s) Affected
- [x] `api`
- [x] `tests`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
The test mocks all heavy dependencies (agents, logging, LLM services) to keep it fast and isolated. A cleanup fixture removes the cached module after each test to prevent stale imports from leaking.