### PR TITLE
fix: embedding progress tracking + 429 rate limit retry

### DIFF
--- a/deeptutor/knowledge/initializer.py
+++ b/deeptutor/knowledge/initializer.py
@@ -176,8 +176,22 @@ class KnowledgeBaseInitializer:
         )
         file_paths = [str(doc_file) for doc_file in doc_files]
 
+        total_docs = len(doc_files)
+
+        def _on_progress(batch_num, total_batches):
+            self.progress_tracker.update(
+                ProgressStage.PROCESSING_DOCUMENTS,
+                f"Embedding batches: {batch_num}/{total_batches} complete",
+                current=batch_num,
+                total=total_batches,
+            )
+
         try:
-            success = await rag_service.initialize(kb_name=self.kb_name, file_paths=file_paths)
+            success = await rag_service.initialize(
+                kb_name=self.kb_name,
+                file_paths=file_paths,
+                progress_callback=_on_progress,
+            )
             if not success:
                 self.progress_tracker.update(
                     ProgressStage.ERROR,

--- a/deeptutor/services/embedding/adapters/openai_compatible.py
+++ b/deeptutor/services/embedding/adapters/openai_compatible.py
@@ -88,8 +88,10 @@ class OpenAICompatibleEmbeddingAdapter(BaseEmbeddingAdapter):
             f"Top-level keys={keys}, expected one of: data/embeddings/result/output."
         )
 
-    _MAX_RETRIES = 2
+    _MAX_RETRIES = 5
     _RETRY_BACKOFF = 1.0
+    _RATE_LIMIT_BACKOFF = 5.0
+    _BATCH_DELAY = 1.5
 
     async def embed(self, request: EmbeddingRequest) -> EmbeddingResponse:
         import asyncio
@@ -136,6 +138,18 @@ class OpenAICompatibleEmbeddingAdapter(BaseEmbeddingAdapter):
                 async with httpx.AsyncClient(timeout=timeout) as client:
                     response = await client.post(url, json=payload, headers=headers)
 
+                    # Handle rate limiting (429) with retry
+                    if response.status_code == 429:
+                        retry_after = float(response.headers.get("Retry-After", 0))
+                        wait = max(retry_after, self._RATE_LIMIT_BACKOFF * (2 ** attempt))
+                        logger.warning(
+                            f"Rate limited (429) on attempt {attempt + 1}/{1 + self._MAX_RETRIES}, "
+                            f"retrying in {wait:.1f}s..."
+                        )
+                        await asyncio.sleep(wait)
+                        last_exc = Exception(f"HTTP 429 Too Many Requests")
+                        continue
+
                     if response.status_code >= 400:
                         logger.error(f"HTTP {response.status_code} response body: {response.text}")
 
@@ -145,10 +159,10 @@ class OpenAICompatibleEmbeddingAdapter(BaseEmbeddingAdapter):
             except (httpx.ReadTimeout, httpx.ConnectTimeout, httpx.PoolTimeout) as exc:
                 last_exc = exc
                 if attempt < self._MAX_RETRIES:
-                    wait = self._RETRY_BACKOFF * (attempt + 1)
+                    wait = self._RETRY_BACKOFF * (2 ** attempt)
                     logger.warning(
                         f"Embedding request timeout (attempt {attempt + 1}/{1 + self._MAX_RETRIES}), "
-                        f"retrying in {wait:.0f}s..."
+                        f"retrying in {wait:.1f}s..."
                     )
                     await asyncio.sleep(wait)
                 else:
@@ -156,6 +170,13 @@ class OpenAICompatibleEmbeddingAdapter(BaseEmbeddingAdapter):
                         f"Embedding request failed after {1 + self._MAX_RETRIES} attempts: {exc}"
                     )
                     raise
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code == 429:
+                    continue
+                raise
+        else:
+            if last_exc:
+                raise last_exc
 
         embeddings = self._extract_embeddings_from_response(data)
         if not embeddings:

