### PR TITLE
fix: add ConnectError to embedding retry exceptions

### DIFF
--- a/deeptutor/services/embedding/adapters/openai_compatible.py
+++ b/deeptutor/services/embedding/adapters/openai_compatible.py
@@ -166,7 +166,7 @@ class OpenAICompatibleEmbeddingAdapter(BaseEmbeddingAdapter):
                     response.raise_for_status()
                     data = response.json()
                 break
-            except (httpx.ReadTimeout, httpx.ConnectTimeout, httpx.PoolTimeout) as exc:
+            except (httpx.ReadTimeout, httpx.ConnectTimeout, httpx.PoolTimeout, httpx.ConnectError) as exc:
                 last_exc = exc
                 if attempt < self._MAX_RETRIES:
                     wait = self._RETRY_BACKOFF * (2 ** attempt)


### PR DESCRIPTION
## Summary

- Added `httpx.ConnectError` to the retry exception list in the embedding adapter
- This fixes an issue where transient network connectivity errors (TLS handshake failures, proxy connection issues) would cause immediate failure instead of retry

## Problem

When creating a knowledge base, the embedding process would occasionally fail with `httpx.ConnectError`. The retry mechanism only caught timeout errors (`ReadTimeout`, `ConnectTimeout`, `PoolTimeout`) but not `ConnectError`, which occurs during TLS handshake failures or proxy connection issues.

## Solution

Added `httpx.ConnectError` to the exception tuple in the retry handler, ensuring that transient connection errors are retried with exponential backoff (up to 5 retries).

## Testing

- Verified that embedding requests work correctly with the change
- Tested both direct connection and proxy scenarios
- Confirmed retry behavior works as expected