### PR TITLE
Fix stale embedding client during knowledge base indexing

### DIFF
--- a/deeptutor/services/rag/pipelines/llamaindex/embedding_adapter.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/embedding_adapter.py
@@ -10,7 +10,11 @@ from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.bridge.pydantic import PrivateAttr
 
 from deeptutor.logging import get_logger
-from deeptutor.services.embedding import get_embedding_client, get_embedding_config
+from deeptutor.services.embedding import (
+    get_embedding_client,
+    get_embedding_config,
+    reset_embedding_client,
+)
 from deeptutor.services.embedding.validation import validate_embedding_batch
 
 
@@ -93,6 +97,7 @@ class CustomEmbedding(BaseEmbedding):
 
 def configure_llamaindex_settings(logger=None) -> None:
     """Configure LlamaIndex globals for DeepTutor's current embedding config."""
+    reset_embedding_client()
     embedding_cfg = get_embedding_config()
 
     Settings.embed_model = CustomEmbedding()

--- a/deeptutor/services/rag/pipelines/llamaindex/pipeline.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/pipeline.py
@@ -87,6 +87,7 @@ class LlamaIndexPipeline:
         storage_dir = resolve_storage_dir_for_write(kb_dir, signature)
 
         try:
+            self._configure_settings()
             await self._verify_embedding_connectivity()
             documents = await self.document_loader.load(file_paths)
             if not documents:


### PR DESCRIPTION
## Summary

This PR fixes a stale embedding client issue during knowledge base initialization.

When users change the active embedding provider/model, diagnostics can read the updated configuration correctly, but LlamaIndex indexing may still reuse a previously cached embedding client. As a result, indexing can fall back to the old/default embedding provider.

This change:
- resets the cached embedding client when configuring LlamaIndex embedding settings
- refreshes LlamaIndex settings before knowledge base initialization

## Test

Manually verified that knowledge base initialization uses the active SiliconFlow embedding configuration instead of falling back to OpenAI `text-embedding-3-large`.

The issue was reproduced locally when switching from the default OpenAI embedding configuration to SiliconFlow `BAAI/bge-m3`.
