### PR TITLE
fix(research): use f-string in reporting_agent logger.warning call

### DIFF
--- a/deeptutor/agents/research/agents/reporting_agent.py
+++ b/deeptutor/agents/research/agents/reporting_agent.py
@@ -1625,8 +1625,7 @@ class ReportingAgent(BaseAgent):
             raise ValueError("LLM returned empty or invalid section_content field")
         except ValueError:
             self.logger.warning(
-                "JSON parsing failed for section '%s', falling back to raw LLM output",
-                section.get("title", "unknown"),
+                f"JSON parsing failed for section '{section.get('title', 'unknown')}', falling back to raw LLM output"
             )
             # Fallback: call LLM again without strict JSON requirement and use raw text
             _chunks: list[str] = []


### PR DESCRIPTION
## Problem

The research pipeline crashes with:

```
TypeError: Logger.warning() takes 2 positional arguments but 3 were given
```

when `_write_section_with_subsections` falls back to raw LLM output after JSON parsing fails.

## Root Cause

DeepTutor's custom `Logger.warning(self, message: str, **kwargs)` only accepts a single positional `message` argument — it does not support standard-library `%s`-style formatting with extra positional args.

The call at line 1627 in `reporting_agent.py` used:
```python
self.logger.warning(
    "JSON parsing failed for section '%s', falling back to raw LLM output",
    section.get("title", "unknown"),
)
```

This passes 2 positional args (`message` + `section.get(...)`), but the custom logger only accepts 1.

## Fix

Switch to f-string formatting, consistent with every other `self.logger.*` call in `reporting_agent.py` (e.g., lines 537, 556).

## Impact

Without this fix, any deep_research run that encounters a JSON parsing failure in section writing will crash instead of gracefully falling back to raw LLM output.

Closes #400

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.