### PR TITLE
feat(chat): make per-stage token limits and temperature configurable via agents.yaml

### DIFF
--- a/deeptutor/agents/chat/agentic_pipeline.py
+++ b/deeptutor/agents/chat/agentic_pipeline.py
@@ -22,26 +22,25 @@ from deeptutor.core.trace import (
 )
 from deeptutor.runtime.registry.tool_registry import get_tool_registry
 from deeptutor.services.config import get_chat_params
-from deeptutor.services.prompt import get_prompt_manager
 from deeptutor.services.llm import (
     clean_thinking_tags,
-    complete as llm_complete,
     get_llm_config,
     get_token_limit_kwargs,
     prepare_multimodal_messages,
-    stream as llm_stream,
     supports_response_format,
     supports_tools,
 )
+from deeptutor.services.llm import (
+    stream as llm_stream,
+)
+from deeptutor.services.prompt import get_prompt_manager
 from deeptutor.tools.builtin import BUILTIN_TOOL_NAMES
 from deeptutor.utils.json_parser import parse_json_response
 
 logger = logging.getLogger(__name__)
 
 CHAT_EXCLUDED_TOOLS = {"geogebra_analysis"}
-CHAT_OPTIONAL_TOOLS = [
-    name for name in BUILTIN_TOOL_NAMES if name not in CHAT_EXCLUDED_TOOLS
-]
+CHAT_OPTIONAL_TOOLS = [name for name in BUILTIN_TOOL_NAMES if name not in CHAT_EXCLUDED_TOOLS]
 MAX_PARALLEL_TOOL_CALLS = 8
 MAX_TOOL_RESULT_CHARS = 4000
 
@@ -274,7 +273,9 @@ class AgenticChatPipeline:
                 )
 
             chunks: list[str] = []
-            async for chunk in self._stream_messages(messages, max_tokens=self._chat_limits.thinking):
+            async for chunk in self._stream_messages(
+                messages, max_tokens=self._chat_limits.thinking
+            ):
                 if not chunk:
                     continue
                 chunks.append(chunk)
@@ -370,7 +371,9 @@ class AgenticChatPipeline:
             )
 
             chunks: list[str] = []
-            async for chunk in self._stream_messages(messages, max_tokens=self._chat_limits.observing):
+            async for chunk in self._stream_messages(
+                messages, max_tokens=self._chat_limits.observing
+            ):
                 if not chunk:
                     continue
                 chunks.append(chunk)
@@ -432,7 +435,9 @@ class AgenticChatPipeline:
             )
 
             chunks: list[str] = []
-            async for chunk in self._stream_messages(messages, max_tokens=self._chat_limits.responding):
+            async for chunk in self._stream_messages(
+                messages, max_tokens=self._chat_limits.responding
+            ):
                 if not chunk:
                     continue
                 chunks.append(chunk)
@@ -487,7 +492,9 @@ class AgenticChatPipeline:
             user_prompt = self._t(
                 "answer_now.user",
                 original_user_message=original_user_message,
-                partial_response=partial_response.strip() if partial_response.strip() else "(empty)",
+                partial_response=partial_response.strip()
+                if partial_response.strip()
+                else "(empty)",
                 trace_summary=trace_summary,
             )
             messages = self._build_messages(
@@ -497,7 +504,9 @@ class AgenticChatPipeline:
             )
 
             chunks: list[str] = []
-            async for chunk in self._stream_messages(messages, max_tokens=self._chat_limits.answer_now):
+            async for chunk in self._stream_messages(
+                messages, max_tokens=self._chat_limits.answer_now
+            ):
                 if not chunk:
                     continue
                 chunks.append(chunk)
@@ -880,9 +889,7 @@ class AgenticChatPipeline:
         if context.memory_context:
             system_parts.append(context.memory_context)
 
-        messages: list[dict[str, Any]] = [
-            {"role": "system", "content": "\n\n".join(system_parts)}
-        ]
+        messages: list[dict[str, Any]] = [{"role": "system", "content": "\n\n".join(system_parts)}]
         for item in context.conversation_history:
             role = item.get("role")
             content = item.get("content")
@@ -958,7 +965,14 @@ class AgenticChatPipeline:
     def _can_use_native_tool_calling(self) -> bool:
         if not supports_tools(self.binding, self.model):
             return False
