### PR TITLE
fix: server startup on Windows + missing runtime deps in server.txt

### DIFF
--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -11,3 +11,7 @@ fastapi>=0.100.0
 uvicorn[standard]>=0.24.0
 websockets>=12.0
 python-multipart>=0.0.6
+
+# --- LLM provider runtime (unconditionally imported by provider_core) ---
+loguru>=0.7.3,<1.0.0
+json-repair>=0.57.0,<1.0.0

--- a/scripts/start_web.py
+++ b/scripts/start_web.py
@@ -78,6 +78,8 @@ def _spawn(
         "stderr": subprocess.STDOUT,
         "text": True,
         "bufsize": 1,
+        "encoding": "utf-8",
+        "errors": "replace",
     }
     if os.name == "nt":
         kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]


### PR DESCRIPTION
Two independent issues that block `python scripts/start_web.py` after a clean install on Windows. Both block users from reaching the API server, so I'm bundling them into a single PR.

---

## Issue 1 — `UnicodeDecodeError` streaming subprocess output

`_spawn()` opens the backend / frontend stdout pipes with `text=True` but no explicit `encoding`. On Windows, `text=True` falls back to the system ANSI codepage (e.g. `gbk` on Chinese Windows). The reader thread crashes the moment a child process emits a UTF-8 byte:

```
File ""E:\works\study\DeepTutor\scripts\start_web.py"", line 40, in _stream_output
    for line in process.stdout:
UnicodeDecodeError: 'gbk' codec can't decode byte 0xb2 in position 2: illegal multibyte sequence
```

### Fix

Pin `encoding=""utf-8""` and `errors=""replace""` on the `Popen` kwargs. Both Node 24 (Next.js dev) and the FastAPI/uvicorn backend write UTF-8 to stdout, so this matches the actual byte stream and is locale-independent.

```python
kwargs: dict[str, object] = {
    ""cwd"": str(cwd),
    ""env"": env,
    ""stdout"": subprocess.PIPE,
    ""stderr"": subprocess.STDOUT,
    ""text"": True,
    ""bufsize"": 1,
+   ""encoding"": ""utf-8"",
+   ""errors"": ""replace"",
}
```

---

## Issue 2 — `ModuleNotFoundError: loguru` / `json_repair` after `pip install -r requirements/server.txt`

`deeptutor/services/llm/provider_core/__init__.py` unconditionally imports:

- `AnthropicProvider` → `import json_repair`
- `OpenAICompatProvider` → `import json_repair`
- `OpenAICodexProvider` → `from loguru import logger`
- `provider_core/base.py` → `from loguru import logger`
- `openai_responses/parsing.py` → both

Both packages are declared only in `requirements/tutorbot.txt`. So the documented install path for the web server:

```
pip install -r requirements/server.txt && pip install -e .
python scripts/start_web.py
```

crashes the uvicorn worker before it can serve a single request:

```
File ""...\deeptutor\services\llm\provider_core\anthropic_provider.py"", line 16, in <module>
    import json_repair
ModuleNotFoundError: No module named 'json_repair'
```

### Fix

Add both packages to `requirements/server.txt` with the same version bounds already used in `tutorbot.txt`:

```
loguru>=0.7.3,<1.0.0
json-repair>=0.57.0,<1.0.0
```

These are core LLM-provider dependencies, not TutorBot-specific, so the right home is `server.txt`.

---

## Reproduction

```powershell
git clone https://github.com/HKUDS/DeepTutor
cd DeepTutor
python -m venv .venv
.venv\Scripts\activate
pip install -r requirements/server.txt
pip install -e .
python scripts/start_web.py
```

- Without fix #1: backend log streaming crashes the moment uvicorn prints non-ASCII output.
- Without fix #2: backend import chain raises `ModuleNotFoundError` before serving a request.

## Verification

Tested on Windows 11 + Python 3.12.1 + a fresh `.venv`. After applying both fixes, `python scripts/start_web.py` boots cleanly:

- backend: `Uvicorn running on http://0.0.0.0:8001`
- frontend: `Next.js Ready in <1s`

Frontend page loads and successfully reaches the backend `/api/...` routes.