### PR TITLE
feat: add delete chat turn functionality with attachment cleanup

### DIFF
--- a/deeptutor/api/routers/sessions.py
+++ b/deeptutor/api/routers/sessions.py
@@ -118,10 +118,10 @@ async def delete_session(session_id: str):
 async def delete_turn_by_message(session_id: str, message_id: int):
     store = get_sqlite_session_store()
     result = await store.delete_turn_by_message(session_id, message_id)
-    if not result["deleted"]:
-        raise HTTPException(status_code=404, detail="Message not found")
     if result["was_running"]:
         raise HTTPException(status_code=409, detail="Cannot delete a message while its turn is running")
+    if not result["deleted"]:
+        raise HTTPException(status_code=404, detail="Message not found")
     attachment_store = get_attachment_store()
     for aid in result["attachment_ids"]:
         try:

--- a/deeptutor/api/routers/sessions.py
+++ b/deeptutor/api/routers/sessions.py
@@ -119,7 +119,9 @@ async def delete_turn_by_message(session_id: str, message_id: int):
     store = get_sqlite_session_store()
     result = await store.delete_turn_by_message(session_id, message_id)
     if result["was_running"]:
-        raise HTTPException(status_code=409, detail="Cannot delete a message while its turn is running")
+        raise HTTPException(
+            status_code=409, detail="Cannot delete a message while its turn is running"
+        )
     if not result["deleted"]:
         raise HTTPException(status_code=404, detail="Message not found")
     attachment_store = get_attachment_store()

--- a/deeptutor/api/routers/sessions.py
+++ b/deeptutor/api/routers/sessions.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field, field_validator
 
 from deeptutor.services.session import get_session_store, get_sqlite_session_store
