### PR TITLE
fix: raise context_window ceiling and add qwen vision support

### DIFF
--- a/deeptutor/services/llm/capabilities.py
+++ b/deeptutor/services/llm/capabilities.py
@@ -176,6 +176,7 @@ MODEL_OVERRIDES: dict[str, dict[str, object]] = {
     },
     "qwen": {
         "has_thinking_tags": True,
+        "supports_vision": True,
     },
     "qwq": {
         "has_thinking_tags": True,

--- a/deeptutor/services/llm/context_window.py
+++ b/deeptutor/services/llm/context_window.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 DEFAULT_CONTEXT_WINDOW_FALLBACK = 16_384
-MAX_EFFECTIVE_CONTEXT_WINDOW = 65_536
+MAX_EFFECTIVE_CONTEXT_WINDOW = 1_000_000
+LARGE_CONTEXT_MODEL_DEFAULT = 65_536
 KNOWN_LARGE_CONTEXT_MARKERS = (
     "gpt-4.1",
     "gpt-4o",
@@ -44,7 +45,7 @@ def default_context_window_for_model(
 ) -> int:
     """Return the fallback window used when no explicit model metadata exists."""
     if looks_like_large_context_model(model):
-        return MAX_EFFECTIVE_CONTEXT_WINDOW
+        return LARGE_CONTEXT_MODEL_DEFAULT
     output_limit = coerce_positive_int(max_tokens) or 4096
     return max(DEFAULT_CONTEXT_WINDOW_FALLBACK, output_limit * 4)
 
@@ -68,6 +69,7 @@ def resolve_effective_context_window(
 __all__ = [
     "DEFAULT_CONTEXT_WINDOW_FALLBACK",
     "MAX_EFFECTIVE_CONTEXT_WINDOW",
+    "LARGE_CONTEXT_MODEL_DEFAULT",
     "KNOWN_LARGE_CONTEXT_MARKERS",
     "coerce_positive_int",
     "default_context_window_for_model",

--- a/tests/services/session/test_context_builder.py
+++ b/tests/services/session/test_context_builder.py
@@ -143,7 +143,7 @@ class TestContextBuilderBudgets:
     def test_history_budget_uses_explicit_context_window(self) -> None:
         builder = ContextBuilder(store=MagicMock(), history_budget_ratio=0.35)
         budget = builder._history_budget(self._make_llm_config(4096, context_window=128000))
-        assert budget == int(65536 * 0.35)
+        assert budget == int(128000 * 0.35)
 
     def test_history_budget_uses_large_context_model_heuristic(self) -> None:
         builder = ContextBuilder(store=MagicMock(), history_budget_ratio=0.35)


### PR DESCRIPTION
### Description

Fix two bugs that cause incorrect model capability detection at runtime:

**Bug 1: `context_window` is hardcoded to 65536, truncating all user-configured values**

`MAX_EFFECTIVE_CONTEXT_WINDOW = 65_536` serves as both the safety ceiling and the default value returned by `default_context_window_for_model()`, creating a circular reference: `default == ceiling == 65536`. Combined with `min(configured, MAX_EFFECTIVE_CONTEXT_WINDOW)`, any user-configured value (via WebUI or `model_catalog.json`) is silently truncated to 65536.

For example, when a user sets `context_window=128000` for qwen3.6-plus:
- Before: `min(128000, 65536) = 65536` ❌
- After: `min(128000, 1000000) = 128000` ✅

**Bug 2: `supports_vision=False` for qwen models when `binding=custom` or `binding=dashscope`**

`MODEL_OVERRIDES["qwen"]` only sets `has_thinking_tags: True` without `supports_vision`. When `binding=custom`, `PROVIDER_CAPABILITIES` has no `"custom"` entry, so it falls back to `DEFAULT_CAPABILITIES["supports_vision"] = False`. This means qwen models (which do support vision) are incorrectly treated as non-vision-capable unless `binding=openai`.

### Related Issues
- Related to context_window 65536 limitation
- Related to qwen vision capability detection

### Module(s) Affected
- [x] `services`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

**Changes summary:**

| File | Change | Description |
|------|--------|-------------|
| `deeptutor/services/llm/context_window.py` | `MAX_EFFECTIVE_CONTEXT_WINDOW` 65536→1,000,000 | Safety cap only, not a ceiling for reasonable configs |
| `deeptutor/services/llm/context_window.py` | Add `LARGE_CONTEXT_MODEL_DEFAULT = 65_536` | Separate constant to break the circular reference (default == ceiling) |
| `deeptutor/services/llm/context_window.py` | `default_context_window_for_model()` returns `LARGE_CONTEXT_MODEL_DEFAULT` | No longer returns `MAX_EFFECTIVE_CONTEXT_WINDOW`, breaking the circular reference |
| `deeptutor/services/llm/capabilities.py` | Add `supports_vision: True` to `MODEL_OVERRIDES["qwen"]` | qwen models recognized as vision-capable regardless of binding |

**Priority logic after fix:**
1. User-configured value (via WebUI or `model_catalog.json`) → used directly, only capped by 1M safety limit
2. Model name heuristic default (large models → 65536, small models → 16384)
3. Fallback default (only when nothing else is available)

**All default values unchanged:** `LARGE_CONTEXT_MODEL_DEFAULT` keeps `65_536` — identical to the current behavior. The only behavioral change is that user-configured values are no longer silently truncated.

**Why `MAX_EFFECTIVE_CONTEXT_WINDOW = 1_000_000` instead of removing the cap entirely?**

The `min()` ceiling serves as a safety guard against typos (e.g., accidentally entering `100000000`). 1M is well above any current model's context window while still catching unreasonable inputs. The key fix is decoupling the ceiling from the default value.

**Why add `LARGE_CONTEXT_MODEL_DEFAULT` as a separate constant?**

Previously `default_context_window_for_model()` returned `MAX_EFFECTIVE_CONTEXT_WINDOW` for large models, creating a circular reference where the default equaled the ceiling. By introducing a separate `LARGE_CONTEXT_MODEL_DEFAULT`, the two concerns are decoupled: the default can stay at 65536 (conservative, identical to current behavior) while the ceiling is raised to 1M (allowing user-configured values to pass through).

**Why add `supports_vision: True` to `MODEL_OVERRIDES["qwen"]` instead of adding `"custom"` to `PROVIDER_CAPABILITIES`?**

Vision capability is a model-level property, not a binding-level one. qwen models support vision regardless of which binding (custom, dashscope, openai) is used. Adding it to `MODEL_OVERRIDES` is the correct layer — consistent with how `gpt-4o`, `claude-3`, `gemini` etc. are already configured.