### PR TITLE
fix : Tutorbot websocket resilience and CLI config parsing edge case

### DIFF
--- a/deeptutor/api/routers/tutorbot.py
+++ b/deeptutor/api/routers/tutorbot.py
@@ -329,22 +329,45 @@ async def get_bot_history(bot_id: str, limit: int = 100):
 async def bot_chat_ws(ws: WebSocket, bot_id: str):
     import asyncio
 
+    async def _safe_send(payload: dict) -> bool:
+        try:
+            await ws.send_json(payload)
+            return True
+        except (WebSocketDisconnect, RuntimeError):
+            return False
+
     mgr = get_tutorbot_manager()
     instance = mgr.get_bot(bot_id)
-    if not instance or not instance.running:
-        await ws.close(code=4004, reason="Bot not found or not running")
-        return
 
     await ws.accept()
+
+    if not instance or not instance.running:
+        config = mgr.load_bot_config(bot_id)
+        if config is None:
+            await ws.send_json({"type": "error", "content": "Bot not found"})
+            await ws.close(code=4004, reason="Bot not found")
+            return
+        try:
+            instance = await mgr.start_bot(bot_id, config)
+        except Exception:
+            logger.exception("Failed to auto-start bot '%s' for websocket", bot_id)
+            await ws.send_json({"type": "error", "content": "Failed to start bot"})
+            await ws.close(code=1011, reason="Failed to start bot")
+            return
+
     logger.info("WebSocket connected for bot '%s'", bot_id)
 
     async def _handle_user_messages():
         while True:
-            raw = await ws.receive_text()
+            try:
+                raw = await ws.receive_text()
+            except WebSocketDisconnect:
+                break
             try:
                 data = json.loads(raw)
             except json.JSONDecodeError:
-                await ws.send_json({"type": "error", "content": "Invalid JSON"})
+                if not await _safe_send({"type": "error", "content": "Invalid JSON"}):
+                    break
                 continue
 
             content = data.get("content", "").strip()
@@ -352,20 +375,27 @@ async def bot_chat_ws(ws: WebSocket, bot_id: str):
                 continue
 
             async def on_progress(text: str) -> None:
-                await ws.send_json({"type": "thinking", "content": text})
+                if not await _safe_send({"type": "thinking", "content": text}):
+                    raise WebSocketDisconnect()
 
             try:
                 response = await mgr.send_message(
                     bot_id, content, chat_id=data.get("chat_id", "web"),
                     on_progress=on_progress,
                 )
-                await ws.send_json({"type": "content", "content": response})
-                await ws.send_json({"type": "done"})
+                if not await _safe_send({"type": "content", "content": response}):
+                    break
+                if not await _safe_send({"type": "done"}):
+                    break
             except RuntimeError as exc:
-                await ws.send_json({"type": "error", "content": str(exc)})
+                if not await _safe_send({"type": "error", "content": str(exc)}):
+                    break
+            except WebSocketDisconnect:
+                break
             except Exception:
                 logger.exception("Error processing message for bot '%s'", bot_id)
-                await ws.send_json({"type": "error", "content": "Internal error"})
+                if not await _safe_send({"type": "error", "content": "Internal error"}):
+                    break
 
     async def _handle_notifications():
         while True:

--- a/deeptutor_cli/common.py
+++ b/deeptutor_cli/common.py
@@ -27,10 +27,11 @@ def parse_config_items(items: list[str]) -> dict[str, Any]:
 
 
 def parse_json_object(raw: str | None) -> dict[str, Any]:
-    if not raw:
+    normalized = (raw or "").strip()
+    if not normalized:
         return {}
     try:
-        value = json.loads(raw)
+        value = json.loads(normalized)
     except json.JSONDecodeError as exc:
         raise ValueError(f"Invalid JSON config: {exc.msg}") from exc
     if not isinstance(value, dict):

--- a/tests/api/test_tutorbot_router.py
+++ b/tests/api/test_tutorbot_router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 from typing import Any
 from unittest.mock import MagicMock
@@ -461,3 +462,63 @@ class TestPatchBotStoppedAndRunning:
         detail = resp.json()["detail"]
         assert "RuntimeError" in detail
         assert "stopping and starting" in detail.lower()
+
+
+class TestBotChatWebSocketStartup:
+    """WebSocket endpoint should auto-start stopped configured bots."""
+
+    def test_ws_autostarts_stopped_bot(self, monkeypatch):
+        from deeptutor.services.tutorbot.manager import BotConfig
+
+        class FakeInstance:
+            running = True
+
+            def __init__(self):
+                self.notify_queue = asyncio.Queue()
+
+        class FakeMgr:
+            def __init__(self):
+                self.started: list[str] = []
+
+            def get_bot(self, bot_id: str):
+                return None
+
+            def load_bot_config(self, bot_id: str):
+                return BotConfig(name=bot_id)
+
+            async def start_bot(self, bot_id: str, config: BotConfig):
+                self.started.append(bot_id)
+                return FakeInstance()
+
+        mgr = FakeMgr()
+        tutorbot_router_mod = importlib.import_module("deeptutor.api.routers.tutorbot")
+        monkeypatch.setattr(tutorbot_router_mod, "get_tutorbot_manager", lambda: mgr)
+
+        app = FastAPI()
+        app.include_router(tutorbot_router_mod.router, prefix="/api/v1/tutorbot")
+        client = TestClient(app)
+
+        with client.websocket_connect("/api/v1/tutorbot/ielts-tutor/ws") as ws:
+            ws.close()
+
+        assert mgr.started == ["ielts-tutor"]
+
+    def test_ws_unknown_bot_returns_error_payload(self, monkeypatch):
+        class FakeMgr:
+            def get_bot(self, bot_id: str):
+                return None
+
+            def load_bot_config(self, bot_id: str):
+                return None
+
+        tutorbot_router_mod = importlib.import_module("deeptutor.api.routers.tutorbot")
+        monkeypatch.setattr(tutorbot_router_mod, "get_tutorbot_manager", lambda: FakeMgr())
+
+        app = FastAPI()
+        app.include_router(tutorbot_router_mod.router, prefix="/api/v1/tutorbot")
+        client = TestClient(app)
+
+        with client.websocket_connect("/api/v1/tutorbot/missing/ws") as ws:
+            payload = ws.receive_json()
+            assert payload["type"] == "error"
+            assert "not found" in payload["content"].lower()

