### PR TITLE
fix(llm): stop sending reasoning_effort=minimal as top-level param to providers that reject it

### DIFF
--- a/deeptutor/services/llm/cloud_provider.py
+++ b/deeptutor/services/llm/cloud_provider.py
@@ -83,6 +83,19 @@ def _coerce_int(value: object, default: int | None) -> int | None:
 # Use lowercase to avoid constant redefinition warning
 _ssl_warning_logged = False
 
+# Providers that handle thinking mode through extra_body (rather than
+# top-level reasoning_effort).  "minimal" means disable thinking — these
+# providers reject the literal "minimal" value and expect extra_body instead.
+_BINDINGS_WITH_EXTRA_BODY_THINKING = frozenset({
+    "deepseek",
+    "dashscope",
+    "volcengine",
+    "volcengine_coding_plan",
+    "byteplus",
+    "byteplus_coding_plan",
+    "minimax",
+})
+
 
 def _looks_like_unsupported_response_format(error_text: str) -> bool:
     """Detect whether a 400 error body indicates ``response_format`` is unsupported.
@@ -328,7 +341,12 @@ async def _openai_complete(
         data["response_format"] = response_format
     reasoning_effort = kwargs.get("reasoning_effort")
     if isinstance(reasoning_effort, str) and reasoning_effort.strip():
-        data["reasoning_effort"] = reasoning_effort.strip()
+        effort = reasoning_effort.strip()
+        if not (
+            effort.lower() == "minimal"
+            and binding.lower() in _BINDINGS_WITH_EXTRA_BODY_THINKING
+        ):
+            data["reasoning_effort"] = effort
 
     timeout = aiohttp.ClientTimeout(total=120)
     connector = _get_aiohttp_connector()
@@ -493,7 +511,12 @@ async def _openai_stream(
         data["response_format"] = response_format
     reasoning_effort = kwargs.get("reasoning_effort")
     if isinstance(reasoning_effort, str) and reasoning_effort.strip():
-        data["reasoning_effort"] = reasoning_effort.strip()
+        effort = reasoning_effort.strip()
+        if not (
+            effort.lower() == "minimal"
+            and binding.lower() in _BINDINGS_WITH_EXTRA_BODY_THINKING
+        ):
+            data["reasoning_effort"] = effort
 
     timeout = aiohttp.ClientTimeout(total=300)
     connector = _get_aiohttp_connector()

--- a/deeptutor/services/llm/provider_core/openai_compat_provider.py
+++ b/deeptutor/services/llm/provider_core/openai_compat_provider.py
@@ -308,7 +308,12 @@ class OpenAICompatProvider(LLMProvider):
         if spec and spec.name == "dashscope" and semantic_effort == "minimal":
             wire_effort = "minimum"
 
-        if wire_effort:
+        # Providers with thinking_style handle thinking via extra_body.
+        # "minimal" means disable thinking — only send via extra_body, never
+        # as a top-level reasoning_effort (e.g. DeepSeek rejects it).
+        if wire_effort and not (
+            spec and spec.thinking_style and semantic_effort == "minimal"
+        ):
             kwargs["reasoning_effort"] = wire_effort
 
         if spec and spec.thinking_style and reasoning_effort is not None:

--- a/deeptutor/tutorbot/providers/openai_compat_provider.py
+++ b/deeptutor/tutorbot/providers/openai_compat_provider.py
@@ -257,12 +257,9 @@ class OpenAICompatProvider(LLMProvider):
                     kwargs.update(overrides)
                     break
 
-        if reasoning_effort:
-            kwargs["reasoning_effort"] = reasoning_effort
-
+        extra: dict[str, Any] | None = None
         if spec and reasoning_effort is not None:
             thinking_enabled = reasoning_effort.lower() != "minimal"
-            extra: dict[str, Any] | None = None
             if spec.name == "dashscope":
                 extra = {"enable_thinking": thinking_enabled}
             elif spec.name in (
@@ -270,10 +267,20 @@ class OpenAICompatProvider(LLMProvider):
                 "volcengine_coding_plan",
                 "byteplus",
                 "byteplus_coding_plan",
+                "deepseek",
             ):
                 extra = {"thinking": {"type": "enabled" if thinking_enabled else "disabled"}}
+            elif spec.name == "minimax":
+                extra = {"reasoning_split": thinking_enabled}
             if extra:
                 kwargs.setdefault("extra_body", {}).update(extra)
+
+        # Providers that handle thinking via extra_body don't need a
+        # top-level reasoning_effort when the intent is to disable thinking.
+        if reasoning_effort and not (
+            extra and reasoning_effort.lower() == "minimal"
+        ):
+            kwargs["reasoning_effort"] = reasoning_effort
 
         if tools:
             kwargs["tools"] = tools


### PR DESCRIPTION
## Summary
- DeepSeek rejects `reasoning_effort=minimal` — it only accepts `high`/`max`/`low`/`medium`/`xhigh`
- When user sets `LLM_REASONING_EFFORT=minimal` to disable thinking, the code was sending it as a top-level parameter to DeepSeek, causing API errors
- Fix: for providers that handle thinking via `extra_body` (DeepSeek, DashScope, VolcEngine, BytePlus, MiniMax), skip the top-level `reasoning_effort` when the intent is to disable thinking — the `extra_body` already carries the `thinking.type=disabled` signal

## Changes
| File | Change |
|------|--------|
| `provider_core/openai_compat_provider.py` | Skip top-level `reasoning_effort` when `thinking_style` is set and semantic effort is `minimal` |
| `tutorbot/providers/openai_compat_provider.py` | Same logic + add deepseek & minimax to `extra_body` chain |
| `cloud_provider.py` | Skip `reasoning_effort=minimal` for providers that use `extra_body` thinking control |

## Affected providers
Only 7 providers with `thinking_style` are affected. OpenAI, Anthropic, Gemini, Mistral, and all others are untouched.

## Related
- PR #428: DeepSeek reasoning_content fallback
- Issue #430: DeepSeek thinking support tracking
- Commit `44686ab`: documented `minimal` as a valid value for DeepSeek (but it was broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)