### PR TITLE
fix: restore theme-aware backgrounds for form elements and visualization

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -26,6 +26,7 @@
   }
 
   .dark {
+    color-scheme: dark;
     --background: #1a1918;
     --foreground: #e8e4de;
     --card: #242220;
@@ -70,6 +71,7 @@
   }
 
   .theme-glass {
+    color-scheme: dark;
     --background: #111111;
     --foreground: #ffffff;
     --card: rgba(255, 255, 255, 0.05);

--- a/web/components/visualize/VisualizationViewer.tsx
+++ b/web/components/visualize/VisualizationViewer.tsx
@@ -115,7 +115,7 @@ function HtmlRenderer({ html }: { html: string }) {
         ref={iframeRef}
         title="HTML visualization"
         sandbox="allow-scripts"
-        className="w-full rounded-lg border border-[var(--border)] bg-white"
+        className="w-full rounded-lg border border-[var(--border)] bg-[var(--card)]"
         style={{ minHeight: 480, height: 560 }}
       />
     </div>
@@ -316,7 +316,7 @@ export default function VisualizationViewer({
             </button>
           </div>
           <div
-            className="flex flex-1 items-center justify-center overflow-auto rounded-xl bg-white p-6 shadow-2xl"
+            className="flex flex-1 items-center justify-center overflow-auto rounded-xl bg-[var(--card)] p-6 shadow-2xl"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="w-full max-w-[1600px]">


### PR DESCRIPTION
Fixes #363

## Problem

In dark and glass themes, chat input fields (textarea, select) always show a white background even though text colour correctly follows the active theme. The same issue affects the chart visualization panel which also shows a white background.

**Root cause 1 — missing `color-scheme`**: Chromium/WebKit apply their system-default *light* UA stylesheet to native form elements (`<textarea>`, `<input>`, `<select>`) regardless of any CSS `background-color` overrides. The only reliable way to opt these elements into dark rendering is to declare `color-scheme: dark` on the dark theme selector. Without it, `background: transparent` on the textarea still exposes the browser's own white background rather than inheriting the parent card colour.

**Root cause 2 — hardcoded `bg-white`**: `VisualizationViewer` used a hardcoded `bg-white` Tailwind class for both the HTML iframe border area and the fullscreen chart container, so charts always rendered against a white backdrop.

## Solution

1. **`web/app/globals.css`** — add `color-scheme: dark` to the `.dark` and `.theme-glass` blocks. This is the standard CSS property that instructs the browser's UA stylesheet to use its dark colour palette for form controls, scrollbars, and other browser-painted UI.

2. **`web/components/visualize/VisualizationViewer.tsx`** — replace `bg-white` with `bg-[var(--card)]` on the HTML iframe element (line 118) and on the fullscreen visualization container (line 319) so both pick up the active theme colour.

## Testing

- Switch to dark theme → chat textarea and all config-panel selects now render with the dark card background instead of white
- Switch to glass theme → same elements show the translucent dark glass background  
- Open a chart visualization in fullscreen → container background now matches the active theme
- Light / snow themes unchanged (no regression)