### PR TITLE
fix: add TutorBot NVIDIA NIM provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ POCKETBASE_PORT=8090
 # 2. LLM (Required)
 # ---------------------------------------------------------------------
 # Supported bindings: openai, anthropic, deepseek, gemini, azure_openai,
-# lm_studio, ollama, vllm, openrouter, siliconflow, dashscope, ...
+# nvidia_nim, lm_studio, ollama, vllm, openrouter, siliconflow, dashscope, ...
 # Full list: `deeptutor provider list`.
 LLM_BINDING=openai
 LLM_MODEL=gpt-4o-mini

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ EMBEDDING_DIMENSION=
 | MiniMax (Anthropic) | `minimax_anthropic` | `https://api.minimaxi.com/anthropic` |
 | Mistral | `mistral` | `https://api.mistral.ai/v1` |
 | Moonshot | `moonshot` | `https://api.moonshot.cn/v1` |
+| NVIDIA NIM | `nvidia_nim` | `https://integrate.api.nvidia.com/v1` |
 | Ollama | `ollama` | `http://localhost:11434/v1` |
 | OpenAI | `openai` | `https://api.openai.com/v1` |
 | OpenAI Codex | `openai_codex` | `https://chatgpt.com/backend-api` |

--- a/deeptutor/tutorbot/config/schema.py
+++ b/deeptutor/tutorbot/config/schema.py
@@ -103,6 +103,7 @@ class ProvidersConfig(Base):
     )  # BytePlus Coding Plan
     openai_codex: ProviderConfig = Field(default_factory=ProviderConfig)  # OpenAI Codex (OAuth)
     github_copilot: ProviderConfig = Field(default_factory=ProviderConfig)  # Github Copilot (OAuth)
+    nvidia_nim: ProviderConfig = Field(default_factory=ProviderConfig)  # NVIDIA NIM
 
 
 class HeartbeatConfig(Base):

--- a/deeptutor/tutorbot/providers/openai_compat_provider.py
+++ b/deeptutor/tutorbot/providers/openai_compat_provider.py
@@ -561,7 +561,8 @@ class OpenAICompatProvider(LLMProvider):
             tool_choice,
         )
         kwargs["stream"] = True
-        kwargs["stream_options"] = {"include_usage": True}
+        if self._spec is None or self._spec.supports_stream_options:
+            kwargs["stream_options"] = {"include_usage": True}
         idle_timeout_s = 90
         try:
             stream = await self._client.chat.completions.create(**kwargs)

--- a/deeptutor/tutorbot/providers/registry.py
+++ b/deeptutor/tutorbot/providers/registry.py
@@ -47,6 +47,7 @@ class ProviderSpec:
     # gateway behavior
     strip_model_prefix: bool = False
     supports_max_completion_tokens: bool = False
+    supports_stream_options: bool = True
 
     # per-model param overrides, e.g. (("kimi-k2.5", {"temperature": 1.0}),)
     model_overrides: tuple[tuple[str, dict[str, Any]], ...] = ()
@@ -325,6 +326,18 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="http://localhost:8000/v3",
     ),
     # === Auxiliary ==========================================================
+    ProviderSpec(
+        name="nvidia_nim",
+        keywords=("nvidia_nim", "nvidia-nim", "nim"),
+        env_key="NVIDIA_NIM_API_KEY",
+        display_name="NVIDIA NIM",
+        backend="openai_compat",
+        is_gateway=True,
+        detect_by_key_prefix="nvapi-",
+        detect_by_base_keyword="api.nvidia.com",
+        default_api_base="https://integrate.api.nvidia.com/v1",
+        supports_stream_options=False,
+    ),
     ProviderSpec(
         name="groq",
         keywords=("groq",),

--- a/tests/services/tutorbot/test_nvidia_nim_provider.py
+++ b/tests/services/tutorbot/test_nvidia_nim_provider.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from deeptutor.tutorbot.config.schema import ProviderConfig, ProvidersConfig
+from deeptutor.tutorbot.providers.openai_compat_provider import OpenAICompatProvider
+from deeptutor.tutorbot.providers.registry import find_by_name, find_gateway
+
+
+class _EmptyAsyncStream:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+class _FakeCompletions:
+    def __init__(self) -> None:
+        self.kwargs: dict | None = None
+
+    async def create(self, **kwargs):
+        self.kwargs = kwargs
+        return _EmptyAsyncStream()
+
+
+def test_tutorbot_registry_includes_nvidia_nim_gateway() -> None:
+    spec = find_by_name("nvidia_nim")
+
+    assert spec is not None
+    assert spec.display_name == "NVIDIA NIM"
+    assert spec.default_api_base == "https://integrate.api.nvidia.com/v1"
+    assert spec.supports_stream_options is False
+    assert find_gateway(api_key="nvapi-test-key") == spec
+    assert find_gateway(api_base="https://integrate.api.nvidia.com/v1") == spec
+
+
+def test_tutorbot_schema_accepts_nvidia_nim_provider_config() -> None:
+    providers = ProvidersConfig()
+
+    assert isinstance(providers.nvidia_nim, ProviderConfig)
+
+
+@pytest.mark.asyncio
+async def test_tutorbot_nvidia_nim_stream_omits_stream_options() -> None:
+    spec = find_by_name("nvidia_nim")
+    assert spec is not None
+    completions = _FakeCompletions()
+    provider = OpenAICompatProvider(
+        api_key="nvapi-test-key",
+        default_model="meta/llama-3.1-70b-instruct",
+        spec=spec,
+    )
+    provider._client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+
+    await provider.chat_stream(
+        messages=[{"role": "user", "content": "hello"}],
+        max_tokens=32,
+    )
+
+    assert completions.kwargs is not None
+    assert completions.kwargs["stream"] is True
+    assert "stream_options" not in completions.kwargs


### PR DESCRIPTION
## Summary
- add `nvidia_nim` to TutorBot provider registry and provider config schema
- omit `stream_options` for NIM streaming requests, matching the main runtime registry behavior
- document the `nvidia_nim` binding in `.env.example` and README provider list

Closes #377

## Verification
- RED before fix: `python -m pytest tests/services/tutorbot/test_nvidia_nim_provider.py -q` failed because TutorBot did not know `nvidia_nim`
- `python -m pytest tests/services/tutorbot/test_nvidia_nim_provider.py -q`
- `python -m pytest tests/services/tutorbot/test_nvidia_nim_provider.py tests/services/test_provider_registry.py tests/services/llm/test_openai_compat_reasoning_content.py -q`
- `python -m compileall -q deeptutor/tutorbot tests/services/tutorbot`
- `git diff --check -- .env.example README.md deeptutor/tutorbot/config/schema.py deeptutor/tutorbot/providers/openai_compat_provider.py deeptutor/tutorbot/providers/registry.py tests/services/tutorbot/test_nvidia_nim_provider.py`