+from deeptutor.services.storage.attachment_store import get_attachment_store
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +107,28 @@ async def delete_session(session_id: str):
     deleted = await store.delete_session(session_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Session not found")
+    try:
+        await get_attachment_store().delete_session(session_id)
+    except Exception:
+        logger.exception("failed to clean up attachments for session %s", session_id)
     return {"deleted": True, "session_id": session_id}
+
+
+@router.delete("/{session_id}/messages/{message_id}")
+async def delete_turn_by_message(session_id: str, message_id: int):
+    store = get_sqlite_session_store()
+    result = await store.delete_turn_by_message(session_id, message_id)
+    if not result["deleted"]:
+        raise HTTPException(status_code=404, detail="Message not found")
+    if result["was_running"]:
+        raise HTTPException(status_code=409, detail="Cannot delete a message while its turn is running")
+    attachment_store = get_attachment_store()
+    for aid in result["attachment_ids"]:
+        try:
+            await attachment_store.delete_attachment(session_id, aid)
+        except Exception:
+            logger.exception("failed to delete attachment %s for session %s", aid, session_id)
+    return result
 
 
 @router.post("/{session_id}/quiz-results")

--- a/deeptutor/services/session/sqlite_store.py
+++ b/deeptutor/services/session/sqlite_store.py
@@ -648,6 +648,110 @@ class SQLiteSessionStore:
     async def delete_message(self, message_id: int | str) -> bool:
         return await self._run(self._delete_message_sync, message_id)
 
+    def _delete_turn_by_message_sync(self, session_id: str, message_id: int) -> dict[str, Any]:
+        with self._connect() as conn:
+            msg = conn.execute(
+                """
+                SELECT id, session_id, role, attachments_json, created_at
+                FROM messages
+                WHERE id = ?
+                """,
+                (int(message_id),),
+            ).fetchone()
+            if msg is None or msg["session_id"] != session_id:
+                return {"deleted": False, "attachment_ids": [], "turn_id": None, "was_running": False}
+
+            role = msg["role"]
+            paired_msg = None
+            if role == "user":
+                paired_msg = conn.execute(
+                    """
+                    SELECT id, session_id, role, attachments_json, created_at
+                    FROM messages
+                    WHERE session_id = ? AND role = 'assistant' AND id > ?
+                    ORDER BY id ASC
+                    LIMIT 1
+                    """,
+                    (session_id, int(message_id)),
+                ).fetchone()
+            elif role == "assistant":
+                paired_msg = conn.execute(
+                    """
+                    SELECT id, session_id, role, attachments_json, created_at
+                    FROM messages
+                    WHERE session_id = ? AND role = 'user' AND id < ?
+                    ORDER BY id DESC
+                    LIMIT 1
+                    """,
+                    (session_id, int(message_id)),
+                ).fetchone()
+
+            attachment_ids: list[str] = []
+            for m in [msg, paired_msg]:
+                if m is not None:
+                    atts = _json_loads(m["attachments_json"], [])
+                    for att in atts:
+                        aid = att.get("id") or att.get("attachment_id")
+                        if aid:
+                            attachment_ids.append(aid)
+
+            user_msg = msg if role == "user" else paired_msg
+            turn_id = None
+            was_running = False
+            if user_msg is not None:
+                user_created_at = user_msg["created_at"]
+                turn_row = conn.execute(
+                    """
+                    SELECT id, status
+                    FROM turns
+                    WHERE session_id = ? AND created_at >= ?
+                    ORDER BY created_at ASC
+                    LIMIT 1
+                    """,
+                    (session_id, user_created_at),
+                ).fetchone()
+                if turn_row is not None:
+                    turn_id = turn_row["id"]
+                    was_running = turn_row["status"] == "running"
+                    conn.execute("DELETE FROM turn_events WHERE turn_id = ?", (turn_id,))
+                    conn.execute("DELETE FROM turns WHERE id = ?", (turn_id,))
+
+            ids_to_delete = [int(message_id)]
+            if paired_msg is not None:
+                ids_to_delete.append(int(paired_msg["id"]))
+            conn.execute(
+                f"DELETE FROM messages WHERE id IN ({','.join('?' * len(ids_to_delete))})",
+                tuple(ids_to_delete),
+            )
+
+            session_row = conn.execute(
+                "SELECT summary_up_to_msg_id FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if session_row is not None:
+                summary_up_to = int(session_row["summary_up_to_msg_id"])
+                if any(mid <= summary_up_to for mid in ids_to_delete):
+                    conn.execute(
+                        "UPDATE sessions SET summary_up_to_msg_id = 0 WHERE id = ?",
+                        (session_id,),
+                    )
+
+            conn.execute(
+                "UPDATE sessions SET updated_at = ? WHERE id = ?",
+                (time.time(), session_id),
+            )
+            conn.commit()
+
+        return {
+            "deleted": True,
+            "attachment_ids": attachment_ids,
+            "turn_id": turn_id,
+            "was_running": was_running,
+        }
+
+    async def delete_turn_by_message(self, session_id: str, message_id: int) -> dict[str, Any]:
+        return await self._run(self._delete_turn_by_message_sync, session_id, message_id)
+
     def _get_last_message_sync(
         self, session_id: str, role: str | None = None
     ) -> dict[str, Any] | None:

--- a/deeptutor/services/session/sqlite_store.py
+++ b/deeptutor/services/session/sqlite_store.py
@@ -686,15 +686,6 @@ class SQLiteSessionStore:
                     (session_id, int(message_id)),
                 ).fetchone()
 
-            attachment_ids: list[str] = []
-            for m in [msg, paired_msg]:
-                if m is not None:
-                    atts = _json_loads(m["attachments_json"], [])
-                    for att in atts:
-                        aid = att.get("id") or att.get("attachment_id")
-                        if aid:
-                            attachment_ids.append(aid)
-
             user_msg = msg if role == "user" else paired_msg
             turn_id = None
             was_running = False
@@ -713,8 +704,22 @@ class SQLiteSessionStore:
                 if turn_row is not None:
                     turn_id = turn_row["id"]
                     was_running = turn_row["status"] == "running"
-                    conn.execute("DELETE FROM turn_events WHERE turn_id = ?", (turn_id,))
-                    conn.execute("DELETE FROM turns WHERE id = ?", (turn_id,))
+
+            if was_running:
+                return {"deleted": False, "attachment_ids": [], "turn_id": turn_id, "was_running": True}
+
+            attachment_ids: list[str] = []
+            for m in [msg, paired_msg]:
+                if m is not None:
+                    atts = _json_loads(m["attachments_json"], [])
+                    for att in atts:
+                        aid = att.get("id") or att.get("attachment_id")
+                        if aid:
+                            attachment_ids.append(aid)
+
+            if turn_id is not None:
+                conn.execute("DELETE FROM turn_events WHERE turn_id = ?", (turn_id,))
+                conn.execute("DELETE FROM turns WHERE id = ?", (turn_id,))
 
             ids_to_delete = [int(message_id)]
             if paired_msg is not None:

--- a/deeptutor/services/session/sqlite_store.py
+++ b/deeptutor/services/session/sqlite_store.py
@@ -659,7 +659,12 @@ class SQLiteSessionStore:
                 (int(message_id),),
             ).fetchone()
             if msg is None or msg["session_id"] != session_id:
