### PR TITLE
fix: prefer unresolved sys.executable to stay inside venv

### DIFF
--- a/scripts/start_tour.py
+++ b/scripts/start_tour.py
@@ -28,11 +28,14 @@ def _resolve_python() -> str:
     """
     exe = sys.executable
     if exe:
+        # Prefer the unresolved path first — resolving symlinks can escape
+        # a virtual-env and point at the system Python, which on modern
+        # Homebrew / PEP 668 installs will refuse ``pip install``.
+        if Path(exe).exists():
+            return exe
         resolved = str(Path(exe).resolve())
         if Path(resolved).exists():
             return resolved
-        if Path(exe).exists():
-            return exe
     for name in ("python3", "python"):
         found = shutil.which(name)
         if found:


### PR DESCRIPTION
## Summary
- On macOS with Homebrew Python, `_resolve_python()` in `start_tour.py` resolves venv symlinks back to the system interpreter. PEP 668 then blocks `pip install` with an "externally-managed-environment" error, causing the setup tour to fail.
- Swaps the check order so the unresolved venv path (`sys.executable`) is preferred when it exists, falling back to the resolved path only when necessary.

## Test plan
- [x] Run `python -m venv .venv && source .venv/bin/activate && python scripts/start_tour.py` on macOS with Homebrew Python
- [x] Verify the bootstrap and pip installs use the venv Python, not the system Python
- [x] Confirm the tour completes without "externally-managed-environment" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)