-        return self.binding not in {"anthropic", "claude", "ollama", "lm_studio", "vllm", "llama_cpp"}
+        return self.binding not in {
+            "anthropic",
+            "claude",
+            "ollama",
+            "lm_studio",
+            "vllm",
+            "llama_cpp",
+        }
 
     def _normalize_enabled_tools(self, enabled_tools: list[str] | None) -> list[str]:
         selected = enabled_tools or []
@@ -973,6 +987,7 @@ class AgenticChatPipeline:
         # Delegate to the shared helper so every capability uses the
         # exact same gate (presence + non-empty original_user_message).
         from deeptutor.capabilities._answer_now import extract_answer_now_context
+
         return extract_answer_now_context(context)
 
     async def _execute_tool_call(

--- a/deeptutor/agents/chat/agentic_pipeline.py
+++ b/deeptutor/agents/chat/agentic_pipeline.py
@@ -21,6 +21,7 @@ from deeptutor.core.trace import (
     new_call_id,
 )
 from deeptutor.runtime.registry.tool_registry import get_tool_registry
+from deeptutor.services.config import get_chat_params
 from deeptutor.services.prompt import get_prompt_manager
 from deeptutor.services.llm import (
     clean_thinking_tags,
@@ -43,6 +44,52 @@ CHAT_OPTIONAL_TOOLS = [
 ]
 MAX_PARALLEL_TOOL_CALLS = 8
 MAX_TOOL_RESULT_CHARS = 4000
+
+CHAT_STAGE_KEYS: tuple[str, ...] = (
+    "responding",
+    "answer_now",
+    "thinking",
+    "observing",
+    "acting",
+    "react_fallback",
+)
+
+
+@dataclass
+class _ChatLimits:
+    """Per-stage ``max_tokens`` resolved from ``capabilities.chat`` in agents.yaml."""
+
+    responding: int
+    answer_now: int
+    thinking: int
+    observing: int
+    acting: int
+    react_fallback: int
+
+    @classmethod
+    def from_config(cls, cfg: dict[str, Any]) -> "_ChatLimits":
+        # Defaults below mirror DEFAULT_CHAT_PARAMS so the pipeline still works
+        # if the YAML block is missing entirely (e.g. minimal/legacy installs).
+        fallback = {
+            "responding": 8000,
+            "answer_now": 8000,
+            "thinking": 2000,
+            "observing": 2000,
+            "acting": 2000,
+            "react_fallback": 1500,
+        }
+        resolved: dict[str, int] = {}
+        for key in CHAT_STAGE_KEYS:
+            stage_cfg = cfg.get(key) if isinstance(cfg, dict) else None
+            if isinstance(stage_cfg, dict):
+                value = stage_cfg.get("max_tokens", fallback[key])
+            else:
+                value = fallback[key]
+            try:
+                resolved[key] = int(value)
+            except (TypeError, ValueError):
+                resolved[key] = fallback[key]
+        return cls(**resolved)
 
 
 @dataclass
@@ -68,6 +115,19 @@ class AgenticChatPipeline:
         self.api_version = getattr(self.llm_config, "api_version", None)
         self.registry = get_tool_registry()
         self._usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "calls": 0}
+        # capabilities.chat in agents.yaml drives token budgets and temperature
+        # for every LLM call below; falls back to DEFAULT_CHAT_PARAMS if the
+        # block is missing.
+        try:
+            chat_cfg = get_chat_params()
+        except Exception as exc:
+            logger.warning("Failed to load chat params, using defaults: %s", exc)
+            chat_cfg = {}
+        try:
+            self._chat_temperature = float(chat_cfg.get("temperature", 0.2))
+        except (TypeError, ValueError):
+            self._chat_temperature = 0.2
+        self._chat_limits = _ChatLimits.from_config(chat_cfg)
         # Prompts live in deeptutor/agents/chat/prompts/{zh,en}/agentic_chat.yaml
         # so all user-visible / LLM-facing copy is editable without touching code.
         try:
@@ -214,7 +274,7 @@ class AgenticChatPipeline:
                 )
 
             chunks: list[str] = []
-            async for chunk in self._stream_messages(messages, max_tokens=1200):
+            async for chunk in self._stream_messages(messages, max_tokens=self._chat_limits.thinking):
                 if not chunk:
                     continue
                 chunks.append(chunk)