-                return {"deleted": False, "attachment_ids": [], "turn_id": None, "was_running": False}
+                return {
+                    "deleted": False,
+                    "attachment_ids": [],
+                    "turn_id": None,
+                    "was_running": False,
+                }
 
             role = msg["role"]
             paired_msg = None
@@ -706,7 +711,12 @@ class SQLiteSessionStore:
                     was_running = turn_row["status"] == "running"
 
             if was_running:
-                return {"deleted": False, "attachment_ids": [], "turn_id": turn_id, "was_running": True}
+                return {
+                    "deleted": False,
+                    "attachment_ids": [],
+                    "turn_id": turn_id,
+                    "was_running": True,
+                }
 
             attachment_ids: list[str] = []
             for m in [msg, paired_msg]:
@@ -725,7 +735,7 @@ class SQLiteSessionStore:
             if paired_msg is not None:
                 ids_to_delete.append(int(paired_msg["id"]))
             conn.execute(
-                f"DELETE FROM messages WHERE id IN ({','.join('?' * len(ids_to_delete))})",
+                f"DELETE FROM messages WHERE id IN ({','.join('?' * len(ids_to_delete))})",  # nosec B608
                 tuple(ids_to_delete),
             )
 

--- a/deeptutor/services/storage/attachment_store.py
+++ b/deeptutor/services/storage/attachment_store.py
@@ -88,6 +88,9 @@ class AttachmentStore(Protocol):
     async def delete_session(self, session_id: str) -> None:
         """Best-effort cleanup of all attachments for *session_id*."""
 
