### PR TITLE
fix: extend o-series regex to cover o4-mini and future o-series models

### DIFF
--- a/deeptutor/services/llm/config.py
+++ b/deeptutor/services/llm/config.py
@@ -278,7 +278,7 @@ def uses_max_completion_tokens(model: str) -> bool:
     # - gpt-4o series
     # - gpt-5.x and later
     patterns = [
-        r"^o[13]",  # o1, o3 models
+        r"^o\d",  # o1, o3, o4-mini, o4, and future o-series models
         r"^gpt-4o",  # gpt-4o models
         r"^gpt-[5-9]",  # gpt-5.x and later
         r"^gpt-\d{2,}",  # gpt-10+ (future proofing)


### PR DESCRIPTION
## Problem

The `uses_max_completion_tokens()` function in `deeptutor/services/llm/config.py` uses the regex pattern `r"^o[13]"` which only matches `o1` and `o3` models. This misses `o4-mini`, `o4`, and any future o-series OpenAI reasoning models.

When users configure DeepTutor with `o4-mini` (released April 2025), `get_token_limit_kwargs()` returns `{"max_tokens": ...}` instead of the required `{"max_completion_tokens": ...}`, causing OpenAI to return a **400 Bad Request** error on every API call.

## Fix

Changed `r"^o[13]"` → `r"^o\d"` to match all single-digit o-series models (o1, o2, o3, o4, o4-mini, o5, etc.).

```python
# Before
r"^o[13]",  # o1, o3 models

# After  
r"^o\d",  # o1, o3, o4-mini, o4, and future o-series models
```

This is a minimal, non-breaking fix — all previously-supported models still match, and new models are now correctly covered.

Closes #274