### PR TITLE
fix: pass extra_headers to llm_complete in config test runner

### DIFF
--- a/deeptutor/services/config/test_runner.py
+++ b/deeptutor/services/config/test_runner.py
@@ -165,6 +165,7 @@ class ConfigTestRunner:
             api_key=llm_config.api_key or "sk-no-key-required",
             base_url=llm_config.base_url or "",
             temperature=0.1,
+            extra_headers=llm_config.extra_headers,
             **token_kwargs,
         )
         snippet = (response or "").strip()


### PR DESCRIPTION
## Problem

When users configure custom `extra_headers` (e.g., custom `User-Agent`) in the model settings page, the **connection test** still sends the default SDK headers (e.g., `user-agent: AsyncOpenAI/Python 2.31.0`) instead of the user-configured values.

## Root Cause

`deeptutor/services/config/test_runner.py` — the `_test_llm` method builds an `LLMConfig` with `extra_headers` correctly, but does not pass it to `llm_complete()`.

## Fix

One-line change: add `extra_headers=llm_config.extra_headers` to the `llm_complete()` call.

```diff
+            extra_headers=llm_config.extra_headers,
```

## Impact

- **Users with custom headers**: connection test now correctly sends user-configured headers
- **Regular users (no extra_headers)**: no change — `{}` is falsy and skipped
- Fully backward compatible