### PR TITLE
fix(rag): guard against None embeddings in LlamaIndex pipeline

### DIFF
--- a/deeptutor/services/embedding/adapters/openai_compatible.py
+++ b/deeptutor/services/embedding/adapters/openai_compatible.py
@@ -85,7 +85,10 @@ class OpenAICompatibleEmbeddingAdapter(BaseEmbeddingAdapter):
             first = c[0]
             # list of {"embedding":[...]}
             if isinstance(first, dict) and "embedding" in first:
-                return [item.get("embedding", []) for item in c if isinstance(item, dict)]
+                return [
+                    item.get("embedding") or []
+                    for item in c if isinstance(item, dict)
+                ]
             # list of vectors [[...], ...]
             if isinstance(first, list):
                 return [item for item in c if isinstance(item, list)]

--- a/deeptutor/services/rag/pipelines/llamaindex.py
+++ b/deeptutor/services/rag/pipelines/llamaindex.py
@@ -99,6 +99,18 @@ class CustomEmbedding(BaseEmbedding):
         """Sync batch version - called by LlamaIndex for bulk embedding."""
         self._logger.info(f"Embedding {len(texts)} text chunks...")
         result = self._run_in_new_loop(self._aget_text_embeddings(texts))
+        # Guard against None embeddings that would crash similarity computation
+        none_indices = [i for i, vec in enumerate(result) if vec is None]
+        if none_indices:
+            self._logger.error(
+                f"Embedding returned None for {len(none_indices)} chunk(s) "
+                f"at indices {none_indices}. These will be replaced with "
+                f"zero vectors to prevent storage corruption."
+            )
+            # Determine dimension from the first valid embedding
+            dim = next((len(v) for v in result if v is not None), 0)
+            for i in none_indices:
+                result[i] = [0.0] * dim
         self._logger.info(f"Embedding complete: {len(result)} vectors")
         return result
 

--- a/tests/services/embedding/test_extract_embeddings.py
+++ b/tests/services/embedding/test_extract_embeddings.py
@@ -159,3 +159,18 @@ class TestErrorHandling:
     def test_empty_embedding_singular_falls_through(self) -> None:
         with pytest.raises(ValueError, match="Cannot parse embeddings"):
             _extract({"embedding": []})
+
+    def test_none_embedding_value_replaced_with_empty_list(self) -> None:
+        """When a provider returns {"embedding": null}, use [] instead of None.
+
+        Prevents TypeError in LlamaIndex similarity computation (issue #346).
+        """
+        data = {
+            "data": [
+                {"embedding": [0.1, 0.2]},
+                {"embedding": None},
+                {"embedding": [0.3, 0.4]},
+            ]
+        }
+        result = _extract(data)
+        assert result == [[0.1, 0.2], [], [0.3, 0.4]]


### PR DESCRIPTION
## Summary

Fixes #346 — RAG queries crash with `TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'` when a stored embedding vector is `None`.

## Root Cause

When an embedding provider returns `{"embedding": null}` for a chunk, two things go wrong:

1. **`_extract_embeddings_from_response`** uses `item.get("embedding", [])` — but `dict.get()` only returns the default when the key is *absent*, not when the value is explicitly `None`. So `None` passes through.
2. **`CustomEmbedding._get_text_embeddings`** trusts the result without validation, allowing `None` vectors to be stored in the index and crash `np.dot` at query time.

## Fix

Two-layer defense:

1. **Adapter layer** (`openai_compatible.py`): Changed `item.get("embedding", [])` → `item.get("embedding") or []` so explicit `None` values are caught.
2. **Pipeline layer** (`llamaindex.py`): Added post-embed validation in `_get_text_embeddings` — any `None` vectors are replaced with zero vectors and logged as errors. This prevents silent storage corruption regardless of which adapter is used.

## Testing

- Added unit test for `None` embedding extraction in `test_extract_embeddings.py`
- All 22 extraction tests pass
- All 45 passing embedding/RAG tests still pass (10 pre-existing failures due to missing async plugin — unrelated)