### PR TITLE
docs: add long-horizon reasoning and safety checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Feishu](https://img.shields.io/badge/Feishu-Group-00D4AA?style=flat-square&logo=feishu&logoColor=white)](./Communication.md)
 [![WeChat](https://img.shields.io/badge/WeChat-Group-07C160?style=flat-square&logo=wechat&logoColor=white)](https://github.com/HKUDS/DeepTutor/issues/78)
 
-[Features](#-key-features) · [Get Started](#-get-started) · [Explore](#-explore-deeptutor) · [TutorBot](#-tutorbot--persistent-autonomous-ai-tutors) · [CLI](#%EF%B8%8F-deeptutor-cli--agent-native-interface) · [Community](#-community--ecosystem)
+[Features](#-key-features) · [Get Started](#-get-started) · [Explore](#-explore-deeptutor) · [TutorBot](#-tutorbot--persistent-autonomous-ai-tutors) · [CLI](#%EF%B8%8F-deeptutor-cli--agent-native-interface) · [Safety Checklist](docs/deep_tutor_reasoning_and_safety_checklist.md) · [Community](#-community--ecosystem)
 
 [🇨🇳 中文](assets/README/README_CN.md) · [🇯🇵 日本語](assets/README/README_JA.md) · [🇪🇸 Español](assets/README/README_ES.md) · [🇫🇷 Français](assets/README/README_FR.md) · [🇸🇦 العربية](assets/README/README_AR.md) · [🇷🇺 Русский](assets/README/README_RU.md) · [🇮🇳 हिन्दी](assets/README/README_HI.md) · [🇵🇹 Português](assets/README/README_PT.md)
 
@@ -42,9 +42,9 @@
 
 ### 📰 News
 
-> **[2026.4.4]** Long time no see! ✨ DeepTutor v1.0.0 is finally here — an agent-native evolution featuring a ground-up architecture rewrite, TutorBot, and flexible mode switching under the Apache-2.0 license. A new chapter begins, and our story continues! 
+> **[2026.4.4]** Long time no see! ✨ DeepTutor v1.0.0 is finally here — an agent-native evolution featuring a ground-up architecture rewrite, TutorBot, and flexible mode switching under the Apache-2.0 license. A new chapter begins, and our story continues!
 
-> **[2026.2.6]** 🚀 We've reached 10k stars in just 39 days! A huge thank you to our incredible community for the support! 
+> **[2026.2.6]** 🚀 We've reached 10k stars in just 39 days! A huge thank you to our incredible community for the support!
 
 > **[2026.1.1]** Happy New Year! Join our [Discord](https://discord.gg/eRsjPgMU4t), [WeChat](https://github.com/HKUDS/DeepTutor/issues/78), or [Discussions](https://github.com/HKUDS/DeepTutor/discussions) — let's shape the future of DeepTutor together!
 
@@ -70,9 +70,9 @@
 
 ### 📰 News
 
-> **[2026.4.4]** Long time no see! ✨ DeepTutor v1.0.0 is finally here — an agent-native evolution featuring a ground-up architecture rewrite, TutorBot, and flexible mode switching under the Apache-2.0 license. A new chapter begins, and our story continues! 
+> **[2026.4.4]** Long time no see! ✨ DeepTutor v1.0.0 is finally here — an agent-native evolution featuring a ground-up architecture rewrite, TutorBot, and flexible mode switching under the Apache-2.0 license. A new chapter begins, and our story continues!
 
-> **[2026.2.6]** 🚀 We've reached 10k stars in just 39 days! A huge thank you to our incredible community for the support! 
+> **[2026.2.6]** 🚀 We've reached 10k stars in just 39 days! A huge thank you to our incredible community for the support!
 
 > **[2026.1.1]** Happy New Year! Join our [Discord](https://discord.gg/eRsjPgMU4t), [WeChat](https://github.com/HKUDS/DeepTutor/issues/78), or [Discussions](https://github.com/HKUDS/DeepTutor/discussions) — let's shape the future of DeepTutor together!
 

--- a/docs/deep_tutor_reasoning_and_safety_checklist.md
+++ b/docs/deep_tutor_reasoning_and_safety_checklist.md
@@ -1,0 +1,121 @@
+# DeepTutor Long-Horizon Reasoning and Safety Checklist
+
+This guide is a practical debugging checklist for tutoring scenarios that involve multi-turn reasoning, retrieval, and tool calls.
+
+Use it when:
+- the assistant loses earlier constraints in long conversations,
+- retrieval drifts away from the actual learning goal,
+- responses sound overconfident despite weak evidence,
+- feedback is not clearly grounded in retrieved material.
+
+## 1) Typical Failure Modes
+
+| Failure mode | Typical symptom | Why it matters |
+|:--|:--|:--|
+| Context drift in long-horizon reasoning | The tutor ignores earlier assumptions, constraints, or student level | Can produce contradictory guidance and confuse learners |
+| Retrieval drift / low-quality evidence | Retrieved snippets are off-topic, stale, or unreliable | Reduces factual quality and pedagogical trust |
+| Overconfidence with weak evidence | The tutor gives strong recommendations without enough support | Encourages incorrect understanding and unsafe decisions |
+| Ungrounded tutoring feedback | Feedback references conclusions but not traceable evidence | Makes it hard for students and maintainers to verify claims |
+
+## 2) Symptom -> Likely Causes -> Recommended Checks
+
+### A. Context drift in long-horizon reasoning
+
+- Symptom:
+  - Later answers conflict with earlier user constraints.
+  - Prior assumptions disappear after multiple tool calls.
+- Likely causes:
+  - Prompt window pressure or missing summary checkpoints.
+  - Important constraints not persisted in system/session memory.
+- Recommended checks:
+  - Review conversation trace near the first turn where behavior diverges.
+  - Verify whether key constraints are repeated in planner/task prompts.
+  - Confirm memory/profile updates include learning goals and boundaries.
+
+### B. Retrieval drift / low-quality evidence
+
+- Symptom:
+  - Retrieved chunks are weakly related to the current question.
+  - The model cites snippets that do not support the answer.
+- Likely causes:
+  - Query expansion mismatch with student intent.
+  - Embedding/search config mismatch (provider/model/dimension/index config).
+  - Missing quality filters or poor source curation.
+- Recommended checks:
+  - Log top-k retrieval results with scores and source metadata.
+  - Compare user query vs retrieval query after rewrite/expansion.
+  - Validate embedding + index compatibility and reranking settings.
+
+### C. Overconfidence with weak evidence
+
+- Symptom:
+  - Definitive wording where evidence is sparse or conflicting.
+  - No uncertainty language when confidence should be low.
+- Likely causes:
+  - Prompting does not require uncertainty calibration.
+  - Missing guardrails for "insufficient evidence" behavior.
+- Recommended checks:
+  - Check generation prompts for explicit uncertainty and citation rules.
+  - Verify fallback behavior when retrieval confidence is low.
+  - Add assertions in tests for "unknown/needs-evidence" responses.
+
+### D. Ungrounded tutoring feedback
+
+- Symptom:
+  - Feedback appears generic, with no clear source references.
+  - Student cannot inspect why a recommendation was made.
+- Likely causes:
+  - Missing citation policy or evidence rendering path.
+  - UI/response layer drops source references.
+- Recommended checks:
+  - Inspect response payloads for source IDs/citations.
+  - Verify frontend rendering keeps source traces visible.
+  - Check that tool outputs are passed through without truncating references.
+
+## 3) Quick Debugging Checklist
+
+Before opening an issue or diagnosing a regression, collect:
+- tool/capability path used (Chat / Deep Solve / Research / Quiz / TutorBot),
+- model + provider settings (LLM, embedding, search),
+- anonymized conversation trace for the failing turns,
+- retrieval snippets (top-k items + scores + sources),
+- exact prompts or prompt templates involved (if shareable),
+- expected behavior vs actual behavior,
+- environment details (OS, Python version, backend, GPU if relevant).
+
+## 4) Issue Report Template (Copy/Paste)
+
+```md
+### Failure mode
+- [ ] Context drift
+- [ ] Retrieval drift / weak evidence
+- [ ] Overconfidence with weak evidence
+- [ ] Ungrounded feedback
+
+### What happened
+- Expected:
+- Actual:
+
+### Minimal reproduction
+1.
+2.
+3.
+
+### Configuration
+- Mode/Capability:
+- LLM provider + model:
+- Embedding provider + model:
+- Search provider:
+- Backend (if applicable):
+
+### Evidence bundle
+- Conversation trace (anonymized):
+- Retrieved snippets (top-k + score + source):
+- Relevant logs/errors:
+```
+
+## 5) Operational Notes
+
+- Keep student privacy first: redact personal or sensitive data before sharing traces.
+- Prefer deterministic reproductions with the smallest possible prompt/input set.
+- When uncertain, mark uncertainty explicitly in outputs rather than forcing a confident answer.


### PR DESCRIPTION
## Summary
- add `docs/deep_tutor_reasoning_and_safety_checklist.md` as a concise docs-only guide for long-horizon tutoring reliability
- cover four common failure modes with symptom -> likely cause -> recommended checks
- include a copy/paste issue-report template with tool path, retrieval snippets, and anonymized trace requirements
- add a README navigation link so users can find the checklist quickly

## Validation
- `pre-commit run --files README.md docs/deep_tutor_reasoning_and_safety_checklist.md`

Closes #199