### PR TITLE
feat(diagnostics): make LLM probe max_tokens configurable via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ LLM_MODEL=gpt-4o-mini
 LLM_API_KEY=sk-xxx
 LLM_HOST=https://api.openai.com/v1
 LLM_API_VERSION=
+# Max completion tokens used by the Settings → LLM diagnostic probe.
+# Bump this if you point the probe at a reasoning model (thinking tokens
+# eat into the budget and empty out the visible response otherwise).
+LLM_TEST_MAX_TOKENS=1024
 
 # --------------------------------------------
 # Embedding (Required for knowledge base features)

--- a/deeptutor/services/config/test_runner.py
+++ b/deeptutor/services/config/test_runner.py
@@ -155,7 +155,14 @@ class ConfigTestRunner:
         )
         run.emit("info", f"Resolved model `{llm_config.model}` with binding `{llm_config.binding}`.")
         run.emit("info", f"Request target: {llm_config.base_url}")
-        token_kwargs = get_token_limit_kwargs(llm_config.model, max_tokens=200)
+        # Reasoning models spend part of the budget on internal thinking;
+        # too tight a cap makes them return empty content. Override via
+        # LLM_TEST_MAX_TOKENS when the default (1024) isn't enough.
+        try:
+            max_tokens = max(1, int(os.getenv("LLM_TEST_MAX_TOKENS", "1024")))
+        except ValueError:
+            max_tokens = 1024
+        token_kwargs = get_token_limit_kwargs(llm_config.model, max_tokens=max_tokens)
         run.emit("info", f"Token options: {json.dumps(token_kwargs)}")
         response = await llm_complete(
             model=llm_config.model,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - LLM_API_KEY=${LLM_API_KEY}
       - LLM_HOST=${LLM_HOST}
       - LLM_API_VERSION=${LLM_API_VERSION:-}
+      - LLM_TEST_MAX_TOKENS=${LLM_TEST_MAX_TOKENS:-1024}
       - DISABLE_SSL_VERIFY=${DISABLE_SSL_VERIFY:-false}
       # Embedding Configuration (Required for Knowledge Base)
       - EMBEDDING_BINDING=${EMBEDDING_BINDING:-openai}


### PR DESCRIPTION
## Summary
- The Settings → LLM diagnostic probe in `test_runner.py` hardcodes `max_tokens=200`. Reasoning-capable models (minimax-m2, o1, Gemini thinking) spend most of that budget on internal thinking tokens and return empty visible content, so the probe reports `LLM returned an empty response` even though the API call succeeded.
- Read the budget from `LLM_TEST_MAX_TOKENS` with a `1024` default (non-numeric values fall back to 1024). Documented in `.env.example` and plumbed through `docker-compose.yml`.

## Test plan
- [ ] Run Settings → LLM diagnostic against a reasoning model with the new default (1024) — non-empty response.
- [ ] Set `LLM_TEST_MAX_TOKENS=2048` in `.env`, rebuild, rerun — log shows `Token options: {"max_tokens": 2048}`.
- [ ] Set a non-numeric value — probe still works, falls back to 1024.
- [ ] Non-reasoning model (gpt-4o-mini) — unchanged behaviour.