### PR TITLE
fix(agents): normalize single newlines to markdown paragraphs in quiz content

### DIFF
--- a/deeptutor/agents/question/agents/generator.py
+++ b/deeptutor/agents/question/agents/generator.py
@@ -286,6 +286,47 @@ class Generator(BaseAgent):
         normalized = str(question_type or "").strip().lower()
         return normalized if normalized in {"choice", "written", "coding"} else "written"
 
+    @staticmethod
+    def _normalize_markdown_paragraphs(text: str) -> str:
+        """Convert single newlines into paragraph breaks for markdown rendering.
+
+        LLMs often emit single ``\n`` characters between logical paragraphs
+        (e.g.  (1)…  (2)…).  In markdown a single newline is treated as a
+        soft-break / space, so the front-end renders everything as one dense
+        block.  This helper turns isolated single newlines into ``\n\n`` so
+        that react-markdown creates separate ``<p>`` tags, while preserving
+        existing blank lines and structural markers (lists, code fences, etc.).
+        """
+        if not text:
+            return text
+        lines = text.split("\n")
+        result: list[str] = []
+        prev_blank = True
+        for line in lines:
+            stripped = line.rstrip()
+            if stripped == "":
+                result.append("")
+                prev_blank = True
+                continue
+            # Structural lines that should start a new paragraph
+            is_structural = (
+                stripped.startswith("```")
+                or stripped.startswith("|")
+                or stripped.startswith("#")
+                or stripped.startswith("-")
+                or stripped.startswith("*")
+                or stripped.startswith(">")
+                or re.match(r"^\s*\d+[.):]", stripped)
+                or re.match(r"^\s*[-*+]\s", stripped)
+            )
+            if not prev_blank and not is_structural:
+                # This line continues the previous paragraph in the raw text,
+                # but we want it as its own paragraph for display.
+                result.append("")
+            result.append(stripped)
+            prev_blank = False
+        return "\n".join(result)
+
     @classmethod
     def _normalize_payload_shape(
         cls,
@@ -294,9 +335,15 @@ class Generator(BaseAgent):
     ) -> dict[str, Any]:
         normalized = dict(payload or {})
         normalized["question_type"] = expected_type
-        normalized["question"] = str(normalized.get("question", "") or "").strip()
-        normalized["correct_answer"] = str(normalized.get("correct_answer", "") or "").strip()
-        normalized["explanation"] = str(normalized.get("explanation", "") or "").strip()
+        normalized["question"] = cls._normalize_markdown_paragraphs(
+            str(normalized.get("question", "") or "").strip()
+        )
+        normalized["correct_answer"] = cls._normalize_markdown_paragraphs(
+            str(normalized.get("correct_answer", "") or "").strip()
+        )
+        normalized["explanation"] = cls._normalize_markdown_paragraphs(
+            str(normalized.get("explanation", "") or "").strip()
+        )
 
         raw_options = normalized.get("options")
         if expected_type == "choice":


### PR DESCRIPTION
### Description

Fix quiz question content not rendering with proper paragraph spacing in the web UI.

LLMs often emit single `\n` characters between logical paragraphs in `question`, `correct_answer`, and `explanation` fields (e.g. `(1)…` `(2)…`). In Markdown, a single newline is treated as a soft-break and rendered as a space, causing `react-markdown` to collapse everything into one dense `<p>` block.

This PR adds `_normalize_markdown_paragraphs()` to the `Generator` class so that isolated single newlines are converted to `\n\n` paragraph breaks before the payload is returned. Structural markers (lists, code fences, tables, headings) are preserved to avoid breaking intentional formatting.

### Related Issues

- Related to quiz content readability in the web UI

### Module(s) Affected

- [x] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend) — indirectly fixes rendering
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

**File changed**: `deeptutor/agents/question/agents/generator.py`

**Summary of changes**:
- Added `_normalize_markdown_paragraphs()` static method
- Applied paragraph normalization to `question`, `correct_answer`, and `explanation` fields in `_normalize_payload_shape()`

**Before fix** (raw LLM output):
```markdown
已知平面向量 $\boldsymbol{a}=(n,2)$...
（1）若 $\boldsymbol{a} \perp \boldsymbol{b}$，求...
（2）若 $\boldsymbol{a}$ 与 $\boldsymbol{b}$ 的夹角为锐角...
```
→ Renders as one dense block with no paragraph breaks.

**After fix** (normalized):
```markdown
已知平面向量 $\boldsymbol{a}=(n,2)$...

（1）若 $\boldsymbol{a} \perp \boldsymbol{b}$，求...

（2）若 $\boldsymbol{a}$ 与 $\boldsymbol{b}$ 的夹角为锐角...
```
→ Each sub-question renders as a separate `<p>` element, significantly improving readability.

**Rebased onto**: v1.3.7 (latest upstream `main`)