### PR TITLE
feat: Hide the API key on settings page

### DIFF
--- a/web/app/(utility)/settings/page.tsx
+++ b/web/app/(utility)/settings/page.tsx
@@ -9,6 +9,8 @@ import {
   ChevronDown,
   ChevronRight,
   Database,
+  Eye,
+  EyeOff,
   Loader2,
   Plus,
   Rocket,
@@ -376,6 +378,7 @@ function SettingsPageContent() {
   const [testRunning, setTestRunning] = useState<ServiceName | null>(null);
   const [saving, setSaving] = useState(false);
   const [applying, setApplying] = useState(false);
+  const [showApiKey, setShowApiKey] = useState(false);
   const [toast, setToast] = useState<string>("");
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const [providers, setProviders] = useState<Record<ServiceName, ProviderOption[]>>({ llm: [], embedding: [], search: [] });
@@ -457,6 +460,10 @@ function SettingsPageContent() {
     activeService === "search" &&
     searchProviderRaw === "perplexity" &&
     !String(activeProfile?.api_key || "").trim();
+
+  useEffect(() => {
+    setShowApiKey(false);
+  }, [activeService, activeProfile?.id]);
 
   // -- UI preference helpers ----------------------------------------------
 
@@ -1081,12 +1088,26 @@ function SettingsPageContent() {
                     </div>
                     <div className="sm:col-span-2">
                       <div className="mb-1.5 text-[12px] text-[var(--muted-foreground)]">{t("API Key")}</div>
-                      <input
-                        className={inputClass}
-                        value={activeProfile.api_key}
-                        onChange={(e) => updateProfileField("api_key", e.target.value)}
-                        placeholder="sk-..."
-                      />
+                      <div className="relative">
+                        <input
+                          type={showApiKey ? "text" : "password"}
+                          autoComplete="new-password"
+                          spellCheck={false}
+                          className={`${inputClass} pr-10 font-mono`}
+                          value={activeProfile.api_key}
+                          onChange={(e) => updateProfileField("api_key", e.target.value)}
+                          placeholder="sk-..."
+                        />
+                        <button
+                          type="button"
+                          onClick={() => setShowApiKey((prev) => !prev)}
+                          className="absolute right-1 top-1/2 -translate-y-1/2 rounded-md p-1.5 text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-[var(--foreground)]"
+                          aria-label={showApiKey ? t("Hide API key") : t("Show API key")}
+                          title={showApiKey ? t("Hide API key") : t("Show API key")}
+                        >
+                          {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                        </button>
+                      </div>
                     </div>
                     <div>
                       <div className="mb-1.5 text-[12px] text-[var(--muted-foreground)]">{t("API Version")}</div>


### PR DESCRIPTION
### Description
Adds a secure-by-default API key input behavior in Settings UI by masking API keys initially and introducing an eye toggle (`Eye`/`EyeOff`) to reveal/hide on demand.  
This keeps existing save/apply data flow unchanged while reducing accidental on-screen key exposure and aligns the interaction style with the channel config secret toggle pattern.

### Related Issues
- Closes #N/A
- Related to #N/A

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
- UI-only change in `web/app/(utility)/settings/page.tsx`.
- API key field now uses password/text toggle with accessible labels (`Show API key` / `Hide API key`).
- Reveal state resets when switching service/profile to avoid unintended exposure.
- Verified no linter errors on the updated frontend file.


<img width="1041" height="855" alt="Screenshot 2026-04-20 135546" src="https://github.com/user-attachments/assets/52352483-1144-46d6-99bb-fa954bb14a00" />


