### PR TITLE
fix: use parse_json_response for LLM outputs to handle markdown fences

### DIFF
--- a/deeptutor/agents/guide/agents/design_agent.py
+++ b/deeptutor/agents/guide/agents/design_agent.py
@@ -8,6 +8,7 @@ import json
 from typing import Optional
 
 from deeptutor.agents.base_agent import BaseAgent
+from deeptutor.utils.json_parser import parse_json_response
 
 
 class DesignAgent(BaseAgent):
@@ -73,7 +74,7 @@ class DesignAgent(BaseAgent):
             response = "".join(_chunks)
 
             try:
-                result = json.loads(response)
+                result = parse_json_response(response, logger_instance=self.logger)
 
                 if isinstance(result, list):
                     knowledge_points = result

--- a/deeptutor/agents/question/agents/idea_agent.py
+++ b/deeptutor/agents/question/agents/idea_agent.py
@@ -9,6 +9,7 @@ import json
 from typing import Any
 
 from deeptutor.agents.base_agent import BaseAgent
+from deeptutor.utils.json_parser import parse_json_response
 from deeptutor.agents.question.models import QuestionTemplate
 from deeptutor.core.trace import build_trace_metadata, new_call_id
 from deeptutor.tools.rag_tool import rag_search
@@ -227,7 +228,7 @@ class IdeaAgent(BaseAgent):
             ):
                 _chunks.append(_c)
             response = "".join(_chunks)
-            payload = json.loads(response)
+            payload = parse_json_response(response, logger_instance=self.logger)
             ideas_raw = payload.get("ideas", [])
             if not isinstance(ideas_raw, list):
                 ideas_raw = []

--- a/deeptutor/agents/research/agents/note_agent.py
+++ b/deeptutor/agents/research/agents/note_agent.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 from deeptutor.agents.base_agent import BaseAgent
 from deeptutor.agents.research.data_structures import ToolTrace
 from deeptutor.core.trace import build_trace_metadata, new_call_id
+from deeptutor.utils.json_parser import parse_json_response
 
 from ..utils.json_utils import extract_json_from_text
 
@@ -158,9 +159,8 @@ class NoteAgent(BaseAgent):
 
     def _extract_summary_by_rule(self, tool_type: str, raw_answer: str) -> str:
         """Extract a concise summary from structured tool output without LLM."""
-        try:
-            data = json.loads(raw_answer)
-        except Exception:
+        data = parse_json_response(raw_answer, fallback=None)
+        if data is None:
             return ""
 
         tool_type = (tool_type or "").lower()

--- a/deeptutor/agents/research/agents/reporting_agent.py
+++ b/deeptutor/agents/research/agents/reporting_agent.py
@@ -1507,9 +1507,11 @@ class ReportingAgent(BaseAgent):
     @staticmethod
     def _strip_json_wrapper(resp: str) -> str:
         """Best-effort extraction of readable text from a JSON response."""
-        import json as _json
+        from deeptutor.utils.json_parser import parse_json_response
         try:
-            obj = _json.loads(resp.strip())
+            obj = parse_json_response(resp.strip(), fallback=None)
+            if obj is None:
+                raise ValueError("parse failed")
             if isinstance(obj, dict):
                 for key in ("report", "content", "text", "markdown", "output"):
                     if key in obj and isinstance(obj[key], str):

--- a/deeptutor/agents/research/data_structures.py
+++ b/deeptutor/agents/research/data_structures.py
@@ -11,6 +11,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from deeptutor.utils.json_parser import parse_json_response
+
 
 class TopicStatus(Enum):
     """Topic block status enumeration"""
@@ -79,7 +81,9 @@ class ToolTrace:
 
         # Try to parse as JSON and truncate intelligently
         try:
-            data = json.loads(raw_answer)
+            data = parse_json_response(raw_answer, fallback=None)
+            if data is None:
+                raise ValueError("not JSON")
 
             # If it's a dict with common RAG response fields, truncate content fields
             if isinstance(data, dict):

--- a/deeptutor/agents/research/utils/citation_manager.py
+++ b/deeptutor/agents/research/utils/citation_manager.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from deeptutor.services.path_service import get_path_service
+from deeptutor.utils.json_parser import parse_json_response
 
 
 class CitationManager:
@@ -293,7 +294,7 @@ class CitationManager:
 
         try:
             # Parse raw_answer to extract source information
-            answer_data = json.loads(raw_answer)
+            answer_data = parse_json_response(raw_answer)
 
             # Extract source documents if available
             # Common fields in RAG responses: chunks, documents, sources, context
@@ -349,7 +350,7 @@ class CitationManager:
 
         try:
             # Parse raw_answer to extract web source information
-            answer_data = json.loads(raw_answer)
+            answer_data = parse_json_response(raw_answer)
 
             web_sources = []
 
@@ -396,7 +397,7 @@ class CitationManager:
 
         try:
             # Parse raw_answer JSON
-            answer_data = json.loads(raw_answer)
+            answer_data = parse_json_response(raw_answer)
             papers = answer_data.get("papers", [])
 
             if not papers:

--- a/deeptutor/agents/solve/agents/planner_agent.py
+++ b/deeptutor/agents/solve/agents/planner_agent.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from deeptutor.agents.base_agent import BaseAgent
 from deeptutor.core.trace import build_trace_metadata, derive_trace_metadata, new_call_id
+from deeptutor.utils.json_parser import parse_json_response
 
 from ..memory.scratchpad import Plan, PlanStep, Scratchpad
 from ..tool_runtime import SolveToolRuntime
@@ -214,7 +215,7 @@ class PlannerAgent(BaseAgent):
             ):
                 parts.append(chunk)
             response = "".join(parts)
-            payload = json.loads(response)
+            payload = parse_json_response(response, logger_instance=logger)
             queries = payload.get("queries", [])
             if not isinstance(queries, list):
                 queries = []


### PR DESCRIPTION
## Problem

When `response_format` is unsupported by a provider (e.g. DeepSeek), LLMs return JSON wrapped in markdown code fences. Seven agent modules used raw `json.loads()` which fails with `JSONDecodeError`, causing features like idea generation and research to silently produce empty results.

## Fix

Replace raw `json.loads()` calls with the existing `parse_json_response()` utility from `deeptutor/utils/json_parser.py`, which handles markdown fence extraction, json-repair fallback, and graceful failure.

### Affected modules (10 call sites across 7 files):

| File | Call sites |
|------|-----------|
| `agents/question/agents/idea_agent.py` | 1 |
| `agents/solve/agents/planner_agent.py` | 1 |
| `agents/guide/agents/design_agent.py` | 1 |
| `agents/research/utils/citation_manager.py` | 3 |
| `agents/research/agents/reporting_agent.py` | 1 |
| `agents/research/agents/note_agent.py` | 1 |
| `agents/research/data_structures.py` | 1 |

**Not changed:** `agents/question/agents/generator.py` already has its own markdown fence stripping logic.

## Testing

- All modified files compile without errors
- No behavioral change for providers that return raw JSON
- Fixes the exact error path shown in #179

Closes #179