### PR TITLE
fix: paint settings select dark-mode dropdown popover background

### DIFF
--- a/web/app/(utility)/settings/page.tsx
+++ b/web/app/(utility)/settings/page.tsx
@@ -205,7 +205,7 @@ const inputClass =
   "w-full rounded-lg border border-[var(--border)] bg-transparent px-3 py-2 text-[14px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--ring)] placeholder:text-[var(--muted-foreground)]/40";
 
 const selectClass =
-  "w-full appearance-none rounded-lg border border-[var(--border)] bg-transparent px-3 py-2 text-[14px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--ring)] cursor-pointer";
+  "w-full appearance-none rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[14px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--ring)] cursor-pointer";
 
 function stringifyExtraHeaders(value: CatalogProfile["extra_headers"]): string {
   if (!value) return "";


### PR DESCRIPTION
Closes #433.

The Provider `<select>` in `web/app/(utility)/settings/page.tsx` uses `bg-transparent` via the shared `selectClass`. When the user opens the dropdown in `.dark` theme on Chromium/Edge (reporter is on Edge + Ubuntu 24.04), the OS-rendered popover doesn't pick up `color-scheme: dark` correctly because there is no concrete background on the element to inherit — the popover ends up white, and the light option text is unreadable on white. Reporter pinned the symptom to v1.3.4 with two screenshots in the issue.

Switching `bg-transparent` → `bg-[var(--background)]` gives the popover a real surface to inherit from in every theme, while keeping the closed select visually identical (the surrounding profile editor card has no explicit bg, so it sits on `--background`):

| Theme        | `--background`              |
|--------------|-----------------------------|
| `:root`      | `#faf9f6` (warm paper)      |
| `.dark`      | `#1a1918`                   |
| `theme-snow` | `#f8fafc`                   |
| `theme-glass`| `#111111`                   |

Same shape as the reporter's `dark:bg-gray-800` suggestion, expressed through the existing design-system token rather than a literal palette so other themes get the same fix for free.

Tested locally with `npx tsc --noEmit` (clean) and `npx eslint web/app/(utility)/settings/page.tsx` (the only error is pre-existing on `dev` at line 315 — `react-hooks/set-state-in-effect`, unrelated to this diff).

The other `<select>` in the file (line 491, embedding-dimension picker) uses `inputClass` rather than `selectClass` and therefore still has `bg-transparent`. I left it alone because `inputClass` is shared with text inputs — happy to do a follow-up that splits the dimension picker off `inputClass` if you'd prefer to sweep both in this PR instead.