### PR TITLE
fix(deps): relax numpy upper bound to resolve manim conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ cli = [
     # RAG (LlamaIndex)
     "llama-index>=0.14.12",
     "PyMuPDF>=1.26.0",
-    "numpy>=1.24.0,<2.0.0",
+    "numpy>=1.24.0,<3.0.0",
     "arxiv>=2.0.0",
     # Document text extraction (chat attachments)
     "python-docx>=1.1.0",

--- a/requirements/cli.txt
+++ b/requirements/cli.txt
@@ -39,7 +39,7 @@ aiosqlite>=0.19.0
 # --- RAG (LlamaIndex) ---
 llama-index>=0.14.12
 PyMuPDF>=1.26.0
-numpy>=1.24.0,<2.0.0
+numpy>=1.24.0,<3.0.0
 arxiv>=2.0.0
 
 # --- Document text extraction (chat attachments) ---


### PR DESCRIPTION
### Description
Relaxed the CLI NumPy upper bound from `<2.0.0` to `<3.0.0` in both `pyproject.toml` and `requirements/cli.txt` to resolve dependency conflicts when installing `deeptutor[all]`.

This was required because `deeptutor[all]` includes `math-animator` (`manim>=0.19.0`), and current `manim` releases require `numpy>=2.1`. With the previous `<2.0.0` pin, `uv sync` could not find a satisfiable dependency set.

### Related Issues
- Closes #...
- Related to #...

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [x] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [x] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `dependency management / packaging`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
Verified locally by running `uv sync` after the dependency update; resolution now succeeds where it previously failed due to incompatible NumPy constraints.