### PR TITLE
feat: detect embedding model mismatch in knowledge bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,6 @@
 </div>
 
 ---
-### 📰 News
-
-> **[2026.4.4]** Long time no see! ✨ DeepTutor v1.0.0 is finally here — an agent-native evolution featuring a ground-up architecture rewrite, TutorBot, and flexible mode switching under the Apache-2.0 license. A new chapter begins, and our story continues! 
-
-> **[2026.2.6]** 🚀 We've reached 10k stars in just 39 days! A huge thank you to our incredible community for the support! 
-
-> **[2026.1.1]** Happy New Year! Join our [Discord](https://discord.gg/eRsjPgMU4t), [WeChat](https://github.com/HKUDS/DeepTutor/issues/78), or [Discussions](https://github.com/HKUDS/DeepTutor/discussions) — let's shape the future of DeepTutor together!
-
-> **[2025.12.29]** DeepTutor is officially released!
 
 ### 📦 Releases
 
@@ -46,6 +37,17 @@
 > **[2026.4.7]** [v1.0.0-beta.2](https://github.com/HKUDS/DeepTutor/releases/tag/v1.0.0-beta.2) — Runtime cache invalidation for hot settings reload, MinerU nested output support, mimic WebSocket fix, Python 3.11+ minimum, and CI improvements.
 
 > **[2026.4.4]** [v1.0.0-beta.1](https://github.com/HKUDS/DeepTutor/releases/tag/v1.0.0-beta.1) — Agent-native architecture rewrite (～200k lines) with two-layer plugin model (Tools + Capabilities), CLI & SDK entry points, TutorBot multi-channel bot agent, Co-Writer, Guided Learning, and persistent memory.
+
+### 📰 News
+
+> **[2026.4.4]** Long time no see! ✨ DeepTutor v1.0.0 is finally here — an agent-native evolution featuring a ground-up architecture rewrite, TutorBot, and flexible mode switching under the Apache-2.0 license. A new chapter begins, and our story continues! 
+
+> **[2026.2.6]** 🚀 We've reached 10k stars in just 39 days! A huge thank you to our incredible community for the support! 
+
+> **[2026.1.1]** Happy New Year! Join our [Discord](https://discord.gg/eRsjPgMU4t), [WeChat](https://github.com/HKUDS/DeepTutor/issues/78), or [Discussions](https://github.com/HKUDS/DeepTutor/discussions) — let's shape the future of DeepTutor together!
+
+> **[2025.12.29]** DeepTutor is officially released!
+
 
 <details>
 <summary><b>Past releases</b></summary>

--- a/deeptutor/knowledge/manager.py
+++ b/deeptutor/knowledge/manager.py
@@ -19,6 +19,8 @@ from deeptutor.services.rag.components.routing import FileTypeRouter
 
 from deeptutor.services.rag.factory import DEFAULT_PROVIDER, LEGACY_PROVIDER_ALIASES, normalize_provider_name
 
+_EMBEDDING_FINGERPRINT_KEYS = ("embedding_model", "embedding_dim")
+
 logger = get_logger("KnowledgeBaseManager")
 
 
@@ -65,6 +67,21 @@ def file_lock_exclusive(file_handle):
             yield
         finally:
             fcntl.flock(file_handle.fileno(), fcntl.LOCK_UN)
+
+
+def _get_current_embedding_fingerprint() -> dict[str, str | int] | None:
+    """Return the active embedding model name and dimension, or *None* on failure.
+
+    The fingerprint is stored alongside each knowledge-base entry so that a
+    mismatch can be detected after the user switches embedding models.
+    """
+    try:
+        from deeptutor.services.embedding import get_embedding_config
+
+        cfg = get_embedding_config()
+        return {"embedding_model": cfg.model, "embedding_dim": cfg.dim}
+    except Exception:
+        return None
 
 
 class KnowledgeBaseManager:
@@ -131,6 +148,30 @@ class KnowledgeBaseManager:
                         if not kb_entry.get("needs_reindex", False):
                             kb_entry["needs_reindex"] = True
                             config_changed = True
+
+                # Detect embedding model mismatch: if the currently configured
+                # embedding model differs from the one used to index a KB, mark
+                # the KB so the user knows search quality may be degraded.
+                current_fp = _get_current_embedding_fingerprint()
+                if current_fp:
+                    for kb_name, kb_entry in knowledge_bases.items():
+                        if not isinstance(kb_entry, dict):
+                            continue
+                        stored_model = kb_entry.get("embedding_model")
+                        if not stored_model:
+                            # Legacy KB without fingerprint – skip detection
+                            continue
+                        if stored_model != current_fp["embedding_model"]:
+                            if not kb_entry.get("embedding_mismatch"):
+                                kb_entry["embedding_mismatch"] = True
+                                if not kb_entry.get("needs_reindex", False):
+                                    kb_entry["needs_reindex"] = True
+                                config_changed = True
+                        else:
+                            # Model matches again (user reverted) – clear flag
+                            if kb_entry.get("embedding_mismatch"):
+                                del kb_entry["embedding_mismatch"]
+                                config_changed = True
 
                 if config_changed:
                     try:
@@ -204,6 +245,14 @@ class KnowledgeBaseManager:
                 "message": "Ready",
                 "percent": 100,
             }
+
+        # Record the embedding model used for indexing so we can detect
+        # mismatches after the user switches to a different model.
+        if status == "ready":
+            fingerprint = _get_current_embedding_fingerprint()
+            if fingerprint:
+                kb_config["embedding_model"] = fingerprint["embedding_model"]
+                kb_config["embedding_dim"] = fingerprint["embedding_dim"]
 
         self._save_config()
 
@@ -441,6 +490,12 @@ class KnowledgeBaseManager:
                 "created_at": kb_config.get("created_at"),
                 "last_updated": kb_config.get("updated_at"),
             }
+            if kb_config.get("embedding_model"):
+                metadata["embedding_model"] = kb_config["embedding_model"]
+            if kb_config.get("embedding_dim"):
+                metadata["embedding_dim"] = kb_config["embedding_dim"]
+            if kb_config.get("embedding_mismatch"):
+                metadata["embedding_mismatch"] = True
             # Remove None values
             metadata = {k: v for k, v in metadata.items() if v is not None}
             return metadata
@@ -506,7 +561,16 @@ class KnowledgeBaseManager:
             metadata["created_at"] = created_at
         if updated_at:
             metadata["last_updated"] = updated_at
-        
+
+        # Include embedding fingerprint so callers can see which model was
+        # used to index this KB and whether it still matches the active config.
+        if kb_config.get("embedding_model"):
+            metadata["embedding_model"] = kb_config["embedding_model"]
+        if kb_config.get("embedding_dim"):
+            metadata["embedding_dim"] = kb_config["embedding_dim"]
+        if kb_config.get("embedding_mismatch"):
+            metadata["embedding_mismatch"] = True
+
         # Remove None values
         metadata = {k: v for k, v in metadata.items() if v is not None}
 

--- a/deeptutor/services/rag/pipelines/llamaindex.py
+++ b/deeptutor/services/rag/pipelines/llamaindex.py
@@ -310,6 +310,26 @@ class LlamaIndexPipeline:
                 "provider": "llamaindex",
             }
 
+        # Detect embedding model mismatch before searching.
+        embedding_mismatch_warning = ""
+        try:
+            from deeptutor.knowledge.manager import KnowledgeBaseManager
+
+            kb_mgr = KnowledgeBaseManager(self.kb_base_dir)
+            kb_meta = kb_mgr.get_metadata(kb_name)
+            if kb_meta.get("embedding_mismatch"):
+                stored = kb_meta.get("embedding_model", "unknown")
+                current_cfg = get_embedding_config()
+                embedding_mismatch_warning = (
+                    f"Warning: This knowledge base was indexed with embedding model "
+                    f"'{stored}' but the current model is '{current_cfg.model}'. "
+                    f"Search quality may be degraded. Please re-index the knowledge "
+                    f"base for accurate results."
+                )
+                self.logger.warning(embedding_mismatch_warning)
+        except Exception as exc:
+            self.logger.debug(f"Embedding mismatch check skipped: {exc}")
+
         try:
             # Load index from storage (run in thread pool)
             loop = asyncio.get_event_loop()
@@ -343,13 +363,16 @@ class LlamaIndexPipeline:
 
             content = "\n\n".join(context_parts) if context_parts else ""
 
-            return {
+            result: Dict[str, Any] = {
                 "query": query,
                 "answer": content,
                 "content": content,
                 "sources": sources,
                 "provider": "llamaindex",
             }
+            if embedding_mismatch_warning:
+                result["warning"] = embedding_mismatch_warning
+            return result
 
         except Exception as e:
             self.logger.error(f"Search failed: {e}")


### PR DESCRIPTION
## Summary

Switching the embedding model (e.g., from `text-embedding-3-large` to `nomic-embed-text`) silently degrades search quality in existing knowledge bases because the stored vectors are incompatible with the new model's embedding space. There is currently no mechanism to detect or warn about this mismatch.

This PR adds embedding model fingerprinting to prevent silent data corruption:

1. **Record embedding fingerprint at index time** — When a KB reaches `ready` status, the active `embedding_model` and `embedding_dim` are stored in `kb_config.json`.

2. **Auto-detect mismatch on config load** — During `_load_config()`, each KB's stored embedding model is compared against the current config. Mismatched KBs are flagged with `embedding_mismatch=True` and `needs_reindex=True`.

3. **Warn on search** — When searching a mismatched KB, a warning is included in the search result informing the user that re-indexing is recommended.

4. **Expose in metadata** — `get_info()` and `get_metadata()` now include `embedding_model`, `embedding_dim`, and `embedding_mismatch` fields.

### Design Decisions

- **Backward compatible**: Legacy KBs without fingerprint are simply skipped during mismatch detection.
- **Auto-clearing**: The `embedding_mismatch` flag is automatically removed if the user reverts to the original embedding model.
- **Lazy import**: The mismatch check in `llamaindex.py` uses a lazy import to avoid circular dependencies between `knowledge.manager` and `services.rag.pipelines`.
- **Fail-safe**: All fingerprint operations are wrapped in try/except to avoid breaking existing functionality if embedding config is unavailable.

### Files Changed

- `deeptutor/knowledge/manager.py` — Fingerprint recording, mismatch detection, metadata exposure
- `deeptutor/services/rag/pipelines/llamaindex.py` — Search-time mismatch warning

### Related Issues

- Partially addresses #279 (scalable KB prerequisites — embedding model tracking)
- Prevents silent data corruption scenario described in knowledge base discussions