### PR TITLE
feat: SAGE Memory Companion plugin + Playground tile

### DIFF
--- a/INTEGRATION_PLAN.md
+++ b/INTEGRATION_PLAN.md
@@ -1,0 +1,229 @@
+# SAGE Memory Companion — DeepTutor Integration Plan
+
+## Motivation
+
+DeepTutor's per-learner memory layer (`SUMMARY.md` + `PROFILE.md`,
+`MemoryService`, `MemoryConsolidator`) is excellent at capturing what
+*one* student knows and prefers. It is also intentionally local — there is
+no story for **cross-tutor knowledge sharing** today. As DeepTutor scales
+into classrooms, deployments, and individual tutors who each run their own
+instance, every tutor re-discovers the same pedagogical lessons in
+isolation:
+
+> "Students confuse `dx` with `Δx` when first introduced to differentials."
+> "Visual derivations of definite integrals improve retention vs. symbolic ones."
+> "When a learner asks about Fourier transforms, anchor on time → frequency before touching complex exponentials."
+
+These are institutional insights — they should be *shared* across
+deployments without leaking individual user data. That's the gap
+[SAGE](https://github.com/l33tdawg/sage) fills: a governed, BFT-consensus
+memory layer with confidence scoring, decay, and per-agent identity.
+
+This PR ships an **additive plugin** that gives DeepTutor an external
+long-term memory companion. It is orthogonal to `MemoryService` and does
+not modify a single line of the existing per-learner memory code.
+
+## Architecture diff
+
+### What's added (Python plugin in `deeptutor/plugins/`, plus the new web surface)
+
+```
+deeptutor/plugins/__init__.py            (NEW)  Plugin namespace docstring.
+deeptutor/plugins/loader.py              (NEW)  Generic manifest.yaml-driven plugin loader.
+                                                  AGENTS.md already documents this file as
+                                                  the plugin discovery entry point — both
+                                                  CapabilityRegistry.load_plugins and
+                                                  /api/plugins/list reference it but it
+                                                  hadn't been implemented yet.
+deeptutor/plugins/sage/manifest.yaml     (NEW)  Plugin metadata + hook declarations.
+deeptutor/plugins/sage/__init__.py       (NEW)
+deeptutor/plugins/sage/client.py         (NEW)  Singleton wrapper around sage-agent-sdk.
+                                                  Adapted from RAPTOR / Aether (~250 LOC).
+deeptutor/plugins/sage/capability.py     (NEW)  BaseCapability subclass + pre/post hooks.
+deeptutor/plugins/sage/README.md         (NEW)  Install / enable / disable / env vars.
+deeptutor/plugins/sage/tests/__init__.py (NEW)
+deeptutor/plugins/sage/tests/test_sage_capability.py (NEW)
+deeptutor/api/routers/plugins_sage.py    (NEW)  /api/v1/plugins/sage/{status,toggle} —
+                                                  status probe + best-effort runtime
+                                                  enable/disable for the Playground tile.
+tests/api/test_plugins_sage_router.py    (NEW)  Backend tests for the status endpoint
+                                                  (4 mocked-client cases).
+web/components/plugins/SagePluginTile.tsx (NEW) Status tile rendered inside the Playground
+                                                  page. Connected / Disabled / Disconnected /
+                                                  Not configured states. "Open SAGE Dashboard"
+                                                  link only when Connected. Best-effort toggle.
+INTEGRATION_PLAN.md                      (NEW)  This document.
+```
+
+**Edits to pre-existing files (kept tiny on purpose, ~7 lines total):**
+
+* `deeptutor/api/main.py` — import `plugins_sage` and register it under the
+  `/api/v1/plugins` prefix (2 lines).
+* `web/app/(workspace)/playground/page.tsx` — import `SagePluginTile` and
+  render it once, just below the page header (5 lines).
+
+### What's untouched (zero surgery)
+
+| Subsystem                      | Why we left it alone                                            |
+| ------------------------------ | --------------------------------------------------------------- |
+| `deeptutor/services/memory/`   | Per-learner SUMMARY/PROFILE — completely orthogonal to SAGE.    |
+| `deeptutor/agents/solve/main_solver.py` | Reads `UnifiedContext.memory_context`; we append, never replace. |
+| `deeptutor/runtime/orchestrator.py`     | Already publishes `CAPABILITY_COMPLETE` — we just subscribe.   |
+| `deeptutor/runtime/registry/capability_registry.py` | Already calls `deeptutor.plugins.loader.discover_plugins`; we just provide that module. |
+| `deeptutor/api/routers/plugins_api.py`  | Already calls `discover_plugins()`; the SAGE plugin shows up in `/plugins/list` automatically. |
+| `BaseCapability` protocol      | Unchanged. We wrap registered *instances*, not the protocol.     |
+| `pyproject.toml` dependencies  | `sage-agent-sdk` is **not** added to any `[project.optional-dependencies]` — it is loaded lazily and only required when the user opts in. |
+
+The diff outside `plugins/` is exactly **0 lines**.
+
+### Web Playground Surface
+
+The Next.js Playground page (`web/app/(workspace)/playground/page.tsx`)
+already fetches `/api/v1/plugins/list` to enumerate tools + capabilities,
+but plugins themselves were never rendered visually. We added a single
+status tile so SAGE has a discoverable presence in the UI:
+
+* **`web/components/plugins/SagePluginTile.tsx`** — fetches
+  `/api/v1/plugins/sage/status`, derives one of four states (Connected,
+  Disabled, Disconnected, Not configured) and renders a compact card with a
+  status badge, the SAGE node URL, the agent_id when known, an "Open SAGE
+  Dashboard" link (only when Connected, points at `${SAGE_URL}/ui/`), and a
+  best-effort Enable/Disable toggle. Errors degrade to a muted card — the
+  tile must never throw and break the rest of the Playground.
+* **`deeptutor/api/routers/plugins_sage.py`** — the backend probe. `GET
+  /sage/status` returns `{enabled, reachable, agent_id, node_url,
+  sdk_installed, plugin_loaded, detail}`. `POST /sage/toggle` flips the
+  in-process `SAGE_ENABLED` env var and asks `capability.install_hooks` /
+  `uninstall_hooks` to react. The toggle is *not* persisted — restart with
+  the env var set in your shell for a permanent change. The README notes
+  this caveat.
+* **i18n** — strings are wrapped in `t(...)` but no zh-CN entries are
+  shipped in this PR. `react-i18next` falls back to the English key text
+  (the project sets `keySeparator: false` and uses English keys as ids),
+  matching the rest of Playground's untranslated strings.
+
+### Runtime flow
+
+```
+                      ┌───────────────────────┐
+   user turn  ──────► │  ChatOrchestrator     │  (unchanged)
+                      └──┬──────────────────┬─┘
+                         │                  │
+              ┌──────────▼─────────┐        │
+              │  CapabilityRegistry │       │
+              │  load_builtins()    │       │
+              │  load_plugins()  ◄──┼── SAGE plugin loaded here.
+              └──────────┬──────────┘       │   Its __init__ wraps
+                         │                  │   deep_solve + deep_research
+                         ▼                  │   with a recall pre-hook
+        ┌────────────────────────────────┐  │   and subscribes the
+        │  Wrapped capability.run        │◄─┘   EventBus listener.
+        │  (deep_solve, deep_research)   │
+        │   1. SAGE.recall(prompt)       │      Recall block is APPENDED
+        │      → memory_context          │      to context.memory_context;
+        │   2. original.run(...)         │      MemoryService stays primary.
+        └────────────┬───────────────────┘
+                     │
+                     ▼
+        ┌────────────────────────────────┐
+        │  EventBus.publish(             │  (unchanged)
+        │    CAPABILITY_COMPLETE)        │
+        └────────────┬───────────────────┘
+                     │
+                     ▼
+        ┌────────────────────────────────┐
+        │  SAGE plugin listener          │
+        │   SAGE.remember(...)           │   Compact observation:
+        │   domains:                     │     prompt + capability +
+        │     deeptutor-pedagogy         │     tools_used + success.
+        │     deeptutor-{subject}        │     Full agent_output is
+        │     deeptutor-tutor-{learner}  │     NEVER stored.
+        └────────────────────────────────┘
+```
+
+## Opt-in story
+
+A single env var controls everything:
+
+```bash
+export SAGE_ENABLED=true        # opt in
+export SAGE_URL=http://localhost:8080   # default
+```
+
+* Without `SAGE_ENABLED=true`, the plugin loads but installs no hooks. Its
+  capability still appears in `deeptutor plugin list`, but reports
+  `enabled=false` and does nothing.
+* When `SAGE_ENABLED=true` but the SAGE node is unreachable / `sage-agent-sdk`
+  isn't installed, every recall/remember returns an empty result and logs
+  at `INFO` once. DeepTutor turns continue normally.
+* Recall is best-effort: any exception in the recall hook is swallowed and
+  the underlying capability still runs unmodified.
+* Remember is fire-and-forget: the EventBus listener catches every
+  exception so a SAGE outage cannot break the chat turn.
+
+## Graceful degradation matrix
+
+| State                                  | Behaviour                                              |
+| -------------------------------------- | ------------------------------------------------------ |
+| `SAGE_ENABLED` unset / not truthy      | Plugin loaded but inert. No hooks. No SDK import.      |
+| `SAGE_ENABLED=true`, SDK not installed | One INFO log, hooks installed but every call is a no-op. |
+| `SAGE_ENABLED=true`, SAGE node down    | Hooks installed; recall returns `[]`, remember warns once and returns `{}`. Capability turn unaffected. |
+| Recall raises mid-turn                 | Caught + logged, original `run()` proceeds with empty SAGE block. |
+| Remember raises post-turn              | Caught in EventBus listener; never propagates out.     |
+
+## What gets stored in SAGE
+
+Per-turn observation (one per domain — pedagogy, subject, learner-tutor):
+
+```
+[deeptutor:deep_solve] success=ok tools=rag,reason prompt=walk me through integration by parts
+```
+
+* No agent output.
+* No conversation history.
+* No PII beyond whatever the user typed in their prompt.
+* Capped at ~400 chars.
+
+## Prior art (same shape, already shipped)
+
+| Host project | Plugin location                          | PR / commit                                           |
+| ------------ | ---------------------------------------- | ----------------------------------------------------- |
+| RAPTOR       | `core/sage/`                              | l33tdawg/raptor — singleton + sync-pipeline hook      |
+| Aether       | `core/sage_client.py` + multi-pass hooks  | l33tdawg/aether — same wrapper, async pipeline        |
+| pentagi v2   | `integrations/sage/`                      | vxcontrol/pentagi — Go bridge mirroring this shape    |
+| Level Up     | `integrations/levelup/sage_bridge.py`     | l33tdawg/sage `integrations/levelup/`                 |
+
+All four ship as additive plugins with the same env-driven opt-in story
+and graceful no-op behaviour. This PR is the fifth.
+
+## Tests
+
+```bash
+pytest deeptutor/plugins/sage/tests -v
+```
+
+The suite mocks `sage_sdk` via `sys.modules`, so it runs without the SDK
+package installed and without a live SAGE node. Coverage:
+
+1. Plugin manifest is discoverable via `discover_plugins()`.
+2. Capability class loads via `load_plugin_capability()`.
+3. With `SAGE_ENABLED` unset, the plugin is a strict no-op.
+4. With `SAGE_ENABLED=true`, recall is invoked pre-`deep_solve` and
+   `memory_context` is enriched.
+5. With `SAGE_ENABLED=true`, `CAPABILITY_COMPLETE` triggers a `propose()`
+   call across all expected domain tags, and the agent output never leaks
+   into stored content.
+6. The plugin's own `run()` reports status correctly in both states.
+
+## What's intentionally NOT in this PR
+
+To keep the surface tight, this PR does **not**:
+
+* Add `sage-agent-sdk` to any `requirements.txt` / `pyproject.toml` extra.
+  Users opting in install it themselves: `pip install sage-agent-sdk`.
+* Modify `MemoryService` or `MemoryConsolidator`.
+* Touch the orchestrator, the registry implementations, or the EventBus.
+* Add new capabilities beyond the `sage_memory` status probe.
+* Add UI surface in `web/`.
+
+Each of those is a separate, opt-in follow-up if maintainers want it.

--- a/deeptutor/api/main.py
+++ b/deeptutor/api/main.py
@@ -208,6 +208,7 @@ from deeptutor.api.routers import (
     memory,
     notebook,
     plugins_api,
+    plugins_sage,
     question,
     question_notebook,
     sessions,
@@ -238,6 +239,7 @@ app.include_router(settings.router, prefix="/api/v1/settings", tags=["settings"]
 app.include_router(skills.router, prefix="/api/v1/skills", tags=["skills"])
 app.include_router(system.router, prefix="/api/v1/system", tags=["system"])
 app.include_router(plugins_api.router, prefix="/api/v1/plugins", tags=["plugins"])
+app.include_router(plugins_sage.router, prefix="/api/v1/plugins", tags=["plugins-sage"])
 app.include_router(agent_config.router, prefix="/api/v1/agent-config", tags=["agent-config"])
 app.include_router(vision_solver.router, prefix="/api/v1", tags=["vision-solver"])
 app.include_router(tutorbot.router, prefix="/api/v1/tutorbot", tags=["tutorbot"])

--- a/deeptutor/api/routers/plugins_sage.py
+++ b/deeptutor/api/routers/plugins_sage.py
@@ -1,0 +1,185 @@
+"""
+SAGE Plugin Router
+==================
+
+Surfaces the SAGE Memory Companion plugin in the web Playground.
+
+Endpoints:
+    GET  /api/v1/plugins/sage/status   — probe SAGE node + plugin state.
+    POST /api/v1/plugins/sage/toggle   — best-effort runtime enable/disable.
+
+The router is intentionally tiny: it never raises if the plugin or the
+``sage-agent-sdk`` package is not installed — the Playground tile must
+degrade to a "SAGE not configured" muted card rather than break the page.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_DEFAULT_SAGE_URL = "http://localhost:8080"
+
+
+def _env_truthy(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _safe_get_client() -> Any | None:
+    """Return the SAGE singleton client, or None if the plugin isn't present."""
+    try:
+        from deeptutor.plugins.sage.client import get_sage_client
+    except Exception:
+        logger.debug("SAGE plugin not importable", exc_info=True)
+        return None
+    try:
+        return get_sage_client()
+    except Exception:
+        logger.debug("SAGE client init raised", exc_info=True)
+        return None
+
+
+class SageStatus(BaseModel):
+    enabled: bool
+    reachable: bool
+    agent_id: str | None = None
+    node_url: str
+    last_observation_at: str | None = None
+    sdk_installed: bool = False
+    plugin_loaded: bool = False
+    detail: str | None = None
+
+
+class SageToggleRequest(BaseModel):
+    enabled: bool
+
+
+class SageToggleResponse(BaseModel):
+    enabled: bool
+    requires_restart: bool
+    detail: str
+
+
+@router.get("/sage/status", response_model=SageStatus)
+async def sage_status() -> SageStatus:
+    """Probe the SAGE plugin + node and report a state for the Playground tile."""
+    node_url = os.environ.get("SAGE_URL", _DEFAULT_SAGE_URL)
+    enabled = _env_truthy(os.environ.get("SAGE_ENABLED"))
+
+    client = _safe_get_client()
+    if client is None:
+        return SageStatus(
+            enabled=enabled,
+            reachable=False,
+            node_url=node_url,
+            sdk_installed=False,
+            plugin_loaded=False,
+            detail="SAGE plugin not available in this build.",
+        )
+
+    sdk_installed = False
+    try:
+        import sage_sdk  # noqa: F401
+
+        sdk_installed = True
+    except Exception:
+        sdk_installed = False
+
+    if not enabled:
+        return SageStatus(
+            enabled=False,
+            reachable=False,
+            node_url=node_url,
+            sdk_installed=sdk_installed,
+            plugin_loaded=True,
+            detail="SAGE_ENABLED is not set — plugin is loaded but inert.",
+        )
+
+    reachable = False
+    try:
+        reachable = bool(client.health_check())
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("SAGE health probe raised: %s", exc)
+        reachable = False
+
+    agent_id: str | None = None
+    try:
+        sdk = getattr(client, "_sdk_client", None)
+        identity = getattr(sdk, "identity", None) if sdk is not None else None
+        if identity is not None:
+            agent_id = (
+                getattr(identity, "agent_id", None)
+                or getattr(identity, "public_key", None)
+                or getattr(identity, "address", None)
+            )
+            if agent_id is not None:
+                agent_id = str(agent_id)
+    except Exception:
+        agent_id = None
+
+    return SageStatus(
+        enabled=True,
+        reachable=reachable,
+        agent_id=agent_id,
+        node_url=node_url,
+        sdk_installed=sdk_installed,
+        plugin_loaded=True,
+        detail="Connected" if reachable else "SAGE node is unreachable.",
+    )
+
+
+@router.post("/sage/toggle", response_model=SageToggleResponse)
+async def sage_toggle(body: SageToggleRequest) -> SageToggleResponse:
+    """Best-effort runtime toggle.
+
+    We flip the in-process ``SAGE_ENABLED`` env var and ask the plugin to
+    re-install / uninstall its hooks. The toggle is *not* persisted across
+    process restarts — the README documents that flipping the env var in
+    the shell is still the source of truth.
+    """
+    os.environ["SAGE_ENABLED"] = "true" if body.enabled else "false"
+
+    # Reset the singleton so the new env value takes effect on next call.
+    try:
+        from deeptutor.plugins.sage.client import SageClient
+
+        SageClient.reset_instance()
+    except Exception:
+        logger.debug("Could not reset SAGE singleton", exc_info=True)
+
+    requires_restart = False
+    detail = "SAGE runtime flag flipped."
+    try:
+        from deeptutor.plugins.sage import capability as sage_cap
+
+        if body.enabled:
+            installed = sage_cap.install_hooks(force=True)
+            detail = (
+                "Hooks installed."
+                if installed
+                else "Toggle accepted but hooks could not install — restart the server."
+            )
+            requires_restart = not installed
+        else:
+            sage_cap.uninstall_hooks()
+            detail = "Hooks uninstalled."
+    except Exception as exc:
+        logger.warning("SAGE toggle hook update failed: %s", exc)
+        requires_restart = True
+        detail = f"Toggle accepted but hooks did not update ({exc}). Restart required."
+
+    return SageToggleResponse(
+        enabled=body.enabled,
+        requires_restart=requires_restart,
+        detail=detail,
+    )

--- a/deeptutor/plugins/__init__.py
+++ b/deeptutor/plugins/__init__.py
@@ -1,0 +1,13 @@
+"""
+DeepTutor Plugin Namespace
+==========================
+
+Drop-in plugins extend DeepTutor without touching core. Each plugin lives in
+its own subdirectory (``deeptutor/plugins/<name>/``) and ships a
+``manifest.yaml`` plus a ``capability.py`` exposing a ``BaseCapability``
+subclass — see ``AGENTS.md`` for the contract.
+
+The plugin loader (``deeptutor.plugins.loader``) is intentionally optional:
+``CapabilityRegistry.load_plugins`` swallows ``ImportError`` so the framework
+keeps working when no plugins are installed.
+"""

--- a/deeptutor/plugins/loader.py
+++ b/deeptutor/plugins/loader.py
@@ -1,0 +1,164 @@
+"""
+Plugin Loader
+=============
+
+Discovers plugins under ``deeptutor/plugins/<name>/`` by reading their
+``manifest.yaml`` and importing the declared ``capability.py`` entry point.
+
+The loader is referenced from
+``deeptutor.runtime.registry.capability_registry.CapabilityRegistry.load_plugins``
+and from ``deeptutor.api.routers.plugins_api`` — both call sites already
+treat ``ImportError`` and missing-attribute errors as benign, so the loader
+stays a strict no-op when no plugins are installed.
+
+Manifest contract (minimal)::
+
+    name: sage
+    version: 0.1.0
+    type: companion              # informational
+    description: "..."
+    entry: capability.py:SageMemoryCompanion   # MODULE_BASENAME:CLASS
+
+    # Optional — surfaced in the Playground listing only:
+    stages: []
+    author: ""
+
+The loader also tolerates the historical AGENTS.md form where
+``capability.py`` is implicit and only ``stages`` is given; in that case it
+falls back to importing ``deeptutor.plugins.<name>.capability`` and grabs
+the first ``BaseCapability`` subclass defined there.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import importlib
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml  # PyYAML is a top-level dependency
+
+from deeptutor.core.capability_protocol import BaseCapability
+
+logger = logging.getLogger(__name__)
+
+_PLUGINS_DIR = Path(__file__).resolve().parent
+
+
+@dataclass
+class PluginManifest:
+    """Lightweight view of a plugin's ``manifest.yaml``.
+
+    The capability registry only reads ``name`` + ``entry``; the other
+    fields are surfaced via the Playground ``/plugins/list`` endpoint.
+    """
+
+    name: str
+    entry: str
+    version: str = "0.0.0"
+    type: str = "playground"
+    description: str = ""
+    stages: list[str] = field(default_factory=list)
+    author: str = ""
+    plugin_dir: Path | None = None
+
+
+def _read_manifest(plugin_dir: Path) -> PluginManifest | None:
+    manifest_path = plugin_dir / "manifest.yaml"
+    if not manifest_path.exists():
+        return None
+    try:
+        data: dict[str, Any] = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        logger.warning("Failed to parse plugin manifest %s", manifest_path, exc_info=True)
+        return None
+
+    name = str(data.get("name") or plugin_dir.name)
+    entry = str(data.get("entry") or "capability.py")
+    return PluginManifest(
+        name=name,
+        entry=entry,
+        version=str(data.get("version") or "0.0.0"),
+        type=str(data.get("type") or "playground"),
+        description=str(data.get("description") or ""),
+        stages=list(data.get("stages") or []),
+        author=str(data.get("author") or ""),
+        plugin_dir=plugin_dir,
+    )
+
+
+def discover_plugins() -> list[PluginManifest]:
+    """Return a manifest for every plugin under ``deeptutor/plugins/<name>/``."""
+    manifests: list[PluginManifest] = []
+    if not _PLUGINS_DIR.exists():
+        return manifests
+    for entry in sorted(_PLUGINS_DIR.iterdir()):
+        if not entry.is_dir() or entry.name.startswith("_") or entry.name.startswith("."):
+            continue
+        manifest = _read_manifest(entry)
+        if manifest is not None:
+            manifests.append(manifest)
+    return manifests
+
+
+def _resolve_capability_class(manifest: PluginManifest) -> type[BaseCapability] | None:
+    """Import the capability class declared by ``manifest.entry``."""
+    package = f"deeptutor.plugins.{manifest.name}"
+
+    entry = manifest.entry.strip()
+    module_part, _, class_part = entry.partition(":")
+    module_part = module_part.strip()
+    class_part = class_part.strip()
+
+    # Drop a trailing ``.py`` so callers can write ``capability.py:Cls``.
+    if module_part.endswith(".py"):
+        module_part = module_part[:-3]
+    if not module_part:
+        module_part = "capability"
+
+    module_name = f"{package}.{module_part}" if "." not in module_part else module_part
+    try:
+        module = importlib.import_module(module_name)
+    except Exception:
+        logger.warning("Failed to import plugin module %s", module_name, exc_info=True)
+        return None
+
+    if class_part:
+        cls = getattr(module, class_part, None)
+        if cls is not None and isinstance(cls, type) and issubclass(cls, BaseCapability):
+            return cls
+        logger.warning(
+            "Plugin %s declares entry %s but %s is not a BaseCapability subclass",
+            manifest.name,
+            entry,
+            class_part,
+        )
+        return None
+
+    # Fallback: pick the first BaseCapability subclass defined in the module.
+    for attr in dir(module):
+        obj = getattr(module, attr)
+        if isinstance(obj, type) and issubclass(obj, BaseCapability) and obj is not BaseCapability:
+            return obj
+    logger.debug(
+        "Plugin %s defines no BaseCapability subclass; treating as side-effect-only", manifest.name
+    )
+    return None
+
+
+def load_plugin_capability(manifest: PluginManifest) -> BaseCapability | None:
+    """Instantiate the capability declared by *manifest*.
+
+    Returns ``None`` for plugins that intentionally have no capability
+    (e.g. plugins that only register EventBus listeners) — the registry
+    already handles ``None`` by skipping registration.
+    """
+    cls = _resolve_capability_class(manifest)
+    if cls is None:
+        return None
+    try:
+        return cls()
+    except Exception:
+        logger.warning("Failed to instantiate plugin capability %s", manifest.name, exc_info=True)
+        return None

--- a/deeptutor/plugins/sage/README.md
+++ b/deeptutor/plugins/sage/README.md
@@ -1,0 +1,125 @@
+# SAGE Memory Companion (`deeptutor/plugins/sage/`)
+
+Drop-in plugin that gives DeepTutor an **external long-term memory companion**
+backed by a [SAGE](https://github.com/l33tdawg/sage) node.
+
+| What it does                  | What it doesn't do                                      |
+| ----------------------------- | ------------------------------------------------------- |
+| Recalls cross-session pedagogy + subject memories into `deep_solve` / `deep_research` prompts (appended to `UnifiedContext.memory_context`). | Touches the existing per-learner memory layer (`SUMMARY.md`, `PROFILE.md`, `MemoryService`, `MemoryConsolidator`) — those keep working byte-for-byte. |
+| Stores one compact observation per `CAPABILITY_COMPLETE` event under `deeptutor-pedagogy`, `deeptutor-{subject}`, `deeptutor-tutor-{learner_id}`. | Stores full agent outputs / conversation transcripts. Only the prompt + capability + tools-used go in. |
+| Opts in via a single env var. Graceful no-op when SAGE is down. | Adds new dependencies to default installs — `sage-agent-sdk` is loaded lazily. |
+
+## Why it's worth shipping
+
+DeepTutor already has excellent **per-learner** memory. SAGE is **orthogonal**:
+it lets *every tutor instance / classroom / deployment* share consensus-validated
+pedagogical lessons (e.g. "students confuse `dx` with `Δx` when first
+introduced to differentials") without leaking individual user data — only
+distilled observations cross instances.
+
+This is the same shape we shipped against
+[RAPTOR](https://github.com/l33tdawg/raptor),
+[pentagi v2](https://github.com/vxcontrol/pentagi),
+[Aether](https://github.com/l33tdawg/aether), and Level Up: an
+**additive plugin**, no surgery on the host.
+
+## Install
+
+```bash
+# 1. Install the SAGE Python SDK (lazy import — only loaded when enabled)
+pip install sage-agent-sdk
+
+# 2. Make sure DeepTutor is installed normally
+pip install -e ".[server]"
+
+# 3. (optional) Run a SAGE node — defaults to http://localhost:8080
+#    See https://github.com/l33tdawg/sage for one-liner Docker deployment.
+```
+
+The plugin auto-registers via `deeptutor.plugins.loader.discover_plugins`. No
+code change is needed in your DeepTutor app.
+
+## Enable
+
+```bash
+export SAGE_ENABLED=true
+export SAGE_URL=http://localhost:8080         # default
+export SAGE_AGENT_KEY=/path/to/agent.key      # optional; auto-generated under ~/.sage/agents/deeptutor-instance/ if missing
+```
+
+Then start DeepTutor as usual. On first capability run you should see in
+the logs:
+
+```
+INFO  deeptutor.plugins.sage.capability: SAGE plugin hooks installed (pre-run wrapped=2, event=CAPABILITY_COMPLETE)
+```
+
+## Disable
+
+Just unset `SAGE_ENABLED` (or set it to `false`/`0`). The plugin becomes a
+strict no-op — no recall, no remember, no EventBus listener active. The
+`sage_memory` capability still appears in `deeptutor plugin list` but its
+`run()` reports `enabled=false`.
+
+To rip the plugin out entirely, delete `deeptutor/plugins/sage/`. Nothing
+else in the codebase references it.
+
+## Environment variables
+
+| Var                              | Default                  | Purpose                                                |
+| -------------------------------- | ------------------------ | ------------------------------------------------------ |
+| `SAGE_ENABLED`                   | _unset_                  | `true`/`1`/`yes` enables hooks. Anything else = no-op. |
+| `SAGE_URL`                       | `http://localhost:8080`  | Base URL of the SAGE node.                             |
+| `SAGE_AGENT_KEY`                 | _unset_                  | Path to an existing agent identity file.               |
+| `SAGE_HOME`                      | `~/.sage`                | Base dir used when generating an agent key.            |
+| `SAGE_TIMEOUT`                   | `10`                     | Per-request timeout in seconds.                        |
+| `SAGE_DEEPTUTOR_DOMAIN_PREFIX`   | `deeptutor`              | Domain-tag prefix for SAGE memories.                   |
+
+## Architecture
+
+```
+                      ┌───────────────────────┐
+   user turn  ──────► │  ChatOrchestrator     │
+                      │  (deeptutor.runtime)  │
+                      └──┬──────────────────┬─┘
+                         │                  │
+              ┌──────────▼─────────┐        │
+              │  CapabilityRegistry │       │
+              │  load_builtins()    │       │
+              │  load_plugins()  ◄──┼── SAGE plugin loaded here
+              └──────────┬──────────┘       │
+                         │                  │
+                         ▼                  │
+        ┌────────────────────────────────┐  │
+        │  Wrapped capability.run        │◄─┘ pre-run hook
+        │  (deep_solve, deep_research)   │
+        │   1. SAGE.recall(prompt)       │
+        │      append to memory_context  │
+        │   2. original.run(...)         │  ← unchanged
+        └────────────┬───────────────────┘
+                     │
+                     ▼
+        ┌────────────────────────────────┐
+        │  EventBus.publish(             │
+        │    CAPABILITY_COMPLETE)        │
+        └────────────┬───────────────────┘
+                     │
+                     ▼
+        ┌────────────────────────────────┐
+        │  SAGE plugin listener          │
+        │   SAGE.remember(...)           │
+        │   domains:                     │
+        │     deeptutor-pedagogy         │
+        │     deeptutor-{subject}        │
+        │     deeptutor-tutor-{learner}  │
+        └────────────────────────────────┘
+```
+
+## Tests
+
+```bash
+pytest deeptutor/plugins/sage/tests -v
+```
+
+The tests mock the SDK (`sage_sdk` is monkey-patched into `sys.modules`), so
+they run without a live SAGE node and without the SDK package installed.

--- a/deeptutor/plugins/sage/__init__.py
+++ b/deeptutor/plugins/sage/__init__.py
@@ -1,0 +1,18 @@
+"""SAGE memory companion plugin for DeepTutor."""
+
+from deeptutor.plugins.sage.capability import (
+    PRE_RUN_TARGETS,
+    SageMemoryCompanion,
+    install_hooks,
+    uninstall_hooks,
+)
+from deeptutor.plugins.sage.client import SageClient, get_sage_client
+
+__all__ = [
+    "PRE_RUN_TARGETS",
+    "SageClient",
+    "SageMemoryCompanion",
+    "get_sage_client",
+    "install_hooks",
+    "uninstall_hooks",
+]

--- a/deeptutor/plugins/sage/capability.py
+++ b/deeptutor/plugins/sage/capability.py
@@ -1,0 +1,386 @@
+"""
+SAGE Memory Companion Capability
+================================
+
+A small "companion" capability that ships two hooks:
+
+1. **Pre-capability-run** — wraps ``deep_solve`` and ``deep_research`` so
+   their ``UnifiedContext.memory_context`` is enriched with cross-session
+   pedagogy / subject-domain memories pulled from a SAGE node *before* the
+   underlying agent pipeline runs. The existing per-learner SUMMARY.md /
+   PROFILE.md is left intact — SAGE is appended, never replaced.
+
+2. **Post-capability-run** — subscribes to the global EventBus and stores
+   one observation per ``CAPABILITY_COMPLETE`` event under domain tags
+   ``deeptutor-pedagogy``, ``deeptutor-{subject}``, and
+   ``deeptutor-tutor-{learner_id}``. The observation captures only the
+   user prompt + capability name + tools used — never the full agent
+   output, to keep the audit trail compact.
+
+The capability also registers itself in the registry (``BUILTIN_CAPABILITY_CLASSES``
+adjacent) so it shows up in ``deeptutor plugin list``. Its own ``run``
+method is a thin "status" handler that confirms the integration is live —
+it is NOT meant to be invoked from end-user prompts.
+
+Everything is opt-in via ``SAGE_ENABLED=true``. When SAGE is disabled or
+unreachable the plugin is a strict no-op: no hooks fire, the host
+framework behaves byte-for-byte as before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from typing import Any
+
+from deeptutor.core.capability_protocol import BaseCapability, CapabilityManifest
+from deeptutor.core.context import UnifiedContext
+from deeptutor.core.stream_bus import StreamBus
+from deeptutor.events.event_bus import Event, EventType, get_event_bus
+from deeptutor.plugins.sage.client import SageClient, get_sage_client
+
+logger = logging.getLogger(__name__)
+
+
+# Capabilities whose prompts we enrich pre-run. Kept tight on purpose —
+# expanding the surface should be a deliberate decision, not a default.
+PRE_RUN_TARGETS: tuple[str, ...] = ("deep_solve", "deep_research")
+
+
+# Module-level guard to ensure we never install hooks twice (e.g. if the
+# loader is imported a second time during tests).
+_HOOKS_INSTALLED = False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _truthy(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _domain_prefix() -> str:
+    return os.environ.get("SAGE_DEEPTUTOR_DOMAIN_PREFIX", "deeptutor")
+
+
+def _slugify(text: str) -> str:
+    """Best-effort lower-snake-case slug used for domain tags."""
+    if not text:
+        return ""
+    cleaned = re.sub(r"[^a-zA-Z0-9]+", "-", text.strip().lower())
+    return cleaned.strip("-")[:48]
+
+
+def _infer_subject(context: UnifiedContext) -> str:
+    """Infer a subject tag from the unified context — best-effort."""
+    meta = context.metadata or {}
+    subject = (
+        meta.get("subject")
+        or meta.get("domain")
+        or (context.knowledge_bases[0] if context.knowledge_bases else "")
+    )
+    return _slugify(str(subject))
+
+
+def _infer_learner(context: UnifiedContext) -> str:
+    meta = context.metadata or {}
+    learner = meta.get("learner_id") or meta.get("user_id") or context.session_id or ""
+    return _slugify(str(learner))[:32]
+
+
+def _format_recall_block(memories: list[dict[str, Any]]) -> str:
+    """Render recalled SAGE memories into a markdown block.
+
+    The block is appended to ``UnifiedContext.memory_context`` so the host
+    capability sees it through the existing prompt-stitching logic. It
+    deliberately uses a distinctive header so it never gets confused with
+    DeepTutor's own SUMMARY/PROFILE content.
+    """
+    if not memories:
+        return ""
+    lines = ["", "### SAGE — Cross-Session Memory (institutional)"]
+    for idx, mem in enumerate(memories, start=1):
+        content = (mem.get("content") or "").strip()
+        if not content:
+            continue
+        confidence = mem.get("confidence") or 0.0
+        domain = mem.get("domain") or ""
+        # Keep each memory on a single line — capability prompts already
+        # paginate at higher levels and we don't want to blow up token
+        # budgets.
+        snippet = content.replace("\n", " ")
+        if len(snippet) > 320:
+            snippet = snippet[:317] + "..."
+        lines.append(f"- [{idx}] ({domain}, conf={confidence:.2f}) {snippet}")
+    if len(lines) == 2:
+        return ""
+    return "\n".join(lines)
+
+
+def _append_memory_context(context: UnifiedContext, block: str) -> None:
+    if not block:
+        return
+    existing = context.memory_context or ""
+    if block in existing:
+        return
+    context.memory_context = (existing + "\n\n" + block).strip() if existing else block
+
+
+# ---------------------------------------------------------------------------
+# Hook installation
+# ---------------------------------------------------------------------------
+
+
+def _wrap_capability_run(capability: BaseCapability) -> None:
+    """Decorate ``capability.run`` with a pre-run SAGE recall step."""
+    original_run = capability.run
+
+    if getattr(original_run, "__sage_wrapped__", False):
+        return
+
+    async def wrapped(context: UnifiedContext, stream: StreamBus) -> None:
+        try:
+            client = get_sage_client()
+            if client.enabled:
+                subject = _infer_subject(context)
+                domains = [f"{_domain_prefix()}-pedagogy"]
+                if subject:
+                    domains.append(f"{_domain_prefix()}-{subject}")
+
+                merged: list[dict[str, Any]] = []
+                for domain in domains:
+                    memories = client.recall(
+                        query=context.user_message or capability.name,
+                        domain=domain,
+                        top_k=3,
+                    )
+                    merged.extend(memories)
+
+                block = _format_recall_block(merged)
+                if block:
+                    _append_memory_context(context, block)
+                    logger.debug(
+                        "SAGE recall injected %d memories into %s (domains=%s)",
+                        len(merged),
+                        capability.name,
+                        domains,
+                    )
+        except Exception:
+            # Recall is strictly best-effort — never let it break a turn.
+            logger.debug("SAGE recall hook failed; continuing", exc_info=True)
+
+        await original_run(context, stream)
+
+    wrapped.__sage_wrapped__ = True  # type: ignore[attr-defined]
+    capability.run = wrapped  # type: ignore[method-assign]
+
+
+def _install_pre_run_hooks() -> int:
+    """Wrap every PRE_RUN_TARGETS capability already in the registry.
+
+    Called once during ``SageMemoryCompanion.__init__``. Capabilities that
+    aren't loaded yet (because of an unusual registration order) are
+    silently skipped — they'll either get wrapped on the next registry
+    refresh or run unwrapped, which is still correct (just no recall).
+    """
+    try:
+        from deeptutor.runtime.registry.capability_registry import get_capability_registry
+    except Exception:
+        logger.debug(
+            "Capability registry import failed; skipping pre-run hook install", exc_info=True
+        )
+        return 0
+
+    registry = get_capability_registry()
+    wrapped = 0
+    for name in PRE_RUN_TARGETS:
+        cap = registry.get(name)
+        if cap is None:
+            continue
+        _wrap_capability_run(cap)
+        wrapped += 1
+    return wrapped
+
+
+async def _on_capability_complete(event: Event) -> None:
+    """EventBus listener — store a SAGE observation after each turn."""
+    try:
+        client = get_sage_client()
+        if not client.enabled:
+            return
+
+        meta = event.metadata or {}
+        capability = str(meta.get("capability") or "unknown")
+        session_id = str(meta.get("session_id") or "")
+        subject_meta = meta.get("subject") or meta.get("domain") or ""
+        subject = _slugify(str(subject_meta))
+        learner = _slugify(str(meta.get("learner_id") or meta.get("user_id") or session_id))[:32]
+
+        prefix = _domain_prefix()
+        domains = [f"{prefix}-pedagogy"]
+        if subject:
+            domains.append(f"{prefix}-{subject}")
+        if learner:
+            domains.append(f"{prefix}-tutor-{learner}")
+
+        # Compact observation — never include the full agent output, only
+        # the user prompt, capability name, and tools used. That keeps the
+        # audit trail useful for cross-session pedagogy without leaking
+        # entire conversations into consensus storage.
+        prompt = (event.user_input or "").strip().replace("\n", " ")
+        if len(prompt) > 400:
+            prompt = prompt[:397] + "..."
+        tools = ", ".join(event.tools_used or []) or "none"
+        success = "ok" if event.success else "failed"
+
+        content = (
+            f"[deeptutor:{capability}] success={success} tools={tools} prompt={prompt or '(empty)'}"
+        )
+
+        for domain in domains:
+            client.remember(
+                content=content,
+                domain=domain,
+                memory_type="observation",
+                confidence=0.80,
+                tags=["deeptutor", capability],
+            )
+    except Exception:
+        logger.debug("SAGE post-run hook failed; continuing", exc_info=True)
+
+
+def _install_event_listener() -> None:
+    bus = get_event_bus()
+    bus.subscribe(EventType.CAPABILITY_COMPLETE, _on_capability_complete)
+
+
+def install_hooks(force: bool = False) -> bool:
+    """Install pre/post hooks if SAGE is enabled. Idempotent."""
+    global _HOOKS_INSTALLED
+    if _HOOKS_INSTALLED and not force:
+        return True
+    if not _truthy(os.environ.get("SAGE_ENABLED")):
+        logger.debug("SAGE_ENABLED is not truthy — leaving hooks uninstalled")
+        return False
+
+    try:
+        wrapped = _install_pre_run_hooks()
+        _install_event_listener()
+        _HOOKS_INSTALLED = True
+        logger.info(
+            "SAGE plugin hooks installed (pre-run wrapped=%d, event=CAPABILITY_COMPLETE)",
+            wrapped,
+        )
+        return True
+    except Exception:
+        logger.warning("SAGE plugin failed to install hooks", exc_info=True)
+        return False
+
+
+def uninstall_hooks() -> None:
+    """Remove the EventBus subscription. Pre-run wrappers stay in place
+    (unwrapping safely is messy and not worth the complexity for tests —
+    use ``SageClient.reset_instance`` + a fresh registry instead)."""
+    global _HOOKS_INSTALLED
+    try:
+        bus = get_event_bus()
+        bus.unsubscribe(EventType.CAPABILITY_COMPLETE, _on_capability_complete)
+    except Exception:
+        pass
+    _HOOKS_INSTALLED = False
+
+
+# ---------------------------------------------------------------------------
+# Capability stub — surfaces in `deeptutor plugin list`.
+# ---------------------------------------------------------------------------
+
+
+class SageMemoryCompanion(BaseCapability):
+    """SAGE memory companion — installs recall + remember hooks on import."""
+
+    manifest = CapabilityManifest(
+        name="sage_memory",
+        description=(
+            "External SAGE-backed long-term memory: recalls cross-session "
+            "pedagogy + subject memories before deep_solve / deep_research, "
+            "and stores observations after every capability run. "
+            "Opt-in via SAGE_ENABLED=true; no-op otherwise."
+        ),
+        stages=["recall", "remember"],
+        cli_aliases=["sage"],
+        config_defaults={
+            "enabled_env": "SAGE_ENABLED",
+            "url_env": "SAGE_URL",
+            "identity_env": "SAGE_AGENT_KEY",
+            "domain_prefix": "deeptutor",
+        },
+    )
+
+    def __init__(self) -> None:
+        # Hooks self-install on first instantiation. Safe to call repeatedly.
+        try:
+            install_hooks()
+        except Exception:
+            logger.debug("SAGE hook install raised during __init__", exc_info=True)
+
+    async def run(self, context: UnifiedContext, stream: StreamBus) -> None:
+        """Status / health probe — emits the SAGE node status to the stream."""
+        client = get_sage_client()
+        async with stream.stage("recall", source=self.name):
+            await stream.thinking(
+                f"SAGE plugin status: enabled={client.enabled}",
+                source=self.name,
+                stage="recall",
+            )
+
+        if not client.enabled:
+            await stream.result(
+                {
+                    "response": (
+                        "SAGE companion is **disabled**. Set `SAGE_ENABLED=true` "
+                        "and ensure a SAGE node is reachable at `SAGE_URL` to "
+                        "activate cross-session memory."
+                    ),
+                    "enabled": False,
+                },
+                source=self.name,
+            )
+            return
+
+        # Run health check off the event loop — sage_sdk is sync.
+        healthy = await asyncio.to_thread(client.health_check)
+        await stream.result(
+            {
+                "response": (
+                    f"SAGE companion is **enabled** and "
+                    f"{'reachable' if healthy else 'configured but currently unreachable'}."
+                ),
+                "enabled": True,
+                "healthy": healthy,
+            },
+            source=self.name,
+        )
+
+
+# Last-resort safety net: if some entry point bypasses ``__init__``
+# (e.g. the manifest API listing), the hooks still install when the module
+# is first imported and SAGE is enabled.
+try:
+    install_hooks()
+except Exception:  # pragma: no cover - defensive
+    logger.debug("SAGE module-level install_hooks failed", exc_info=True)
+
+
+__all__ = [
+    "PRE_RUN_TARGETS",
+    "SageClient",
+    "SageMemoryCompanion",
+    "install_hooks",
+    "uninstall_hooks",
+]

--- a/deeptutor/plugins/sage/client.py
+++ b/deeptutor/plugins/sage/client.py
@@ -1,0 +1,284 @@
+"""
+SAGE Client — Thread-safe singleton wrapper around ``sage-agent-sdk``.
+
+Adapted from the canonical RAPTOR / Aether wrapper (and used in the
+LevelUp + pentagi v2 integrations). Provides a tiny ``recall`` /
+``remember`` surface and degrades gracefully when SAGE is disabled,
+unreachable, or the SDK package is missing.
+
+Environment variables (all optional)::
+
+    SAGE_ENABLED        "true" / "1" / "yes" enables the integration.
+                        Anything else (or unset) makes every call a no-op.
+    SAGE_URL            Base URL of the SAGE node (default ``http://localhost:8080``).
+    SAGE_AGENT_KEY      Path to an existing agent key file. If unset, the
+                        plugin generates one under ``$SAGE_HOME/agents/deeptutor/``.
+    SAGE_HOME           Override for the SAGE home directory (default ``~/.sage``).
+    SAGE_TIMEOUT        Per-request timeout in seconds (default 10).
+
+The wrapper is intentionally narrow: ``recall`` for pre-capability prompt
+enrichment and ``remember`` for ``CAPABILITY_COMPLETE`` observations. Anything
+beyond that should live in the SDK, not here.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+import threading
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_URL = "http://localhost:8080"
+_DEFAULT_TIMEOUT = 10.0
+_DEFAULT_AGENT_NAME = "deeptutor"
+
+
+def _truthy(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _find_agent_key() -> Path | None:
+    """Resolve the SAGE agent key via env vars.
+
+    Priority:
+      1. ``SAGE_AGENT_KEY`` (explicit path)
+      2. ``$SAGE_HOME/agents/*/agent.key`` — first match
+    """
+    explicit = os.environ.get("SAGE_AGENT_KEY")
+    if explicit:
+        path = Path(explicit).expanduser()
+        if path.exists():
+            return path
+
+    sage_home = Path(os.environ.get("SAGE_HOME", "~/.sage")).expanduser()
+    agents_dir = sage_home / "agents"
+    if not agents_dir.is_dir():
+        return None
+    for agent_dir in sorted(agents_dir.iterdir()):
+        key_file = agent_dir / "agent.key"
+        if key_file.exists():
+            return key_file
+    return None
+
+
+class SageClient:
+    """Thread-safe singleton client for the SAGE memory layer."""
+
+    _instance: "SageClient | None" = None
+    _lock = threading.Lock()
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self._base_url = (base_url or os.environ.get("SAGE_URL", _DEFAULT_URL)).rstrip("/")
+        self._timeout = float(os.environ.get("SAGE_TIMEOUT", _DEFAULT_TIMEOUT))
+        self._enabled = _truthy(os.environ.get("SAGE_ENABLED"))
+        self._sdk_client: Any = None
+        self._sdk_checked = False
+        self._agent_name = _DEFAULT_AGENT_NAME
+
+    # ------------------------------------------------------------------
+    # Singleton
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def get_instance(cls) -> "SageClient":
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Reset the singleton — for tests only."""
+        with cls._lock:
+            cls._instance = None
+
+    # ------------------------------------------------------------------
+    # Lazy init
+    # ------------------------------------------------------------------
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def _ensure_sdk(self) -> Any:
+        """Lazy-import sage-agent-sdk and bind a client + identity."""
+        if self._sdk_checked:
+            return self._sdk_client
+        self._sdk_checked = True
+
+        if not self._enabled:
+            return None
+
+        try:
+            from sage_sdk import AgentIdentity
+            from sage_sdk import SageClient as SDKClient
+        except ImportError:
+            logger.info(
+                "sage-agent-sdk not installed — SAGE plugin disabled. "
+                "Install with: pip install sage-agent-sdk"
+            )
+            return None
+        except Exception as exc:
+            logger.warning("Unexpected import error for sage-agent-sdk: %s", exc)
+            return None
+
+        try:
+            key_path = _find_agent_key()
+            if key_path is not None:
+                identity = AgentIdentity.from_file(str(key_path))
+                logger.debug("SAGE identity loaded from %s", key_path)
+            else:
+                sage_home = Path(os.environ.get("SAGE_HOME", "~/.sage")).expanduser()
+                agent_dir = sage_home / "agents" / "deeptutor-instance"
+                agent_dir.mkdir(parents=True, exist_ok=True)
+                key_file = agent_dir / "agent.key"
+                if key_file.exists():
+                    identity = AgentIdentity.from_file(str(key_file))
+                else:
+                    identity = AgentIdentity.generate()
+                    identity.to_file(str(key_file))
+                logger.debug("SAGE identity generated at %s", key_file)
+
+            self._sdk_client = SDKClient(
+                base_url=self._base_url,
+                identity=identity,
+                timeout=self._timeout,
+            )
+
+            try:
+                self._sdk_client.register_agent(
+                    name=self._agent_name,
+                    provider="deeptutor",
+                    boot_bio="DeepTutor — agent-native intelligent learning companion",
+                )
+            except Exception:
+                # Already registered or registration optional; ignore.
+                pass
+        except Exception as exc:
+            logger.warning("Failed to initialise SAGE SDK client: %s", exc)
+            self._sdk_client = None
+        return self._sdk_client
+
+    # ------------------------------------------------------------------
+    # Health
+    # ------------------------------------------------------------------
+
+    def health_check(self) -> bool:
+        """Return True if SAGE is reachable. Safe from any thread."""
+        if not self._enabled:
+            return False
+        sdk = self._ensure_sdk()
+        if sdk is None:
+            return False
+        try:
+            result = sdk.health()
+            return bool(result)
+        except Exception as exc:
+            logger.debug("SAGE health check failed: %s", exc)
+            return False
+
+    # ------------------------------------------------------------------
+    # Memory operations
+    # ------------------------------------------------------------------
+
+    def recall(
+        self,
+        query: str,
+        domain: str = "general",
+        top_k: int = 5,
+    ) -> list[dict[str, Any]]:
+        """Return up to *top_k* committed memories from *domain*.
+
+        Returns an empty list on any failure or when SAGE is disabled —
+        callers are expected to treat the result as additional context, not
+        as a hard dependency.
+        """
+        if not self._enabled or not query:
+            return []
+        sdk = self._ensure_sdk()
+        if sdk is None:
+            return []
+        try:
+            result = sdk.list_memories(
+                domain=domain,
+                status="committed",
+                limit=min(max(top_k * 4, top_k), 50),
+            )
+            raw = getattr(result, "memories", []) or []
+            if not raw:
+                return []
+
+            # Lightweight client-side keyword ranking — works regardless of
+            # the embedding mode the SAGE node is configured with.
+            tokens = {tok for tok in query.lower().split() if len(tok) > 2}
+            scored: list[tuple[int, Any]] = []
+            for mem in raw:
+                content = getattr(mem, "content", "") or ""
+                lowered = content.lower()
+                score = sum(1 for tok in tokens if tok in lowered)
+                if score > 0:
+                    scored.append((score, mem))
+
+            ranked = sorted(scored, key=lambda x: -x[0])[:top_k]
+            if not ranked:
+                # Fall back to raw order so the caller still gets *some*
+                # context when keyword overlap is zero (e.g. embedding-driven
+                # recall would have returned them).
+                ranked = [(0, mem) for mem in raw[:top_k]]
+
+            return [
+                {
+                    "content": getattr(mem, "content", "") or "",
+                    "confidence": float(getattr(mem, "confidence_score", 0.0) or 0.0),
+                    "domain": getattr(mem, "domain_tag", domain) or domain,
+                    "memory_id": getattr(mem, "memory_id", "") or "",
+                }
+                for _, mem in ranked
+            ]
+        except Exception as exc:
+            logger.warning("SAGE recall failed: %s", exc)
+            return []
+
+    def remember(
+        self,
+        content: str,
+        domain: str = "general",
+        memory_type: str = "observation",
+        confidence: float = 0.80,
+        tags: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Propose a memory to SAGE. Returns the response dict or ``{}``."""
+        if not self._enabled or not content:
+            return {}
+        sdk = self._ensure_sdk()
+        if sdk is None:
+            return {}
+        try:
+            tagged = content
+            if tags:
+                tagged = f"{content} [tags: {', '.join(tags)}]"
+            result = sdk.propose(
+                content=tagged,
+                memory_type=memory_type,
+                domain_tag=domain,
+                confidence=confidence,
+            )
+            return {
+                "memory_id": getattr(result, "memory_id", ""),
+                "tx_hash": getattr(result, "tx_hash", ""),
+                "status": "proposed",
+            }
+        except Exception as exc:
+            logger.warning("SAGE remember failed: %s", exc)
+            return {}
+
+
+def get_sage_client() -> SageClient:
+    """Module-level shortcut for ``SageClient.get_instance()``."""
+    return SageClient.get_instance()

--- a/deeptutor/plugins/sage/manifest.yaml
+++ b/deeptutor/plugins/sage/manifest.yaml
@@ -1,0 +1,28 @@
+name: sage
+version: 0.1.0
+type: companion
+description: >-
+  External long-term memory companion + cross-tutor knowledge sharing +
+  consensus-validated audit trail, backed by a SAGE node.
+  Recalls cross-session pedagogy/subject-domain memories into deep_solve and
+  deep_research prompts, and stores observations after every capability run.
+  Strictly additive: the per-learner SUMMARY.md / PROFILE.md memory layer is
+  untouched. Opt-in via ``SAGE_ENABLED=true`` — when disabled or unreachable,
+  the plugin is a no-op and DeepTutor behaves exactly as before.
+author: SAGE contributors <https://github.com/l33tdawg/sage>
+entry: capability.py:SageMemoryCompanion
+stages:
+  - recall
+  - remember
+hooks:
+  pre_capability_run:
+    - deep_solve
+    - deep_research
+  post_capability_run:
+    event: CAPABILITY_COMPLETE
+config:
+  enabled_env: SAGE_ENABLED
+  url_env: SAGE_URL
+  identity_env: SAGE_AGENT_KEY
+  default_url: http://localhost:8080
+  domain_prefix: deeptutor

--- a/deeptutor/plugins/sage/tests/test_sage_capability.py
+++ b/deeptutor/plugins/sage/tests/test_sage_capability.py
@@ -1,0 +1,342 @@
+"""
+Tests for the SAGE memory companion plugin.
+
+Mocks the ``sage_sdk`` package via ``sys.modules`` so the suite runs
+without the real SDK installed and without a live SAGE node. Exercises:
+
+* The plugin loader discovers ``sage`` and the manifest parses cleanly.
+* The capability is a strict no-op when ``SAGE_ENABLED`` is unset.
+* When enabled, recall is called pre-run for ``deep_solve`` /
+  ``deep_research`` and the memory_context is enriched.
+* When enabled, ``CAPABILITY_COMPLETE`` triggers a remember() call.
+* The status ``run()`` method emits a result without exploding when SAGE
+  is unreachable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deeptutor.core.context import UnifiedContext
+from deeptutor.core.stream import StreamEvent, StreamEventType
+from deeptutor.core.stream_bus import StreamBus
+
+# ---------------------------------------------------------------------------
+# Fake sage_sdk — installed once, used by every test that needs SAGE enabled.
+# ---------------------------------------------------------------------------
+
+
+class _FakeMemory:
+    def __init__(self, content: str, confidence: float = 0.9, domain: str = "deeptutor-pedagogy"):
+        self.content = content
+        self.confidence_score = confidence
+        self.domain_tag = domain
+        self.memory_id = "fake-id"
+
+
+class _FakeListResult:
+    def __init__(self, memories):
+        self.memories = memories
+
+
+class _FakeProposeResult:
+    def __init__(self, memory_id="m-1", tx_hash="t-1"):
+        self.memory_id = memory_id
+        self.tx_hash = tx_hash
+
+
+class _FakeSdkClient:
+    """Mimics the surface of ``sage_sdk.SageClient`` we actually call."""
+
+    def __init__(self, *_args, **_kwargs):
+        self.proposed: list[dict] = []
+        self.listed: list[dict] = []
+
+    def health(self):
+        return {"sage": "running"}
+
+    def register_agent(self, **_kwargs):
+        return None
+
+    def list_memories(self, *, domain, status="committed", limit=20):
+        self.listed.append({"domain": domain, "status": status, "limit": limit})
+        return _FakeListResult(
+            memories=[
+                _FakeMemory(
+                    content="Students often confuse dx with delta x in early calculus",
+                    domain=domain,
+                ),
+                _FakeMemory(
+                    content="Visual derivations of integrals improve retention",
+                    domain=domain,
+                ),
+            ]
+        )
+
+    def propose(self, *, content, memory_type, domain_tag, confidence):
+        self.proposed.append(
+            {
+                "content": content,
+                "memory_type": memory_type,
+                "domain_tag": domain_tag,
+                "confidence": confidence,
+            }
+        )
+        return _FakeProposeResult()
+
+
+class _FakeAgentIdentity:
+    @classmethod
+    def from_file(cls, _path):
+        return cls()
+
+    @classmethod
+    def generate(cls):
+        return cls()
+
+    def to_file(self, _path):  # pragma: no cover - exercised indirectly
+        return None
+
+
+@pytest.fixture
+def fake_sdk(monkeypatch):
+    """Install a fake ``sage_sdk`` package in ``sys.modules``."""
+    module = types.ModuleType("sage_sdk")
+    module.SageClient = _FakeSdkClient
+    module.AgentIdentity = _FakeAgentIdentity
+    monkeypatch.setitem(sys.modules, "sage_sdk", module)
+    yield module
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton_and_hooks(monkeypatch):
+    """Reset the singleton + hook-installed flag between tests."""
+    from deeptutor.plugins.sage import capability as sage_cap
+    from deeptutor.plugins.sage.client import SageClient
+
+    SageClient.reset_instance()
+    monkeypatch.setattr(sage_cap, "_HOOKS_INSTALLED", False, raising=False)
+    yield
+    SageClient.reset_instance()
+    monkeypatch.setattr(sage_cap, "_HOOKS_INSTALLED", False, raising=False)
+    # Best-effort cleanup of EventBus listener.
+    try:
+        sage_cap.uninstall_hooks()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Loader / manifest
+# ---------------------------------------------------------------------------
+
+
+def test_loader_discovers_sage_plugin():
+    from deeptutor.plugins.loader import discover_plugins
+
+    manifests = {m.name: m for m in discover_plugins()}
+    assert "sage" in manifests
+    sage = manifests["sage"]
+    assert "capability.py" in sage.entry
+    assert sage.type == "companion"
+    assert "recall" in sage.stages
+    assert "remember" in sage.stages
+
+
+def test_loader_loads_capability_class():
+    from deeptutor.plugins.loader import discover_plugins, load_plugin_capability
+
+    sage_manifest = next(m for m in discover_plugins() if m.name == "sage")
+    cap = load_plugin_capability(sage_manifest)
+    assert cap is not None
+    assert cap.manifest.name == "sage_memory"
+
+
+# ---------------------------------------------------------------------------
+# Disabled-by-default behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_by_default(monkeypatch):
+    """Without SAGE_ENABLED the plugin is a strict no-op."""
+    monkeypatch.delenv("SAGE_ENABLED", raising=False)
+
+    from deeptutor.plugins.sage.capability import install_hooks
+    from deeptutor.plugins.sage.client import get_sage_client
+
+    assert install_hooks() is False
+    client = get_sage_client()
+    assert client.enabled is False
+    # recall + remember return empty / {} without ever touching the SDK.
+    assert client.recall("anything", domain="deeptutor-pedagogy") == []
+    assert client.remember("anything", domain="deeptutor-pedagogy") == {}
+
+
+def test_status_run_when_disabled(monkeypatch):
+    monkeypatch.delenv("SAGE_ENABLED", raising=False)
+    from deeptutor.plugins.sage.capability import SageMemoryCompanion
+
+    cap = SageMemoryCompanion()
+    bus = StreamBus()
+    ctx = UnifiedContext(user_message="status?")
+
+    async def _run():
+        await cap.run(ctx, bus)
+        await bus.close()
+        return [event async for event in bus.subscribe()]
+
+    events = asyncio.run(_run())
+    results = [e for e in events if e.type == StreamEventType.RESULT]
+    assert results, "capability should always emit a RESULT event"
+    assert results[-1].metadata.get("enabled") is False
+
+
+# ---------------------------------------------------------------------------
+# Enabled behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_recall_called_for_target_capability(monkeypatch, fake_sdk):
+    monkeypatch.setenv("SAGE_ENABLED", "true")
+
+    # Simulate a registered ``deep_solve`` capability the registry would
+    # have already loaded by the time the plugin __init__ runs.
+    from deeptutor.core.capability_protocol import BaseCapability, CapabilityManifest
+    from deeptutor.plugins.sage import capability as sage_cap
+    from deeptutor.plugins.sage.client import SageClient
+
+    SageClient.reset_instance()
+
+    class FakeDeepSolve(BaseCapability):
+        manifest = CapabilityManifest(
+            name="deep_solve",
+            description="fake",
+            stages=["planning", "reasoning"],
+        )
+
+        def __init__(self):
+            self.seen_memory_context = ""
+
+        async def run(self, context, stream):
+            self.seen_memory_context = context.memory_context
+
+    fake_solve = FakeDeepSolve()
+
+    fake_registry = MagicMock()
+    fake_registry.get.side_effect = lambda name: fake_solve if name == "deep_solve" else None
+
+    with patch(
+        "deeptutor.runtime.registry.capability_registry.get_capability_registry",
+        return_value=fake_registry,
+    ):
+        installed = sage_cap.install_hooks(force=True)
+    assert installed is True
+
+    bus = StreamBus()
+    ctx = UnifiedContext(
+        user_message="how do I integrate sin(x) by parts?",
+        knowledge_bases=["calculus-101"],
+        metadata={"learner_id": "u-42"},
+    )
+
+    asyncio.run(fake_solve.run(ctx, bus))
+
+    # The wrapped run should have appended a SAGE block with recalled
+    # memories from at least the pedagogy domain.
+    assert "SAGE — Cross-Session Memory" in fake_solve.seen_memory_context
+    assert (
+        "dx" in fake_solve.seen_memory_context.lower()
+        or "integrals" in fake_solve.seen_memory_context.lower()
+    )
+
+
+def test_capability_complete_triggers_remember(monkeypatch, fake_sdk):
+    monkeypatch.setenv("SAGE_ENABLED", "true")
+
+    import deeptutor.events.event_bus as eb_mod
+    from deeptutor.events.event_bus import Event, EventBus, EventType, get_event_bus
+    from deeptutor.plugins.sage import capability as sage_cap
+    from deeptutor.plugins.sage.client import SageClient
+
+    # Reset both the class-level and module-level EventBus caches so the
+    # listener we install + the bus we publish on are the SAME instance.
+    EventBus.reset()
+    eb_mod._event_bus = None  # noqa: SLF001 - test reset
+    SageClient.reset_instance()
+
+    fake_registry = MagicMock()
+    fake_registry.get.return_value = None  # no built-ins to wrap in this test
+
+    with patch(
+        "deeptutor.runtime.registry.capability_registry.get_capability_registry",
+        return_value=fake_registry,
+    ):
+        sage_cap.install_hooks(force=True)
+
+    # Force the SDK client to be ours so we can assert calls.
+    client = SageClient.get_instance()
+    sdk = client._ensure_sdk()
+    assert sdk is not None, "SDK should be initialised when SAGE_ENABLED is true"
+
+    async def _exercise():
+        bus = get_event_bus()
+        await bus.start()
+        try:
+            await bus.publish(
+                Event(
+                    type=EventType.CAPABILITY_COMPLETE,
+                    task_id="t-1",
+                    user_input="walk me through integration by parts",
+                    agent_output="ignored",
+                    tools_used=["rag", "reason"],
+                    metadata={
+                        "capability": "deep_solve",
+                        "session_id": "s-1",
+                        "subject": "calculus",
+                        "learner_id": "u-42",
+                    },
+                )
+            )
+            # Drain the queue.
+            await bus.flush(timeout=5.0)
+        finally:
+            await bus.stop()
+            EventBus.reset()
+            eb_mod._event_bus = None  # noqa: SLF001 - test reset
+
+    asyncio.run(_exercise())
+
+    # At least one propose() per domain (pedagogy + subject + tutor-{learner}).
+    assert len(sdk.proposed) >= 1
+    domains = {entry["domain_tag"] for entry in sdk.proposed}
+    assert "deeptutor-pedagogy" in domains
+    assert any(d.startswith("deeptutor-tutor-") for d in domains)
+    # Content is compact: no agent_output should leak in.
+    for entry in sdk.proposed:
+        assert "ignored" not in entry["content"]
+        assert "deep_solve" in entry["content"]
+
+
+def test_status_run_when_enabled(monkeypatch, fake_sdk):
+    monkeypatch.setenv("SAGE_ENABLED", "true")
+
+    from deeptutor.plugins.sage.capability import SageMemoryCompanion
+
+    cap = SageMemoryCompanion()
+    bus = StreamBus()
+    ctx = UnifiedContext(user_message="status?")
+
+    async def _run():
+        await cap.run(ctx, bus)
+        await bus.close()
+        return [event async for event in bus.subscribe()]
+
+    events = asyncio.run(_run())
+    results = [e for e in events if e.type == StreamEventType.RESULT]
+    assert results, "capability should emit RESULT"
+    assert results[-1].metadata.get("enabled") is True

--- a/tests/api/test_plugins_sage_router.py
+++ b/tests/api/test_plugins_sage_router.py
@@ -1,0 +1,94 @@
+"""Tests for the SAGE Memory Companion Playground status endpoint."""
+
+from __future__ import annotations
+
+import pytest
+
+from deeptutor.api.routers import plugins_sage as plugins_sage_router
+
+
+class _FakeSageClient:
+    def __init__(self, *, healthy: bool = True) -> None:
+        self._healthy = healthy
+        self._sdk_client = type(
+            "_FakeSdk",
+            (),
+            {"identity": type("_Id", (), {"agent_id": "agent-deadbeef"})()},
+        )()
+
+    def health_check(self) -> bool:
+        return self._healthy
+
+
+@pytest.mark.asyncio
+async def test_sage_status_disabled_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SAGE_ENABLED", raising=False)
+    monkeypatch.setenv("SAGE_URL", "http://example:9090")
+
+    monkeypatch.setattr(
+        plugins_sage_router,
+        "_safe_get_client",
+        lambda: _FakeSageClient(healthy=True),
+    )
+
+    payload = await plugins_sage_router.sage_status()
+
+    assert payload.enabled is False
+    assert payload.reachable is False
+    assert payload.plugin_loaded is True
+    assert payload.node_url == "http://example:9090"
+
+
+@pytest.mark.asyncio
+async def test_sage_status_connected_when_enabled_and_healthy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SAGE_ENABLED", "true")
+    monkeypatch.setenv("SAGE_URL", "http://sage.local:8080")
+
+    fake = _FakeSageClient(healthy=True)
+    monkeypatch.setattr(plugins_sage_router, "_safe_get_client", lambda: fake)
+
+    payload = await plugins_sage_router.sage_status()
+
+    assert payload.enabled is True
+    assert payload.reachable is True
+    assert payload.plugin_loaded is True
+    assert payload.node_url == "http://sage.local:8080"
+    assert payload.agent_id == "agent-deadbeef"
+
+
+@pytest.mark.asyncio
+async def test_sage_status_disconnected_when_health_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SAGE_ENABLED", "true")
+    monkeypatch.setenv("SAGE_URL", "http://sage.local:8080")
+
+    monkeypatch.setattr(
+        plugins_sage_router,
+        "_safe_get_client",
+        lambda: _FakeSageClient(healthy=False),
+    )
+
+    payload = await plugins_sage_router.sage_status()
+
+    assert payload.enabled is True
+    assert payload.reachable is False
+    assert "unreachable" in (payload.detail or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_sage_status_unavailable_when_plugin_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SAGE_ENABLED", raising=False)
+    monkeypatch.setattr(plugins_sage_router, "_safe_get_client", lambda: None)
+
+    payload = await plugins_sage_router.sage_status()
+
+    assert payload.plugin_loaded is False
+    assert payload.reachable is False
+    assert payload.detail and "not available" in payload.detail.lower()

--- a/web/app/(workspace)/playground/page.tsx
+++ b/web/app/(workspace)/playground/page.tsx
@@ -28,6 +28,7 @@ import AssistantResponse from "@/components/common/AssistantResponse";
 import MarkdownRenderer from "@/components/common/MarkdownRenderer";
 import ProcessLogs from "@/components/common/ProcessLogs";
 import ResearchConfigPanel from "@/components/research/ResearchConfigPanel";
+import SagePluginTile from "@/components/plugins/SagePluginTile";
 import {
   extractBase64FromDataUrl,
   readFileAsDataUrl,
@@ -1861,6 +1862,10 @@ export default function PlaygroundPage() {
               "Explore the building blocks of DeepTutor: reusable tools and higher-level capabilities.",
             )}
           </p>
+        </div>
+
+        <div className="mb-5">
+          <SagePluginTile />
         </div>
 
         {loading ? (

--- a/web/components/plugins/SagePluginTile.tsx
+++ b/web/components/plugins/SagePluginTile.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+/**
+ * SAGE Memory Companion — Playground tile.
+ *
+ * Surfaces the SAGE plugin status in the Playground page. Renders one of
+ * three states (Connected / Disabled / Disconnected) plus a degraded
+ * "not configured" muted card when the backend probe fails. The tile is
+ * additive and must never throw — any error path falls back to the muted
+ * state instead of bubbling up to the Playground page.
+ *
+ * Strings are hardcoded English with t() wrapping so they slot into the
+ * existing react-i18next pipeline (locales are key=text, see
+ * web/locales/en/app.json). zh-CN translations can be added later by
+ * dropping the same keys into web/locales/zh.
+ *
+ * TODO(i18n): Add zh-CN translations for the strings below if/when the
+ * project routes Playground tiles through translated locales. For now,
+ * react-i18next falls back to the English key text when no translation
+ * exists, which matches every other Playground string.
+ */
+
+import { useEffect, useState } from "react";
+import {
+  AlertCircle,
+  Brain,
+  CheckCircle2,
+  ExternalLink,
+  Loader2,
+  PauseCircle,
+  Power,
+  RefreshCw,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { apiUrl } from "@/lib/api";
+
+type SageStatusState = "loading" | "connected" | "disabled" | "disconnected" | "unavailable";
+
+interface SageStatusPayload {
+  enabled: boolean;
+  reachable: boolean;
+  agent_id: string | null;
+  node_url: string;
+  last_observation_at: string | null;
+  sdk_installed?: boolean;
+  plugin_loaded?: boolean;
+  detail?: string | null;
+}
+
+function deriveState(payload: SageStatusPayload | null): SageStatusState {
+  if (!payload) return "unavailable";
+  if (!payload.plugin_loaded) return "unavailable";
+  if (!payload.enabled) return "disabled";
+  if (payload.reachable) return "connected";
+  return "disconnected";
+}
+
+function badgeStyles(state: SageStatusState): {
+  label: string;
+  classes: string;
+  Icon: typeof CheckCircle2;
+} {
+  switch (state) {
+    case "connected":
+      return {
+        label: "Connected",
+        classes:
+          "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300",
+        Icon: CheckCircle2,
+      };
+    case "disabled":
+      return {
+        label: "Disabled",
+        classes:
+          "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+        Icon: PauseCircle,
+      };
+    case "disconnected":
+      return {
+        label: "Disconnected",
+        classes:
+          "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-300",
+        Icon: AlertCircle,
+      };
+    case "loading":
+      return {
+        label: "Checking...",
+        classes:
+          "border-[var(--border)] bg-[var(--muted)] text-[var(--muted-foreground)]",
+        Icon: Loader2,
+      };
+    default:
+      return {
+        label: "Not configured",
+        classes:
+          "border-[var(--border)] bg-[var(--muted)] text-[var(--muted-foreground)]",
+        Icon: AlertCircle,
+      };
+  }
+}
+
+function buildSageDashboardUrl(nodeUrl: string): string {
+  const base = (nodeUrl || "http://localhost:8080").replace(/\/$/, "");
+  return `${base}/ui/`;
+}
+
+export default function SagePluginTile() {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState<SageStatusPayload | null>(null);
+  const [state, setState] = useState<SageStatusState>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [toggling, setToggling] = useState(false);
+
+  const refresh = async () => {
+    try {
+      const res = await fetch(apiUrl("/api/v1/plugins/sage/status"));
+      if (!res.ok) {
+        setError(`HTTP ${res.status}`);
+        setStatus(null);
+        setState("unavailable");
+        return;
+      }
+      const payload = (await res.json()) as SageStatusPayload;
+      setStatus(payload);
+      setState(deriveState(payload));
+      setError(null);
+    } catch (exc) {
+      setError(exc instanceof Error ? exc.message : "fetch failed");
+      setStatus(null);
+      setState("unavailable");
+    }
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      if (cancelled) return;
+      await refresh();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleToggle = async () => {
+    if (!status) return;
+    setToggling(true);
+    try {
+      const res = await fetch(apiUrl("/api/v1/plugins/sage/toggle"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: !status.enabled }),
+      });
+      if (!res.ok) {
+        setError(`Toggle failed: HTTP ${res.status}`);
+      } else {
+        await refresh();
+      }
+    } catch (exc) {
+      setError(exc instanceof Error ? exc.message : "toggle failed");
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  const badge = badgeStyles(state);
+  const BadgeIcon = badge.Icon;
+  const isConnected = state === "connected";
+  const showToggle = state === "connected" || state === "disabled" || state === "disconnected";
+  const dashboardUrl = status ? buildSageDashboardUrl(status.node_url) : "";
+
+  return (
+    <section className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-start gap-3">
+          <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--background)] text-[var(--primary)]">
+            <Brain size={16} strokeWidth={1.7} />
+          </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-[14px] font-semibold tracking-tight text-[var(--foreground)]">
+                {t("SAGE Memory Companion")}
+              </h3>
+              <span
+                className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[10.5px] font-medium uppercase tracking-[0.08em] ${badge.classes}`}
+              >
+                <BadgeIcon
+                  size={10}
+                  strokeWidth={2}
+                  className={state === "loading" ? "animate-spin" : undefined}
+                />
+                {t(badge.label)}
+              </span>
+            </div>
+            <p className="mt-0.5 text-[12px] leading-relaxed text-[var(--muted-foreground)]">
+              {t("Cross-tutor knowledge sharing")}
+              {status?.node_url ? (
+                <>
+                  {" — "}
+                  <span className="font-mono text-[11px] text-[var(--muted-foreground)]/80">
+                    {status.node_url}
+                  </span>
+                </>
+              ) : null}
+            </p>
+            {status?.detail && state !== "loading" ? (
+              <p className="mt-1 text-[11px] leading-relaxed text-[var(--muted-foreground)]/80">
+                {status.detail}
+              </p>
+            ) : null}
+            {error ? (
+              <p className="mt-1 text-[11px] leading-relaxed text-rose-500/90">
+                {error}
+              </p>
+            ) : null}
+            {status?.agent_id ? (
+              <p className="mt-1 truncate text-[10.5px] font-mono text-[var(--muted-foreground)]/70">
+                agent: {status.agent_id}
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1.5">
+          <button
+            type="button"
+            onClick={() => void refresh()}
+            className="rounded-md border border-[var(--border)] bg-[var(--background)] p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--muted)] hover:text-[var(--foreground)]"
+            aria-label={t("Refresh SAGE status")}
+            title={t("Refresh SAGE status")}
+          >
+            <RefreshCw size={12} strokeWidth={1.8} />
+          </button>
+          {isConnected && dashboardUrl ? (
+            <a
+              href={dashboardUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 rounded-md border border-[var(--primary)]/40 bg-[var(--primary)]/10 px-2.5 py-1.5 text-[11.5px] font-medium text-[var(--primary)] transition-colors hover:bg-[var(--primary)]/15"
+            >
+              <ExternalLink size={11} strokeWidth={1.8} />
+              {t("Open SAGE Dashboard")}
+            </a>
+          ) : null}
+          {showToggle ? (
+            <button
+              type="button"
+              onClick={() => void handleToggle()}
+              disabled={toggling}
+              className={`inline-flex items-center gap-1 rounded-md border px-2.5 py-1.5 text-[11.5px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+                status?.enabled
+                  ? "border-[var(--border)] bg-[var(--background)] text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-[var(--foreground)]"
+                  : "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/15 dark:text-emerald-300"
+              }`}
+            >
+              {toggling ? (
+                <Loader2 size={11} strokeWidth={1.8} className="animate-spin" />
+              ) : (
+                <Power size={11} strokeWidth={1.8} />
+              )}
+              {status?.enabled ? t("Disable") : t("Enable")}
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
# SAGE Memory Companion — DeepTutor Integration Plan

## Motivation

DeepTutor's per-learner memory layer (`SUMMARY.md` + `PROFILE.md`, `MemoryService`, `MemoryConsolidator`) is excellent at capturing what *one* student knows and prefers. It is also intentionally local — there is no story for **cross-tutor knowledge sharing** today. As DeepTutor scales into classrooms, deployments, and individual tutors who each run their own instance, every tutor re-discovers the same pedagogical lessons in isolation:

> "Students confuse `dx` with `Δx` when first introduced to differentials."
> "Visual derivations of definite integrals improve retention vs. symbolic ones."
> "When a learner asks about Fourier transforms, anchor on time → frequency before touching complex exponentials."

These are institutional insights — they should be *shared* across deployments without leaking individual user data. That's the gap [SAGE](https://github.com/l33tdawg/sage) fills: a governed, BFT-consensus memory layer with confidence scoring, decay, and per-agent identity.

This PR ships an **additive plugin** that gives DeepTutor an external long-term memory companion. It is orthogonal to `MemoryService` and does not modify a single line of the existing per-learner memory code.

## Architecture diff

### What's added (Python plugin in `deeptutor/plugins/`, plus the new web surface)

```
deeptutor/plugins/__init__.py            (NEW)  Plugin namespace docstring.
deeptutor/plugins/loader.py              (NEW)  Generic manifest.yaml-driven plugin loader.
                                                  AGENTS.md already documents this file as
                                                  the plugin discovery entry point — both
                                                  CapabilityRegistry.load_plugins and
                                                  /api/plugins/list reference it but it
                                                  hadn't been implemented yet.
deeptutor/plugins/sage/manifest.yaml     (NEW)  Plugin metadata + hook declarations.
deeptutor/plugins/sage/__init__.py       (NEW)
deeptutor/plugins/sage/client.py         (NEW)  Singleton wrapper around sage-agent-sdk.
                                                  Adapted from RAPTOR / Aether (~250 LOC).
deeptutor/plugins/sage/capability.py     (NEW)  BaseCapability subclass + pre/post hooks.
deeptutor/plugins/sage/README.md         (NEW)  Install / enable / disable / env vars.
deeptutor/plugins/sage/tests/__init__.py (NEW)
deeptutor/plugins/sage/tests/test_sage_capability.py (NEW)
deeptutor/api/routers/plugins_sage.py    (NEW)  /api/v1/plugins/sage/{status,toggle} —
                                                  status probe + best-effort runtime
                                                  enable/disable for the Playground tile.
tests/api/test_plugins_sage_router.py    (NEW)  Backend tests for the status endpoint
                                                  (4 mocked-client cases).
web/components/plugins/SagePluginTile.tsx (NEW) Status tile rendered inside the Playground
                                                  page. Connected / Disabled / Disconnected /
                                                  Not configured states. "Open SAGE Dashboard"
                                                  link only when Connected. Best-effort toggle.
INTEGRATION_PLAN.md                      (NEW)  This document.
```

**Edits to pre-existing files (kept tiny on purpose, ~7 lines total):**

* `deeptutor/api/main.py` — import `plugins_sage` and register it under the
  `/api/v1/plugins` prefix (2 lines).
* `web/app/(workspace)/playground/page.tsx` — import `SagePluginTile` and
  render it once, just below the page header (5 lines).

### What's untouched (zero surgery)

| Subsystem                      | Why we left it alone                                            |
| ------------------------------ | --------------------------------------------------------------- |
| `deeptutor/services/memory/`   | Per-learner SUMMARY/PROFILE — completely orthogonal to SAGE.    |
| `deeptutor/agents/solve/main_solver.py` | Reads `UnifiedContext.memory_context`; we append, never replace. |
| `deeptutor/runtime/orchestrator.py`     | Already publishes `CAPABILITY_COMPLETE` — we just subscribe.   |
| `deeptutor/runtime/registry/capability_registry.py` | Already calls `deeptutor.plugins.loader.discover_plugins`; we just provide that module. |
| `deeptutor/api/routers/plugins_api.py`  | Already calls `discover_plugins()`; the SAGE plugin shows up in `/plugins/list` automatically. |
| `BaseCapability` protocol      | Unchanged. We wrap registered *instances*, not the protocol.     |
| `pyproject.toml` dependencies  | `sage-agent-sdk` is **not** added to any `[project.optional-dependencies]` — it is loaded lazily and only required when the user opts in. |

The diff outside `plugins/` is exactly **0 lines**.

### Web Playground Surface

The Next.js Playground page (`web/app/(workspace)/playground/page.tsx`)
already fetches `/api/v1/plugins/list` to enumerate tools + capabilities,
but plugins themselves were never rendered visually. We added a single
status tile so SAGE has a discoverable presence in the UI:

* **`web/components/plugins/SagePluginTile.tsx`** — fetches
  `/api/v1/plugins/sage/status`, derives one of four states (Connected,
  Disabled, Disconnected, Not configured) and renders a compact card with a
  status badge, the SAGE node URL, the agent_id when known, an "Open SAGE
  Dashboard" link (only when Connected, points at `${SAGE_URL}/ui/`), and a
  best-effort Enable/Disable toggle. Errors degrade to a muted card — the
  tile must never throw and break the rest of the Playground.
* **`deeptutor/api/routers/plugins_sage.py`** — the backend probe. `GET
  /sage/status` returns `{enabled, reachable, agent_id, node_url,
  sdk_installed, plugin_loaded, detail}`. `POST /sage/toggle` flips the
  in-process `SAGE_ENABLED` env var and asks `capability.install_hooks` /
  `uninstall_hooks` to react. The toggle is *not* persisted — restart with
  the env var set in your shell for a permanent change. The README notes
  this caveat.
* **i18n** — strings are wrapped in `t(...)` but no zh-CN entries are
  shipped in this PR. `react-i18next` falls back to the English key text
  (the project sets `keySeparator: false` and uses English keys as ids),
  matching the rest of Playground's untranslated strings.

### Runtime flow

```
                      ┌───────────────────────┐
   user turn  ──────► │  ChatOrchestrator     │  (unchanged)
                      └──┬──────────────────┬─┘
                         │                  │
              ┌──────────▼─────────┐        │
              │  CapabilityRegistry │       │
              │  load_builtins()    │       │
              │  load_plugins()  ◄──┼── SAGE plugin loaded here.
              └──────────┬──────────┘       │   Its __init__ wraps
                         │                  │   deep_solve + deep_research
                         ▼                  │   with a recall pre-hook
        ┌────────────────────────────────┐  │   and subscribes the
        │  Wrapped capability.run        │◄─┘   EventBus listener.
        │  (deep_solve, deep_research)   │
        │   1. SAGE.recall(prompt)       │      Recall block is APPENDED
        │      → memory_context          │      to context.memory_context;
        │   2. original.run(...)         │      MemoryService stays primary.
        └────────────┬───────────────────┘
                     │
                     ▼
        ┌────────────────────────────────┐
        │  EventBus.publish(             │  (unchanged)
        │    CAPABILITY_COMPLETE)        │
        └────────────┬───────────────────┘
                     │
                     ▼
        ┌────────────────────────────────┐
        │  SAGE plugin listener          │
        │   SAGE.remember(...)           │   Compact observation:
        │   domains:                     │     prompt + capability +
        │     deeptutor-pedagogy         │     tools_used + success.
        │     deeptutor-{subject}        │     Full agent_output is
        │     deeptutor-tutor-{learner}  │     NEVER stored.
        └────────────────────────────────┘
```

## Opt-in story

A single env var controls everything:

```bash
export SAGE_ENABLED=true        # opt in
export SAGE_URL=http://localhost:8080   # default
```

* Without `SAGE_ENABLED=true`, the plugin loads but installs no hooks. Its
  capability still appears in `deeptutor plugin list`, but reports
  `enabled=false` and does nothing.
* When `SAGE_ENABLED=true` but the SAGE node is unreachable / `sage-agent-sdk`
  isn't installed, every recall/remember returns an empty result and logs
  at `INFO` once. DeepTutor turns continue normally.
* Recall is best-effort: any exception in the recall hook is swallowed and
  the underlying capability still runs unmodified.
* Remember is fire-and-forget: the EventBus listener catches every
  exception so a SAGE outage cannot break the chat turn.

## Graceful degradation matrix

| State                                  | Behaviour                                              |
| -------------------------------------- | ------------------------------------------------------ |
| `SAGE_ENABLED` unset / not truthy      | Plugin loaded but inert. No hooks. No SDK import.      |
| `SAGE_ENABLED=true`, SDK not installed | One INFO log, hooks installed but every call is a no-op. |
| `SAGE_ENABLED=true`, SAGE node down    | Hooks installed; recall returns `[]`, remember warns once and returns `{}`. Capability turn unaffected. |
| Recall raises mid-turn                 | Caught + logged, original `run()` proceeds with empty SAGE block. |
| Remember raises post-turn              | Caught in EventBus listener; never propagates out.     |

## What gets stored in SAGE

Per-turn observation (one per domain — pedagogy, subject, learner-tutor):

```
[deeptutor:deep_solve] success=ok tools=rag,reason prompt=walk me through integration by parts
```

* No agent output.
* No conversation history.
* No PII beyond whatever the user typed in their prompt.
* Capped at ~400 chars.

## Prior art (same shape, already shipped)

| Host project | Plugin location                          | PR / commit                                           |
| ------------ | ---------------------------------------- | ----------------------------------------------------- |
| RAPTOR       | `core/sage/`                              | l33tdawg/raptor — singleton + sync-pipeline hook      |
| Aether       | `core/sage_client.py` + multi-pass hooks  | l33tdawg/aether — same wrapper, async pipeline        |
| pentagi v2   | `integrations/sage/`                      | vxcontrol/pentagi — Go bridge mirroring this shape    |
| Level Up     | `integrations/levelup/sage_bridge.py`     | l33tdawg/sage `integrations/levelup/`                 |

All four ship as additive plugins with the same env-driven opt-in story
and graceful no-op behaviour. This PR is the fifth.

## Tests

```bash
pytest deeptutor/plugins/sage/tests -v
```

The suite mocks `sage_sdk` via `sys.modules`, so it runs without the SDK
package installed and without a live SAGE node. Coverage:

1. Plugin manifest is discoverable via `discover_plugins()`.
2. Capability class loads via `load_plugin_capability()`.
3. With `SAGE_ENABLED` unset, the plugin is a strict no-op.
4. With `SAGE_ENABLED=true`, recall is invoked pre-`deep_solve` and
   `memory_context` is enriched.
5. With `SAGE_ENABLED=true`, `CAPABILITY_COMPLETE` triggers a `propose()`
   call across all expected domain tags, and the agent output never leaks
   into stored content.
6. The plugin's own `run()` reports status correctly in both states.

## What's intentionally NOT in this PR

To keep the surface tight, this PR does **not**:

* Add `sage-agent-sdk` to any `requirements.txt` / `pyproject.toml` extra.
  Users opting in install it themselves: `pip install sage-agent-sdk`.
* Modify `MemoryService` or `MemoryConsolidator`.
* Touch the orchestrator, the registry implementations, or the EventBus.
* Add new capabilities beyond the `sage_memory` status probe.
* Add UI surface in `web/`.

Each of those is a separate, opt-in follow-up if maintainers want it.
