### PR TITLE
fix: merge system messages to comply with Qwen vLLM chat template

### DIFF
--- a/deeptutor/agents/chat/agentic_pipeline.py
+++ b/deeptutor/agents/chat/agentic_pipeline.py
@@ -851,14 +851,21 @@ class AgenticChatPipeline:
         system_prompt: str,
         user_content: str,
     ) -> list[dict[str, Any]]:
-        messages: list[dict[str, Any]] = [{"role": "system", "content": system_prompt}]
+        # Merge all system content into a single message to comply with Qwen vLLM requirements
+        system_parts = [system_prompt]
         if context.memory_context:
-            messages.append({"role": "system", "content": context.memory_context})
+            system_parts.append(context.memory_context)
+        system_content = "\n\n".join(system_parts)
+        
+        messages: list[dict[str, Any]] = [{"role": "system", "content": system_content}]
+        
+        # Add conversation history (filter out system messages to avoid duplicates)
         for item in context.conversation_history:
             role = item.get("role")
             content = item.get("content")
-            if role in {"user", "assistant", "system"} and isinstance(content, (str, list)):
+            if role in {"user", "assistant"} and isinstance(content, (str, list)):
                 messages.append({"role": role, "content": content})
+        
         messages.append({"role": "user", "content": user_content})
         return messages
 

--- a/deeptutor/agents/chat/chat_agent.py
+++ b/deeptutor/agents/chat/chat_agent.py
@@ -246,14 +246,13 @@ class ChatAgent(BaseAgent):
         messages = []
 
         # System prompt
-        system_prompt = self.get_prompt("system", "You are a helpful AI assistant.")
-        messages.append({"role": "system", "content": system_prompt})
-
-        # Add context if available
+        # Merge system prompt and context into single system message to comply with Qwen vLLM requirements
+        system_parts = [self.get_prompt("system", "You are a helpful AI assistant.")]
         if context:
             context_template = self.get_prompt("context_template", "Reference context:\n{context}")
-            context_msg = context_template.format(context=context)
-            messages.append({"role": "system", "content": context_msg})
+            system_parts.append(context_template.format(context=context))
+        system_content = "\n\n".join(system_parts)
+        messages.append({"role": "system", "content": system_content})
 
         # Add conversation history
         for msg in history:

--- a/deeptutor/services/session/context_builder.py
+++ b/deeptutor/services/session/context_builder.py
@@ -112,13 +112,14 @@ class ContextBuilder:
         cleaned_summary = summary.strip()
         if cleaned_summary:
             history.append({"role": "system", "content": cleaned_summary})
+        # Filter out system messages from DB since summary is already added as system
         history.extend(
             {
                 "role": item.get("role", "user"),
                 "content": str(item.get("content", "") or ""),
             }
             for item in messages
-            if item.get("role") in {"user", "assistant", "system"}
+            if item.get("role") in {"user", "assistant"}  # Removed "system" to avoid duplicate system messages
             and str(item.get("content", "") or "").strip()
         )
         return history


### PR DESCRIPTION
Summary:
- Fixes 'System message must be at the beginning' error when using Qwen models via vLLM
- Qwen's chat template requires exactly ONE system message at position 0 of messages array

Changes:
1. deeptutor/agents/chat/agentic_pipeline.py: Merge system_prompt and memory_context into single system message, filter out system messages from conversation_history
2. deeptutor/services/session/context_builder.py: Filter out system messages from DB since summary is already added as system
3. deeptutor/agents/chat/chat_agent.py: Merge system prompt and RAG context into single system message

Benefits:
- Fixes Qwen vLLM compatibility issue completely
- Reduces token usage by eliminating duplicate system messages
- Does not break any functionality - system context from DB is already in compressed_summary
- Cleaner message structure with exactly one system message at position 0

Testing:
- Verified with Qwen model via vLLM - no more template errors
- Chat with memory files (PROFILE.md/SUMMARY.md) works correctly
- Chat with conversation history works correctly
- No regression with other models (GPT-4, etc.)

### Description
*A clear and concise description of the changes.*

### Related Issues
- Closes #...
- Related to #...

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [+] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [+] My code follows the project's coding standards.
- [-] I have run `pre-commit run --all-files` and fixed any issues.
- [-] I have added relevant tests for my changes.
- [-] I have updated the documentation (if necessary).
- [+] My changes do not introduce any new security vulnerabilities.

### Additional Notes
Summary
When using Qwen models via vLLM, the chat template throws a jinja2.exceptions.TemplateError because multiple system messages are being sent to the LLM. Qwen's chat template requires exactly one system message at position 0 of the messages array.

Error Message
jinja2.exceptions.TemplateError: System message must be the beginning.
ValueError: System message must be at the beginning.
Full traceback shows the error originates from:

vllm/renderers/hf.py:502 - safe_apply_chat_template()
transformers/tokenization_utils_base.py:3063 - apply_chat_template()
Qwen's Jinja2 chat template at line 85
Reproduction Steps

Start DeepTutor with Qwen model via vLLM
Open a new chat session
Send any message (e.g., "привет" / "hello")
Observe the error in vLLM logs
Note: This happens even in a brand new chat with no conversation history, if memory files (PROFILE.md/SUMMARY.md) exist.

Root Cause Analysis
Message Construction Flow
The issue occurs in the message construction pipeline where multiple system messages are added:

┌─────────────────────────────────────────────────────────┐
│ 1. _build_messages() in agentic_pipeline.py             │
│    ├─ System prompt → {"role": "system", ...}           │
│    ├─ Memory context → {"role": "system", ...} ← BUG    │
│    └─ Conversation history (may include system) ← BUG   │
└─────────────────────────────────────────────────────────┘
                      ↓
┌─────────────────────────────────────────────────────────┐
│ Messages sent to vLLM:                                  │
│ [                                                       │
│   {"role": "system", "content": "thinking prompt"},    │
│   {"role": "system", "content": "## Background Memory"},│
│   {"role": "user", "content": "привет"}                │
│ ]                                                       │
└─────────────────────────────────────────────────────────┘
                      ↓
┌─────────────────────────────────────────────────────────┐
│ Qwen template error: System must be at position 0 only  │
└─────────────────────────────────────────────────────────┘