--- a/deeptutor/services/embedding/client.py
+++ b/deeptutor/services/embedding/client.py
@@ -60,15 +60,21 @@ class EmbeddingClient:
             f"(model: {self.config.model}, dimensions: {self.config.dim})"
         )
 
-    async def embed(self, texts: List[str]) -> List[List[float]]:
+    async def embed(
+        self, texts: List[str], progress_callback=None
+    ) -> List[List[float]]:
         if not texts:
             return []
 
+        import asyncio
+
         batch_size = max(1, self.config.batch_size)
         all_embeddings: List[List[float]] = []
+        batch_delay = getattr(self.adapter, '_BATCH_DELAY', 0.5)
 
         try:
-            for start in range(0, len(texts), batch_size):
+            total_batches = (len(texts) + batch_size - 1) // batch_size
+            for i, start in enumerate(range(0, len(texts), batch_size)):
                 batch = texts[start : start + batch_size]
                 request = EmbeddingRequest(
                     texts=batch,
@@ -77,6 +83,18 @@ class EmbeddingClient:
                 )
                 response = await self.adapter.embed(request)
                 all_embeddings.extend(response.embeddings)
+
+                # Report progress after each batch
+                if progress_callback:
+                    try:
+                        progress_callback(i + 1, total_batches)
+                    except Exception:
+                        pass
+
+                # Delay between batches to avoid rate limiting
+                if i < total_batches - 1 and batch_delay > 0:
+                    await asyncio.sleep(batch_delay)
+
             self.logger.debug(
                 f"Generated {len(all_embeddings)} embeddings using "
                 f"{self.config.binding} (batch_size={batch_size})"

--- a/deeptutor/services/embedding/config.py
+++ b/deeptutor/services/embedding/config.py
@@ -21,8 +21,8 @@ class EmbeddingConfig:
     api_version: str | None = None
     extra_headers: dict[str, str] | None = None
     dim: int = 3072
-    request_timeout: int = 60
-    batch_size: int = 10
+    request_timeout: int = 120
+    batch_size: int = 3
 
 
 def get_embedding_config() -> EmbeddingConfig:

--- a/deeptutor/services/rag/pipelines/llamaindex.py
+++ b/deeptutor/services/rag/pipelines/llamaindex.py
@@ -42,11 +42,18 @@ class CustomEmbedding(BaseEmbedding):
 
     _client: Any = PrivateAttr()
     _logger: Any = PrivateAttr()
+    _progress_callback: Any = PrivateAttr(default=None)
 
     def __init__(self, **kwargs):
+        progress_cb = kwargs.pop("progress_callback", None)
         super().__init__(**kwargs)
         self._client = get_embedding_client()
         self._logger = get_logger("CustomEmbedding")
+        self._progress_callback = progress_cb
+
+    def set_progress_callback(self, callback):
+        """Set progress callback fn(batch_num, total_batches)."""
+        self._progress_callback = callback
 
     @classmethod
     def class_name(cls) -> str:
@@ -76,7 +83,9 @@ class CustomEmbedding(BaseEmbedding):
 
     async def _aget_text_embeddings(self, texts: List[str]) -> List[List[float]]:
         """Get embeddings for multiple texts."""
-        return await self._client.embed(texts)
+        return await self._client.embed(
+            texts, progress_callback=self._progress_callback
+        )
 
     def _get_query_embedding(self, query: str) -> List[float]:
         """Sync version - called by LlamaIndex sync API."""
@@ -88,9 +97,9 @@ class CustomEmbedding(BaseEmbedding):
 
     def _get_text_embeddings(self, texts: List[str]) -> List[List[float]]:
         """Sync batch version - called by LlamaIndex for bulk embedding."""
-        self._logger.info(f"Embedding batch of {len(texts)} texts...")
+        self._logger.info(f"Embedding {len(texts)} text chunks...")
         result = self._run_in_new_loop(self._aget_text_embeddings(texts))
-        self._logger.info(f"Batch embedding complete: {len(result)} vectors")
+        self._logger.info(f"Embedding complete: {len(result)} vectors")
         return result
 
 
@@ -153,11 +162,13 @@ class LlamaIndexPipeline:
         Args:
             kb_name: Knowledge base name
             file_paths: List of file paths to process
-            **kwargs: Additional arguments
+            **kwargs: Additional arguments (accepts progress_callback)
 
         Returns:
             True if successful
         """
+        progress_callback = kwargs.get("progress_callback")
+
         self.logger.info(
             f"Initializing KB '{kb_name}' with {len(file_paths)} files using LlamaIndex"
         )
@@ -221,6 +232,11 @@ class LlamaIndexPipeline:
                 f"Creating VectorStoreIndex with {len(documents)} documents "
                 f"(chunking + embedding)..."
             )
+
+            # Wire progress callback into embedding model
+            if progress_callback:
+                embed_model = CustomEmbedding(progress_callback=progress_callback)
+                Settings.embed_model = embed_model
 
             loop = asyncio.get_event_loop()
             index = await loop.run_in_executor(

--- a/deeptutor/services/rag/service.py
+++ b/deeptutor/services/rag/service.py
@@ -84,10 +84,14 @@ class RAGService:
             self._pipeline = get_pipeline(self.provider, kb_base_dir=self.kb_base_dir)
         return self._pipeline
 
-    async def initialize(self, kb_name: str, file_paths: List[str], **kwargs) -> bool:
+    async def initialize(
+        self, kb_name: str, file_paths: List[str], **kwargs
+    ) -> bool:
         self.logger.info(f"Initializing KB '{kb_name}' with provider '{self.provider}'")
         pipeline = self._get_pipeline()
-        return await pipeline.initialize(kb_name=kb_name, file_paths=file_paths, **kwargs)
+        return await pipeline.initialize(
+            kb_name=kb_name, file_paths=file_paths, **kwargs
+        )
 
     async def search(
         self,


### PR DESCRIPTION
## Problem

During KB initialization with large document sets (265+ files), the progress indicator gets stuck at 0/265 until the entire embedding process completes, then jumps to 100%. Additionally, Gemini and other rate-limited embedding APIs return HTTP 429 errors without any retry logic, causing initialization to fail.

## Changes

### 1. Real-time embedding progress tracking
- Added `progress_callback` parameter through `CustomEmbedding` → `EmbeddingClient` → `LlamaIndexPipeline` → `initializer`
- Progress updates after each embedding batch, giving real-time feedback in the UI
- Callback is optional and backwards-compatible

### 2. HTTP 429 rate limit retry
- Added 429-specific retry logic in `OpenAICompatibleEmbeddingAdapter`
- Exponential backoff: 5s → 10s → 20s → 40s → 80s (up to 5 retries)
- Respects `Retry-After` response header when present

### 3. Gemini free tier friendly defaults
- `batch_size`: 10 → 3 (fewer concurrent requests per batch)
- `request_timeout`: 60s → 120s (slower APIs need more time)
- `BATCH_DELAY`: 1.5s between batches to prevent rate limiting

## Files changed
- `deeptutor/services/embedding/adapters/openai_compatible.py` — 429 handling + exponential backoff
- `deeptutor/services/embedding/client.py` — progress callback + batch delay
- `deeptutor/services/embedding/config.py` — batch_size 10→3, timeout 60→120
- `deeptutor/services/rag/pipelines/llamaindex.py` — wire progress callback through CustomEmbedding
- `deeptutor/knowledge/initializer.py` — pass progress callback to RAG service
- `deeptutor/services/rag/service.py` — pass kwargs through to pipeline

## Testing
- Verified all imports work in venv
- Tested with 265 markdown documents using Gemini embedding API
- Progress now updates in real-time during embedding batches