### PR TITLE
fix(embedding): gate dimensions for text-embedding-3 models

### DIFF
--- a/deeptutor/services/embedding/adapters/openai_compatible.py
+++ b/deeptutor/services/embedding/adapters/openai_compatible.py
@@ -120,7 +120,11 @@ class OpenAICompatibleEmbeddingAdapter(BaseEmbeddingAdapter):
             "encoding_format": request.encoding_format or "float",
         }
 
-        if request.dimensions or self.dimensions:
+        # Only OpenAI's text-embedding-3* family officially supports the `dimensions`
+        # request param. Other providers (e.g. Qwen text-embedding-v4 via litellm gateway)
+        # return 400 if we send it — they always use the model's native dim.
+        _model_name = request.model or self.model or ""
+        if (request.dimensions or self.dimensions) and _model_name.startswith("text-embedding-3"):
             payload["dimensions"] = request.dimensions or self.dimensions
 
         base = self.base_url.rstrip('/')


### PR DESCRIPTION
<!--
Thank you for contributing to DeepTutor! 🚀
Please ensure your PR is ready for review and follows our contribution guidelines.
For more details, see our [CONTRIBUTING.md](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
-->

### Description
Only OpenAI's text-embedding-3* family officially supports the `dimensions` request param. Other providers (e.g. Qwen text-embedding-v4 via litellm gateway) return 400 if we send it — they always use the model's native dim.

### Related Issues
- Closes #...
- Related to #...

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [✔️] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [✔️ ] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [ ✔️] My code follows the project's coding standards.
- [✔️ ] I have run `pre-commit run --all-files` and fixed any issues.
- [✔️ ] I have added relevant tests for my changes.
- [✔️ ] I have updated the documentation (if necessary).
- [✔️ ] My changes do not introduce any new security vulnerabilities.

### Additional Notes
*Add any other context or screenshots about the pull request here.*
