### PR TITLE
fix(web): preserve newlines in user chat messages

### DIFF
--- a/web/components/chat/home/ChatMessages.tsx
+++ b/web/components/chat/home/ChatMessages.tsx
@@ -461,7 +461,7 @@ const UserMessage = memo(function UserMessage({
               </div>
             );
           })()}
-          <div>{msg.content}</div>
+          <div className="whitespace-pre-wrap">{msg.content}</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Fixes #444 — user messages containing newlines (entered via Shift+Enter) are displayed without line breaks, making multi-line content unreadable.

## Root Cause

The user message content in `ChatMessages.tsx` is rendered inside a plain `<div>` which collapses whitespace by default (CSS `white-space: normal`).

## Fix

Add the Tailwind `whitespace-pre-wrap` class to the content `<div>` so that newline characters in the message are preserved during rendering while still wrapping at the container edge.

## Changes

- `web/components/chat/home/ChatMessages.tsx`: Add `className="whitespace-pre-wrap"` to the user message content div (line 464)

## Testing

- Verified that the `<textarea>` input correctly preserves newlines (Shift+Enter) in the message data
- The fix applies standard CSS `white-space: pre-wrap` which is widely supported and consistent with how the assistant response component already handles multi-line content