### PR TITLE
fix: disable json_object response_format for gemma models

### DIFF
--- a/deeptutor/services/llm/capabilities.py
+++ b/deeptutor/services/llm/capabilities.py
@@ -192,7 +192,7 @@ MODEL_OVERRIDES: dict[str, dict[str, object]] = {
     "claude-3": {"supports_vision": True},
     "claude-4": {"supports_vision": True},
     "gemini": {"supports_vision": True},
-    "gemma": {"supports_vision": False},
+    "gemma": {"supports_vision": False, "supports_response_format": False},
     "llava": {"supports_vision": True},
     "bakllava": {"supports_vision": True},
     "moondream": {"supports_vision": True},

--- a/tests/services/llm/test_capabilities.py
+++ b/tests/services/llm/test_capabilities.py
@@ -14,6 +14,20 @@ def test_model_override_capability() -> None:
     assert has_thinking_tags("openai", "deepseek-reasoner") is True
 
 
+def test_gemma_response_format_disabled() -> None:
+    """Gemma models do not support json_object response_format (only json_schema/text).
+
+    LM Studio with gemma-4 and similar models returns a 400 error when
+    response_format={"type": "json_object"} is used.  See issue #344.
+    """
+    assert supports_response_format("lm_studio", "gemma-4-e2b") is False
+    assert supports_response_format("lm_studio", "gemma-3-4b") is False
+    assert supports_response_format("lm_studio", "gemma-2-9b") is False
+    # Other non-gemma local models should still support response_format
+    assert supports_response_format("lm_studio", "mistral-7b") is True
+    assert supports_response_format("lm_studio", "llama-3") is True
+
+
 def test_capability_fallback_default() -> None:
     """Unknown provider should fall back to defaults and explicit values."""
     assert get_capability("unknown", "supports_streaming") is True


### PR DESCRIPTION
Fixes #344

## Problem

When using LM Studio with `gemma` models (e.g. `gemma-4-e2b`), the
visualization and other JSON-structured features fail with:

```
openai.BadRequestError: Error code: 400 - {'error': "'response_format.type' must be 'json_schema' or 'text'"}
```

The root cause: the `lm_studio` binding has `supports_response_format: True`
in `PROVIDER_CAPABILITIES`, so the code sends `response_format={"type": "json_object"}`.
However, newer Gemma models only accept `json_schema` or `text` — they do not
support the legacy `json_object` type.

## Solution

Add `"supports_response_format": False` to the existing `"gemma"` entry in
`MODEL_OVERRIDES` inside `deeptutor/services/llm/capabilities.py`.

When `supports_response_format` returns `False`, the code omits the
`response_format` parameter entirely. The existing `extract_json_object`
utilities in the `visualize` and `math-animator` agents already parse
structured JSON from plain-text responses, so all callers work correctly
without `response_format` being set.

This is the same pattern already used for DeepSeek and Anthropic models.

## Testing

- Direct Python assertions covering `gemma-4-e2b`, `gemma-3-4b`, `gemma-2-9b` all return `False`
- Non-gemma LM Studio models (`mistral-7b`, `llama-3`) continue to return `True`
- Added `test_gemma_response_format_disabled` to `tests/services/llm/test_capabilities.py`