### PR TITLE
fix(llm): map max_completion_tokens to max_output_tokens for Responses API

### DIFF
--- a/deeptutor/services/llm/provider_core/azure_openai_provider.py
+++ b/deeptutor/services/llm/provider_core/azure_openai_provider.py
@@ -11,6 +11,7 @@ from openai import AsyncOpenAI
 
 from deeptutor.services.llm.provider_core.base import LLMProvider, LLMResponse
 from deeptutor.services.llm.provider_core.openai_responses import (
+    adapt_chat_kwargs_to_responses,
     consume_sdk_stream,
     convert_messages,
     convert_tools,
@@ -122,7 +123,7 @@ class AzureOpenAIProvider(LLMProvider):
             reasoning_effort,
             tool_choice,
         )
-        body.update({k: v for k, v in extra_kwargs.items() if v is not None})
+        body.update(adapt_chat_kwargs_to_responses(extra_kwargs))
         try:
             return parse_response_output(await self._client.responses.create(**body))
         except Exception as exc:
@@ -150,7 +151,7 @@ class AzureOpenAIProvider(LLMProvider):
             reasoning_effort,
             tool_choice,
         )
-        body.update({k: v for k, v in extra_kwargs.items() if v is not None})
+        body.update(adapt_chat_kwargs_to_responses(extra_kwargs))
         body["stream"] = True
         idle_timeout_s = 90
 

--- a/deeptutor/services/llm/provider_core/openai_compat_provider.py
+++ b/deeptutor/services/llm/provider_core/openai_compat_provider.py
@@ -21,6 +21,7 @@ from openai import AsyncOpenAI
 from deeptutor.services.llm.capabilities import disable_response_format_at_runtime
 from deeptutor.services.llm.provider_core.base import LLMProvider, LLMResponse, ToolCallRequest
 from deeptutor.services.llm.provider_core.openai_responses import (
+    adapt_chat_kwargs_to_responses,
     consume_sdk_stream,
     convert_messages,
     convert_tools,
@@ -694,7 +695,7 @@ class OpenAICompatProvider(LLMProvider):
                         reasoning_effort,
                         tool_choice,
                     )
-                    body.update({k: v for k, v in extra_kwargs.items() if v is not None})
+                    body.update(adapt_chat_kwargs_to_responses(extra_kwargs))
                     result = parse_response_output(await self._client.responses.create(**body))
                     self._record_responses_success(model, reasoning_effort)
                     return result
@@ -777,7 +778,7 @@ class OpenAICompatProvider(LLMProvider):
                         reasoning_effort,
                         tool_choice,
                     )
-                    body.update({k: v for k, v in extra_kwargs.items() if v is not None})
+                    body.update(adapt_chat_kwargs_to_responses(extra_kwargs))
                     body["stream"] = True
                     stream = await self._client.responses.create(**body)
 

--- a/deeptutor/services/llm/provider_core/openai_responses/__init__.py
+++ b/deeptutor/services/llm/provider_core/openai_responses/__init__.py
@@ -1,6 +1,12 @@
 """Shared helpers for Responses API providers."""
 
