### PR TITLE
feat: add wrong-answer note for cross-session quiz review

### DIFF
--- a/deeptutor/api/main.py
+++ b/deeptutor/api/main.py
@@ -214,6 +214,7 @@ from deeptutor.api.routers import (
     tutorbot,
     unified_ws,
     vision_solver,
+    wrong_answers,
 )
 
 # Include routers
@@ -227,6 +228,7 @@ app.include_router(notebook.router, prefix="/api/v1/notebook", tags=["notebook"]
 app.include_router(guide.router, prefix="/api/v1/guide", tags=["guide"])
 app.include_router(memory.router, prefix="/api/v1/memory", tags=["memory"])
 app.include_router(sessions.router, prefix="/api/v1/sessions", tags=["sessions"])
+app.include_router(wrong_answers.router, prefix="/api/v1/wrong-answers", tags=["wrong-answers"])
 app.include_router(settings.router, prefix="/api/v1/settings", tags=["settings"])
 app.include_router(system.router, prefix="/api/v1/system", tags=["system"])
 app.include_router(plugins_api.router, prefix="/api/v1/plugins", tags=["plugins"])

--- a/deeptutor/api/routers/sessions.py
+++ b/deeptutor/api/routers/sessions.py
@@ -99,9 +99,14 @@ async def record_quiz_results(session_id: str, payload: QuizResultsRequest):
         content=content,
         capability="deep_question",
     )
+    wrong_answer_count = await store.add_wrong_answers(
+        session_id,
+        [item.model_dump() for item in payload.answers],
+    )
     return {
         "recorded": True,
         "session_id": session_id,
         "answer_count": len(payload.answers),
+        "wrong_answer_count": wrong_answer_count,
         "content": content,
     }

--- a/deeptutor/api/routers/wrong_answers.py
+++ b/deeptutor/api/routers/wrong_answers.py
@@ -1,0 +1,74 @@
+"""
+Wrong answer notebook API — persists and exposes quiz mistakes for review.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from deeptutor.services.session import get_sqlite_session_store
+
+router = APIRouter()
+
+
+class WrongAnswerItem(BaseModel):
+    id: int
+    session_id: str
+    session_title: str = ""
+    question_id: str = ""
+    question: str
+    user_answer: str = ""
+    correct_answer: str = ""
+    resolved: bool
+    created_at: float
+    resolved_at: float | None = None
+
+
+class WrongAnswerListResponse(BaseModel):
+    items: list[WrongAnswerItem]
+    total: int
+
+
+class WrongAnswerResolveRequest(BaseModel):
+    resolved: bool
+
+
+@router.get("", response_model=WrongAnswerListResponse)
+async def list_wrong_answers(
+    resolved: bool | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> WrongAnswerListResponse:
+    store = get_sqlite_session_store()
+    items = await store.list_wrong_answers(
+        resolved=resolved, limit=limit, offset=offset
+    )
+    total = await store.count_wrong_answers(resolved=resolved)
+    return WrongAnswerListResponse(
+        items=[WrongAnswerItem(**item) for item in items],
+        total=total,
+    )
+
+
+@router.patch("/{wrong_answer_id}")
+async def update_wrong_answer(
+    wrong_answer_id: int,
+    payload: WrongAnswerResolveRequest,
+):
+    store = get_sqlite_session_store()
+    updated = await store.update_wrong_answer_resolved(
+        wrong_answer_id, payload.resolved
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Wrong answer not found")
+    return {"updated": True, "id": wrong_answer_id, "resolved": payload.resolved}
+
+
+@router.delete("/{wrong_answer_id}")
+async def delete_wrong_answer(wrong_answer_id: int):
+    store = get_sqlite_session_store()
+    deleted = await store.delete_wrong_answer(wrong_answer_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Wrong answer not found")
+    return {"deleted": True, "id": wrong_answer_id}

--- a/deeptutor/services/session/sqlite_store.py
+++ b/deeptutor/services/session/sqlite_store.py
@@ -145,6 +145,24 @@ class SQLiteSessionStore:
 
                 CREATE INDEX IF NOT EXISTS idx_turn_events_turn_seq
                     ON turn_events(turn_id, seq);
+
+                CREATE TABLE IF NOT EXISTS wrong_answers (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                    question_id TEXT DEFAULT '',
+                    question TEXT NOT NULL,
+                    user_answer TEXT DEFAULT '',
+                    correct_answer TEXT DEFAULT '',
+                    resolved INTEGER NOT NULL DEFAULT 0,
+                    created_at REAL NOT NULL,
+                    resolved_at REAL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_wrong_answers_session
+                    ON wrong_answers(session_id, created_at DESC);
+
+                CREATE INDEX IF NOT EXISTS idx_wrong_answers_resolved
+                    ON wrong_answers(resolved, created_at DESC);
                 """
             )
             columns = {row[1] for row in conn.execute("PRAGMA table_info(sessions)").fetchall()}
