### PR TITLE
feat: add deeptutor start command to launch backend and frontend together

### DIFF
--- a/deeptutor_cli/main.py
+++ b/deeptutor_cli/main.py
@@ -104,6 +104,17 @@ def run_capability(
 
 
 @app.command()
+def start() -> None:
+    """Launch backend + frontend together."""
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    script = str(Path(__file__).resolve().parent.parent / "scripts" / "start_web.py")
+    subprocess.run([sys.executable, script])
+
+
+@app.command()
 def serve(
     host: str = typer.Option("0.0.0.0", help="Bind address."),
     port: int = typer.Option(get_backend_port(), help="Port number."),


### PR DESCRIPTION
### Description

Add `deeptutor start` CLI command that launches both backend and frontend
in a single command, delegating to `scripts/start_web.py`.

Currently `deeptutor serve` only starts the backend API server. Users
who want the full web app still need to run `python scripts/start_web.py`
separately. This command fills that gap — `deeptutor start` gives the
same experience with a cleaner entry point.

All port and language configuration stays in `.env` and environment
variables, exactly as `start_web.py` already reads them. No new flags
or configuration surface.

### Changes

- `deeptutor_cli/main.py` — new `start` command (+11 lines)

### Test plan

- [x] `deeptutor start` launches backend + frontend
- [x] `deeptutor start --help` shows help text
- [x] `deeptutor --help` includes `start` in the command list