### PR TITLE
fix: handle non-string message content in TutorBot chat

### DIFF
--- a/deeptutor/services/tutorbot/manager.py
+++ b/deeptutor/services/tutorbot/manager.py
@@ -728,6 +728,15 @@ class TutorBotManager:
                         if data.get("_type") == "metadata":
                             continue
                         if data.get("role") in ("user", "assistant") and data.get("content"):
+                            raw = data["content"]
+                            if isinstance(raw, list):
+                                data["content"] = " ".join(
+                                    p.get("text", "") if isinstance(p, dict) else str(p)
+                                    for p in raw
+                                )
+                            elif not isinstance(raw, str):
+                                data["content"] = str(raw)
+                            data.pop("reasoning_content", None)
                             all_messages.append(data)
             except Exception:
                 continue
@@ -765,7 +774,16 @@ class TutorBotManager:
                         if data.get("_type") == "metadata":
                             continue
                         if data.get("role") in ("user", "assistant") and data.get("content"):
-                            last_msg = data["content"]
+                            raw = data["content"]
+                            if isinstance(raw, list):
+                                last_msg = " ".join(
+                                    p.get("text", "") if isinstance(p, dict) else str(p)
+                                    for p in raw
+                                )
+                            elif isinstance(raw, str):
+                                last_msg = raw
+                            else:
+                                last_msg = str(raw)
             except Exception:
                 pass
 

--- a/web/app/(workspace)/agents/[botId]/chat/page.tsx
+++ b/web/app/(workspace)/agents/[botId]/chat/page.tsx
@@ -10,6 +10,10 @@ import { firstParam } from "@/lib/route-params";
 import AssistantResponse from "@/components/common/AssistantResponse";
 import { SimpleComposerInput } from "@/components/chat/home/SimpleComposerInput";
 import { downloadChatMarkdown } from "@/lib/chat-export";
+import {
+  normalizeMessageContent,
+  type RawMessageContent,
+} from "@/lib/message-content";
 import type { MessageItem } from "@/context/UnifiedChatContext";
 import type {
   NotebookSaveMessage,
@@ -125,22 +129,26 @@ export default function BotChatPage() {
 
     fetch(apiUrl(`/api/v1/tutorbot/${botId}/history`))
       .then((r) => (r.ok ? r.json() : []))
-      .then((history: { role: string; content: string }[]) => {
-        const restored: ChatMsg[] = history
-          .filter((m) => m.role === "user" || m.role === "assistant")
-          .map((m) => ({
-            role: m.role as "user" | "assistant",
-            content: m.content,
-          }));
-        if (restored.length) {
-          setMessages(restored);
-          // Markdown/KaTeX inside AssistantResponse can grow the container after
-          // the first paint — re-snap a few times so we land at the bottom.
-          requestAnimationFrame(() => scrollToBottom("instant"));
-          window.setTimeout(() => scrollToBottom("instant"), 80);
-          window.setTimeout(() => scrollToBottom("instant"), 250);
-        }
-      })
+      .then(
+        (history: {
+          role: string;
+          content: RawMessageContent;
+          reasoning_content?: unknown;
+        }[]) => {
+          const restored: ChatMsg[] = history
+            .filter((m) => m.role === "user" || m.role === "assistant")
+            .map((m) => ({
+              role: m.role as "user" | "assistant",
+              content: normalizeMessageContent(m.content),
+            }));
+          if (restored.length) {
+            setMessages(restored);
+            requestAnimationFrame(() => scrollToBottom("instant"));
+            window.setTimeout(() => scrollToBottom("instant"), 80);
+            window.setTimeout(() => scrollToBottom("instant"), 250);
+          }
+        },
+      )
       .catch(() => {});
   }, [botId, scrollToBottom]);
 

