### PR TITLE
feat: add NVIDIA NIM provider with streaming support

### DIFF
--- a/deeptutor/services/llm/provider_core/openai_compat_provider.py
+++ b/deeptutor/services/llm/provider_core/openai_compat_provider.py
@@ -819,7 +819,8 @@ class OpenAICompatProvider(LLMProvider):
                     self._record_responses_failure(model, reasoning_effort)
 
             request_kwargs["stream"] = True
-            request_kwargs["stream_options"] = {"include_usage": True}
+            if self._spec is None or self._spec.supports_stream_options:
+                request_kwargs["stream_options"] = {"include_usage": True}
             try:
                 stream = await self._client.chat.completions.create(**request_kwargs)
             except Exception as exc:

--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -42,6 +42,7 @@ class ProviderSpec:
     strip_model_prefix: bool = False
     supports_max_completion_tokens: bool = False
     supports_prompt_caching: bool = False
+    supports_stream_options: bool = True
     model_overrides: tuple[tuple[str, dict[str, Any]], ...] = ()
     is_oauth: bool = False
     is_direct: bool = False
@@ -389,6 +390,18 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="http://localhost:8000/v3",
     ),
     # === Auxiliary ==========================================================
+    ProviderSpec(
+        name="nvidia_nim",
+        keywords=("nvidia_nim", "nvidia-nim", "nim"),
+        env_key="NVIDIA_NIM_API_KEY",
+        display_name="NVIDIA NIM",
+        backend="openai_compat",
+        is_gateway=True,
+        detect_by_key_prefix="nvapi-",
+        detect_by_base_keyword="api.nvidia.com",
+        default_api_base="https://integrate.api.nvidia.com/v1",
+        supports_stream_options=False,
+    ),
     ProviderSpec(
         name="groq",
         keywords=("groq",),


### PR DESCRIPTION
- Add nvidia_nim provider to the registry (is_gateway, detect_by_key_prefix=nvapi-, detect_by_base_keyword=api.nvidia.com, default_api_base=https://integrate.api.nvidia.com/v1)
- Add supports_stream_options field to ProviderSpec (defaults True, preserves existing provider behavior)
- Set supports_stream_options=False for nvidia_nim — NVIDIA NIM silently hangs when stream_options={"include_usage": True} is sent, so we omit it for this provider

<!--
Thank you for contributing to DeepTutor! 🚀
Please ensure your PR is ready for review and follows our contribution guidelines.
For more details, see our [CONTRIBUTING.md](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
-->

### Description

### Related Issues
- Closes #377 
- Related to #...

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [ ] My changes do not introduce any new security vulnerabilities.

### Additional Notes
*Add any other context or screenshots about the pull request here.*
