### PR TITLE
fix(embedding): skip `dimensions` for models that don't support matryoshka

### DIFF
--- a/deeptutor/services/embedding/adapters/openai_compatible.py
+++ b/deeptutor/services/embedding/adapters/openai_compatible.py
@@ -117,8 +117,14 @@ class OpenAICompatibleEmbeddingAdapter(BaseEmbeddingAdapter):
             "encoding_format": request.encoding_format or "float",
         }
 
-        if request.dimensions or self.dimensions:
-            payload["dimensions"] = request.dimensions or self.dimensions
+        # Only models in MODELS_INFO are known to accept the `dimensions`
+        # parameter (OpenAI matryoshka embeddings). Sending it to third-party
+        # endpoints such as Qodo-Embed-1-7B makes them reject the request
+        # with HTTP 400 ("does not support matryoshka representation").
+        if payload["model"] in self.MODELS_INFO:
+            dims = request.dimensions or self.dimensions
+            if dims:
+                payload["dimensions"] = dims
 
         base = self.base_url.rstrip('/')
         if base.endswith('/embeddings'):


### PR DESCRIPTION
## Summary
The OpenAI-compatible embedding adapter (`deeptutor/services/embedding/adapters/openai_compatible.py`) unconditionally puts `dimensions` into the payload whenever `self.dimensions` is set. This is safe for OpenAI's `text-embedding-3-*` (matryoshka) but breaks on many third-party OpenAI-compatible endpoints. Concretely, `Qodo-Embed-1-7B` responds with:

```
HTTP 400 {"message":"Model \"/genesis/model\" does not support matryoshka representation, changing output dimensions will lead to poor results."}
```

This PR gates the parameter on the already-present `MODELS_INFO` whitelist (`text-embedding-3-large`, `text-embedding-3-small`), matching the set of models known to support it. OpenAI callers keep existing behaviour; non-matryoshka providers finally succeed.

## Test plan
- [ ] Qodo-Embed-1-7B (or any non-matryoshka OpenAI-compatible endpoint) — embedding request now succeeds.
- [ ] `text-embedding-3-large` with a non-default `dimension` set in the catalog — still passes the value to the server.
- [ ] `text-embedding-3-small` with default — unchanged.
- [ ] Explicit `request.dimensions` override on a non-whitelisted model — intentionally dropped (documented in inline comment).