### PR TITLE
fix: pass extra_headers to llm_complete in config test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,6 @@
 
 > **[2026.4.4]** [v1.0.0-beta.1](https://github.com/HKUDS/DeepTutor/releases/tag/v1.0.0-beta.1) — Agent-native architecture rewrite (～200k lines) with two-layer plugin model (Tools + Capabilities), CLI & SDK entry points, TutorBot multi-channel bot agent, Co-Writer, Guided Learning, and persistent memory.
 
-### 📰 News
-
-> **[2026.4.4]** Long time no see! ✨ DeepTutor v1.0.0 is finally here — an agent-native evolution featuring a ground-up architecture rewrite, TutorBot, and flexible mode switching under the Apache-2.0 license. A new chapter begins, and our story continues! 
-
-> **[2026.2.6]** 🚀 We've reached 10k stars in just 39 days! A huge thank you to our incredible community for the support! 
-
-> **[2026.1.1]** Happy New Year! Join our [Discord](https://discord.gg/eRsjPgMU4t), [WeChat](https://github.com/HKUDS/DeepTutor/issues/78), or [Discussions](https://github.com/HKUDS/DeepTutor/discussions) — let's shape the future of DeepTutor together!
-
-> **[2025.12.29]** DeepTutor is officially released!
-
-
 <details>
 <summary><b>Past releases</b></summary>
 

--- a/README.md
+++ b/README.md
@@ -604,8 +604,10 @@ deeptutor session open <id>                         # Resume in REPL
 
 | Status | Milestone |
 |:---:|:---|
-| 🔜 | **Authentication & Login** — Optional login page for public deployments with multi-user support |
-| 🔜 | **Themes & Appearance** — Diverse theme options and customizable UI appearance |
+| 🎯 | **Authentication & Login** — Optional login page for public deployments with multi-user support |
+| 🎯 | **Themes & Appearance** — Diverse theme options and customizable UI appearance |
+| 🎯 | **Interaction Improvement** — optimize icon design and interaction details |
+| 🔜 | **Better Memories** — integrating better memory management |
 | 🔜 | **LightRAG Integration** — Integrate [LightRAG](https://github.com/HKUDS/LightRAG) as an advanced knowledge base engine |
 | 🔜 | **Documentation Site** — Comprehensive docs page with guides, API reference, and tutorials |
 

--- a/README.md
+++ b/README.md
@@ -658,6 +658,16 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on setting up your develop
 
 </div>
 
+<p align="center">
+ <a href="https://www.star-history.com/hkuds/deeptutor">
+  <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/badge?repo=HKUDS/DeepTutor&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/badge?repo=HKUDS/DeepTutor" />
+   <img alt="Star History Rank" src="https://api.star-history.com/badge?repo=HKUDS/DeepTutor" />
+  </picture>
+ </a>
+</p>
+
 <div align="center">
 
 **[Data Intelligence Lab @ HKU](https://github.com/HKUDS)**

--- a/deeptutor/services/config/test_runner.py
+++ b/deeptutor/services/config/test_runner.py
@@ -165,6 +165,7 @@ class ConfigTestRunner:
             api_key=llm_config.api_key or "sk-no-key-required",
             base_url=llm_config.base_url or "",
             temperature=0.1,
+            extra_headers=llm_config.extra_headers,
             **token_kwargs,
         )
         snippet = (response or "").strip()


### PR DESCRIPTION
## Problem

When users configure custom `extra_headers` (e.g., custom `User-Agent`) in the model settings page, the **connection test** still sends the default SDK headers (e.g., `user-agent: AsyncOpenAI/Python 2.31.0`) instead of the user-configured values.

This happens because `_test_llm` in `ConfigTestRunner` creates an `LLMConfig` with `extra_headers` correctly, but never passes it to the `llm_complete()` function call.

## Root Cause

`deeptutor/services/config/test_runner.py` — `llm_complete()` invocation missing `extra_headers` kwarg.

## Fix

One-line change: add `extra_headers=llm_config.extra_headers` to the `llm_complete()` call in `_test_llm`.

```diff
+            extra_headers=llm_config.extra_headers,
```

## Impact

- **Users with custom headers**: Model connection test now correctly sends user-configured headers
- **Regular users (no extra_headers)**: No change — `{}` is falsy and skipped by `default_headers.update()`
- Fully backward compatible