### PR TITLE
fix(web): ensure readable text in dark code blocks on light theme

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -226,6 +226,17 @@
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
+/* Force light text on dark code blocks regardless of theme. The wrapper
+   .md-code-block always uses a fixed dark background (#1f2937 / #292524),
+   so we need to override .prose pre (color: #D6D3D1) and any inherited
+   --foreground from the prose wrapper that would otherwise render as
+   near-black in the light theme. Specificity (0,2,1) beats .prose pre. */
+.md-renderer .md-code-block,
+.md-renderer .md-code-block pre,
+.md-renderer .md-code-block code {
+  color: #e5e7eb;
+}
+
 .md-renderer .md-code-block pre,
 .md-renderer .md-code-block code {
   background: transparent !important;

--- a/web/components/common/RichMarkdownRenderer.tsx
+++ b/web/components/common/RichMarkdownRenderer.tsx
@@ -400,7 +400,7 @@ export default function RichMarkdownRenderer({
             {...lineProps}
           >
             <pre className="overflow-x-auto p-4 text-sm leading-relaxed text-[#e5e7eb]">
-              <code {...props}>{raw}</code>
+              <code className="md-code-block__code" {...props}>{raw}</code>
             </pre>
           </div>
         );

--- a/web/components/common/SimpleMarkdownRenderer.tsx
+++ b/web/components/common/SimpleMarkdownRenderer.tsx
@@ -262,7 +262,7 @@ export default function SimpleMarkdownRenderer({
             className={`md-code-block ${gap} overflow-hidden rounded-xl border border-[var(--border)] bg-[#292524]`}
           >
             <pre className="overflow-x-auto p-4 text-sm leading-relaxed text-[#D6D3D1]">
-              <code {...props}>{raw}</code>
+              <code className="md-code-block__code" {...props}>{raw}</code>
             </pre>
           </div>
         );


### PR DESCRIPTION
## Summary

In the light theme, multi-line code blocks rendered by the chat showed near-black text on the hard-coded dark background (`#1f2937` / `#292524`), making the content unreadable.

<img width="989" height="367" alt="image" src="https://github.com/user-attachments/assets/aecb8a98-74b5-44ea-93d7-815f1d7f4f1a" />

Two issues compounded it:

- `.prose pre { color: #D6D3D1 }` overrode the Tailwind `text-[#e5e7eb]` class on the `<pre>` (higher specificity).
- `.prose code:not(.md-code-block__code):not(.md-inline-code) { color: var(--foreground) }` matched the fallback `<code>` (no `md-code-block__code` class) and pulled it back to `var(--foreground)` (`#1F1D1B` in the light theme).

The fix:

- Add `.md-renderer .md-code-block { ,pre,code } { color: #e5e7eb }` in `web/app/globals.css` (specificity 0,2,1) so the dark code block always shows light text regardless of theme. Doesn't affect Prism `oneDark` syntax highlighting (token colors are inline on `<span>`).
- Tag the `<code>` element in the multi-line fallbacks of `RichMarkdownRenderer` and `SimpleMarkdownRenderer` with the existing `md-code-block__code` class so the `:not(.md-code-block__code)` guard kicks in and the existing `color: inherit !important` chain resolves to the new light color.

Inline code (`.md-inline-code`) is untouched and keeps theming via `var(--foreground)` / `var(--muted)`.

## Test plan

- [ ] Light theme: open chat, render an assistant message with a fenced code block (with and without language). Text inside the dark block must be light gray (`#e5e7eb`) and readable.
- [ ] Dark theme: same — visually unchanged.
- [ ] A code block with a language identifier (e.g. ``` ```python ```) still gets Prism `oneDark` syntax highlighting with proper token colors.
- [ ] Inline code in a paragraph still renders with theme-aware colors (light bg + dark text in light theme).