+    async def delete_attachment(self, session_id: str, attachment_id: str) -> None:
+        """Best-effort cleanup of a single attachment identified by *attachment_id*."""
+
     def resolve_path(self, *, session_id: str, attachment_id: str, filename: str) -> Path | None:
         """Return the absolute path on disk for an attachment, or ``None``
         if it does not exist or escapes the storage root.
@@ -186,6 +189,13 @@ class LocalDiskAttachmentStore:
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._rmtree_sync, session_dir)
 
+    async def delete_attachment(self, session_id: str, attachment_id: str) -> None:
+        session_dir = self._session_dir(session_id)
+        if not session_dir.exists():
+            return
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._delete_attachment_sync, session_dir, attachment_id)
+
     @staticmethod
     def _rmtree_sync(path: Path) -> None:
         import shutil
@@ -194,6 +204,21 @@ class LocalDiskAttachmentStore:
             shutil.rmtree(path)
         except OSError as exc:
             logger.warning("failed to clean up attachment dir %s: %s", path, exc)
+
+    @staticmethod
+    def _delete_attachment_sync(session_dir: Path, attachment_id: str) -> None:
+        prefix = f"{attachment_id}_"
+        for entry in session_dir.iterdir():
+            if entry.name.startswith(prefix):
+                try:
+                    entry.unlink()
+                except OSError as exc:
+                    logger.warning("failed to delete attachment file %s: %s", entry, exc)
+        try:
+            if session_dir.exists() and not any(session_dir.iterdir()):
+                session_dir.rmdir()
+        except OSError as exc:
+            logger.warning("failed to remove empty attachment dir %s: %s", session_dir, exc)
 
     def resolve_path(self, *, session_id: str, attachment_id: str, filename: str) -> Path | None:
         stored = self._stored_filename(attachment_id, filename)

--- a/web/app/(workspace)/chat/[[...sessionId]]/page.tsx
+++ b/web/app/(workspace)/chat/[[...sessionId]]/page.tsx
@@ -310,6 +310,7 @@ export default function ChatPage() {
     sendMessage,
     cancelStreamingTurn,
     regenerateLastMessage,
+    deleteTurn,
     newSession,
     loadSession,
   } = useUnifiedChat();
@@ -1645,6 +1646,7 @@ export default function ChatPage() {
               onRegenerateMessage={handleRegenerateMessage}
               onConfirmOutline={handleConfirmOutline}
               onPreviewAttachment={handlePreviewMessageAttachment}
+              onDeleteTurn={deleteTurn}
             />
             <div ref={messagesEndRef} className="h-px w-full shrink-0" />
           </div>

--- a/web/components/chat/home/ChatMessages.tsx
+++ b/web/components/chat/home/ChatMessages.tsx
@@ -365,7 +365,9 @@ const UserMessage = memo(function UserMessage({
               </button>
             ) : (
               <div className="flex items-center gap-1.5 text-[12px]">
-                <span className="text-[var(--muted-foreground)]">{t("Delete this turn?")}</span>
+                <span className="text-[var(--muted-foreground)]">
+                  {t("Delete this turn?")}
+                </span>
                 <button
                   type="button"
                   onClick={() => {

--- a/web/components/chat/home/ChatMessages.tsx
+++ b/web/components/chat/home/ChatMessages.tsx
@@ -12,6 +12,7 @@ import {
   RefreshCcw,
   Wand2,
   X,
+  Trash2,
   Zap,
   type LucideIcon,
 } from "lucide-react";
@@ -52,6 +53,7 @@ const VisualizationViewer = dynamic(
 );
 
 interface ChatMessageItem {
+  id?: number;
   role: "user" | "assistant" | "system";
   content: string;
   capability?: string;
@@ -336,17 +338,55 @@ const UserMessage = memo(function UserMessage({
   msg,
   index,
   onPreviewAttachment,
+  onDeleteTurn,
 }: {
   msg: ChatMessageItem;
   index: number;
   onPreviewAttachment?: (attachment: MessageAttachment) => void;
+  onDeleteTurn?: (messageId: number) => void;
 }) {
   const { t } = useTranslation();
+  const [confirmDelete, setConfirmDelete] = useState(false);
   if (msg.content.startsWith("[Quiz Performance]")) return null;
 
   return (
-    <div key={`${msg.role}-${index}`} className="flex justify-end">
+    <div key={`${msg.role}-${index}`} className="group flex justify-end">
       <div className="max-w-[75%] space-y-1.5">
+        <div className="flex justify-end">
+          <div className="relative">
+            {!confirmDelete ? (
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(true)}
+                className="rounded-md p-1 text-[var(--muted-foreground)] opacity-0 transition-opacity group-hover:opacity-100 hover:text-[var(--destructive)]"
+                title={t("Delete")}
+              >
+                <Trash2 size={14} strokeWidth={1.5} />
+              </button>
+            ) : (
+              <div className="flex items-center gap-1.5 text-[12px]">
+                <span className="text-[var(--muted-foreground)]">{t("Delete this turn?")}</span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (msg.id != null) onDeleteTurn?.(msg.id);
+                    setConfirmDelete(false);
+                  }}
+                  className="rounded-md px-2 py-0.5 font-medium text-[var(--destructive)] hover:bg-[var(--destructive)]/10"
+                >
+                  {t("Delete")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirmDelete(false)}
+                  className="rounded-md px-2 py-0.5 font-medium text-[var(--muted-foreground)] hover:bg-[var(--muted)]/40"
+                >
+                  {t("Cancel")}
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
         <div className="flex justify-end pr-1">
           <span className="text-[10px] tracking-wide text-[var(--muted-foreground)]">
             {t(getModeBadgeLabel(msg.capability))}
@@ -686,6 +726,7 @@ export const ChatMessageList = memo(function ChatMessageList({
   onConfirmOutline,
   onPreviewAttachment,
   onSwitchToManualMode,
+  onDeleteTurn,
 }: {
   messages: ChatMessageItem[];
   isStreaming: boolean;
@@ -707,6 +748,7 @@ export const ChatMessageList = memo(function ChatMessageList({
   // button after a terminal failure. Optional so non-auto chat surfaces don't
   // have to wire it.
   onSwitchToManualMode?: () => void;
+  onDeleteTurn?: (messageId: number) => void;
 }) {
   const { t } = useTranslation();
   const outlineStatusByIndex = useMemo(() => {
@@ -783,6 +825,7 @@ export const ChatMessageList = memo(function ChatMessageList({
               msg={msg}
               index={i}
               onPreviewAttachment={onPreviewAttachment}
+              onDeleteTurn={onDeleteTurn}
             />
           );
         }

--- a/web/context/UnifiedChatContext.tsx
+++ b/web/context/UnifiedChatContext.tsx
@@ -117,6 +117,7 @@ export interface MessageRequestSnapshot {
 }
 
 export interface MessageItem {
+  id?: number;
   role: "user" | "assistant" | "system";
   content: string;
   capability?: string;
@@ -269,6 +270,7 @@ function reducer(state: ProviderState, action: Action): ProviderState {
             messages: [
               ...session.messages,
               {
+                id: -Date.now(),
                 role: "user",
                 content: action.content,
                 capability: action.capability || "",
@@ -343,6 +345,7 @@ function reducer(state: ProviderState, action: Action): ProviderState {
             messages: [
               ...(state.sessions[action.key]?.messages ?? []),
               {
+                id: -Date.now(),
                 role: "assistant",
                 content: "",
                 events: [],
@@ -362,6 +365,7 @@ function reducer(state: ProviderState, action: Action): ProviderState {
       let last = msgs[msgs.length - 1];
       if (last?.role !== "assistant") {
         msgs.push({
+          id: -Date.now(),
           role: "assistant",
           content: "",
           events: [],
@@ -714,6 +718,7 @@ export function UnifiedChatProvider({
             attachments,
           );
           return {
+            id: message.id,
             role: message.role,
             content:
               message.role === "assistant"

--- a/web/context/UnifiedChatContext.tsx
+++ b/web/context/UnifiedChatContext.tsx
@@ -1264,14 +1264,28 @@ export function UnifiedChatProvider({
       const session = currentState.sessions[key];
       if (!session || !session.sessionId) return;
       if (session.isStreaming) return;
+      let effectiveId = messageId;
+      if (messageId < 0) {
+        const origIdx = session.messages.findIndex((m) => m.id === messageId);
+        if (origIdx === -1) return;
+        try {
+          await loadSession(session.sessionId);
+        } catch {
+          return;
+        }
+        const refreshed = stateRef.current.sessions[key];
+        const realId = refreshed?.messages[origIdx]?.id;
+        if (realId == null || realId < 0) return;
+        effectiveId = realId;
+      }
       try {
-        await deleteMessage(session.sessionId, messageId);
-        dispatch({ type: "DELETE_TURN", key, messageId });
+        await deleteMessage(session.sessionId, effectiveId);
+        dispatch({ type: "DELETE_TURN", key, messageId: effectiveId });
       } catch (err) {
         console.error("Failed to delete turn:", err);
       }
     },
-    [],
+    [loadSession],
   );
 
   const value: ChatContextValue = {

--- a/web/context/UnifiedChatContext.tsx
+++ b/web/context/UnifiedChatContext.tsx
@@ -19,7 +19,11 @@ import {
 } from "@/context/app-shell-storage";
 import type { StreamEvent, ChatMessage, LLMSelection } from "@/lib/unified-ws";
 import { UnifiedWSClient } from "@/lib/unified-ws";
-import { getSession, deleteMessage, type SessionMessage } from "@/lib/session-api";
+import {
+  getSession,
+  deleteMessage,
+  type SessionMessage,
+} from "@/lib/session-api";
 import { normalizeMarkdownForDisplay } from "@/lib/markdown-display";
 import { normalizeMessageContent } from "@/lib/message-content";
 import { shouldAppendEventContent } from "@/lib/stream";
@@ -494,7 +498,10 @@ function reducer(state: ProviderState, action: Action): ProviderState {
       const toRemove = new Set<number>();
       toRemove.add(idx);
       if (msg.role === "user") {
-        if (idx + 1 < session.messages.length && session.messages[idx + 1].role === "assistant") {
+        if (
+          idx + 1 < session.messages.length &&
+          session.messages[idx + 1].role === "assistant"
+        ) {
           toRemove.add(idx + 1);
         }
       } else if (msg.role === "assistant") {

--- a/web/context/UnifiedChatContext.tsx
+++ b/web/context/UnifiedChatContext.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/context/app-shell-storage";
 import type { StreamEvent, ChatMessage, LLMSelection } from "@/lib/unified-ws";
 import { UnifiedWSClient } from "@/lib/unified-ws";
-import { getSession, type SessionMessage } from "@/lib/session-api";
+import { getSession, deleteMessage, type SessionMessage } from "@/lib/session-api";
 import { normalizeMarkdownForDisplay } from "@/lib/markdown-display";
 import { normalizeMessageContent } from "@/lib/message-content";
 import { shouldAppendEventContent } from "@/lib/stream";
@@ -183,6 +183,7 @@ type Action =
       llmSelection?: LLMSelection | null;
       language?: string;
     }
+  | { type: "DELETE_TURN"; key: string; messageId: number }
   | { type: "NEW_SESSION"; key: string };
 
 function createSessionEntry(
@@ -484,6 +485,39 @@ function reducer(state: ProviderState, action: Action): ProviderState {
         },
       };
     }
+    case "DELETE_TURN": {
+      const session = state.sessions[action.key];
+      if (!session) return state;
+      const idx = session.messages.findIndex((m) => m.id === action.messageId);
+      if (idx === -1) return state;
+      const msg = session.messages[idx];
+      const toRemove = new Set<number>();
+      toRemove.add(idx);
+      if (msg.role === "user") {
+        if (idx + 1 < session.messages.length && session.messages[idx + 1].role === "assistant") {
+          toRemove.add(idx + 1);
+        }
+      } else if (msg.role === "assistant") {
+        if (idx - 1 >= 0 && session.messages[idx - 1].role === "user") {
+          toRemove.add(idx - 1);
+        }
+      }
+      const nextMessages = session.messages.filter((_, i) => !toRemove.has(i));
+      return {
+        ...state,
+        sessions: {
+          ...state.sessions,
+          [action.key]: {
+            ...session,
+            messages: nextMessages,
+            isStreaming: false,
+            status: "idle",
+            updatedAt: Date.now(),
+          },
+        },
+        sidebarRefreshToken: state.sidebarRefreshToken + 1,
+      };
+    }
     case "NEW_SESSION": {
       const MAX_CACHED_SESSIONS = 20;
       let nextSessions = {
@@ -535,6 +569,7 @@ interface ChatContextValue {
   ) => void;
   cancelStreamingTurn: () => void;
   regenerateLastMessage: () => void;
+  deleteTurn: (messageId: number) => Promise<void>;
   newSession: () => void;
   loadSession: (sessionId: string) => Promise<void>;
   selectedSessionId: string | null;
@@ -1221,6 +1256,24 @@ export function UnifiedChatProvider({
     dispatch({ type: "NEW_SESSION", key: makeDraftKey() });
   }, [makeDraftKey]);
 
+  const deleteTurn = useCallback(
+    async (messageId: number) => {
+      const currentState = stateRef.current;
+      const key = currentState.selectedKey;
+      if (!key) return;
+      const session = currentState.sessions[key];
+      if (!session || !session.sessionId) return;
+      if (session.isStreaming) return;
+      try {
+        await deleteMessage(session.sessionId, messageId);
+        dispatch({ type: "DELETE_TURN", key, messageId });
+      } catch (err) {
+        console.error("Failed to delete turn:", err);
+      }
+    },
+    [],
+  );
+
   const value: ChatContextValue = {
     state: derivedState,
     setTools,
@@ -1231,6 +1284,7 @@ export function UnifiedChatProvider({
     sendMessage,
     cancelStreamingTurn,
     regenerateLastMessage,
+    deleteTurn,
     newSession,
     loadSession,
     selectedSessionId: derivedState.sessionId,

--- a/web/lib/session-api.ts
+++ b/web/lib/session-api.ts
@@ -189,3 +189,14 @@ export async function recordQuizResults(
   );
   await expectJson<{ recorded: boolean }>(response);
 }
+
+export async function deleteMessage(
+  sessionId: string,
+  messageId: number,
+): Promise<void> {
+  const response = await fetch(
+    apiUrl(`/api/v1/sessions/${sessionId}/messages/${messageId}`),
+    { method: "DELETE" },
+  );
+  await expectJson<{ deleted: boolean }>(response);
+}

--- a/web/lib/session-api.ts
+++ b/web/lib/session-api.ts
@@ -194,7 +194,7 @@ export async function deleteMessage(
   sessionId: string,
   messageId: number,
 ): Promise<void> {
-  const response = await fetch(
+  const response = await apiFetch(
     apiUrl(`/api/v1/sessions/${sessionId}/messages/${messageId}`),
     { method: "DELETE" },
   );


### PR DESCRIPTION
### Description

This PR adds the ability to delete a specific Q&A turn (user + assistant message pair) from a WebUI Chat session, along with proper cleanup of associated attachment files.

**Key changes:**

**Backend:**
- Added `AttachmentStore.delete_attachment(session_id, attachment_id)` method to delete individual attachment files from disk
- Added `SQLiteSessionStore.delete_turn_by_message(session_id, message_id)` method that:
  - Finds the paired user/assistant message and associated turn
  - Checks if the turn is currently running (returns early with `was_running=True` to prevent data loss)
  - Extracts attachment IDs from `attachments_json` for cleanup
  - Cascades deletion to turn_events, turns, and messages
  - Resets `summary_up_to_msg_id` when deleted messages fall within the summary range
- Added `DELETE /api/v1/sessions/{session_id}/messages/{message_id}` endpoint with:
  - 409 response for running turns (checked before 404)
  - 404 response for non-existent messages
  - Best-effort attachment file cleanup after DB deletion
- **Bug fix**: `delete_session` endpoint now calls `AttachmentStore.delete_session()` to clean up attachment files (previously implemented but never called)

**Frontend:**
- Extended `MessageItem` interface with `id?: number` field, mapped from backend `SessionMessage.id`
- Added `deleteMessage(sessionId, messageId)` API function in `session-api.ts`
- Added `DELETE_TURN` reducer action that removes the user+assistant message pair from state
- Added `deleteTurn(messageId)` context method with temporary ID resolution (reloads session if message has a client-side temporary ID)
- Added delete button on user message bubbles (visible on hover) with inline confirmation dialog
- Wired up `onDeleteTurn` callback through `ChatMessageList` → `UserMessage` → page component

### Related Issues
- Fixes attachment file leak when deleting sessions (existing bug)

### Module(s) Affected
- [x] `api`
- [x] `services`
- [x] `web` (Frontend)

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

**Design decisions:**
- **Turn-level deletion** (not single message): Deleting a Q&A pair avoids orphan messages and matches user mental model ("delete this conversation turn")
- **Running turn protection**: The `was_running` check happens *before* any data deletion to prevent data loss. The API returns 409 if the turn is actively streaming
- **Attachment cleanup**: Attachment file deletion failures are logged but don't block the message deletion (best-effort cleanup)
- **Temporary ID handling**: If a user tries to delete a message that still has a client-side temporary ID (negative number), the frontend first reloads the session to get the real backend ID before making the API call