### PR TITLE
feat(embedding): add Gemini embedding provider support across runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,7 @@ LLM_API_VERSION=
 # IMPORTANT (v1.3.0+): EMBEDDING_HOST is the FULL endpoint URL, not a base.
 # What you set here is exactly what gets called — no path appending. Examples:
 #   OpenAI:       https://api.openai.com/v1/embeddings
+#   Gemini:       https://generativelanguage.googleapis.com/v1beta/openai/embeddings
 #   Cohere v4:    https://api.cohere.com/v2/embed
 #   Jina:         https://api.jina.ai/v1/embeddings
 #   Ollama:       http://localhost:11434/api/embed
@@ -60,6 +61,7 @@ SILICONFLOW_API_KEY=
 DASHSCOPE_API_KEY=
 COHERE_API_KEY=
 JINA_API_KEY=
+GEMINI_API_KEY=
 
 # ⚠️  Docker + local LLM (LM Studio / Ollama / vLLM)
 # ─────────────────────────────────────────────────────

--- a/deeptutor/services/config/embedding_endpoint.py
+++ b/deeptutor/services/config/embedding_endpoint.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 from urllib.parse import urlparse
 
 EMBEDDING_PROVIDER_ALIASES = {
-    "google": "openai",
-    "gemini": "openai",
+    "google": "gemini",
     "huggingface": "custom",
     "lm_studio": "vllm",
     "llama_cpp": "vllm",
@@ -19,6 +18,7 @@ EMBEDDING_PROVIDER_ALIASES = {
 
 EMBEDDING_PROVIDER_LABELS = {
     "openai": "OpenAI",
+    "gemini": "Gemini",
     "openrouter": "OpenRouter",
     "jina": "Jina",
     "vllm": "vLLM / LM Studio",
@@ -29,6 +29,7 @@ EMBEDDING_PROVIDER_LABELS = {
 
 EMBEDDING_PROVIDER_DEFAULT_ENDPOINTS = {
     "openai": "https://api.openai.com/v1/embeddings",
+    "gemini": "https://generativelanguage.googleapis.com/v1beta/openai/embeddings",
     "openrouter": "https://openrouter.ai/api/v1/embeddings",
     "cohere": "https://api.cohere.com/v2/embed",
     "jina": "https://api.jina.ai/v1/embeddings",
@@ -43,6 +44,7 @@ EMBEDDING_PROVIDER_DEFAULT_ENDPOINTS = {
 
 EMBEDDING_PROVIDERS_REQUIRING_EMBEDDINGS_PATH = {
     "openai",
+    "gemini",
     "openrouter",
     "jina",
     "vllm",

--- a/deeptutor/services/config/provider_runtime.py
+++ b/deeptutor/services/config/provider_runtime.py
@@ -84,6 +84,15 @@ EMBEDDING_PROVIDERS: dict[str, EmbeddingProviderSpec] = {
         default_model="text-embedding-3-large",
         default_dim=3072,
     ),
+    "gemini": EmbeddingProviderSpec(
+        label="Gemini",
+        default_api_base=EMBEDDING_PROVIDER_DEFAULT_ENDPOINTS["gemini"],
+        keywords=("gemini", "gemini-embedding", "text-embedding"),
+        is_local=False,
+        api_key_envs=("GEMINI_API_KEY",),
+        default_model="gemini-embedding-001",
+        default_dim=3072,
+    ),
     "azure_openai": EmbeddingProviderSpec(
         label="Azure OpenAI",
         mode="direct",

--- a/scripts/start_tour.py
+++ b/scripts/start_tour.py
@@ -425,6 +425,7 @@ LLM_MODEL_SUGGESTIONS = {
 
 EMBEDDING_MODEL_SUGGESTIONS = {
     "openai": "text-embedding-3-large",
+    "gemini": "gemini-embedding-001",
     "cohere": "embed-v4.0",
     "jina": "jina-embeddings-v3",
     "ollama": "nomic-embed-text",
@@ -685,7 +686,7 @@ def _llm_provider_options(current: str | None) -> list[tuple[str, str, str]]:
 
 def _embedding_provider_options(current: str | None) -> list[tuple[str, str, str]]:
     embedding_providers, _, _ = _load_provider_metadata()
-    common = ["openai", "jina", "cohere", "ollama", "vllm", "azure_openai", "custom"]
+    common = ["openai", "gemini", "jina", "cohere", "ollama", "vllm", "azure_openai", "custom"]
     options: list[tuple[str, str, str]] = []
     for name in common:
         spec = embedding_providers.get(name)

--- a/tests/scripts/test_start_tour.py
+++ b/tests/scripts/test_start_tour.py
@@ -167,3 +167,24 @@ def test_save_ui_language_preserves_existing_theme(tmp_path: Path) -> None:
     saved = settings_path.read_text(encoding="utf-8")
     assert '"theme": "glass"' in saved
     assert '"language": "zh"' in saved
+
+
+def test_embedding_model_suggestions_include_gemini() -> None:
+    start_tour = _load_start_tour_module()
+    assert start_tour.EMBEDDING_MODEL_SUGGESTIONS["gemini"] == "gemini-embedding-001"
+
+
+def test_embedding_provider_options_include_gemini() -> None:
+    start_tour = _load_start_tour_module()
+    fake_spec = types.SimpleNamespace(
+        label="Gemini",
+        default_api_base="https://generativelanguage.googleapis.com/v1beta/openai/embeddings",
+        is_local=False,
+    )
+    with mock.patch.object(
+        start_tour,
+        "_load_provider_metadata",
+        return_value=({"gemini": fake_spec}, None, None),
+    ):
+        options = start_tour._embedding_provider_options(current=None)
+    assert any(value == "gemini" for value, _label, _desc in options)

--- a/tests/services/config/test_embedding_runtime.py
+++ b/tests/services/config/test_embedding_runtime.py
@@ -69,6 +69,7 @@ def _env(tmp_path: Path, lines: list[str]) -> EnvStore:
         "AZURE_API_KEY=",
         "COHERE_API_KEY=",
         "JINA_API_KEY=",
+        "GEMINI_API_KEY=",
         "HOSTED_VLLM_API_KEY=",
     ]
     env_path = tmp_path / ".env"
@@ -116,7 +117,7 @@ def test_embedding_explicit_binding_and_headers(tmp_path: Path) -> None:
     assert resolved.dimension == 1024
 
 
-def test_embedding_alias_canonicalization_google_to_openai(tmp_path: Path) -> None:
+def test_embedding_alias_canonicalization_google_to_gemini(tmp_path: Path) -> None:
     catalog = _build_catalog(
         embedding_profile={
             "id": "embedding-p",
@@ -130,8 +131,32 @@ def test_embedding_alias_canonicalization_google_to_openai(tmp_path: Path) -> No
         }
     )
     resolved = resolve_embedding_runtime_config(catalog=catalog, env_store=_env(tmp_path, []))
-    assert resolved.provider_name == "openai"
-    assert resolved.binding == "openai"
+    assert resolved.provider_name == "gemini"
+    assert resolved.binding == "gemini"
+
+
+def test_embedding_gemini_default_base_and_env_key_fallback(tmp_path: Path) -> None:
+    catalog = _build_catalog(
+        embedding_profile={
+            "id": "embedding-p",
+            "name": "Embedding",
+            "binding": "gemini",
+            "base_url": "",
+            "api_key": "",
+            "api_version": "",
+            "extra_headers": {},
+            "models": [{"id": "embedding-m", "name": "m", "model": "gemini-embedding-001"}],
+        }
+    )
+    env = _env(tmp_path, ["GEMINI_API_KEY=gemini-test-key"])
+    resolved = resolve_embedding_runtime_config(catalog=catalog, env_store=env)
+    assert resolved.provider_name == "gemini"
+    assert resolved.binding == "gemini"
+    assert resolved.api_key == "gemini-test-key"
+    assert (
+        resolved.effective_url
+        == "https://generativelanguage.googleapis.com/v1beta/openai/embeddings"
+    )
 
 
 def test_embedding_local_fallback_from_base_url(tmp_path: Path) -> None:


### PR DESCRIPTION
### Description
Add Gemini embedding support end-to-end in runtime config and setup flow.

- Register Gemini as a first-class embedding provider in embedding runtime metadata with:
  - default endpoint (`https://generativelanguage.googleapis.com/v1beta/openai/embeddings`)
  - env key fallback (`GEMINI_API_KEY`)
  - default model/dimension (`gemini-embedding-001`, `3072`)
- Expose Gemini in `scripts/start_tour.py` embedding setup:
  - add provider option in embedding provider selection
  - add default model suggestion for Gemini
- Update embedding endpoint normalization/validation mappings so Gemini is treated as its own provider (instead of aliasing to OpenAI).
- Update `.env.example` with Gemini embedding endpoint example and `GEMINI_API_KEY` fallback entry.
- Add regression tests for:
  - embedding runtime resolution for Gemini binding/defaults/env fallback
  - setup tour provider/model suggestion exposure for Gemini

### Related Issues
- Closes #...
- Related to #...

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [x] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [x] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
- Targeted tests and syntax/lint checks were run locally for touched files.
- Full `pre-commit run --all-files` was not executed in this session.