### PR TITLE
fix: add deepseek-v4-flash and deepseek-v4-pro to model pricing table

### DIFF
--- a/deeptutor/agents/research/utils/token_tracker.py
+++ b/deeptutor/agents/research/utils/token_tracker.py
@@ -29,6 +29,8 @@ MODEL_PRICING = {
     "gpt-3.5-turbo": {"input": 0.0005, "output": 0.0015},
     "deepseek-chat": {"input": 0.00014, "output": 0.00028},
     "deepseek-coder": {"input": 0.00014, "output": 0.00028},
+    "deepseek-v4-flash": {"input": 0.00014, "output": 0.00028},
+    "deepseek-v4-pro": {"input": 0.000435, "output": 0.00087},
 }
 
 


### PR DESCRIPTION
### Description

Add `deepseek-v4-flash` and `deepseek-v4-pro` to the hardcoded model pricing
table. These models were missing, causing cost calculations to fall back to
`gpt-4o-mini` pricing instead of the correct DeepSeek rates.

Pricing from https://api-docs.deepseek.com/quick_start/pricing/ (per 1K tokens):

| Model | Input | Output |
|---|---|---|
| deepseek-v4-flash | $0.00014 | $0.00028 |
| deepseek-v4-pro | $0.000435 | $0.00087 |

This is a stopgap fix. A proper Settings UI for configurable model pricing is
tracked in #446.

### Changes

- `deeptutor/agents/research/utils/token_tracker.py` — 2 new pricing entries (+2 lines)

### Test plan

- [ ] DeepSeek v4 model cost displays match the API pricing page