--- a/tests/cli/test_common.py
+++ b/tests/cli/test_common.py
@@ -1,0 +1,16 @@
+"""Unit tests for shared CLI helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from deeptutor_cli.common import parse_json_object
+
+
+def test_parse_json_object_whitespace_is_empty_dict() -> None:
+    assert parse_json_object("   ") == {}
+
+
+def test_parse_json_object_invalid_json_still_errors() -> None:
+    with pytest.raises(ValueError, match="Invalid JSON config"):
+        parse_json_object("{")

--- a/web/app/(workspace)/agents/[botId]/chat/page.tsx
+++ b/web/app/(workspace)/agents/[botId]/chat/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft, Bot, Loader2, Send } from "lucide-react";
 import { apiUrl, wsUrl } from "@/lib/api";
+import { firstParam } from "@/lib/route-params";
 import AssistantResponse from "@/components/common/AssistantResponse";
 
 interface BotInfo {
@@ -20,7 +21,8 @@ interface ChatMsg {
 }
 
 export default function BotChatPage() {
-  const { botId } = useParams<{ botId: string }>();
+  const params = useParams<{ botId?: string | string[] }>();
+  const botId = firstParam(params?.botId);
   const router = useRouter();
   const { t } = useTranslation();
 
@@ -42,6 +44,9 @@ export default function BotChatPage() {
   }, []);
 
   useEffect(() => {
+    if (!botId) {
+      return;
+    }
     fetch(apiUrl(`/api/v1/tutorbot/${botId}`))
       .then((r) => (r.ok ? r.json() : null))
       .then(setBot)
@@ -59,6 +64,9 @@ export default function BotChatPage() {
   }, [botId]);
 
   useEffect(() => {
+    if (!botId) {
+      return;
+    }
     const ws = new WebSocket(wsUrl(`/api/v1/tutorbot/${botId}/ws`));
     wsRef.current = ws;
 
@@ -102,6 +110,7 @@ export default function BotChatPage() {
   }, [botId, scrollToBottom]);
 
   const send = useCallback(() => {
+    if (!botId) return;
     const text = input.trim();
     if (!text || streaming || !wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
 
@@ -111,7 +120,7 @@ export default function BotChatPage() {
     setThinking([]);
     wsRef.current.send(JSON.stringify({ content: text }));
     scrollToBottom();
-  }, [input, streaming, scrollToBottom]);
+  }, [botId, input, streaming, scrollToBottom]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/web/lib/route-params.ts
+++ b/web/lib/route-params.ts
@@ -1,0 +1,6 @@
+export function firstParam(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}

--- a/web/tests/route-params.test.ts
+++ b/web/tests/route-params.test.ts
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { firstParam } from "../lib/route-params.ts";
+
+test("firstParam returns undefined for missing param", () => {
+  assert.equal(firstParam(undefined), undefined);
+});
+
+test("firstParam returns scalar param unchanged", () => {
+  assert.equal(firstParam("ielts-tutor"), "ielts-tutor");
+});
+
+test("firstParam returns first element for catch-all array", () => {
+  assert.equal(firstParam(["ielts-tutor", "extra"]), "ielts-tutor");
+});


### PR DESCRIPTION
### Description
This PR hardens TutorBot and CLI behavior across three failure modes that surfaced in local UI usage on Windows:

- Prevents CLI crashes when `--config-json` is present but arrives as blank/whitespace by normalizing and treating it as `{}` before JSON parsing.
- Improves TutorBot WebSocket startup by auto-starting a configured bot when a chat socket connects and the bot is currently not running.
- Makes TutorBot WebSocket send/receive flow resilient to client disconnects so normal browser/tab closure does not cascade into noisy secondary exceptions.
- Guards route param handling in the bot chat UI so `botId` is normalized safely and no API/WS calls are attempted with `undefined`.

Regression coverage was added for CLI parsing, TutorBot WS startup behavior, and web route-param normalization.

### Related Issues
- Closes #...
- Related to #...

### Module(s) Affected
- [ ] `agents`
- [x] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [x] Other: `cli`

### Checklist
- [ ] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
Tests run locally:

- `uv run pytest tests/cli/test_common.py tests/api/test_tutorbot_router.py`
- `node --test "web/tests/route-params.test.ts"`

Key files touched:

- `deeptutor_cli/common.py`
- `deeptutor/api/routers/tutorbot.py`
- `web/app/(workspace)/agents/[botId]/chat/page.tsx`
- `web/lib/route-params.ts`
- `tests/cli/test_common.py`
- `tests/api/test_tutorbot_router.py`
- `web/tests/route-params.test.ts`