### PR TITLE
Fix #296: [Bug]:LLM 0, EMBEDDING 0, SEARCH 0

### DIFF
--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -18,6 +18,35 @@ export const API_BASE_URL =
   })();
 
 /**
+ * Resolve the effective API base URL at runtime.
+ *
+ * NEXT_PUBLIC_API_BASE is a build-time constant that is typically set to
+ * http://localhost:<port>.  When another machine on the LAN opens the app that
+ * constant still points at "localhost", which the remote browser resolves to
+ * its *own* loopback address instead of the server.  We detect this situation
+ * and swap the hostname for window.location.hostname so the request reaches
+ * the actual server regardless of which machine opened the page.
+ */
+function resolveBase(): string {
+  const base = API_BASE_URL;
+  if (typeof window === "undefined") return base;
+  try {
+    const url = new URL(base);
+    const isLoopback = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+    const clientIsRemote =
+      window.location.hostname !== "localhost" &&
+      window.location.hostname !== "127.0.0.1";
+    if (isLoopback && clientIsRemote) {
+      url.hostname = window.location.hostname;
+      return url.origin;
+    }
+  } catch {
+    // base is not a valid absolute URL – return as-is
+  }
+  return base;
+}
+
+/**
  * Construct a full API URL from a path
  * @param path - API path (e.g., '/api/v1/knowledge/list')
  * @returns Full URL (e.g., 'http://localhost:8001/api/v1/knowledge/list')
@@ -27,11 +56,10 @@ export function apiUrl(path: string): string {
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
 
   // Remove trailing slash from base URL if present
-  const base = API_BASE_URL.endsWith("/")
-    ? API_BASE_URL.slice(0, -1)
-    : API_BASE_URL;
+  const base = resolveBase();
+  const normalizedBase = base.endsWith("/") ? base.slice(0, -1) : base;
 
-  return `${base}${normalizedPath}`;
+  return `${normalizedBase}${normalizedPath}`;
 }
 
 /**
@@ -42,7 +70,7 @@ export function apiUrl(path: string): string {
 export function wsUrl(path: string): string {
   // Security Hardening: Convert http to ws and https to wss.
   // In production environments (where API_BASE_URL starts with https), this ensures secure websockets.
-  const base = API_BASE_URL.replace(/^http:/, "ws:").replace(/^https:/, "wss:");
+  const base = resolveBase().replace(/^http:/, "ws:").replace(/^https:/, "wss:");
 
   // Remove leading slash if present to avoid double slashes
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;


### PR DESCRIPTION
Closes #296

<!--
Thank you for contributing to DeepTutor! 🚀
Please ensure your PR is ready for review and follows our contribution guidelines.
For more details, see our [CONTRIBUTING.md](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
-->

### Description
`NEXT_PUBLIC_API_BASE` is a build-time constant that typically resolves to `http://localhost:<port>`. When a remote machine on the same LAN opens the app, the browser resolves `localhost` against its own loopback interface rather than the server's, causing all API and WebSocket calls to fail — resulting in LLM 0, EMBEDDING 0, and SEARCH 0 on the dashboard.

This PR introduces `resolveBase()` in `web/lib/api.ts`, which detects this mismatch at runtime: if the build-time base URL points to a loopback address (`localhost` or `127.0.0.1`) but the client's `window.location.hostname` is a non-loopback address, it substitutes `window.location.hostname` into the URL before returning it. The function is SSR-safe (falls back to the static constant when `window` is undefined) and silently passes through non-absolute URLs.

`apiUrl()` and `wsUrl()` are both updated to call `resolveBase()` instead of reading `API_BASE_URL` directly, so all HTTP and WebSocket connections benefit from the fix.

### Related Issues
- Closes #296

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
Manual verification: serve the app from one machine and open it from a second machine on the same LAN. Before this fix, the settings dashboard shows LLM 0 / EMBEDDING 0 / SEARCH 0 and chat is non-functional. After this fix, `resolveBase()` replaces `localhost` with the server's LAN IP, and all API calls resolve correctly.

No behaviour change for local access (`window.location.hostname === "localhost"`), production deployments with a non-loopback `NEXT_PUBLIC_API_BASE`, or SSR contexts.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*