### PR TITLE
fix(start-tour): tolerate non-UTF-8 subprocess output

### DIFF
--- a/scripts/start_tour.py
+++ b/scripts/start_tour.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import locale
 import os
 from pathlib import Path
 import platform
@@ -443,15 +444,31 @@ def _tour_banner() -> None:
 # Web path — install deps, start temp server, wait for browser config
 # ===================================================================
 
+def _stream_text_kwargs() -> dict[str, object]:
+    """Best-effort text decoding for background process output."""
+    # Some Windows child processes emit locale-specific bytes even when Python
+    # runs in UTF-8 mode. Replace undecodable bytes so the background drain
+    # thread keeps consuming output instead of crashing.
+    encoding = locale.getpreferredencoding(False) or "utf-8"
+    return {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.STDOUT,
+        "text": True,
+        "encoding": encoding,
+        "errors": "replace",
+        "bufsize": 1,
+    }
+
+
 def _spawn_process(
     cmd: list[str], *, cwd: Path, env: dict[str, str], name: str,
 ) -> subprocess.Popen[str]:
     import threading
 
     kwargs: dict[str, object] = {
-        "cwd": str(cwd), "env": env,
-        "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT,
-        "text": True, "bufsize": 1,
+        "cwd": str(cwd),
+        "env": env,
+        **_stream_text_kwargs(),
     }
     if os.name == "nt":
         kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]

--- a/tests/scripts/test_start_tour.py
+++ b/tests/scripts/test_start_tour.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib.util
+import locale
+from pathlib import Path
+import sys
+import types
+
+
+def _load_start_tour_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "start_tour.py"
+
+    cli_kit = types.ModuleType("_cli_kit")
+    for name in (
+        "accent",
+        "banner",
+        "bold",
+        "confirm",
+        "countdown",
+        "dim",
+        "log_error",
+        "log_info",
+        "log_success",
+        "log_warn",
+        "select",
+        "step",
+        "text_input",
+    ):
+        setattr(cli_kit, name, lambda *args, **kwargs: None)
+
+    deeptutor_pkg = types.ModuleType("deeptutor")
+    services_pkg = types.ModuleType("deeptutor.services")
+    config_module = types.ModuleType("deeptutor.services.config")
+    config_module.get_config_test_runner = lambda: None
+    config_module.get_env_store = lambda: None
+    config_module.get_model_catalog_service = lambda: None
+
+    original_modules = {
+        "_cli_kit": sys.modules.get("_cli_kit"),
+        "deeptutor": sys.modules.get("deeptutor"),
+        "deeptutor.services": sys.modules.get("deeptutor.services"),
+        "deeptutor.services.config": sys.modules.get("deeptutor.services.config"),
+    }
+
+    services_pkg.config = config_module
+    deeptutor_pkg.services = services_pkg
+    sys.modules["_cli_kit"] = cli_kit
+    sys.modules["deeptutor"] = deeptutor_pkg
+    sys.modules["deeptutor.services"] = services_pkg
+    sys.modules["deeptutor.services.config"] = config_module
+
+    try:
+        spec = importlib.util.spec_from_file_location("start_tour_under_test", module_path)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for module_name, original_module in original_modules.items():
+            if original_module is None:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = original_module
+
+
+def test_stream_text_kwargs_use_best_effort_decoding() -> None:
+    start_tour = _load_start_tour_module()
+
+    kwargs = start_tour._stream_text_kwargs()
+
+    assert kwargs["text"] is True
+    assert kwargs["errors"] == "replace"
+    assert kwargs["encoding"] == locale.getpreferredencoding(False)


### PR DESCRIPTION
## Summary
- make the start tour subprocess drain use best-effort text decoding instead of crashing on undecodable bytes
- decode child process output with the system-preferred encoding and replace undecodable bytes during background draining
- add a focused regression test for the stream text decoding kwargs used by the start tour

## Why
Issue #258 shows the setup tour crashing inside the background drain thread while iterating over child process output on Windows. The tour only drains output to keep the terminal clean, so undecodable bytes should never terminate the helper thread.

This change keeps the drain thread alive even when child processes emit locale-specific bytes.

## Verification
- ran the new focused start-tour regression test locally
- verified the updated script and test file compile locally

Closes #258