@@ -310,7 +370,7 @@ class AgenticChatPipeline:
             )
 
             chunks: list[str] = []
-            async for chunk in self._stream_messages(messages, max_tokens=1200):
+            async for chunk in self._stream_messages(messages, max_tokens=self._chat_limits.observing):
                 if not chunk:
                     continue
                 chunks.append(chunk)
@@ -372,7 +432,7 @@ class AgenticChatPipeline:
             )
 
             chunks: list[str] = []
-            async for chunk in self._stream_messages(messages, max_tokens=1800):
+            async for chunk in self._stream_messages(messages, max_tokens=self._chat_limits.responding):
                 if not chunk:
                     continue
                 chunks.append(chunk)
@@ -437,7 +497,7 @@ class AgenticChatPipeline:
             )
 
             chunks: list[str] = []
-            async for chunk in self._stream_messages(messages, max_tokens=1800):
+            async for chunk in self._stream_messages(messages, max_tokens=self._chat_limits.answer_now):
                 if not chunk:
                     continue
                 chunks.append(chunk)
@@ -496,7 +556,7 @@ class AgenticChatPipeline:
             messages=messages,
             tools=tool_schemas,
             tool_choice="auto",
-            **self._completion_kwargs(max_tokens=1500),
+            **self._completion_kwargs(max_tokens=self._chat_limits.acting),
         )
         self._accumulate_usage(response)
         if not response.choices:
@@ -689,7 +749,7 @@ class AgenticChatPipeline:
             response_format={"type": "json_object"}
             if supports_response_format(self.binding, self.model)
             else None,
-            **self._completion_kwargs(max_tokens=800),
+            **self._completion_kwargs(max_tokens=self._chat_limits.react_fallback),
         ):
             _chunks.append(_c)
         response = "".join(_chunks)
@@ -890,7 +950,7 @@ class AgenticChatPipeline:
         )
 
     def _completion_kwargs(self, max_tokens: int) -> dict[str, Any]:
-        kwargs: dict[str, Any] = {"temperature": 0.2}
+        kwargs: dict[str, Any] = {"temperature": self._chat_temperature}
         if self.model:
             kwargs.update(get_token_limit_kwargs(self.model, max_tokens))
         return kwargs

--- a/deeptutor/services/config/__init__.py
+++ b/deeptutor/services/config/__init__.py
@@ -5,18 +5,18 @@ from .knowledge_base_config import (
     KnowledgeBaseConfigService,
     get_kb_config_service,
 )
-from .model_catalog import ModelCatalogService, get_model_catalog_service
 from .loader import (
     DEFAULT_CHAT_PARAMS,
     PROJECT_ROOT,
     get_agent_params,
     get_chat_params,
-    get_runtime_settings_dir,
     get_path_from_config,
+    get_runtime_settings_dir,
     load_config_with_main,
     parse_language,
     resolve_config_path,
 )
