### PR TITLE
Fix: TutorBot channel config wiped on every server restart

### DIFF
--- a/deeptutor/api/routers/tutorbot.py
+++ b/deeptutor/api/routers/tutorbot.py
@@ -103,12 +103,14 @@ async def recent_bots(limit: int = 3):
 @router.post("")
 async def create_and_start_bot(payload: CreateBotRequest):
     mgr = get_tutorbot_manager()
+    # Load existing config from disk first so fields like channels are preserved
+    existing = mgr._load_bot_config(payload.bot_id)
     config = BotConfig(
-        name=payload.name or payload.bot_id,
-        description=payload.description,
-        persona=payload.persona,
-        channels=payload.channels,
-        model=payload.model,
+        name=payload.name or (existing.name if existing else payload.bot_id),
+        description=payload.description or (existing.description if existing else ""),
+        persona=payload.persona or (existing.persona if existing else ""),
+        channels=payload.channels if payload.channels else (existing.channels if existing else {}),
+        model=payload.model or (existing.model if existing else None),
     )
     try:
         instance = await mgr.start_bot(payload.bot_id, config)

--- a/tests/api/test_tutorbot_router.py
+++ b/tests/api/test_tutorbot_router.py
@@ -1,0 +1,142 @@
+"""Tests for the TutorBot API router."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+except Exception:  # pragma: no cover
+    FastAPI = None
+    TestClient = None
+
+pytestmark = pytest.mark.skipif(
+    FastAPI is None or TestClient is None, reason="fastapi not installed"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_fake_manager(existing_channels: dict | None = None):
+    """Return a (manager, saved) pair.
+
+    manager   — fake TutorBotManager whose start_bot captures the final config
+    saved     — dict populated with {"config": BotConfig} after start_bot runs
+    """
+    from deeptutor.services.tutorbot.manager import BotConfig
+
+    saved: dict = {}
+
+    class FakeManager:
+        def _load_bot_config(self, bot_id: str) -> BotConfig | None:
+            if existing_channels is not None:
+                return BotConfig(
+                    name=bot_id,
+                    description="existing description",
+                    persona="existing persona",
+                    channels=existing_channels,
+                )
+            return None
+
+        async def start_bot(self, bot_id: str, config: BotConfig):
+            saved["config"] = config
+            instance = MagicMock()
+            instance.to_dict.return_value = {
+                "bot_id": bot_id,
+                "name": config.name,
+                "channels": list(config.channels.keys()),
+                "running": True,
+            }
+            return instance
+
+    return FakeManager(), saved
+
+
+def _make_client(monkeypatch, existing_channels: dict | None = None):
+    """Build a TestClient with the tutorbot router and a patched manager."""
+    manager, saved = _make_fake_manager(existing_channels)
+
+    tutorbot_router_mod = importlib.import_module("deeptutor.api.routers.tutorbot")
+    monkeypatch.setattr(tutorbot_router_mod, "get_tutorbot_manager", lambda: manager)
+
+    app = FastAPI()
+    app.include_router(tutorbot_router_mod.router, prefix="/api/v1/tutorbot")
+    return TestClient(app), saved
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestCreateBotPreservesExistingConfig:
+    """Regression tests for the config-wipe bug.
+
+    When the web UI starts a bot via POST /api/v1/tutorbot without supplying
+    channel config, the previously saved channels must be kept — not wiped.
+    """
+
+    def test_channels_preserved_when_payload_has_no_channels(self, monkeypatch):
+        """Existing channels on disk must not be wiped when payload omits channels."""
+        existing_channels = {
+            "telegram": {
+                "enabled": True,
+                "token": "123:ABC",
+                "allow_from": ["999"],
+            }
+        }
+        client, saved = _make_client(monkeypatch, existing_channels=existing_channels)
+
+        resp = client.post("/api/v1/tutorbot", json={"bot_id": "my-bot"})
+
+        assert resp.status_code == 200
+        assert saved["config"].channels == existing_channels, (
+            "Channels were wiped even though none were provided in the payload"
+        )
+
+    def test_payload_channels_override_existing(self, monkeypatch):
+        """Explicitly provided channels in payload must take precedence over disk."""
+        existing_channels = {"telegram": {"enabled": True, "token": "old"}}
+        new_channels = {"slack": {"enabled": True, "token": "new-slack-token"}}
+
+        client, saved = _make_client(monkeypatch, existing_channels=existing_channels)
+
+        resp = client.post(
+            "/api/v1/tutorbot",
+            json={"bot_id": "my-bot", "channels": new_channels},
+        )
+
+        assert resp.status_code == 200
+        assert saved["config"].channels == new_channels, (
+            "Explicitly provided channels should override existing disk config"
+        )
+
+    def test_fresh_bot_with_no_existing_config(self, monkeypatch):
+        """A brand-new bot with no existing config should start without error."""
+        client, saved = _make_client(monkeypatch, existing_channels=None)
+
+        resp = client.post(
+            "/api/v1/tutorbot",
+            json={"bot_id": "new-bot", "name": "New Bot"},
+        )
+
+        assert resp.status_code == 200
+        assert saved["config"].channels == {}
+        assert saved["config"].name == "New Bot"
+
+    def test_existing_name_and_persona_preserved(self, monkeypatch):
+        """Other fields (description, persona) from disk must also survive when not in payload."""
+        existing_channels = {"telegram": {"enabled": True, "token": "tok"}}
+        client, saved = _make_client(monkeypatch, existing_channels=existing_channels)
+
+        resp = client.post("/api/v1/tutorbot", json={"bot_id": "my-bot"})
+
+        assert resp.status_code == 200
+        assert saved["config"].description == "existing description"
+        assert saved["config"].persona == "existing persona"


### PR DESCRIPTION
<!--
Thank you for contributing to DeepTutor! 🚀
Please ensure your PR is ready for review and follows our contribution guidelines.
For more details, see our [CONTRIBUTING.md](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
-->
### Description
When starting a TutorBot via `POST /api/v1/tutorbot`, the endpoint constructed a fresh
`BotConfig` using request payload defaults (`channels: {}`), ignoring any existing
`config.yaml` on disk. This caused `_save_bot_config` to unconditionally overwrite the file
on every server restart or bot start from the web UI — silently wiping user-configured
channels (e.g. Telegram token, allowed users).

The fix loads the existing on-disk config first and only falls back to payload defaults when
no existing values are present, so manually configured channels survive restarts.

### Related Issues
- Closes #331
- Related to #331

### Module(s) Affected
- [ ] `agents`
- [x] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
Four regression tests added in `tests/api/test_tutorbot_router.py` covering:
- Existing channels are preserved when the payload omits `channels`
- Payload channels override disk config when explicitly provided
- Fresh bot with no existing config starts cleanly
- Existing `description` and `persona` fields are also preserved
