### PR TITLE
fix: use lowercased filename in mimetypes.guess_type() for consistent MIME validation

### DIFF
--- a/deeptutor/utils/document_validator.py
+++ b/deeptutor/utils/document_validator.py
@@ -106,7 +106,7 @@ class DocumentValidator:
             )
 
         # Additional MIME type validation for security
-        guessed_mime, _ = mimetypes.guess_type(filename)
+        guessed_mime, _ = mimetypes.guess_type(filename.lower())
         if guessed_mime and guessed_mime not in DocumentValidator.ALLOWED_MIME_TYPES:
             raise ValueError(
                 f"MIME type validation failed: {guessed_mime}. File may be malicious or corrupted."


### PR DESCRIPTION
Closes #271

## Problem
`validate_upload_safety()` in `DocumentValidator` extracts the file extension from the **lowercased** filename:
```python
_, ext = os.path.splitext(filename.lower())
```

But MIME type guessing uses the **original** filename (preserving the original case):
```python
guessed_mime, _ = mimetypes.guess_type(filename)
```

On Linux (case-sensitive), `mimetypes.guess_type("report.PDF")` returns `None`, causing a `ValueError` for valid files with uppercase extensions. This is a platform-dependent bug — it works on Windows (case-insensitive MIME lookup) but fails on Linux.

## Fix
Pass `filename.lower()` to `mimetypes.guess_type()` to match the extension check:
```python
guessed_mime, _ = mimetypes.guess_type(filename.lower())
```

This ensures files like `report.PDF`, `notes.TXT`, or `data.JSON` are accepted consistently on all platforms.