### PR TITLE
[codex] Normalize Azure OpenAI max token aliases

### DIFF
--- a/deeptutor/services/llm/factory.py
+++ b/deeptutor/services/llm/factory.py
@@ -272,6 +272,8 @@ def _sanitize_call_kwargs(
 
     if not supports_response_format(binding, model):
         extra_kwargs.pop("response_format", None)
+    if binding == "azure_openai" and "max_completion_tokens" in extra_kwargs:
+        extra_kwargs["max_tokens"] = extra_kwargs.pop("max_completion_tokens")
     return extra_kwargs
 
 

--- a/tests/services/llm/test_factory_provider_exec.py
+++ b/tests/services/llm/test_factory_provider_exec.py
@@ -202,6 +202,28 @@ async def test_complete_strips_unsupported_response_format(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_complete_normalizes_azure_max_completion_tokens(monkeypatch) -> None:
+    cfg = _make_cfg(
+        model="gpt-5.4",
+        binding="azure_openai",
+        provider_name="azure_openai",
+    )
+    provider = _FakeProvider()
+
+    monkeypatch.setattr("deeptutor.services.llm.factory.get_llm_config", lambda: cfg)
+    monkeypatch.setattr(
+        "deeptutor.services.llm.factory.get_runtime_provider",
+        lambda _config: provider,
+    )
+
+    result = await complete("hello", max_completion_tokens=200)
+
+    assert result == "ok"
+    assert provider.complete_kwargs["max_tokens"] == 200
+    assert "max_completion_tokens" not in provider.complete_kwargs
+
+
+@pytest.mark.asyncio
 async def test_complete_passes_retry_delays(monkeypatch) -> None:
     cfg = _make_cfg()
     provider = _FakeProvider()


### PR DESCRIPTION
## Summary
- normalize max_completion_tokens to max_tokens before Azure OpenAI provider execution
- add regression coverage for Azure OpenAI factory calls

## Root cause
Newer model helpers emit max_completion_tokens for gpt-5.* models, but DeepTutor's Azure Responses provider accepts max_tokens and maps that internally to max_output_tokens. The alias leaked through and caused Azure OpenAI calls to fail before reaching the API.

## Validation
- python -m py_compile deeptutor/services/llm/factory.py tests/services/llm/test_factory_provider_exec.py
- live Docker backend LLM and embedding connection tests passed