### PR TITLE
feat: Revamp soul template creation and usage

### DIFF
--- a/web/app/(workspace)/agents/page.tsx
+++ b/web/app/(workspace)/agents/page.tsx
@@ -134,7 +134,7 @@ export default function AgentsPage() {
             { key: "bots" as Tab, label: t("Bots"), icon: Bot },
             { key: "profiles" as Tab, label: t("Profiles"), icon: FileText },
             { key: "channels" as Tab, label: t("Channels"), icon: Settings2 },
-            { key: "souls" as Tab, label: t("Souls"), icon: Heart },
+            { key: "souls" as Tab, label: t("Soul Templates"), icon: Heart },
           ].map((tab) => {
             const Icon = tab.icon;
             const active = activeTab === tab.key;
@@ -165,7 +165,13 @@ export default function AgentsPage() {
             router={router}
           />
         ) : activeTab === "profiles" ? (
-          <ProfilesTab bots={bots} loading={loading} onToast={setToast} />
+          <ProfilesTab
+            bots={bots}
+            souls={souls}
+            loading={loading}
+            onToast={setToast}
+            onReloadSouls={loadSouls}
+          />
         ) : activeTab === "channels" ? (
           <ChannelsTab
             bots={bots}
@@ -1173,23 +1179,50 @@ function BotsTab({
 
 function ProfilesTab({
   bots,
+  souls,
   loading,
   onToast,
+  onReloadSouls,
 }: {
   bots: BotInfo[];
+  souls: SoulTemplate[];
   loading: boolean;
   onToast: (msg: string) => void;
+  onReloadSouls: () => Promise<void>;
 }) {
   const { t } = useTranslation();
   const [selectedBot, setSelectedBot] = useState<string>("");
   const [activeFile, setActiveFile] = useState<BotFile>("SOUL.md");
   const [files, setFiles] = useState<Record<string, string>>({});
   const [editor, setEditor] = useState("");
+  const [selectedSoulId, setSelectedSoulId] = useState("_custom");
+  const [sourceSoulId, setSourceSoulId] = useState<string | null>(null);
   const [loadingFiles, setLoadingFiles] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [saveModalOpen, setSaveModalOpen] = useState(false);
+  const [saveMode, setSaveMode] = useState<
+    "file_only" | "update_template" | "new_template"
+  >("file_only");
+  const [newTemplateName, setNewTemplateName] = useState("");
+  const [replaceModalOpen, setReplaceModalOpen] = useState(false);
+  const [pendingSoulId, setPendingSoulId] = useState<string | null>(null);
   const [activeView, setActiveView] = useState<"edit" | "preview">("edit");
 
   const hasChanges = editor !== (files[activeFile] ?? "");
+  const activeSoulTemplate = useMemo(
+    () => souls.find((s) => s.id === selectedSoulId) ?? null,
+    [souls, selectedSoulId],
+  );
+  const sourceSoulTemplate = useMemo(
+    () => souls.find((s) => s.id === sourceSoulId) ?? null,
+    [souls, sourceSoulId],
+  );
+
+  const matchSoulId = useCallback(
+    (content: string): string =>
+      souls.find((s) => s.content === content)?.id ?? "_custom",
+    [souls],
+  );
 
   useEffect(() => {
     if (bots.length > 0 && !selectedBot) {
@@ -1206,11 +1239,14 @@ function ProfilesTab({
         const data: Record<string, string> = await res.json();
         setFiles(data);
         setEditor(data[activeFile] ?? "");
+        const matched = matchSoulId(data["SOUL.md"] ?? "");
+        setSelectedSoulId(matched);
+        setSourceSoulId(matched === "_custom" ? null : matched);
       } finally {
         setLoadingFiles(false);
       }
     },
-    [activeFile],
+    [activeFile, matchSoulId],
   );
 
   useEffect(() => {
@@ -1219,13 +1255,122 @@ function ProfilesTab({
 
   useEffect(() => {
     setEditor(files[activeFile] ?? "");
+    if (activeFile === "SOUL.md") {
+      const matched = matchSoulId(files["SOUL.md"] ?? "");
+      setSelectedSoulId(matched);
+      setSourceSoulId(matched === "_custom" ? null : matched);
+    }
     setActiveView("edit");
-  }, [activeFile, files]);
+  }, [activeFile, files, matchSoulId]);
 
-  const saveFile = useCallback(async () => {
-    if (!selectedBot) return;
+  const applySoulSelection = useCallback(
+    (nextId: string) => {
+      if (nextId === "_custom") {
+        setSelectedSoulId("_custom");
+        setSourceSoulId(null);
+        return;
+      }
+      const soul = souls.find((s) => s.id === nextId);
+      if (!soul) return;
+      setSelectedSoulId(nextId);
+      setSourceSoulId(nextId);
+      setEditor(soul.content);
+    },
+    [souls],
+  );
+
+  const handleSoulSelect = useCallback(
+    (nextId: string) => {
+      if (hasChanges) {
+        setPendingSoulId(nextId);
+        setReplaceModalOpen(true);
+        return;
+      }
+      applySoulSelection(nextId);
+    },
+    [applySoulSelection, hasChanges],
+  );
+
+  const saveFile = useCallback(async (
+    mode: "file_only" | "update_template" | "new_template",
+    createTemplateName?: string,
+  ) => {
+    if (!selectedBot) return false;
     setSaving(true);
     try {
+      if (activeFile === "SOUL.md") {
+        const content = editor.trim();
+        if (!content) {
+          onToast(t("SOUL.md is empty"));
+          return false;
+        }
+        if (mode === "update_template") {
+          if (!sourceSoulTemplate) {
+            onToast(t("No template selected to update"));
+            return false;
+          }
+          const tplRes = await fetch(
+            apiUrl(`/api/v1/tutorbot/souls/${sourceSoulTemplate.id}`),
+            {
+              method: "PUT",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                name: sourceSoulTemplate.name,
+                content: editor,
+              }),
+            },
+          );
+          if (!tplRes.ok) {
+            onToast(t("Failed to update soul template"));
+            return false;
+          }
+          await onReloadSouls();
+          setSelectedSoulId(sourceSoulTemplate.id);
+          setSourceSoulId(sourceSoulTemplate.id);
+        } else if (mode === "new_template") {
+          const rawName = (createTemplateName ?? "").trim();
+          if (!rawName) {
+            onToast(t("Template name is required"));
+            return false;
+          }
+          const baseId = rawName
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/^-|-$/g, "");
+          if (!baseId) {
+            onToast(t("Please choose a name with letters or numbers"));
+            return false;
+          }
+          const existing = new Set(souls.map((s) => s.id));
+          let soulId = baseId;
+          let n = 2;
+          while (existing.has(soulId)) {
+            soulId = `${baseId}-${n}`;
+            n += 1;
+          }
+          const tplRes = await fetch(apiUrl("/api/v1/tutorbot/souls"), {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              id: soulId,
+              name: rawName,
+              content: editor,
+            }),
+          });
+          if (tplRes.status === 409) {
+            onToast(t("A soul with this id already exists, try another name"));
+            return false;
+          }
+          if (!tplRes.ok) {
+            onToast(t("Failed to save soul template"));
+            return false;
+          }
+          await onReloadSouls();
+          setSelectedSoulId(soulId);
+          setSourceSoulId(soulId);
+        }
+      }
+
       const res = await fetch(
         apiUrl(`/api/v1/tutorbot/${selectedBot}/files/${activeFile}`),
         {
@@ -1236,21 +1381,58 @@ function ProfilesTab({
       );
       if (res.ok) {
         setFiles((prev) => ({ ...prev, [activeFile]: editor }));
+        if (activeFile === "SOUL.md") {
+          const personaRes = await fetch(apiUrl(`/api/v1/tutorbot/${selectedBot}`), {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ persona: editor }),
+          });
+          if (!personaRes.ok) {
+            onToast(t("SOUL.md saved, but persona sync failed"));
+            return false;
+          }
+        }
         onToast(`${activeFile} saved`);
+        return true;
       }
+      return false;
     } finally {
       setSaving(false);
     }
-  }, [selectedBot, activeFile, editor, onToast]);
+  }, [
+    selectedBot,
+    activeFile,
+    editor,
+    onToast,
+    onReloadSouls,
+    sourceSoulTemplate,
+    souls,
+    t,
+  ]);
+
+  const handleSaveClick = useCallback(() => {
+    if (activeFile !== "SOUL.md") {
+      void saveFile("file_only");
+      return;
+    }
+    setSaveMode(sourceSoulTemplate ? "update_template" : "file_only");
+    setNewTemplateName(`${selectedBot || "custom"} soul`);
+    setSaveModalOpen(true);
+  }, [activeFile, saveFile, selectedBot, sourceSoulTemplate]);
+
+  const handleConfirmSave = useCallback(async () => {
+    const ok = await saveFile(saveMode, newTemplateName);
+    if (ok) setSaveModalOpen(false);
+  }, [newTemplateName, saveFile, saveMode]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if ((e.metaKey || e.ctrlKey) && e.key === "s") {
         e.preventDefault();
-        void saveFile();
+        handleSaveClick();
       }
     },
-    [saveFile],
+    [handleSaveClick],
   );
 
   if (loading) {
@@ -1316,7 +1498,7 @@ function ProfilesTab({
 
       {/* Toolbar */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-2">
           {(["edit", "preview"] as const).map((v) => (
             <button
               key={v}
@@ -1330,11 +1512,43 @@ function ProfilesTab({
               {v === "edit" ? t("Edit") : t("Preview")}
             </button>
           ))}
+          {activeFile === "SOUL.md" && (
+            <>
+              <select
+                value={selectedSoulId}
+                onChange={(e) => handleSoulSelect(e.target.value)}
+                className="rounded-lg border border-[var(--border)] bg-transparent px-2.5 py-1.5 text-[12px] text-[var(--foreground)] outline-none focus:border-[var(--ring)]"
+              >
+                <option value="_custom">{t("Custom")}</option>
+                {souls.map((soul) => (
+                  <option key={soul.id} value={soul.id}>
+                    {soul.name}
+                  </option>
+                ))}
+              </select>
+              {activeSoulTemplate && (
+                <span className="text-[11px] text-[var(--muted-foreground)]/70">
+                  {hasChanges
+                    ? t('Editing template "{{name}}"', { name: activeSoulTemplate.name })
+                    : t('Using "{{name}}"', { name: activeSoulTemplate.name })}
+                </span>
+              )}
+              {!activeSoulTemplate && (
+                <span className="text-[11px] text-[var(--muted-foreground)]/70">
+                  {t("Custom soul")}
+                </span>
+              )}
+            </>
+          )}
         </div>
         <button
-          onClick={saveFile}
+          onClick={handleSaveClick}
           disabled={saving || !hasChanges}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)]/50 px-3 py-1.5 text-[12px] font-medium text-[var(--muted-foreground)] transition-colors hover:border-[var(--border)] hover:text-[var(--foreground)] disabled:opacity-40"
+          className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[12px] font-medium transition-colors disabled:opacity-40 ${
+            hasChanges
+              ? "bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90"
+              : "border border-[var(--border)]/50 text-[var(--muted-foreground)]"
+          }`}
         >
           {saving ? (
             <Loader2 className="h-3 w-3 animate-spin" />
@@ -1354,7 +1568,10 @@ function ProfilesTab({
         <div>
           <textarea
             value={editor}
-            onChange={(e) => setEditor(e.target.value)}
+            onChange={(e) => {
+              const next = e.target.value;
+              setEditor(next);
+            }}
             onKeyDown={handleKeyDown}
             spellCheck={false}
             className="min-h-[420px] w-full resize-none rounded-xl border border-[var(--border)] bg-transparent px-5 py-4 font-mono text-[13px] leading-7 text-[var(--foreground)] outline-none transition-colors focus:border-[var(--ring)] placeholder:text-[var(--muted-foreground)]/40"
@@ -1381,6 +1598,132 @@ function ProfilesTab({
           <p className="mt-1 text-[13px] text-[var(--muted-foreground)]">
             {t("Switch to Edit to add content.")}
           </p>
+        </div>
+      )}
+      {saveModalOpen && activeFile === "SOUL.md" && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+          <div className="w-full max-w-md rounded-xl border border-[var(--border)] bg-[var(--background)] p-5 shadow-xl">
+            <h3 className="text-[15px] font-medium text-[var(--foreground)]">
+              {t("Save SOUL.md")}
+            </h3>
+            <p className="mt-1 text-[12px] text-[var(--muted-foreground)]">
+              {t(
+                "Choose whether to only save this bot profile, overwrite the selected template, or save your edits as a new template.",
+              )}
+            </p>
+
+            <div className="mt-4 space-y-2">
+              <label className="flex items-center gap-2 text-[12px] text-[var(--foreground)]">
+                <input
+                  type="radio"
+                  name="save-mode"
+                  checked={saveMode === "file_only"}
+                  onChange={() => setSaveMode("file_only")}
+                />
+                {t("Save profile only")}
+              </label>
+              {sourceSoulTemplate && (
+                <label className="flex items-center gap-2 text-[12px] text-[var(--foreground)]">
+                  <input
+                    type="radio"
+                    name="save-mode"
+                    checked={saveMode === "update_template"}
+                    onChange={() => setSaveMode("update_template")}
+                  />
+                  {t('Save and overwrite template "{{name}}"', {
+                    name: sourceSoulTemplate.name,
+                  })}
+                </label>
+              )}
+              <label className="flex items-center gap-2 text-[12px] text-[var(--foreground)]">
+                <input
+                  type="radio"
+                  name="save-mode"
+                  checked={saveMode === "new_template"}
+                  onChange={() => setSaveMode("new_template")}
+                />
+                {t("Save and create new template")}
+              </label>
+            </div>
+
+            {saveMode === "new_template" && (
+              <div className="mt-4">
+                <label className="mb-1 block text-[12px] font-medium text-[var(--muted-foreground)]">
+                  {t("Template name")}
+                </label>
+                <input
+                  value={newTemplateName}
+                  onChange={(e) => setNewTemplateName(e.target.value)}
+                  placeholder={t("e.g. IELTS Mentor")}
+                  className="w-full rounded-lg border border-[var(--border)] bg-transparent px-3 py-2 text-[13px] text-[var(--foreground)] outline-none focus:border-[var(--ring)] placeholder:text-[var(--muted-foreground)]/40"
+                />
+              </div>
+            )}
+
+            <div className="mt-5 flex items-center justify-end gap-2">
+              <button
+                onClick={() => setSaveModalOpen(false)}
+                disabled={saving}
+                className="rounded-lg border border-[var(--border)]/50 px-3 py-1.5 text-[12px] text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] disabled:opacity-40"
+              >
+                {t("Cancel")}
+              </button>
+              <button
+                onClick={handleConfirmSave}
+                disabled={
+                  saving ||
+                  (saveMode === "new_template" && !newTemplateName.trim())
+                }
+                className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-1.5 text-[12px] font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90 disabled:opacity-40"
+              >
+                {saving ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Save className="h-3 w-3" />
+                )}
+                {saveMode === "update_template"
+                  ? t("Save and overwrite")
+                  : saveMode === "new_template"
+                    ? t("Save and create")
+                    : t("Save profile")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {replaceModalOpen && activeFile === "SOUL.md" && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+          <div className="w-full max-w-md rounded-xl border border-[var(--border)] bg-[var(--background)] p-5 shadow-xl">
+            <h3 className="text-[15px] font-medium text-[var(--foreground)]">
+              {t("Replace SOUL.md content?")}
+            </h3>
+            <p className="mt-1 text-[12px] text-[var(--muted-foreground)]">
+              {t(
+                "You have unsaved changes. Switching templates will replace the current editor content.",
+              )}
+            </p>
+            <div className="mt-5 flex items-center justify-end gap-2">
+              <button
+                onClick={() => {
+                  setReplaceModalOpen(false);
+                  setPendingSoulId(null);
+                }}
+                className="rounded-lg border border-[var(--border)]/50 px-3 py-1.5 text-[12px] text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)]"
+              >
+                {t("Cancel")}
+              </button>
+              <button
+                onClick={() => {
+                  if (pendingSoulId) applySoulSelection(pendingSoulId);
+                  setReplaceModalOpen(false);
+                  setPendingSoulId(null);
+                }}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-1.5 text-[12px] font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90"
+              >
+                {t("Replace")}
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
### Description
You can now manage soul templates directly from the Profiles page while editing `SOUL.md`.  
This removes the old two-step flow (create/update in Soul Templates tab, then copy/paste into Profiles) by introducing an integrated save flow in Profiles.

Key improvements:
- Added soul template selection in Profiles for `SOUL.md`.
- Kept selected template context while editing (does not immediately revert to `Custom`).
- Added a single Save flow with modal options:
  - Save profile only
  - Save and overwrite selected template
  - Save and create a new template
- Added in-app replace confirmation modal when switching templates with unsaved edits.
- Synced `SOUL.md` save with bot `persona` update for consistency across restarts.
- Updated tab label from **Souls** to **Soul Templates** for clarity.
- Improved Save button state styling to clearly indicate unsaved changes.

### Related Issues
- Closes #...
- Related to #...

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [x ] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
- Main implementation is in `web/app/(workspace)/agents/page.tsx`.
- No backend API changes were required; existing soul CRUD and bot patch endpoints were reused.

### UI Changes

#### UI now shows the soul template selection 
<img width="1170" height="802" alt="image" src="https://github.com/user-attachments/assets/a46ec9cd-d6dd-435d-9b11-a4820aa6c521" />

#### Editing preselected soul template provide an option to override or create new template
<img width="1194" height="791" alt="image" src="https://github.com/user-attachments/assets/2b2f1178-934b-4460-b961-fcecc85ba834" />


