### PR TITLE
fix: Add C++ compiler prerequisite in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Before you begin, make sure the following are installed on your system:
 | [Node.js](https://nodejs.org/) | 18+ | `node --version` | Frontend build (not needed for CLI-only or Docker) |
 | [npm](https://www.npmjs.com/) | 9+ | `npm --version` | Bundled with Node.js |
 
+> **Windows only (missing compiler fix):** If you do not have Visual Studio, install [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) and ensure the **Desktop development with C++** workload is selected.
+
 You'll also need an **API key** from at least one LLM provider (e.g. [OpenAI](https://platform.openai.com/api-keys), [DeepSeek](https://platform.deepseek.com/), [Anthropic](https://console.anthropic.com/)). The Setup Tour will walk you through entering it.
 
 ### Option A — Setup Tour (Recommended)


### PR DESCRIPTION
### Description
Adds a Windows-only prerequisite note to the setup documentation in `README.md` under **Get Started → Prerequisites**.  
This documents the missing compiler fix: install **Visual Studio Build Tools** (if Visual Studio is not installed) and select the **Desktop development with C++** workload.

### Related Issues
- Closes #...
- Related to #...

### Module(s) Affected
- [x] `docs` (Documentation)
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
This is a docs-only change intended to prevent Windows setup failures caused by missing C++ build tooling during dependency installation.