### PR TITLE
fix: use npm.cmd for version detection on Windows

### DIFF
--- a/scripts/start_tour.py
+++ b/scripts/start_tour.py
@@ -798,7 +798,8 @@ def _install_dependencies() -> None:
 
     # --- detect Node.js / npm ---
     node_version = _get_version(["node", "--version"])
-    npm_version = _get_version(["npm", "--version"])
+    _npm_cmd = _get_npm_command()
+    npm_version = _get_version([_npm_cmd, "--version"])
 
     if node_version and npm_version:
         log_success(_t("install_node_ok", version=node_version))


### PR DESCRIPTION
## Problem

On Windows, `npm` is installed as `npm.cmd` (not a plain executable). In `scripts/start_tour.py`, the Node.js/npm detection step calls:

```python
npm_version = _get_version(["npm", "--version"])
```

`subprocess.run()` without `shell=True` cannot find `.cmd` files, so it raises `FileNotFoundError` and always reports npm as missing — even when Node.js and npm are properly installed.

## Root Cause

`_get_version(["npm", "--version"])` was not using the existing `_get_npm_command()` helper, which already handles Windows by returning `npm.cmd`.

## Fix

Reuse `_get_npm_command()` for the version-detection call, consistent with how npm is invoked later during `npm install`:

```python
# before
npm_version = _get_version(["npm", "--version"])

# after
_npm_cmd = _get_npm_command()
npm_version = _get_version([_npm_cmd, "--version"])
```

## Steps to Reproduce

1. Install Node.js on Windows (via nvm4w or the official installer)
2. Create and activate a Python venv
3. Run `python scripts/start_tour.py`
4. Observe "未检测到 Node.js / npm" even though `node --version` works fine

## Testing

Verified on Windows 11 with Node.js v24.12.0 installed via nvm4w. After the fix, the setup wizard correctly detects both Node.js and npm versions.