-from .converters import convert_messages, convert_tools, convert_user_message, split_tool_call_id
+from .converters import (
+    adapt_chat_kwargs_to_responses,
+    convert_messages,
+    convert_tools,
+    convert_user_message,
+    split_tool_call_id,
+)
 from .parsing import (
     FINISH_REASON_MAP,
     consume_sdk_stream,
@@ -11,6 +17,7 @@ from .parsing import (
 )
 
 __all__ = [
+    "adapt_chat_kwargs_to_responses",
     "convert_messages",
     "convert_tools",
     "convert_user_message",

--- a/deeptutor/services/llm/provider_core/openai_responses/converters.py
+++ b/deeptutor/services/llm/provider_core/openai_responses/converters.py
@@ -108,3 +108,30 @@ def split_tool_call_id(tool_call_id: Any) -> tuple[str, str | None]:
             return call_id, item_id or None
         return tool_call_id, None
     return "call_0", None
+
+
+def adapt_chat_kwargs_to_responses(extra_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Translate Chat Completions kwargs to Responses API equivalents.
+
+    Callers building requests for the Chat Completions endpoint may pass
+    ``max_completion_tokens`` for newer OpenAI models (o1/o3/gpt-4o/gpt-5.x).
+    The Responses API does not accept that name and uses ``max_output_tokens``
+    instead, so the OpenAI SDK raises ``TypeError`` from ``responses.create``
+    before any HTTP request leaves the client. See DeepTutor#437.
+
+    Drops keys with ``None`` values to match the existing merge filter, and
+    only applies the alias when the caller did not already set the Responses
+    name explicitly.
+    """
+    result: dict[str, Any] = {}
+    legacy_max_completion: int | None = None
+    for key, value in extra_kwargs.items():
+        if value is None:
+            continue
+        if key == "max_completion_tokens":
+            legacy_max_completion = value
+            continue
+        result[key] = value
+    if legacy_max_completion is not None and "max_output_tokens" not in result:
+        result["max_output_tokens"] = legacy_max_completion
+    return result

--- a/tests/services/llm/test_openai_responses_converters.py
+++ b/tests/services/llm/test_openai_responses_converters.py
@@ -1,0 +1,45 @@
+"""Tests for the Responses API converter helpers."""
+
+from __future__ import annotations
+
+from deeptutor.services.llm.provider_core.openai_responses import (
+    adapt_chat_kwargs_to_responses,
+)
+
+
+class TestAdaptChatKwargsToResponses:
+    def test_passes_through_unrelated_kwargs(self) -> None:
+        result = adapt_chat_kwargs_to_responses({"temperature": 0.2, "tool_choice": "auto"})
+        assert result == {"temperature": 0.2, "tool_choice": "auto"}
+
+    def test_drops_none_values(self) -> None:
+        result = adapt_chat_kwargs_to_responses({"temperature": 0.2, "response_format": None})
+        assert result == {"temperature": 0.2}
+
+    def test_translates_max_completion_tokens_to_max_output_tokens(self) -> None:
+        # Regression for DeepTutor#437: gpt-5.x callers pass
+        # `max_completion_tokens` from `get_token_limit_kwargs(model, n)`,
+        # but the Responses API only accepts `max_output_tokens`.
+        result = adapt_chat_kwargs_to_responses({"max_completion_tokens": 8192, "temperature": 0.2})
+        assert result == {"max_output_tokens": 8192, "temperature": 0.2}
+        assert "max_completion_tokens" not in result
+
+    def test_drops_max_completion_tokens_when_none(self) -> None:
+        result = adapt_chat_kwargs_to_responses({"max_completion_tokens": None, "temperature": 0.2})
+        assert result == {"temperature": 0.2}
+
+    def test_explicit_max_output_tokens_wins_over_alias(self) -> None:
+        # If the caller already set the Responses API name explicitly, do not
+        # overwrite it with the chat-completions alias value.
+        result = adapt_chat_kwargs_to_responses(
+            {"max_completion_tokens": 8192, "max_output_tokens": 4096}
+        )
+        assert result == {"max_output_tokens": 4096}
+
+    def test_empty_input_returns_empty_dict(self) -> None:
+        assert adapt_chat_kwargs_to_responses({}) == {}
+
+    def test_does_not_mutate_input(self) -> None:
+        source = {"max_completion_tokens": 8192, "temperature": 0.2}
+        adapt_chat_kwargs_to_responses(source)
+        assert source == {"max_completion_tokens": 8192, "temperature": 0.2}


### PR DESCRIPTION
## What

When the Responses API path is selected for newer OpenAI models (gpt-5.x, o1, o3, o4) and an extra kwarg of \`max_completion_tokens\` flows in, the OpenAI SDK raises \`TypeError\` from \`responses.create()\` before any HTTP request leaves the client. Closes #437.

## Why

\`get_token_limit_kwargs(model, n)\` returns \`{"max_completion_tokens": n}\` for newer models (the Chat Completions name). Both \`OpenAICompatProvider\` and \`AzureOpenAIProvider\` route those kwargs through \`client.responses.create()\` when \`_should_use_responses_api()\` matches, but the Responses API only accepts \`max_output_tokens\`. The SDK rejects the unknown kwarg with \`TypeError\` inside the client, and \`_should_fallback_from_responses_error()\` only catches HTTP errors with \`status_code\` — so the call is never retried via Chat Completions.

The reporter in #437 hit this with \`LLM_BINDING = openai\` and \`LLM_MODEL = gpt-5.5\` on v1.3.5, which routes through \`OpenAICompatProvider\`.

## How

Add \`adapt_chat_kwargs_to_responses()\` to \`provider_core/openai_responses/converters.py\` and use it at all four merge sites: \`chat\` and \`chat_stream\` on both \`OpenAICompatProvider\` (lines 698, 781) and \`AzureOpenAIProvider\` (lines 126, 154).

The helper:
- preserves the existing \`None\`-drop semantics of the previous dict-comprehension merge,
- maps \`max_completion_tokens\` → \`max_output_tokens\`,
- only applies the alias when \`max_output_tokens\` is not explicitly set by the caller,
- does not mutate the input.

## Tests

\`tests/services/llm/test_openai_responses_converters.py\` covers seven cases: passthrough, None-drop, the rename, None for the alias, explicit-name precedence, empty input, and input non-mutation. \`pytest tests/services/llm/test_openai_responses_converters.py -v\` is green; the rest of \`tests/services/llm/\` and \`tests/services/config/test_llm_probe_config.py\` pass with no new failures from this branch (75/76; the one unrelated failure is a missing \`data/user/settings/agents.yaml\` fixture).

## Note on #390

There is an existing open PR (#390, "[codex] Normalize Azure OpenAI max token aliases") that addresses a related problem at the factory layer for Azure only by translating to \`max_tokens\`. The reproduction in #437 uses \`LLM_BINDING = openai\`, which goes through \`OpenAICompatProvider\` and is outside that PR's scope. Happy to defer if a different shape is preferred.