### PR TITLE
fix(scripts): prefer uv pip over python -m pip in start_tour.py

### DIFF
--- a/scripts/start_tour.py
+++ b/scripts/start_tour.py
@@ -41,6 +41,21 @@ def _resolve_python() -> str:
 
 _PYTHON: str = _resolve_python()
 
+
+def _resolve_pip_cmd() -> list[str]:
+    """Return the best available pip invocation for the current environment.
+
+    Prefer ``uv pip`` when uv is on PATH (uv-managed venvs may have pip
+    disabled).  Fall back to ``python -m pip`` otherwise.
+    """
+    uv = shutil.which("uv")
+    if uv:
+        return [uv, "pip"]
+    return [_PYTHON, "-m", "pip"]
+
+
+_PIP_CMD: list[str] = _resolve_pip_cmd()
+
 _BOOTSTRAP_PACKAGES = [
     ("yaml", "PyYAML>=6.0"),
 ]
@@ -61,7 +76,7 @@ def _bootstrap() -> None:
         return
     print(f"  Installing bootstrap dependencies: {', '.join(missing)} ...")
     subprocess.check_call(
-        [_PYTHON, "-m", "pip", "install", *missing, "-q"],
+        [*_PIP_CMD, "install", *missing, "-q"],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
@@ -341,12 +356,12 @@ def _install_commands(
 
     cmds: list[tuple[list[str], Path]] = []
     for req in PROFILE_COMMANDS[profile]:
-        cmds.append(([_PYTHON, "-m", "pip", "install", "-r", req], PROJECT_ROOT))
+        cmds.append(([*_PIP_CMD, "install", "-r", req], PROJECT_ROOT))
     if include_math_animator:
         cmds.append(
-            ([_PYTHON, "-m", "pip", "install", "-r", MATH_ANIMATOR_REQUIREMENTS], PROJECT_ROOT)
+            ([*_PIP_CMD, "install", "-r", MATH_ANIMATOR_REQUIREMENTS], PROJECT_ROOT)
         )
-    cmds.append(([_PYTHON, "-m", "pip", "install", "-e", ".", "--no-deps"], PROJECT_ROOT))
+    cmds.append(([*_PIP_CMD, "install", "-e", ".", "--no-deps"], PROJECT_ROOT))
     if profile.startswith("web"):
         cmds.append(([_get_npm_command(), "install"], PROJECT_ROOT / "web"))
     return cmds


### PR DESCRIPTION
## Problem

When the project's `.venv` is managed by **uv**, `pip` may be disabled inside it (PEP 668 / uv's default hardening). Running `python -m pip install` inside such a venv raises:

```
subprocess.CalledProcessError: Command '['/path/.venv/bin/python3', '-m', 'pip',
'install', 'PyYAML>=6.0', '-q']' returned non-zero exit status 1
```

This blocks `start_tour.py` at the very first bootstrap step, before any user interaction begins.

## Fix

Introduce `_resolve_pip_cmd()` which checks `shutil.which("uv")` at startup:

- **uv found** → use `["uv", "pip"]` (uv auto-detects the active venv)
- **uv not found** → fall back to `[_PYTHON, "-m", "pip"]` (existing behavior, no regression)

All pip invocations in `_bootstrap()` and `_install_commands()` now use the `_PIP_CMD` list instead of the hard-coded `[_PYTHON, "-m", "pip"]` prefix.

## Related Issues

No existing issue — reproduces reliably on any machine that clones the repo and runs `python scripts/start_tour.py` inside a uv-managed venv.

## Module(s) Affected

- [x] `scripts`

## Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes. *(scripts/ has no dedicated test suite)*
- [ ] I have updated the documentation (if necessary). *(no doc change needed)*
- [x] My changes do not introduce any new security vulnerabilities.

## Test plan

- [ ] `python scripts/start_tour.py` inside a uv-managed `.venv` — bootstrap succeeds
- [ ] Same inside a plain `python -m venv` env — falls back to `python -m pip`, no regression
- [ ] Same without uv on PATH — falls back correctly

## Notes

No behavior change for non-uv users. `_resolve_pip_cmd()` mirrors the existing `_resolve_python()` helper pattern already in the file.