+from .model_catalog import ModelCatalogService, get_model_catalog_service
 
 __all__ = [
     "ConfigSummary",

--- a/deeptutor/services/config/__init__.py
+++ b/deeptutor/services/config/__init__.py
@@ -7,8 +7,10 @@ from .knowledge_base_config import (
 )
 from .model_catalog import ModelCatalogService, get_model_catalog_service
 from .loader import (
+    DEFAULT_CHAT_PARAMS,
     PROJECT_ROOT,
     get_agent_params,
+    get_chat_params,
     get_runtime_settings_dir,
     get_path_from_config,
     load_config_with_main,
@@ -28,6 +30,8 @@ __all__ = [
     "get_path_from_config",
     "parse_language",
     "get_agent_params",
+    "get_chat_params",
+    "DEFAULT_CHAT_PARAMS",
     "ResolvedLLMConfig",
     "ResolvedEmbeddingConfig",
     "ResolvedSearchConfig",

--- a/deeptutor/services/config/loader.py
+++ b/deeptutor/services/config/loader.py
@@ -29,6 +29,7 @@ def get_runtime_settings_dir(project_root: Path | None = None) -> Path:
     root = project_root or PROJECT_ROOT
     return root / "data" / "user" / "settings"
 
+
 def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
     """
     Deep merge two dictionaries, values in override will override values in base
@@ -107,8 +108,7 @@ def resolve_config_path(
     if config_path.exists():
         return config_path, False
     raise FileNotFoundError(
-        f"Configuration file not found: {config_file} "
-        f"(expected under {settings_dir})"
+        f"Configuration file not found: {config_file} (expected under {settings_dir})"
     )
 
 

--- a/deeptutor/services/config/loader.py
+++ b/deeptutor/services/config/loader.py
@@ -257,6 +257,39 @@ def get_agent_params(module_name: str) -> dict:
     }
 
 
+DEFAULT_CHAT_PARAMS: dict[str, Any] = {
+    "temperature": 0.2,
+    "responding": {"max_tokens": 8000},
+    "answer_now": {"max_tokens": 8000},
+    "thinking": {"max_tokens": 2000},
+    "observing": {"max_tokens": 2000},
+    "acting": {"max_tokens": 2000},
+    "react_fallback": {"max_tokens": 1500},
+}
+
+
+def get_chat_params() -> dict[str, Any]:
+    """
+    Read ``capabilities.chat`` from agents.yaml with deep-merged defaults.
+
+    Unlike :func:`get_agent_params`, the chat capability has per-stage
+    sub-sections (``responding``, ``answer_now``, ``thinking``, ``observing``,
+    ``acting``, ``react_fallback``), each with its own ``max_tokens``. A single
+    ``temperature`` is shared across all stages.
+
+    Returns:
+        dict: Deep-merged chat configuration. Always contains every stage key
+        from :data:`DEFAULT_CHAT_PARAMS` so callers can index without checks.
+    """
+    path = get_runtime_settings_dir(PROJECT_ROOT) / "agents.yaml"
+    cfg: dict[str, Any] = {}
+    if path.exists():
+        with open(path, encoding="utf-8") as f:
+            agents_config = yaml.safe_load(f) or {}
+        cfg = (agents_config.get("capabilities", {}) or {}).get("chat", {}) or {}
+    return _deep_merge(DEFAULT_CHAT_PARAMS, cfg)
+
+
 __all__ = [
     "PROJECT_ROOT",
     "get_runtime_settings_dir",
@@ -264,5 +297,7 @@ __all__ = [
     "get_path_from_config",
     "parse_language",
     "get_agent_params",
+    "get_chat_params",
+    "DEFAULT_CHAT_PARAMS",
     "_deep_merge",
 ]

--- a/deeptutor/services/setup/init.py
+++ b/deeptutor/services/setup/init.py
@@ -126,7 +126,7 @@ def init_user_directories(project_root: Path | None = None) -> None:
 
     This function uses lazy initialization - directories are created on-demand
     when files are saved, rather than pre-creating all directories at startup.
-    
+
     Only essential configuration files (like settings/interface.json) are
     created at startup if they don't exist.
 
@@ -166,7 +166,7 @@ def init_user_directories(project_root: Path | None = None) -> None:
 def _ensure_essential_settings(path_service) -> None:
     """
     Ensure essential settings files exist.
-    
+
     This is the minimal initialization needed at startup.
     All other directories are created on-demand when files are saved.
     """

--- a/deeptutor/services/setup/init.py
+++ b/deeptutor/services/setup/init.py
@@ -84,6 +84,15 @@ DEFAULT_AGENTS_SETTINGS = {
         "research": {"temperature": 0.5, "max_tokens": 12000},
         "question": {"temperature": 0.7, "max_tokens": 4096},
         "co_writer": {"temperature": 0.7, "max_tokens": 4096},
+        "chat": {
+            "temperature": 0.2,
+            "responding": {"max_tokens": 8000},
+            "answer_now": {"max_tokens": 8000},
+            "thinking": {"max_tokens": 2000},
+            "observing": {"max_tokens": 2000},
+            "acting": {"max_tokens": 2000},
+            "react_fallback": {"max_tokens": 1500},
+        },
     },
     "tools": {
         "brainstorm": {"temperature": 0.8, "max_tokens": 2048},

--- a/tests/services/config/test_chat_params_config.py
+++ b/tests/services/config/test_chat_params_config.py
@@ -1,0 +1,138 @@
+"""Tests for chat capability per-stage token configuration via agents.yaml."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from deeptutor.services.config.loader import (
+    DEFAULT_CHAT_PARAMS,
+    get_chat_params,
+)
+
+
+def _write_agents_yaml(tmp_path: Path, content: dict[str, Any]) -> Path:
+    settings_dir = tmp_path / "data" / "user" / "settings"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    agents_file = settings_dir / "agents.yaml"
+    agents_file.write_text(yaml.dump(content), encoding="utf-8")
+    return tmp_path
+
+
+class TestGetChatParams:
+    """Verify get_chat_params() correctly resolves capabilities.chat."""
+
+    def test_returns_defaults_when_file_missing(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(
+            "deeptutor.services.config.loader.PROJECT_ROOT", tmp_path,
+        )
+        params = get_chat_params()
+        assert params == DEFAULT_CHAT_PARAMS
+
+    def test_returns_defaults_when_chat_section_absent(self, tmp_path: Path, monkeypatch):
+        project_root = _write_agents_yaml(tmp_path, {
+            "capabilities": {"solve": {"temperature": 0.3}},
+        })
+        monkeypatch.setattr(
+            "deeptutor.services.config.loader.PROJECT_ROOT", project_root,
+        )
+        params = get_chat_params()
+        assert params["temperature"] == DEFAULT_CHAT_PARAMS["temperature"]
+        assert params["responding"]["max_tokens"] == 8000
+        assert params["thinking"]["max_tokens"] == 2000
+
+    def test_overrides_specific_stage_only(self, tmp_path: Path, monkeypatch):
+        project_root = _write_agents_yaml(tmp_path, {
+            "capabilities": {
+                "chat": {
+                    "responding": {"max_tokens": 12000},
+                },
+            },
+        })
+        monkeypatch.setattr(
+            "deeptutor.services.config.loader.PROJECT_ROOT", project_root,
+        )
+        params = get_chat_params()
+        assert params["responding"]["max_tokens"] == 12000
+        assert params["answer_now"]["max_tokens"] == 8000
+        assert params["thinking"]["max_tokens"] == 2000
+        assert params["temperature"] == 0.2
+
+    def test_overrides_temperature(self, tmp_path: Path, monkeypatch):
+        project_root = _write_agents_yaml(tmp_path, {
+            "capabilities": {"chat": {"temperature": 0.7}},
+        })
+        monkeypatch.setattr(
+            "deeptutor.services.config.loader.PROJECT_ROOT", project_root,
+        )
+        params = get_chat_params()
+        assert params["temperature"] == 0.7
+        assert params["responding"]["max_tokens"] == 8000
+
+    def test_full_chat_block_round_trip(self, tmp_path: Path, monkeypatch):
+        project_root = _write_agents_yaml(tmp_path, {
+            "capabilities": {
+                "chat": {
+                    "temperature": 0.4,
+                    "responding": {"max_tokens": 16000},
+                    "answer_now": {"max_tokens": 16000},
+                    "thinking": {"max_tokens": 3000},
+                    "observing": {"max_tokens": 3000},
+                    "acting": {"max_tokens": 3000},
+                    "react_fallback": {"max_tokens": 2500},
+                },
+            },
+        })
+        monkeypatch.setattr(
+            "deeptutor.services.config.loader.PROJECT_ROOT", project_root,
+        )
+        params = get_chat_params()
+        assert params["temperature"] == 0.4
+        assert params["responding"]["max_tokens"] == 16000
+        assert params["answer_now"]["max_tokens"] == 16000
+        assert params["thinking"]["max_tokens"] == 3000
+        assert params["observing"]["max_tokens"] == 3000
+        assert params["acting"]["max_tokens"] == 3000
+        assert params["react_fallback"]["max_tokens"] == 2500
+
+
+class TestChatLimitsDataclass:
+    """Verify _ChatLimits.from_config gracefully handles malformed input."""
+
+    def test_from_config_with_empty_dict_uses_fallbacks(self):
+        from deeptutor.agents.chat.agentic_pipeline import _ChatLimits
+
+        limits = _ChatLimits.from_config({})
+        assert limits.responding == 8000
+        assert limits.answer_now == 8000
+        assert limits.thinking == 2000
+        assert limits.observing == 2000
+        assert limits.acting == 2000
+        assert limits.react_fallback == 1500
+
+    def test_from_config_with_chat_params_defaults(self):
+        from deeptutor.agents.chat.agentic_pipeline import _ChatLimits
+
+        limits = _ChatLimits.from_config(DEFAULT_CHAT_PARAMS)
+        assert limits.responding == 8000
+        assert limits.react_fallback == 1500
+
+    def test_from_config_coerces_string_numbers(self):
+        from deeptutor.agents.chat.agentic_pipeline import _ChatLimits
+
+        limits = _ChatLimits.from_config({"responding": {"max_tokens": "5000"}})
+        assert limits.responding == 5000
+
+    def test_from_config_falls_back_on_garbage(self):
+        from deeptutor.agents.chat.agentic_pipeline import _ChatLimits
+
+        limits = _ChatLimits.from_config({"responding": {"max_tokens": "abc"}})
+        assert limits.responding == 8000
+
+    def test_from_config_handles_non_dict_stage_value(self):
+        from deeptutor.agents.chat.agentic_pipeline import _ChatLimits
+
+        limits = _ChatLimits.from_config({"responding": 12345})
+        assert limits.responding == 8000

--- a/tests/services/config/test_chat_params_config.py
+++ b/tests/services/config/test_chat_params_config.py
@@ -26,17 +26,22 @@ class TestGetChatParams:
 
     def test_returns_defaults_when_file_missing(self, tmp_path: Path, monkeypatch):
         monkeypatch.setattr(
-            "deeptutor.services.config.loader.PROJECT_ROOT", tmp_path,
+            "deeptutor.services.config.loader.PROJECT_ROOT",
+            tmp_path,
         )
         params = get_chat_params()
         assert params == DEFAULT_CHAT_PARAMS
 
     def test_returns_defaults_when_chat_section_absent(self, tmp_path: Path, monkeypatch):
-        project_root = _write_agents_yaml(tmp_path, {
-            "capabilities": {"solve": {"temperature": 0.3}},
-        })
+        project_root = _write_agents_yaml(
+            tmp_path,
+            {
+                "capabilities": {"solve": {"temperature": 0.3}},
+            },
+        )
         monkeypatch.setattr(
-            "deeptutor.services.config.loader.PROJECT_ROOT", project_root,
+            "deeptutor.services.config.loader.PROJECT_ROOT",
+            project_root,
         )
         params = get_chat_params()
         assert params["temperature"] == DEFAULT_CHAT_PARAMS["temperature"]
@@ -44,15 +49,19 @@ class TestGetChatParams:
         assert params["thinking"]["max_tokens"] == 2000
 
     def test_overrides_specific_stage_only(self, tmp_path: Path, monkeypatch):
-        project_root = _write_agents_yaml(tmp_path, {
-            "capabilities": {
-                "chat": {
-                    "responding": {"max_tokens": 12000},
+        project_root = _write_agents_yaml(
+            tmp_path,
+            {
+                "capabilities": {
+                    "chat": {
+                        "responding": {"max_tokens": 12000},
+                    },
                 },
             },
-        })
+        )
         monkeypatch.setattr(
-            "deeptutor.services.config.loader.PROJECT_ROOT", project_root,
+            "deeptutor.services.config.loader.PROJECT_ROOT",
+            project_root,
         )
         params = get_chat_params()
         assert params["responding"]["max_tokens"] == 12000
@@ -61,32 +70,40 @@ class TestGetChatParams:
         assert params["temperature"] == 0.2
 
     def test_overrides_temperature(self, tmp_path: Path, monkeypatch):
-        project_root = _write_agents_yaml(tmp_path, {
-            "capabilities": {"chat": {"temperature": 0.7}},
-        })
+        project_root = _write_agents_yaml(
+            tmp_path,
+            {
+                "capabilities": {"chat": {"temperature": 0.7}},
+            },
+        )
         monkeypatch.setattr(
-            "deeptutor.services.config.loader.PROJECT_ROOT", project_root,
+            "deeptutor.services.config.loader.PROJECT_ROOT",
+            project_root,
         )
         params = get_chat_params()
         assert params["temperature"] == 0.7
         assert params["responding"]["max_tokens"] == 8000
 
     def test_full_chat_block_round_trip(self, tmp_path: Path, monkeypatch):
-        project_root = _write_agents_yaml(tmp_path, {
-            "capabilities": {
-                "chat": {
-                    "temperature": 0.4,
-                    "responding": {"max_tokens": 16000},
-                    "answer_now": {"max_tokens": 16000},
-                    "thinking": {"max_tokens": 3000},
-                    "observing": {"max_tokens": 3000},
-                    "acting": {"max_tokens": 3000},
-                    "react_fallback": {"max_tokens": 2500},
+        project_root = _write_agents_yaml(
+            tmp_path,
+            {
+                "capabilities": {
+                    "chat": {
+                        "temperature": 0.4,
+                        "responding": {"max_tokens": 16000},
+                        "answer_now": {"max_tokens": 16000},
+                        "thinking": {"max_tokens": 3000},
+                        "observing": {"max_tokens": 3000},
+                        "acting": {"max_tokens": 3000},
+                        "react_fallback": {"max_tokens": 2500},
+                    },
                 },
             },
-        })
+        )
         monkeypatch.setattr(
-            "deeptutor.services.config.loader.PROJECT_ROOT", project_root,
+            "deeptutor.services.config.loader.PROJECT_ROOT",
+            project_root,
         )
         params = get_chat_params()
         assert params["temperature"] == 0.4


### PR DESCRIPTION
### Description

The agentic chat pipeline currently has six **hardcoded** `max_tokens` values
(`thinking=1200`, `observing=1200`, `responding=1800`, `answer_now=1800`,
`acting=1500`, `react_fallback=800`) and a hardcoded `temperature=0.2` in
`AgenticChatPipeline._completion_kwargs`. These limits cannot be tuned without
editing source code, and the 1800-token cap on `responding` truncates long
final responses mid-sentence on real-world prompts (reproduced on a Russian
LaTeX-heavy "VC-dimension proof plan" question — output cut around the 1800-token
boundary, ~4500–4800 chars).

This PR lifts these knobs into `data/user/settings/agents.yaml` under a new
`capabilities.chat` block, mirroring the existing per-capability config pattern
(`capabilities.solve`, `capabilities.research`, etc.), but with **per-stage**
sub-sections to give granular control:

```yaml
capabilities:
  chat:
    temperature: 0.2
    responding:     { max_tokens: 8000 }
    answer_now:     { max_tokens: 8000 }
    thinking:       { max_tokens: 2000 }
    observing:      { max_tokens: 2000 }
    acting:         { max_tokens: 2000 }
    react_fallback: { max_tokens: 1500 }
```

Defaults are bumped (responding/answer_now: 1800 → 8000) to fix the truncation
bug out of the box. `_ChatLimits.from_config` provides safe fallbacks if the
yaml block is missing entirely (legacy installs), and coerces malformed values
(strings, non-dict stage entries) back to defaults instead of crashing.

**Implementation notes**

- New `get_chat_params()` and `DEFAULT_CHAT_PARAMS` in
  `deeptutor/services/config/loader.py`. Kept separate from `get_agent_params`
  because the chat capability has a nested per-stage shape, while
  `get_agent_params` returns flat `{temperature, max_tokens}`.
- `DEFAULT_AGENTS_SETTINGS` in `deeptutor/services/setup/init.py` extended so
  fresh installs auto-generate the `chat` block in their `agents.yaml`.
- `AgenticChatPipeline.__init__` loads the config once into `self._chat_limits`
  / `self._chat_temperature`; the six callsites and `_completion_kwargs` read
  from these instance attrs.

### Related Issues

- N/A (internal bug report — chat answer truncation on long responses)

### Module(s) Affected

- [x] `agents` (chat pipeline)
- [ ] `api`
- [x] `config` (loader + setup defaults)
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist

- [x] I have read and followed the contribution guidelines.
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Test plan

- New `tests/services/config/test_chat_params_config.py` (10 tests):
  - `get_chat_params()` returns defaults when `agents.yaml` is missing or the
    `capabilities.chat` block is absent.
  - Partial overrides (single stage / temperature only) merge correctly with
    defaults.
  - Full round-trip with all stages overridden.
  - `_ChatLimits.from_config` handles empty dict, `DEFAULT_CHAT_PARAMS`,
    string-numbers, garbage strings, and non-dict stage values.
- Existing related tests still pass: `tests/agents/chat/`,
  `tests/capabilities/test_answer_now.py`, `tests/services/config/`
  (70 passed locally; nothing depended on the old hardcoded literals).

### Additional Notes

- Backwards compatible: existing user `agents.yaml` files that don't have
  the `chat` block keep working through `DEFAULT_CHAT_PARAMS` deep-merge in
  `get_chat_params()`. Behaviour changes only because the *defaults* are
  larger, which is the intended fix.
- `temperature` is now a single value shared by all chat stages
  (matches the existing single-knob pattern of other capabilities).