### PR TITLE
docs: clarify github copilot provider login semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ deeptutor session open <id>                         # Resume in REPL
 | `deeptutor config show` | Print current configuration summary |
 | `deeptutor plugin list` | List registered tools and capabilities |
 | `deeptutor plugin info <name>` | Show tool or capability details |
-| `deeptutor provider login <provider>` | OAuth login (`openai-codex`, `github-copilot`) |
+| `deeptutor provider login <provider>` | Provider auth (`openai-codex` OAuth login; `github-copilot` validates an existing Copilot auth session) |
 
 </details>
 

--- a/deeptutor_cli/README.md
+++ b/deeptutor_cli/README.md
@@ -181,11 +181,11 @@ deeptutor plugin info <name>                     # 查看详情
 deeptutor config show
 ```
 
-### `provider` — OAuth 登录
+### `provider` — 提供方认证 / 校验
 
 ```bash
-deeptutor provider login openai-codex
-deeptutor provider login github-copilot
+deeptutor provider login openai-codex      # 执行 OpenAI Codex OAuth 登录
+deeptutor provider login github-copilot    # 校验现有 GitHub Copilot 认证是否可用
 ```
 
 ---

--- a/deeptutor_cli/provider_cmd.py
+++ b/deeptutor_cli/provider_cmd.py
@@ -1,4 +1,4 @@
-"""CLI commands for provider auth (OAuth-first providers)."""
+"""CLI commands for provider auth and access validation."""
 
 from __future__ import annotations
 
@@ -12,10 +12,10 @@ def register(app: typer.Typer) -> None:
     def provider_login(
         provider: str = typer.Argument(
             ...,
-            help="OAuth provider: openai-codex | github-copilot",
+            help="Provider: openai-codex (OAuth login) | github-copilot (validate existing Copilot auth)",
         ),
     ) -> None:
-        """Authenticate an OAuth-backed provider."""
+        """Authenticate or validate provider access."""
         key = provider.strip().lower().replace("-", "_")
         if key == "openai_codex":
             _login_openai_codex()
@@ -55,6 +55,7 @@ def _login_openai_codex() -> None:
 
 
 async def _login_github_copilot() -> None:
+    """Validate an existing GitHub Copilot auth session via a lightweight request."""
     try:
         from litellm import acompletion
     except ImportError:
@@ -67,6 +68,6 @@ async def _login_github_copilot() -> None:
             max_tokens=1,
         )
     except Exception as exc:
-        typer.echo(f"GitHub Copilot OAuth authentication failed: {exc}")
+        typer.echo(f"GitHub Copilot auth validation failed: {exc}")
         raise typer.Exit(code=1) from exc
-    typer.echo("GitHub Copilot OAuth authentication succeeded.")
+    typer.echo("GitHub Copilot auth validation succeeded.")

--- a/tests/cli/test_provider_cli.py
+++ b/tests/cli/test_provider_cli.py
@@ -1,0 +1,33 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PROVIDER_CMD = (ROOT / "deeptutor_cli" / "provider_cmd.py").read_text(encoding="utf-8")
+CLI_README = (ROOT / "deeptutor_cli" / "README.md").read_text(encoding="utf-8")
+ROOT_README = (ROOT / "README.md").read_text(encoding="utf-8")
+
+
+class ProviderCliDocsContractTest(unittest.TestCase):
+    def test_provider_contract_describes_copilot_as_validation_not_oauth_login(self) -> None:
+        self.assertIn(
+            'help="Provider: openai-codex (OAuth login) | github-copilot (validate existing Copilot auth)"',
+            PROVIDER_CMD,
+        )
+        self.assertIn('"""Authenticate or validate provider access."""', PROVIDER_CMD)
+        self.assertIn('GitHub Copilot auth validation succeeded.', PROVIDER_CMD)
+        self.assertIn('GitHub Copilot auth validation failed:', PROVIDER_CMD)
+        self.assertNotIn('OAuth provider: openai-codex | github-copilot', PROVIDER_CMD)
+        self.assertNotIn('GitHub Copilot OAuth authentication succeeded.', PROVIDER_CMD)
+
+    def test_readmes_match_the_cli_contract(self) -> None:
+        self.assertIn(
+            'Provider auth (`openai-codex` OAuth login; `github-copilot` validates an existing Copilot auth session)',
+            ROOT_README,
+        )
+        self.assertIn('deeptutor provider login github-copilot    # 校验现有 GitHub Copilot 认证是否可用', CLI_README)
+        self.assertNotIn('OAuth login (`openai-codex`, `github-copilot`)', ROOT_README)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Clarify that `deeptutor provider login github-copilot` validates an existing Copilot auth session rather than performing an OAuth login flow.

## Reproduction

`openai-codex` uses `login_oauth_interactive(...)`, but the `github-copilot` path only sends a lightweight `litellm.acompletion(...)` request. Despite that, the root README, CLI README, and provider help text all described both providers under OAuth login wording.

## Patch Summary

- update CLI provider help text to describe provider-specific behavior
- change GitHub Copilot success/failure messages from OAuth wording to auth validation wording
- update root and CLI READMEs to match the real behavior
- add a contract test that keeps docs/help text aligned with the implementation

## Risks

Low. This is a docs/help-text correction only; runtime behavior is unchanged.

## Validation

- `python3 -m unittest tests.cli.test_provider_cli`
