### PR TITLE
fix(embedding): drop `dimensions` on HTTP 400 and latch on success

### DIFF
--- a/deeptutor/services/embedding/adapters/openai_compatible.py
+++ b/deeptutor/services/embedding/adapters/openai_compatible.py
@@ -18,6 +18,20 @@ class OpenAICompatibleEmbeddingAdapter(BaseEmbeddingAdapter):
         "text-embedding-ada-002": 1536,
     }
 
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        # Tri-state memoization of the "drop `dimensions` on HTTP 400"
+        # experiment against this endpoint. Reset implicitly when the
+        # adapter is rebuilt on Settings → Apply.
+        #   None  — never tried; on the first 400 with `dimensions`,
+        #           drop the field and retry.
+        #   True  — retry without `dimensions` succeeded; skip the field
+        #           on every subsequent call (saves a round-trip).
+        #   False — retry without `dimensions` also returned 400, i.e.
+        #           the failure was unrelated to that field; don't do
+        #           the drop-and-retry dance again (another saved call).
+        self._dimensions_fallback: bool | None = None
+
     @staticmethod
     def _extract_embeddings_from_response(data: Any) -> list[list[float]]:
         """
@@ -117,7 +131,7 @@ class OpenAICompatibleEmbeddingAdapter(BaseEmbeddingAdapter):
             "encoding_format": request.encoding_format or "float",
         }
 
-        if request.dimensions or self.dimensions:
+        if (request.dimensions or self.dimensions) and self._dimensions_fallback is not True:
             payload["dimensions"] = request.dimensions or self.dimensions
 
         base = self.base_url.rstrip('/')
@@ -140,6 +154,7 @@ class OpenAICompatibleEmbeddingAdapter(BaseEmbeddingAdapter):
             pool=10.0,
         )
         last_exc: Exception | None = None
+        dropped_dimensions = False
         for attempt in range(1 + self._MAX_RETRIES):
             try:
                 async with httpx.AsyncClient(timeout=timeout) as client:
@@ -157,11 +172,46 @@ class OpenAICompatibleEmbeddingAdapter(BaseEmbeddingAdapter):
                         last_exc = Exception(f"HTTP 429 Too Many Requests")
                         continue
 
+                    # OpenAI's text-embedding-3-* accept a `dimensions` param
+                    # (matryoshka), but many OpenAI-compatible endpoints
+                    # (e.g. Qodo-Embed-1-7B) reject it with HTTP 400. If
+                    # we haven't yet learned that dropping the field is
+                    # useless, drop it and retry; the outcome is latched
+                    # after the loop (on success → True, see below) or
+                    # right before raising (on another 400 → False).
+                    if (
+                        response.status_code == 400
+                        and "dimensions" in payload
+                        and self._dimensions_fallback is not False
+                    ):
+                        logger.warning(
+                            "Embedding endpoint returned HTTP 400 with "
+                            "`dimensions` in payload; dropping the field "
+                            "and retrying once. Body: %s",
+                            response.text[:200],
+                        )
+                        payload.pop("dimensions", None)
+                        dropped_dimensions = True
+                        last_exc = Exception(
+                            "HTTP 400 with `dimensions`; retrying without it"
+                        )
+                        continue
+
                     if response.status_code >= 400:
                         logger.error(f"HTTP {response.status_code} response body: {response.text}")
+                        # We already tried dropping `dimensions` on the
+                        # previous attempt and still got a 400 — the
+                        # fallback is not helpful for this endpoint.
+                        if response.status_code == 400 and dropped_dimensions:
+                            self._dimensions_fallback = False
 
                     response.raise_for_status()
                     data = response.json()
+                # Success. If this attempt was the retry that followed a
+                # 400-with-`dimensions`, we've now confirmed the endpoint
+                # works without the field — latch so future calls skip it.
+                if dropped_dimensions:
+                    self._dimensions_fallback = True
                 break
             except (httpx.ReadTimeout, httpx.ConnectTimeout, httpx.PoolTimeout) as exc:
                 last_exc = exc


### PR DESCRIPTION
## Summary

OpenAI's `text-embedding-3-*` models accept a custom `dimensions` parameter (matryoshka representation), but many OpenAI-compatible endpoints (e.g. `Qodo-Embed-1-7B` and most self-hosted embedding servers) reject any request that carries it with HTTP 400:

```
{"object":"error","message":"Model \"/genesis/model\" does not support matryoshka representation, changing output dimensions will lead to poor results.","type":"BadRequestError","code":400}
```

Previously, `OpenAICompatibleEmbeddingAdapter.embed()` unconditionally attached `dimensions` whenever it was configured on the adapter, so every embedding call against such providers failed before returning any vectors.

## Approach

This PR supersedes #322, which used a hardcoded whitelist of matryoshka-capable models. Per the maintainer's feedback on that PR, a retry-based fallback is more future-proof.

Implementation is a small state machine memoized on the adapter instance:

```python
self._dimensions_fallback: bool | None = None
#   None  — never tried
#   True  — retry without `dimensions` succeeded; skip the field going forward
#   False — retry without `dimensions` also 400'd; don't retry again
```

Flow inside the existing retry loop:

1. If the request carries `dimensions` and the server answers HTTP 400, and we haven't yet learned the fallback is useless (`_dimensions_fallback is not False`), drop the field and retry the request within the same loop.
2. If the retry **succeeds**, set `_dimensions_fallback = True`. All future calls on this adapter send a single request without `dimensions` — one round-trip instead of two.
3. If the retry itself returns another 400, set `_dimensions_fallback = False` right before raising. Future 400s on this adapter skip the retry dance and propagate immediately — also one round-trip.
4. If the first 400 is for an unrelated reason (bad model, quota, input validation), the retry will likely also 400 and step 3 applies; the flag never gets set to True so adapters that actually accept `dimensions` on healthy requests are not penalised.

`OpenAICompatibleEmbeddingAdapter` is held as a process-level singleton by `get_embedding_client()` (`deeptutor/services/embedding/client.py`) and only rebuilt when `reset_embedding_client()` runs on Settings → Apply. The memoized state is implicitly cleared when the user edits the embedding configuration — no extra invalidation hook is needed.

## Test plan

- [ ] Qodo-Embed-1-7B (or any OpenAI-compatible endpoint that rejects `dimensions`) — first request succeeds after one internal retry; subsequent requests send a single call without `dimensions`.
- [ ] `text-embedding-3-large` with a non-default `dimension` in the catalog — still sends `dimensions` and receives a vector of the requested size.
- [ ] Endpoint that 400s with `dimensions` AND without `dimensions` (e.g. bad model name) — adapter latches `False`; subsequent calls issue one round-trip, observe original 400, don't attempt the drop.
- [ ] Settings → Apply after any latch — new adapter instance starts with `_dimensions_fallback = None`.

Closes #322.