### PR TITLE
Fix/test pollution and math animator

### DIFF
--- a/deeptutor/capabilities/math_animator.py
+++ b/deeptutor/capabilities/math_animator.py
@@ -50,7 +50,15 @@ class MathAnimatorCapability(BaseCapability):
         from deeptutor.services.llm.config import get_llm_config
 
         llm_config = get_llm_config()
-        request_config = validate_math_animator_request_config(context.config_overrides)
+
+        answer_now_payload = extract_answer_now_context(context)
+
+        # Strip answer_now_context before validating — it is a transport wrapper,
+        # not a MathAnimatorRequestConfig field.
+        config_for_validation = {
+            k: v for k, v in context.config_overrides.items() if k != "answer_now_context"
+        }
+        request_config = validate_math_animator_request_config(config_for_validation)
         pipeline = MathAnimatorPipeline(
             api_key=llm_config.api_key,
             base_url=llm_config.base_url,
@@ -58,8 +66,6 @@ class MathAnimatorCapability(BaseCapability):
             language=context.language,
             trace_callback=self._build_trace_bridge(stream),
         )
-
-        answer_now_payload = extract_answer_now_context(context)
         if answer_now_payload is not None:
             await self._run_answer_now(
                 context=context,

--- a/scripts/start_tour.py
+++ b/scripts/start_tour.py
@@ -14,8 +14,10 @@ import sys
 from typing import Any
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
+SCRIPTS_ROOT = PROJECT_ROOT / "scripts"
+for p in (str(SCRIPTS_ROOT), str(PROJECT_ROOT)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
 
 ENV_PATH = PROJECT_ROOT / ".env"
 ENV_EXAMPLE_PATH = PROJECT_ROOT / ".env.example"

--- a/tests/core/test_capabilities_runtime.py
+++ b/tests/core/test_capabilities_runtime.py
@@ -34,6 +34,13 @@ def _install_module(
                 setattr(parent, parts[idx - 1], pkg)
 
     module = types.ModuleType(fullname)
+    # Preserve existing attributes (e.g. submodules) on the real module so we
+    # don't break other tests that import from it.
+    if fullname in sys.modules:
+        real = sys.modules[fullname]
+        for key in dir(real):
+            if not key.startswith("__"):
+                setattr(module, key, getattr(real, key))
     for key, value in attrs.items():
         setattr(module, key, value)
     monkeypatch.setitem(sys.modules, fullname, module)

--- a/tests/scripts/test_start_tour.py
+++ b/tests/scripts/test_start_tour.py
@@ -25,6 +25,7 @@ def _load_start_tour_module():
         "log_success",
         "log_warn",
         "select",
+        "spinner",
         "step",
         "text_input",
     ):


### PR DESCRIPTION
<!--
Thank you for contributing to DeepTutor! 🚀
Please ensure your PR is ready for review and follows our contribution guidelines.
For more details, see our [CONTRIBUTING.md](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
-->

### Description
Fix pytest failures

Fix 1 — tests/core/test_capabilities_runtime.py — _install_module now copies existing attributes from the real   module before applying test-specific overrides, preventing submodules like context_window_detection from being wiped out.

Fix 2 — deeptutor/capabilities/math_animator.py — answer_now_context is now extracted from config_overrides before   validation, since MathAnimatorRequestConfig has extra="forbid" and rejects unknown fields.

### Related Issues
- Closes #...
- Related to #...

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [x] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
*Add any other context or screenshots about the pull request here.*