@@ -730,6 +748,164 @@ class SQLiteSessionStore:
         session["messages"] = await self.get_messages(session_id)
         session["active_turns"] = await self.list_active_turns(session_id)
         return session
+
+    def _add_wrong_answers_sync(
+        self,
+        session_id: str,
+        items: list[dict[str, Any]],
+    ) -> int:
+        if not items:
+            return 0
+        now = time.time()
+        with self._connect() as conn:
+            session = conn.execute(
+                "SELECT id FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if session is None:
+                raise ValueError(f"Session not found: {session_id}")
+            inserted = 0
+            for item in items:
+                if item.get("is_correct"):
+                    continue
+                question = (item.get("question") or "").strip()
+                if not question:
+                    continue
+                conn.execute(
+                    """
+                    INSERT INTO wrong_answers (
+                        session_id, question_id, question, user_answer,
+                        correct_answer, resolved, created_at, resolved_at
+                    ) VALUES (?, ?, ?, ?, ?, 0, ?, NULL)
+                    """,
+                    (
+                        session_id,
+                        item.get("question_id") or "",
+                        question,
+                        item.get("user_answer") or "",
+                        item.get("correct_answer") or "",
+                        now,
+                    ),
+                )
+                inserted += 1
+            conn.commit()
+        return inserted
+
+    async def add_wrong_answers(
+        self,
+        session_id: str,
+        items: list[dict[str, Any]],
+    ) -> int:
+        return await self._run(self._add_wrong_answers_sync, session_id, items)
+
+    def _list_wrong_answers_sync(
+        self,
+        resolved: bool | None,
+        limit: int,
+        offset: int,
+    ) -> list[dict[str, Any]]:
+        query = """
+            SELECT
+                w.id,
+                w.session_id,
+                COALESCE(s.title, '') AS session_title,
+                w.question_id,
+                w.question,
+                w.user_answer,
+                w.correct_answer,
+                w.resolved,
+                w.created_at,
+                w.resolved_at
+            FROM wrong_answers w
+            LEFT JOIN sessions s ON s.id = w.session_id
+        """
+        params: list[Any] = []
+        if resolved is not None:
+            query += " WHERE w.resolved = ?"
+            params.append(1 if resolved else 0)
+        query += " ORDER BY w.created_at DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+        with self._connect() as conn:
+            rows = conn.execute(query, tuple(params)).fetchall()
+        return [
+            {
+                "id": int(row["id"]),
+                "session_id": row["session_id"],
+                "session_title": row["session_title"] or "",
+                "question_id": row["question_id"] or "",
+                "question": row["question"],
+                "user_answer": row["user_answer"] or "",
+                "correct_answer": row["correct_answer"] or "",
+                "resolved": bool(row["resolved"]),
+                "created_at": float(row["created_at"]),
+                "resolved_at": (
+                    float(row["resolved_at"]) if row["resolved_at"] is not None else None
+                ),
+            }
+            for row in rows
+        ]
+
+    async def list_wrong_answers(
+        self,
+        resolved: bool | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        return await self._run(
+            self._list_wrong_answers_sync, resolved, limit, offset
+        )
+
+    def _count_wrong_answers_sync(self, resolved: bool | None) -> int:
+        query = "SELECT COUNT(*) AS count FROM wrong_answers"
+        params: tuple[Any, ...] = ()
+        if resolved is not None:
+            query += " WHERE resolved = ?"
+            params = (1 if resolved else 0,)
+        with self._connect() as conn:
+            row = conn.execute(query, params).fetchone()
+        return int(row["count"]) if row else 0
+
+    async def count_wrong_answers(self, resolved: bool | None = None) -> int:
+        return await self._run(self._count_wrong_answers_sync, resolved)
+
+    def _update_wrong_answer_resolved_sync(
+        self,
+        wrong_answer_id: int,
+        resolved: bool,
+    ) -> bool:
+        now = time.time() if resolved else None
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                UPDATE wrong_answers
+                SET resolved = ?, resolved_at = ?
+                WHERE id = ?
+                """,
+                (1 if resolved else 0, now, wrong_answer_id),
+            )
+            conn.commit()
+        return cur.rowcount > 0
+
+    async def update_wrong_answer_resolved(
+        self,
+        wrong_answer_id: int,
+        resolved: bool,
+    ) -> bool:
+        return await self._run(
+            self._update_wrong_answer_resolved_sync, wrong_answer_id, resolved
+        )
+
+    def _delete_wrong_answer_sync(self, wrong_answer_id: int) -> bool:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM wrong_answers WHERE id = ?",
+                (wrong_answer_id,),
+            )
+            conn.commit()
+        return cur.rowcount > 0
+
+    async def delete_wrong_answer(self, wrong_answer_id: int) -> bool:
+        return await self._run(self._delete_wrong_answer_sync, wrong_answer_id)
 
 
 _instance: SQLiteSessionStore | None = None

--- a/tests/api/test_wrong_answers_router.py
+++ b/tests/api/test_wrong_answers_router.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+FastAPI = pytest.importorskip("fastapi").FastAPI
+TestClient = pytest.importorskip("fastapi.testclient").TestClient
+wrong_answers_router = importlib.import_module(
+    "deeptutor.api.routers.wrong_answers"
+).router
+sessions_router = importlib.import_module("deeptutor.api.routers.sessions").router
+
+from deeptutor.services.session.sqlite_store import SQLiteSessionStore
+
+
+def _build_app(store: SQLiteSessionStore) -> FastAPI:
+    app = FastAPI()
+    app.include_router(wrong_answers_router, prefix="/api/v1/wrong-answers")
+    app.include_router(sessions_router, prefix="/api/v1/sessions")
+    return app
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> SQLiteSessionStore:
+    instance = SQLiteSessionStore(db_path=tmp_path / "router-test.db")
+    monkeypatch.setattr(
+        "deeptutor.api.routers.wrong_answers.get_sqlite_session_store",
+        lambda: instance,
+    )
+    monkeypatch.setattr(
+        "deeptutor.api.routers.sessions.get_sqlite_session_store",
+        lambda: instance,
+    )
+    return instance
+
+
+def test_list_wrong_answers_empty(store: SQLiteSessionStore) -> None:
+    with TestClient(_build_app(store)) as client:
+        response = client.get("/api/v1/wrong-answers")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload == {"items": [], "total": 0}
+
+
+def test_record_quiz_results_populates_wrong_answers(
+    store: SQLiteSessionStore,
+) -> None:
+    import asyncio
+
+    session = asyncio.run(store.create_session(title="Quiz Session"))
+    session_id = session["id"]
+
+    with TestClient(_build_app(store)) as client:
+
+        resp = client.post(
+            f"/api/v1/sessions/{session_id}/quiz-results",
+            json={
+                "answers": [
+                    {
+                        "question_id": "q1",
+                        "question": "Capital of France?",
+                        "user_answer": "Berlin",
+                        "correct_answer": "Paris",
+                        "is_correct": False,
+                    },
+                    {
+                        "question_id": "q2",
+                        "question": "2+2?",
+                        "user_answer": "4",
+                        "correct_answer": "4",
+                        "is_correct": True,
+                    },
+                ]
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["recorded"] is True
+        assert body["answer_count"] == 2
+        assert body["wrong_answer_count"] == 1
+        # Regression: the formatted text message is still added.
+        assert "[Quiz Performance]" in body["content"]
+
+        listing = client.get("/api/v1/wrong-answers")
+        assert listing.status_code == 200
+        items = listing.json()["items"]
+        assert len(items) == 1
+        assert items[0]["question_id"] == "q1"
+        assert items[0]["resolved"] is False
+        assert items[0]["session_title"] == "Quiz Session"
+
+
+def test_update_wrong_answer_resolved_endpoint(
+    store: SQLiteSessionStore,
+) -> None:
+    import asyncio
+
+    session = asyncio.run(store.create_session())
+    asyncio.run(
+        store.add_wrong_answers(
+            session["id"],
+            [{"question": "Q?", "is_correct": False}],
+        )
+    )
+    rows = asyncio.run(store.list_wrong_answers())
+    row_id = rows[0]["id"]
+
+    with TestClient(_build_app(store)) as client:
+        resp = client.patch(
+            f"/api/v1/wrong-answers/{row_id}",
+            json={"resolved": True},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "updated": True,
+            "id": row_id,
+            "resolved": True,
+        }
+
+        listing = client.get(
+            "/api/v1/wrong-answers", params={"resolved": "false"}
+        )
+        assert listing.json()["items"] == []
+
+        not_found = client.patch(
+            "/api/v1/wrong-answers/99999",
+            json={"resolved": True},
+        )
+        assert not_found.status_code == 404
+
+
+def test_delete_wrong_answer_endpoint(store: SQLiteSessionStore) -> None:
+    import asyncio
+
+    session = asyncio.run(store.create_session())
+    asyncio.run(
+        store.add_wrong_answers(
+            session["id"],
+            [{"question": "Q?", "is_correct": False}],
+        )
+    )
+    row_id = asyncio.run(store.list_wrong_answers())[0]["id"]
+
+    with TestClient(_build_app(store)) as client:
+        resp = client.delete(f"/api/v1/wrong-answers/{row_id}")
+        assert resp.status_code == 200
+        assert resp.json() == {"deleted": True, "id": row_id}
+
+        missing = client.delete(f"/api/v1/wrong-answers/{row_id}")
+        assert missing.status_code == 404
+
+
+def test_list_wrong_answers_filter_by_resolved(
+    store: SQLiteSessionStore,
+) -> None:
+    import asyncio
+
+    session = asyncio.run(store.create_session())
+    asyncio.run(
+        store.add_wrong_answers(
+            session["id"],
+            [
+                {"question": "Q1", "is_correct": False},
+                {"question": "Q2", "is_correct": False},
+            ],
+        )
+    )
+    rows = asyncio.run(store.list_wrong_answers())
+    asyncio.run(store.update_wrong_answer_resolved(rows[0]["id"], True))
+
+    with TestClient(_build_app(store)) as client:
+        all_resp = client.get("/api/v1/wrong-answers").json()
+        assert all_resp["total"] == 2
+        assert len(all_resp["items"]) == 2
+
+        unresolved = client.get(
+            "/api/v1/wrong-answers", params={"resolved": "false"}
+        ).json()
+        assert unresolved["total"] == 1
+        assert len(unresolved["items"]) == 1
+        assert unresolved["items"][0]["resolved"] is False
+
+        resolved = client.get(
+            "/api/v1/wrong-answers", params={"resolved": "true"}
+        ).json()
+        assert resolved["total"] == 1
+        assert resolved["items"][0]["resolved"] is True

--- a/tests/services/session/test_sqlite_store.py
+++ b/tests/services/session/test_sqlite_store.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 from pathlib import Path
+
+import pytest
 
 from deeptutor.services.path_service import PathService
 from deeptutor.services.session.sqlite_store import SQLiteSessionStore
@@ -46,3 +49,171 @@ def test_sqlite_store_migrates_legacy_chat_history_db(tmp_path: Path) -> None:
     finally:
         service._project_root = original_root
         service._user_data_dir = original_user_dir
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SQLiteSessionStore:
+    return SQLiteSessionStore(db_path=tmp_path / "test.db")
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+
+
+def test_add_wrong_answers_only_persists_incorrect(store: SQLiteSessionStore) -> None:
+    session = _run(store.create_session(title="Test"))
+    session_id = session["id"]
+
+    items = [
+        {
+            "question_id": "q1",
+            "question": "What is 2+2?",
+            "user_answer": "5",
+            "correct_answer": "4",
+            "is_correct": False,
+        },
+        {
+            "question_id": "q2",
+            "question": "What is 3+3?",
+            "user_answer": "6",
+            "correct_answer": "6",
+            "is_correct": True,
+        },
+        {
+            "question_id": "q3",
+            "question": "What is 5+5?",
+            "user_answer": "9",
+            "correct_answer": "10",
+            "is_correct": False,
+        },
+    ]
+
+    inserted = _run(store.add_wrong_answers(session_id, items))
+    assert inserted == 2
+
+    listed = _run(store.list_wrong_answers())
+    assert len(listed) == 2
+    question_ids = {row["question_id"] for row in listed}
+    assert question_ids == {"q1", "q3"}
+    assert all(row["resolved"] is False for row in listed)
+    assert all(row["session_title"] == "Test" for row in listed)
+
+
+def test_add_wrong_answers_skips_blank_questions(store: SQLiteSessionStore) -> None:
+    session = _run(store.create_session())
+    items = [
+        {"question": "", "is_correct": False},
+        {"question": "   ", "is_correct": False},
+        {"question": "Valid?", "is_correct": False},
+    ]
+    inserted = _run(store.add_wrong_answers(session["id"], items))
+    assert inserted == 1
+
+
+def test_add_wrong_answers_unknown_session_raises(store: SQLiteSessionStore) -> None:
+    with pytest.raises(ValueError, match="Session not found"):
+        _run(
+            store.add_wrong_answers(
+                "does_not_exist",
+                [{"question": "Q?", "is_correct": False}],
+            )
+        )
+
+
+def test_list_wrong_answers_filters_by_resolved(store: SQLiteSessionStore) -> None:
+    session = _run(store.create_session())
+    session_id = session["id"]
+    _run(
+        store.add_wrong_answers(
+            session_id,
+            [
+                {"question": "Q1", "is_correct": False},
+                {"question": "Q2", "is_correct": False},
+            ],
+        )
+    )
+    listed = _run(store.list_wrong_answers())
+    first_id = listed[0]["id"]
+    _run(store.update_wrong_answer_resolved(first_id, True))
+
+    unresolved = _run(store.list_wrong_answers(resolved=False))
+    resolved = _run(store.list_wrong_answers(resolved=True))
+    all_rows = _run(store.list_wrong_answers())
+
+    assert len(unresolved) == 1
+    assert unresolved[0]["id"] != first_id
+    assert len(resolved) == 1
+    assert resolved[0]["id"] == first_id
+    assert resolved[0]["resolved"] is True
+    assert resolved[0]["resolved_at"] is not None
+    assert len(all_rows) == 2
+
+
+def test_count_wrong_answers(store: SQLiteSessionStore) -> None:
+    session = _run(store.create_session())
+    _run(
+        store.add_wrong_answers(
+            session["id"],
+            [
+                {"question": "Q1", "is_correct": False},
+                {"question": "Q2", "is_correct": False},
+                {"question": "Q3", "is_correct": True},
+            ],
+        )
+    )
+    assert _run(store.count_wrong_answers()) == 2
+    assert _run(store.count_wrong_answers(resolved=False)) == 2
+    assert _run(store.count_wrong_answers(resolved=True)) == 0
+
+
+def test_update_wrong_answer_resolved_roundtrip(store: SQLiteSessionStore) -> None:
+    session = _run(store.create_session())
+    _run(
+        store.add_wrong_answers(
+            session["id"],
+            [{"question": "Q?", "is_correct": False}],
+        )
+    )
+    rows = _run(store.list_wrong_answers())
+    row_id = rows[0]["id"]
+
+    assert _run(store.update_wrong_answer_resolved(row_id, True)) is True
+    assert _run(store.list_wrong_answers())[0]["resolved"] is True
+
+    assert _run(store.update_wrong_answer_resolved(row_id, False)) is True
+    resurrected = _run(store.list_wrong_answers())[0]
+    assert resurrected["resolved"] is False
+    assert resurrected["resolved_at"] is None
+
+    assert _run(store.update_wrong_answer_resolved(99999, True)) is False
+
+
+def test_delete_wrong_answer(store: SQLiteSessionStore) -> None:
+    session = _run(store.create_session())
+    _run(
+        store.add_wrong_answers(
+            session["id"],
+            [
+                {"question": "Q1", "is_correct": False},
+                {"question": "Q2", "is_correct": False},
+            ],
+        )
+    )
+    rows = _run(store.list_wrong_answers())
+    first_id = rows[0]["id"]
+    assert _run(store.delete_wrong_answer(first_id)) is True
+    assert len(_run(store.list_wrong_answers())) == 1
+    assert _run(store.delete_wrong_answer(99999)) is False
+
+
+def test_wrong_answers_cascade_on_session_delete(store: SQLiteSessionStore) -> None:
+    session = _run(store.create_session())
+    _run(
+        store.add_wrong_answers(
+            session["id"],
+            [{"question": "Q?", "is_correct": False}],
+        )
+    )
+    assert len(_run(store.list_wrong_answers())) == 1
+    _run(store.delete_session(session["id"]))
+    assert _run(store.list_wrong_answers()) == []

--- a/web/app/(utility)/wrong-answers/page.tsx
+++ b/web/app/(utility)/wrong-answers/page.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import {
+  CheckCircle2,
+  Circle,
+  Loader2,
+  NotebookPen,
+  RefreshCw,
+  Trash2,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  deleteWrongAnswer,
+  listWrongAnswers,
+  updateWrongAnswerResolved,
+  type WrongAnswer,
+} from "@/lib/wrong-answer-api";
+
+const MarkdownRenderer = dynamic(
+  () => import("@/components/common/MarkdownRenderer"),
+  { ssr: false },
+);
+
+type FilterMode = "unresolved" | "all";
+
+function formatDate(value: number): string {
+  const date = new Date(value * 1000);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleString();
+}
+
+export default function WrongAnswersPage() {
+  const { t } = useTranslation();
+  const [items, setItems] = useState<WrongAnswer[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [filter, setFilter] = useState<FilterMode>("unresolved");
+  const [pendingId, setPendingId] = useState<number | null>(null);
+
+  const loadItems = useCallback(
+    async (mode: FilterMode) => {
+      setRefreshing(true);
+      try {
+        const response = await listWrongAnswers({
+          resolved: mode === "unresolved" ? false : undefined,
+          limit: 200,
+        });
+        setItems(response.items);
+        setTotal(response.total);
+      } catch (error) {
+        console.error("Failed to load wrong answers", error);
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    void loadItems(filter);
+  }, [filter, loadItems]);
+
+  const handleToggleResolved = useCallback(
+    async (item: WrongAnswer) => {
+      const nextResolved = !item.resolved;
+      setPendingId(item.id);
+      try {
+        await updateWrongAnswerResolved(item.id, nextResolved);
+        setItems((prev) =>
+          filter === "unresolved" && nextResolved
+            ? prev.filter((entry) => entry.id !== item.id)
+            : prev.map((entry) =>
+                entry.id === item.id
+                  ? { ...entry, resolved: nextResolved }
+                  : entry,
+              ),
+        );
+        if (filter === "unresolved" && nextResolved) {
+          setTotal((prev) => Math.max(0, prev - 1));
+        }
+      } catch (error) {
+        console.error("Failed to update wrong answer", error);
+      } finally {
+        setPendingId(null);
+      }
+    },
+    [filter],
+  );
+
+  const handleDelete = useCallback(
+    async (item: WrongAnswer) => {
+      if (!window.confirm(t("Delete this wrong answer?"))) return;
+      setPendingId(item.id);
+      try {
+        await deleteWrongAnswer(item.id);
+        setItems((prev) => prev.filter((entry) => entry.id !== item.id));
+        setTotal((prev) => Math.max(0, prev - 1));
+      } catch (error) {
+        console.error("Failed to delete wrong answer", error);
+      } finally {
+        setPendingId(null);
+      }
+    },
+    [t],
+  );
+
+  return (
+    <div className="h-full overflow-y-auto [scrollbar-gutter:stable]">
+      <div className="mx-auto max-w-[960px] px-6 py-8">
+        <div className="mb-6 flex items-start justify-between">
+          <div>
+            <h1 className="text-[24px] font-semibold tracking-tight text-[var(--foreground)]">
+              {t("Wrong Answer Note")}
+            </h1>
+            <p className="mt-1 text-[13px] text-[var(--muted-foreground)]">
+              {t("Review mistakes from past quizzes across sessions.")}
+            </p>
+          </div>
+          <button
+            onClick={() => void loadItems(filter)}
+            disabled={refreshing}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)]/50 px-3 py-1.5 text-[12px] font-medium text-[var(--muted-foreground)] transition-colors hover:border-[var(--border)] hover:text-[var(--foreground)] disabled:opacity-40"
+          >
+            {refreshing ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3 w-3" />
+            )}
+            {t("Refresh")}
+          </button>
+        </div>
+
+        <div className="mb-5 flex items-center justify-between border-b border-[var(--border)]/50 pb-3">
+          <div className="flex items-center gap-1">
+            {(["unresolved", "all"] as const).map((mode) => {
+              const active = filter === mode;
+              return (
+                <button
+                  key={mode}
+                  onClick={() => setFilter(mode)}
+                  className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] transition-colors ${
+                    active
+                      ? "bg-[var(--muted)] font-medium text-[var(--foreground)]"
+                      : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+                  }`}
+                >
+                  {mode === "unresolved" ? t("Unresolved") : t("All")}
+                </button>
+              );
+            })}
+          </div>
+          <span className="text-[12px] text-[var(--muted-foreground)]">
+            {t("Total")}: {total}
+          </span>
+        </div>
+
+        {loading ? (
+          <div className="flex min-h-[420px] items-center justify-center">
+            <Loader2 className="h-5 w-5 animate-spin text-[var(--muted-foreground)]" />
+          </div>
+        ) : items.length === 0 ? (
+          <div className="flex min-h-[320px] flex-col items-center justify-center rounded-xl border border-dashed border-[var(--border)] text-center">
+            <div className="mb-3 rounded-xl bg-[var(--muted)] p-2.5 text-[var(--muted-foreground)]">
+              <NotebookPen size={18} />
+            </div>
+            <p className="text-[14px] font-medium text-[var(--foreground)]">
+              {t("No wrong answers yet")}
+            </p>
+            <p className="mt-1.5 max-w-xs text-[13px] text-[var(--muted-foreground)]">
+              {t("Mistakes from your quizzes will appear here for review.")}
+            </p>
+          </div>
+        ) : (
+          <ul className="flex flex-col gap-3">
+            {items.map((item) => {
+              const disabled = pendingId === item.id;
+              return (
+                <li
+                  key={item.id}
+                  className={`rounded-xl border border-[var(--border)] px-5 py-4 transition-opacity ${
+                    disabled ? "opacity-60" : ""
+                  } ${item.resolved ? "bg-[var(--muted)]/30" : ""}`}
+                >
+                  <div className="mb-3 flex items-start justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="text-[14px] font-medium text-[var(--foreground)]">
+                        <MarkdownRenderer
+                          content={item.question}
+                          variant="prose"
+                          className="text-[14px] leading-relaxed"
+                        />
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <button
+                        onClick={() => void handleToggleResolved(item)}
+                        disabled={disabled}
+                        title={
+                          item.resolved
+                            ? t("Mark as Unresolved")
+                            : t("Mark as Resolved")
+                        }
+                        className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--muted)] hover:text-[var(--foreground)] disabled:opacity-40"
+                      >
+                        {item.resolved ? (
+                          <CheckCircle2 className="h-4 w-4 text-[var(--primary)]" />
+                        ) : (
+                          <Circle className="h-4 w-4" />
+                        )}
+                      </button>
+                      <button
+                        onClick={() => void handleDelete(item)}
+                        disabled={disabled}
+                        title={t("Delete")}
+                        className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--muted)] hover:text-[var(--foreground)] disabled:opacity-40"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="grid gap-2 text-[13px] sm:grid-cols-2">
+                    <div className="rounded-lg bg-[var(--muted)]/40 px-3 py-2">
+                      <div className="text-[11px] uppercase tracking-wide text-[var(--muted-foreground)]">
+                        {t("Your Answer")}
+                      </div>
+                      <div className="mt-1 text-[var(--foreground)]">
+                        {item.user_answer || <span className="text-[var(--muted-foreground)]">—</span>}
+                      </div>
+                    </div>
+                    <div className="rounded-lg bg-[var(--muted)]/40 px-3 py-2">
+                      <div className="text-[11px] uppercase tracking-wide text-[var(--muted-foreground)]">
+                        {t("Correct Answer")}
+                      </div>
+                      <div className="mt-1 text-[var(--foreground)]">
+                        {item.correct_answer || <span className="text-[var(--muted-foreground)]">—</span>}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="mt-3 flex items-center justify-between text-[11px] text-[var(--muted-foreground)]">
+                    <Link
+                      href={`/?session=${encodeURIComponent(item.session_id)}`}
+                      className="truncate hover:text-[var(--foreground)] hover:underline"
+                    >
+                      {t("From session")}: {item.session_title || item.session_id}
+                    </Link>
+                    <span>{formatDate(item.created_at)}</span>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/components/sidebar/SidebarShell.tsx
+++ b/web/components/sidebar/SidebarShell.tsx
@@ -10,6 +10,7 @@ import {
   Brain,
   GraduationCap,
   MessageSquare,
+  NotebookPen,
   PanelLeftClose,
   PanelLeftOpen,
   PenLine,
@@ -35,6 +36,7 @@ const PRIMARY_NAV: NavEntry[] = [
   { href: "/guide", label: "Guided Learning", icon: GraduationCap },
   { href: "/knowledge", label: "Knowledge", icon: BookOpen },
   { href: "/memory", label: "Memory", icon: Brain },
+  { href: "/wrong-answers", label: "Wrong Answer Note", icon: NotebookPen },
 ];
 
 const SECONDARY_NAV: NavEntry[] = [{ href: "/settings", label: "Settings", icon: Settings }];

--- a/web/lib/wrong-answer-api.ts
+++ b/web/lib/wrong-answer-api.ts
@@ -1,0 +1,66 @@
+import { apiUrl } from "@/lib/api";
+
+export interface WrongAnswer {
+  id: number;
+  session_id: string;
+  session_title: string;
+  question_id: string;
+  question: string;
+  user_answer: string;
+  correct_answer: string;
+  resolved: boolean;
+  created_at: number;
+  resolved_at: number | null;
+}
+
+export interface WrongAnswerListResponse {
+  items: WrongAnswer[];
+  total: number;
+}
+
+async function expectJson<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function listWrongAnswers(
+  filter: { resolved?: boolean; limit?: number; offset?: number } = {},
+): Promise<WrongAnswerListResponse> {
+  const params = new URLSearchParams();
+  if (filter.resolved !== undefined) {
+    params.set("resolved", String(filter.resolved));
+  }
+  if (filter.limit !== undefined) {
+    params.set("limit", String(filter.limit));
+  }
+  if (filter.offset !== undefined) {
+    params.set("offset", String(filter.offset));
+  }
+  const query = params.toString();
+  const response = await fetch(
+    apiUrl(`/api/v1/wrong-answers${query ? `?${query}` : ""}`),
+    { cache: "no-store" },
+  );
+  return expectJson<WrongAnswerListResponse>(response);
+}
+
+export async function updateWrongAnswerResolved(
+  id: number,
+  resolved: boolean,
+): Promise<void> {
+  const response = await fetch(apiUrl(`/api/v1/wrong-answers/${id}`), {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ resolved }),
+  });
+  await expectJson<{ updated: boolean }>(response);
+}
+
+export async function deleteWrongAnswer(id: number): Promise<void> {
+  const response = await fetch(apiUrl(`/api/v1/wrong-answers/${id}`), {
+    method: "DELETE",
+  });
+  await expectJson<{ deleted: boolean }>(response);
+}

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -857,5 +857,20 @@
   "Video Output": "Video Output",
   "Image Output": "Image Output",
   "Fullscreen math animation output": "Fullscreen math animation output",
-  "Delete this chat history?": "Delete this chat history?"
+  "Delete this chat history?": "Delete this chat history?",
+  "Wrong Answer Note": "Wrong Answer Note",
+  "Review mistakes from past quizzes across sessions.": "Review mistakes from past quizzes across sessions.",
+  "Unresolved": "Unresolved",
+  "All": "All",
+  "Total": "Total",
+  "Refresh": "Refresh",
+  "No wrong answers yet": "No wrong answers yet",
+  "Mistakes from your quizzes will appear here for review.": "Mistakes from your quizzes will appear here for review.",
+  "Your Answer": "Your Answer",
+  "Correct Answer": "Correct Answer",
+  "From session": "From session",
+  "Mark as Resolved": "Mark as Resolved",
+  "Mark as Unresolved": "Mark as Unresolved",
+  "Delete": "Delete",
+  "Delete this wrong answer?": "Delete this wrong answer?"
 }

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -857,5 +857,20 @@
   "Video Output": "视频输出",
   "Image Output": "图片输出",
   "Fullscreen math animation output": "全屏数学动画输出",
-  "Delete this chat history?": "确定删除此聊天记录吗？"
+  "Delete this chat history?": "确定删除此聊天记录吗？",
+  "Wrong Answer Note": "错题本",
+  "Review mistakes from past quizzes across sessions.": "跨会话回顾过往测验中答错的题目。",
+  "Unresolved": "未解决",
+  "All": "全部",
+  "Total": "总计",
+  "Refresh": "刷新",
+  "No wrong answers yet": "暂无错题",
+  "Mistakes from your quizzes will appear here for review.": "测验中答错的题目将汇总到此处供复习使用。",
+  "Your Answer": "你的答案",
+  "Correct Answer": "正确答案",
+  "From session": "来自会话",
+  "Mark as Resolved": "标记为已解决",
+  "Mark as Unresolved": "标记为未解决",
+  "Delete": "删除",
+  "Delete this wrong answer?": "确定删除此错题吗？"
 }


### PR DESCRIPTION
## Summary

Adds a **wrong-answer note** feature so learners can review quiz mistakes across sessions from a dedicated page in the utility sidebar.

- Persists each incorrect quiz answer as a structured row in a new `wrong_answers` SQLite table (cascade on session delete), hooked into the existing `POST /api/v1/sessions/{id}/quiz-results` pipeline. The existing `[Quiz Performance]` text message (consumed by the LLM context builder for tutor continuity) is **intentionally preserved** — structured rows and the text message serve different consumers.
- New CRUD endpoints at `/api/v1/wrong-answers` with resolved/pagination filters, and a new `/wrong-answers` page with unresolved/all filter, mark-as-resolved toggle, per-item delete, and a link back to the source session.
- English and Chinese i18n strings for all new UI text. (Korean is intentionally out of scope for this PR — `web/locales/ko/` is not yet in upstream.)

No existing behavior is changed: `record_quiz_results` still writes the same `[Quiz Performance]` text message to the messages table, and `QuizViewer` still auto-calls it once all questions are submitted. The new persistence is purely additive.

## Test plan

- [x] `pytest tests/services/session/test_sqlite_store.py tests/api/test_wrong_answers_router.py` — 15 tests pass on `origin/dev` base
- [x] `npm run build` in `web/` — TypeScript + Next.js production build succeeds, `/wrong-answers` route generated
- [x] Manual E2E: take a quiz with deliberate wrong answers, confirm rows appear in the `/wrong-answers` page with resolve/delete working
- [x] Regression test included: `test_record_quiz_results_populates_wrong_answers` asserts `[Quiz Performance]` is still written to messages table

## Notes for reviewers

- `CREATE TABLE IF NOT EXISTS` on `wrong_answers` is idempotent on existing DBs — no separate migration script needed, just restart the API server once.
- `add_wrong_answers` filters `is_correct=False` at the store layer so the invariant holds regardless of caller.
- `QuizViewer.tsx` was intentionally **not modified** — the existing auto-recording path (`recordQuizResults` on `completedCount === total`) already carries the new structured data once the backend is in place.