### PR TITLE
fix(api): add missing http_version arg in selective_access_log middleware

### DIFF
--- a/deeptutor/api/main.py
+++ b/deeptutor/api/main.py
@@ -1,9 +1,7 @@
-import logging
 from contextlib import asynccontextmanager
-from pathlib import Path
+import logging
 
-from fastapi import FastAPI
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
@@ -107,6 +105,7 @@ async def lifespan(app: FastAPI):
 
     try:
         from deeptutor.services.tutorbot import get_tutorbot_manager
+
         await get_tutorbot_manager().auto_start_bots()
     except Exception as e:
         logger.warning(f"Failed to auto-start TutorBots: {e}")
@@ -119,6 +118,7 @@ async def lifespan(app: FastAPI):
     # Stop TutorBots
     try:
         from deeptutor.services.tutorbot import get_tutorbot_manager
+
         await get_tutorbot_manager().stop_all()
         logger.info("TutorBots stopped")
     except Exception as e:
@@ -155,10 +155,11 @@ async def selective_access_log(request, call_next):
     response = await call_next(request)
     if response.status_code != 200:
         _access_logger.info(
-            '%s - "%s %s" %d',
+            '%s - "%s %s HTTP/%s" %d',
             request.client.host if request.client else "-",
             request.method,
             request.url.path,
+            request.scope.get("http_version", "1.1"),
             response.status_code,
         )
     return response
@@ -207,6 +208,7 @@ from deeptutor.api.routers import (
     notebook,
     plugins_api,
     question,
+    question_notebook,
     sessions,
     settings,
     solve,
@@ -214,7 +216,6 @@ from deeptutor.api.routers import (
     tutorbot,
     unified_ws,
     vision_solver,
-    question_notebook,
 )
 
 # Include routers
@@ -228,7 +229,9 @@ app.include_router(notebook.router, prefix="/api/v1/notebook", tags=["notebook"]
 app.include_router(guide.router, prefix="/api/v1/guide", tags=["guide"])
 app.include_router(memory.router, prefix="/api/v1/memory", tags=["memory"])
 app.include_router(sessions.router, prefix="/api/v1/sessions", tags=["sessions"])
-app.include_router(question_notebook.router, prefix="/api/v1/question-notebook", tags=["question-notebook"])
+app.include_router(
+    question_notebook.router, prefix="/api/v1/question-notebook", tags=["question-notebook"]
+)
 app.include_router(settings.router, prefix="/api/v1/settings", tags=["settings"])
 app.include_router(system.router, prefix="/api/v1/system", tags=["system"])
 app.include_router(plugins_api.router, prefix="/api/v1/plugins", tags=["plugins"])

--- a/tests/api/test_selective_access_log.py
+++ b/tests/api/test_selective_access_log.py
@@ -1,0 +1,88 @@
+"""Tests for the selective_access_log middleware in main.py.
+
+Verifies that non-200 responses are logged with the 5-element args tuple
+expected by uvicorn's AccessFormatter (client_addr, method, full_path,
+http_version, status_code), preventing the ValueError documented in #334.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+
+def _build_app_with_middleware():
+    """Build a minimal app that replicates the selective_access_log middleware."""
+    test_app = FastAPI()
+    _access_logger = logging.getLogger("uvicorn.access")
+
+    @test_app.middleware("http")
+    async def selective_access_log(request: Request, call_next):
+        response = await call_next(request)
+        if response.status_code != 200:
+            _access_logger.info(
+                '%s - "%s %s HTTP/%s" %d',
+                request.client.host if request.client else "-",
+                request.method,
+                request.url.path,
+                request.scope.get("http_version", "1.1"),
+                response.status_code,
+            )
+        return response
+
+    @test_app.get("/ok")
+    def ok():
+        return {"status": "ok"}
+
+    @test_app.get("/not-found")
+    def not_found():
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    return test_app
+
+
+class TestSelectiveAccessLog:
+    """selective_access_log middleware must emit 5-arg tuples for uvicorn."""
+
+    def test_non_200_log_has_five_args(self, caplog):
+        """Non-200 response log record args must have 5 elements (#334)."""
+        app = _build_app_with_middleware()
+        with caplog.at_level(logging.INFO, logger="uvicorn.access"):
+            with TestClient(app) as client:
+                client.get("/not-found")
+
+        access_records = [r for r in caplog.records if r.name == "uvicorn.access"]
+        assert len(access_records) >= 1
+        record = access_records[0]
+        assert len(record.args) == 5, (
+            f"Expected 5-element args for AccessFormatter, got {len(record.args)}"
+        )
+        client_addr, method, path, http_version, status_code = record.args
+        assert method == "GET"
+        assert path == "/not-found"
+        assert http_version in ("1.0", "1.1", "2")
+        assert status_code == 404
+
+    def test_200_not_logged(self, caplog):
+        """200 responses should not produce uvicorn.access log records."""
+        app = _build_app_with_middleware()
+        with caplog.at_level(logging.INFO, logger="uvicorn.access"):
+            with TestClient(app) as client:
+                client.get("/ok")
+
+        access_records = [
+            r
+            for r in caplog.records
+            if r.name == "uvicorn.access" and hasattr(r, "args") and r.args
+        ]
+        ok_records = [r for r in access_records if len(r.args) >= 3 and "/ok" in str(r.args[2])]
+        assert len(ok_records) == 0


### PR DESCRIPTION
## Summary

The `selective_access_log` middleware in `deeptutor/api/main.py` uses `logging.getLogger('uvicorn.access')`, which inherits uvicorn's `AccessFormatter`. That formatter unpacks `record.args` into **five** values:

```python
(client_addr, method, full_path, http_version, status_code) = recordcopy.args
```

But the middleware only passed **four** arguments (omitting `http_version`), causing a `ValueError: not enough values to unpack (expected 5, got 4)` on every non-200 response.

## Changes

- **`deeptutor/api/main.py`**: Add the missing `http_version` argument from the ASGI scope (`request.scope.get('http_version', '1.1')`), matching what uvicorn's `AccessFormatter` expects.
- **`tests/api/test_selective_access_log.py`**: Add regression test verifying 5-element args tuple and that 200 responses are not logged.

## Testing

```bash
python -m pytest tests/api/test_selective_access_log.py -v
# 2 passed
```

Closes #334

Signed-off-by: kagura-agent <kagura.chen28@gmail.com>