--- a/web/components/SessionList.tsx
+++ b/web/components/SessionList.tsx
@@ -4,6 +4,7 @@ import { Check, Pencil, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { type SessionSummary } from "@/lib/session-api";
+import { normalizeMessageContent, truncateText } from "@/lib/message-content";
 
 type SessionRuntimeStatus =
   | "idle"
@@ -361,7 +362,7 @@ export default function SessionList({
                       )}
                       {!isEditing && (
                         <div className="mt-0.5 line-clamp-1 text-[11px] leading-tight text-[var(--muted-foreground)]">
-                          {session.last_message ||
+                          {truncateText(normalizeMessageContent(session.last_message), 120) ||
                             relativeTime(session.updated_at)}
                         </div>
                       )}

--- a/web/components/chat/HistorySessionPicker.tsx
+++ b/web/components/chat/HistorySessionPicker.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { listSessions, type SessionSummary } from "@/lib/session-api";
+import { normalizeMessageContent, truncateText } from "@/lib/message-content";
 
 export interface SelectedHistorySession {
   sessionId: string;
@@ -74,7 +75,7 @@ export default function HistorySessionPicker({
     if (!keyword) return sessions;
     return sessions.filter((session) => {
       const title = String(session.title || "").toLowerCase();
-      const lastMessage = String(session.last_message || "").toLowerCase();
+      const lastMessage = normalizeMessageContent(session.last_message).toLowerCase();
       return title.includes(keyword) || lastMessage.includes(keyword);
     });
   }, [query, sessions]);
@@ -191,7 +192,7 @@ export default function HistorySessionPicker({
                         </div>
                         {session.last_message ? (
                           <p className="mt-1 line-clamp-2 text-[12px] leading-5 text-[var(--muted-foreground)]">
-                            {session.last_message}
+                            {truncateText(normalizeMessageContent(session.last_message), 200)}
                           </p>
                         ) : null}
                         <div className="mt-2 flex items-center gap-3 text-[11px] text-[var(--muted-foreground)]/85">

--- a/web/context/UnifiedChatContext.tsx
+++ b/web/context/UnifiedChatContext.tsx
@@ -18,6 +18,7 @@ import type { StreamEvent, ChatMessage } from "@/lib/unified-ws";
 import { UnifiedWSClient } from "@/lib/unified-ws";
 import { getSession, type SessionMessage } from "@/lib/session-api";
 import { normalizeMarkdownForDisplay } from "@/lib/markdown-display";
+import { normalizeMessageContent } from "@/lib/message-content";
 import { shouldAppendEventContent } from "@/lib/stream";
 
 type SessionRuntimeStatus =
@@ -550,30 +551,33 @@ export function UnifiedChatProvider({
 
   const hydrateMessages = useCallback(
     (messages: SessionMessage[]): MessageItem[] => {
-      // System messages (e.g. quiz follow-up grounding context written by the
-      // backend turn runtime) are LLM-only and must not surface in the chat UI.
       return messages
         .filter((message) => message.role !== "system")
-        .map((message) => ({
-          role: message.role,
-          content:
-            message.role === "assistant"
-              ? normalizeMarkdownForDisplay(message.content)
-              : message.content,
-          capability: message.capability || "",
-          events: Array.isArray(message.events) ? message.events : [],
-          attachments: Array.isArray(message.attachments)
-            ? message.attachments.map((item) => ({
-                type: item.type,
-                filename: item.filename,
-                base64: item.base64,
-                url: item.url,
-                mime_type: item.mime_type,
-                id: item.id,
-                extracted_text: item.extracted_text,
-              }))
-            : [],
-        }));
+        .map((message) => {
+          const raw = normalizeMessageContent(
+            message.content as unknown,
+          );
+          return {
+            role: message.role,
+            content:
+              message.role === "assistant"
+                ? normalizeMarkdownForDisplay(raw)
+                : raw,
+            capability: message.capability || "",
+            events: Array.isArray(message.events) ? message.events : [],
+            attachments: Array.isArray(message.attachments)
+              ? message.attachments.map((item) => ({
+                  type: item.type,
+                  filename: item.filename,
+                  base64: item.base64,
+                  url: item.url,
+                  mime_type: item.mime_type,
+                  id: item.id,
+                  extracted_text: item.extracted_text,
+                }))
+              : [],
+          };
+        });
     },
     [],
   );

--- a/web/lib/message-content.ts
+++ b/web/lib/message-content.ts
@@ -1,0 +1,37 @@
+export type MessageContentItem = {
+  type: string;
+  text?: string;
+  url?: string;
+  alt?: string;
+};
+
+export type RawMessageContent =
+  | string
+  | MessageContentItem[]
+  | null
+  | undefined
+  | unknown;
+
+export function normalizeMessageContent(content: RawMessageContent): string {
+  if (content == null) return "";
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((item) => {
+        if (!item || typeof item !== "object") return String(item);
+        if (item.type === "image" || item.type === "image_url") {
+          return item.alt || item.text || "[image]";
+        }
+        return item.text ?? String(item);
+      })
+      .filter(Boolean)
+      .join(" ");
+  }
+  return String(content);
+}
+
+export function truncateText(text: string, maxLength: number = 100): string {
+  if (!text) return "";
+  if (text.length <= maxLength) return text;
+  return text.substring(0, maxLength) + "…";
+}


### PR DESCRIPTION
### Description

Fix a crash that renders the TutorBot chat page unusable ("This page couldn't load") when the conversation history contains multimedia messages (images, voice, etc.) sent through IM channels.

**Root cause:** When TutorBot is connected to IM channels (e.g. Feishu, WeChat, Matrix), users can send images and other multimedia messages. These messages are stored in the JSONL session files with `content` as an **array of content-part objects** (e.g. `[{"type": "text", "text": "[image]"}, {"type": "text", "text": "[image: photo.jpg"}]`) rather than a plain string. The frontend assumes `content` is always a string and passes it directly to React as a child, triggering **React Error #31** ("Objects are not valid as a React child").

**How to reproduce:**
1. Deploy DeepTutor and connect a TutorBot to an IM channel (e.g. Feishu)
2. Send an image message to the bot through the IM channel
3. Open the TutorBot chat page in the Web UI (`/agents/{botId}/chat`)
4. The page crashes with "This page couldn't load"

**Fix strategy — dual defense (backend + frontend):**

- **Backend:** Normalize `content` to string and strip `reasoning_content` in `get_bot_history()` and `get_recent_active_bots()` API responses
- **Frontend:** Add `normalizeMessageContent()` utility that safely converts any content format (string, array, object, null) to a displayable string, applied at all rendering points

### Related Issues

- N/A (no existing issue found)

### Module(s) Affected

- [x] `api`
- [x] `services`
- [x] `web` (Frontend)

### Changes Summary

| File | Change |
|------|--------|
| `web/lib/message-content.ts` | **New** — `normalizeMessageContent()` and `truncateText()` utilities |
| `web/app/(workspace)/agents/[botId]/chat/page.tsx` | Fix history parsing to handle non-string `content` |
| `web/context/UnifiedChatContext.tsx` | Fix `hydrateMessages()` for non-string `content` |
| `web/components/SessionList.tsx` | Fix `last_message` display with type safety and truncation |
| `web/components/chat/HistorySessionPicker.tsx` | Fix `last_message` search and display |
| `deeptutor/services/tutorbot/manager.py` | Normalize `content` to string in `get_bot_history()` and `get_recent_active_bots()`; strip `reasoning_content` |

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

- The Web UI chat input only supports text, so this issue does **not** occur when chatting exclusively through the Web UI. It only manifests when viewing conversation history that includes messages sent via IM channels.
- The `reasoning_content` field is an internal backend field (from LLM reasoning models) that should not be exposed to the frontend. It is now stripped in the API response.
- `last_message` in the session list could previously be an object array, causing display issues. It is now always a string with truncation.