### PR TITLE
feat: tooltips for sidebar

### DIFF
--- a/assets/releases/ver1-3-7.md
+++ b/assets/releases/ver1-3-7.md
@@ -42,7 +42,7 @@ output under control while making index activity easier to understand in the UI.
   Ctrl/Cmd+Y.
 - **Toolbar controls are clearer** - destructive and template actions now have
   distinct tones, focus states, labels, and accessible tooltips.
-  
+
 ## Tests
 
 - Added OpenAI-compatible provider tests to keep `reasoning_content` separate

--- a/deeptutor/services/config/launch_settings.py
+++ b/deeptutor/services/config/launch_settings.py
@@ -80,13 +80,11 @@ def load_launch_settings(project_root: Path | None = None) -> LaunchSettings:
     process_backend_port = _coerce_port(os.getenv("BACKEND_PORT"))
     process_frontend_port = _coerce_port(os.getenv("FRONTEND_PORT"))
     interface_language = _normalize_language(interface_settings.get("language"))
-    env_language = (
-        _normalize_language(env_values.get("UI_LANGUAGE"))
-        or _normalize_language(env_values.get("LANGUAGE"))
+    env_language = _normalize_language(env_values.get("UI_LANGUAGE")) or _normalize_language(
+        env_values.get("LANGUAGE")
     )
-    process_language = (
-        _normalize_language(os.getenv("UI_LANGUAGE"))
-        or _normalize_language(os.getenv("LANGUAGE"))
+    process_language = _normalize_language(os.getenv("UI_LANGUAGE")) or _normalize_language(
+        os.getenv("LANGUAGE")
     )
     backend_port = env_backend_port or process_backend_port or DEFAULT_BACKEND_PORT
     frontend_port = env_frontend_port or process_frontend_port or DEFAULT_FRONTEND_PORT

--- a/deeptutor/services/llm/config.py
+++ b/deeptutor/services/llm/config.py
@@ -259,9 +259,7 @@ def get_llm_config() -> LLMConfig:
     # Allow LLM_REASONING_EFFORT from .env to override the resolver path
     env_reasoning = _strip_value(get_env_store().get("LLM_REASONING_EFFORT"))
     if env_reasoning:
-        _LLM_CONFIG_CACHE = _LLM_CONFIG_CACHE.model_copy(
-            update={"reasoning_effort": env_reasoning}
-        )
+        _LLM_CONFIG_CACHE = _LLM_CONFIG_CACHE.model_copy(update={"reasoning_effort": env_reasoning})
 
     return _LLM_CONFIG_CACHE
 

--- a/deeptutor/services/tutorbot/model_runtime.py
+++ b/deeptutor/services/tutorbot/model_runtime.py
@@ -22,9 +22,7 @@ def resolve_tutorbot_llm_config(bot_config: Any) -> LLMConfig:
     configs may still contain a raw ``model`` string, which is applied as a
     model-only override on top of the current system default provider.
     """
-    selection = normalize_tutorbot_llm_selection(
-        getattr(bot_config, "llm_selection", None)
-    )
+    selection = normalize_tutorbot_llm_selection(getattr(bot_config, "llm_selection", None))
     if selection:
         return resolve_llm_config_for_selection(selection)
 

--- a/web/app/(workspace)/co-writer/[docId]/page.tsx
+++ b/web/app/(workspace)/co-writer/[docId]/page.tsx
@@ -2373,7 +2373,9 @@ export default function CoWriterPage() {
 
             <div className="px-4 py-3">
               <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-[11px] leading-relaxed text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200">
-                {t("Undo is available with Ctrl/Cmd+Z or the toolbar Undo button.")}
+                {t(
+                  "Undo is available with Ctrl/Cmd+Z or the toolbar Undo button.",
+                )}
               </div>
             </div>
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -567,3 +567,38 @@
     padding-right: min(560px, 92vw);
   }
 }
+
+/* Tooltip Component Styles */
+.tooltip-wrapper {
+  @apply relative inline-flex;
+}
+
+.tooltip-content {
+  @apply absolute z-50 rounded-lg bg-[var(--popover)] px-3 py-1.5 text-xs shadow-md text-[var(--popover-foreground)];
+  animation: tooltip-fade-in 150ms ease-out;
+}
+
+.tooltip-label {
+  @apply font-medium;
+}
+
+.tooltip-desc {
+  @apply mt-0.5 text-[11px] text-[var(--muted-foreground)];
+}
+
+[data-side="right"] {
+  @apply left-full top-1/2 -translate-y-1/2 ml-2;
+}
+
+[data-side="bottom"] {
+  @apply bottom-[-40px] left-1/2 -translate-x-1/2;
+}
+
+@keyframes tooltip-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -574,7 +574,7 @@
 }
 
 .tooltip-content {
-  @apply absolute z-50 rounded-lg bg-[var(--popover)] px-3 py-1.5 text-xs shadow-md text-[var(--popover-foreground)];
+  @apply absolute z-50 rounded-lg bg-[var(--popover)] px-3 py-1.5 text-xs shadow-md text-[var(--popover-foreground)] pointer-events-none;
   animation: tooltip-fade-in 150ms ease-out;
 }
 
@@ -586,11 +586,11 @@
   @apply mt-0.5 text-[11px] text-[var(--muted-foreground)] truncate;
 }
 
-[data-side="right"] {
+.tooltip-content[data-side="right"] {
   @apply left-full top-1/2 -translate-y-1/2 ml-2 max-w-[200px];
 }
 
-[data-side="bottom"] {
+.tooltip-content[data-side="bottom"] {
   @apply bottom-[-40px] left-1/2 -translate-x-1/2 max-w-[180px];
 }
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -579,19 +579,19 @@
 }
 
 .tooltip-label {
-  @apply font-medium;
+  @apply font-medium truncate;
 }
 
 .tooltip-desc {
-  @apply mt-0.5 text-[11px] text-[var(--muted-foreground)];
+  @apply mt-0.5 text-[11px] text-[var(--muted-foreground)] truncate;
 }
 
 [data-side="right"] {
-  @apply left-full top-1/2 -translate-y-1/2 ml-2;
+  @apply left-full top-1/2 -translate-y-1/2 ml-2 max-w-[200px];
 }
 
 [data-side="bottom"] {
-  @apply bottom-[-40px] left-1/2 -translate-x-1/2;
+  @apply bottom-[-40px] left-1/2 -translate-x-1/2 max-w-[180px];
 }
 
 @keyframes tooltip-fade-in {

--- a/web/components/chat/home/ModelSelector.tsx
+++ b/web/components/chat/home/ModelSelector.tsx
@@ -50,7 +50,9 @@ export default function ModelSelector({
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
 
-  const selectedSelection = allowSystemDefault ? value : value ?? activeDefault;
+  const selectedSelection = allowSystemDefault
+    ? value
+    : (value ?? activeDefault);
   const selectedKey = llmSelectionKey(selectedSelection);
   const selectedOption = useMemo(
     () =>
@@ -87,11 +89,11 @@ export default function ModelSelector({
     ? `${selectedOption.profile_name} | ${providerLabel(selectedOption)}`
     : allowSystemDefault && !selectedSelection
       ? defaultDetail
-    : error
-      ? t("Could not load models")
-      : options.length === 0
-        ? t("No configured models")
-        : t("Choose a model");
+      : error
+        ? t("Could not load models")
+        : options.length === 0
+          ? t("No configured models")
+          : t("Choose a model");
   const menuPlacementClass =
     placement === "bottom" ? "top-full mt-1.5" : "bottom-full mb-1.5";
 

--- a/web/components/sidebar/SidebarShell.tsx
+++ b/web/components/sidebar/SidebarShell.tsx
@@ -269,9 +269,6 @@ export function SidebarShell({
 
           {PRIMARY_NAV.map((item) => {
             const active = pathname.startsWith(item.href);
-            const tooltipProps = item.tooltipKey
-              ? { description: t(item.tooltipKey) }
-              : {};
             const hasSessionsBelow =
               item.href === "/chat" &&
               showSessions &&
@@ -280,42 +277,35 @@ export function SidebarShell({
               onDeleteSession;
             const hasBots = item.href === "/agents";
             return (
-              <Tooltip
-                key={item.href}
-                label={t(item.label)}
-                side="right"
-                {...tooltipProps}
-              >
-                <div key={item.href}>
-                  <Link
-                    href={item.href}
-                    className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-[13.5px] transition-colors ${
-                      active
-                        ? "bg-[var(--background)]/70 font-medium text-[var(--foreground)]"
-                        : "text-[var(--muted-foreground)] hover:bg-[var(--background)]/50 hover:text-[var(--foreground)]"
-                    }`}
+              <div key={item.href}>
+                <Link
+                  href={item.href}
+                  className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-[13.5px] transition-colors ${
+                    active
+                      ? "bg-[var(--background)]/70 font-medium text-[var(--foreground)]"
+                      : "text-[var(--muted-foreground)] hover:bg-[var(--background)]/50 hover:text-[var(--foreground)]"
+                  }`}
+                >
+                  <item.icon size={16} strokeWidth={active ? 1.9 : 1.5} />
+                  <span>{t(item.label)}</span>
+                </Link>
+                {hasSessionsBelow && (
+                  <div
+                    className={`${sessionViewportClassName} overflow-y-auto`}
                   >
-                    <item.icon size={16} strokeWidth={active ? 1.9 : 1.5} />
-                    <span>{t(item.label)}</span>
-                  </Link>
-                  {hasSessionsBelow && (
-                    <div
-                      className={`${sessionViewportClassName} overflow-y-auto`}
-                    >
-                      <SessionList
-                        sessions={sessions}
-                        activeSessionId={activeSessionId}
-                        loading={loadingSessions}
-                        onSelect={onSelectSession}
-                        onRename={onRenameSession}
-                        onDelete={onDeleteSession}
-                        compact
-                      />
-                    </div>
-                  )}
-                  {hasBots && <TutorBotRecent />}
-                </div>
-              </Tooltip>
+                    <SessionList
+                      sessions={sessions}
+                      activeSessionId={activeSessionId}
+                      loading={loadingSessions}
+                      onSelect={onSelectSession}
+                      onRename={onRenameSession}
+                      onDelete={onDeleteSession}
+                      compact
+                    />
+                  </div>
+                )}
+                {hasBots && <TutorBotRecent />}
+              </div>
             );
           })}
         </div>

--- a/web/components/sidebar/SidebarShell.tsx
+++ b/web/components/sidebar/SidebarShell.tsx
@@ -283,7 +283,7 @@ export function SidebarShell({
               <Tooltip
                 key={item.href}
                 label={t(item.label)}
-                side="bottom"
+                side="right"
                 {...tooltipProps}
               >
                 <div key={item.href}>

--- a/web/components/sidebar/SidebarShell.tsx
+++ b/web/components/sidebar/SidebarShell.tsx
@@ -24,20 +24,47 @@ import SessionList from "@/components/SessionList";
 import { TutorBotRecent } from "@/components/sidebar/TutorBotRecent";
 import { VersionBadge } from "@/components/sidebar/VersionBadge";
 import type { SessionSummary } from "@/lib/session-api";
+import { Tooltip } from "@/components/ui/Tooltip";
 
 interface NavEntry {
   href: string;
   label: string;
   icon: LucideIcon;
+  tooltipKey?: string;
 }
 
 const PRIMARY_NAV: NavEntry[] = [
-  { href: "/chat", label: "Chat", icon: MessageSquare },
-  { href: "/agents", label: "TutorBot", icon: Bot },
-  { href: "/co-writer", label: "Co-Writer", icon: PenLine },
-  { href: "/book", label: "Book", icon: Library },
-  { href: "/knowledge", label: "Knowledge", icon: BookOpen },
-  { href: "/space", label: "Space", icon: LayoutGrid },
+  {
+    href: "/chat",
+    label: "Chat",
+    icon: MessageSquare,
+    tooltipKey: "Chat tooltip",
+  },
+  {
+    href: "/agents",
+    label: "TutorBot",
+    icon: Bot,
+    tooltipKey: "TutorBot tooltip",
+  },
+  {
+    href: "/co-writer",
+    label: "Co-Writer",
+    icon: PenLine,
+    tooltipKey: "Co-Writer tooltip",
+  },
+  { href: "/book", label: "Book", icon: Library, tooltipKey: "Book tooltip" },
+  {
+    href: "/knowledge",
+    label: "Knowledge",
+    icon: BookOpen,
+    tooltipKey: "Knowledge tooltip",
+  },
+  {
+    href: "/space",
+    label: "Space",
+    icon: LayoutGrid,
+    tooltipKey: "Space tooltip",
+  },
 ];
 
 const SECONDARY_NAV: NavEntry[] = [
@@ -130,22 +157,32 @@ export function SidebarShell({
         <nav className="flex w-full flex-col items-center gap-1 px-1.5">
           {PRIMARY_NAV.map((item) => {
             const active = pathname.startsWith(item.href);
+            const tooltipProps = item.tooltipKey
+              ? { description: t(item.tooltipKey) }
+              : {}; // Pass description to tooltip if it exists
             return (
-              <Link
+              <Tooltip
                 key={item.href}
-                href={item.href}
-                title={t(item.label) as string}
-                className={`relative flex h-9 w-9 items-center justify-center rounded-xl transition-all duration-150 ${
-                  active
-                    ? "bg-[var(--background)]/80 text-[var(--foreground)] shadow-sm"
-                    : "text-[var(--muted-foreground)] hover:bg-[var(--background)]/50 hover:text-[var(--foreground)]"
-                }`}
+                label={t(item.label)}
+                side="right"
+                {...tooltipProps}
               >
-                {active && (
-                  <span className="absolute -left-1.5 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-full bg-[var(--foreground)]/80" />
-                )}
-                <item.icon size={18} strokeWidth={active ? 2 : 1.6} />
-              </Link>
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  title={t(item.label) as string}
+                  className={`relative flex h-9 w-9 items-center justify-center rounded-xl transition-all duration-150 ${
+                    active
+                      ? "bg-[var(--background)]/80 text-[var(--foreground)] shadow-sm"
+                      : "text-[var(--muted-foreground)] hover:bg-[var(--background)]/50 hover:text-[var(--foreground)]"
+                  }`}
+                >
+                  {active && (
+                    <span className="absolute -left-1.5 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-full bg-[var(--foreground)]/80" />
+                  )}
+                  <item.icon size={18} strokeWidth={active ? 2 : 1.6} />
+                </Link>
+              </Tooltip>
             );
           })}
         </nav>

--- a/web/components/sidebar/SidebarShell.tsx
+++ b/web/components/sidebar/SidebarShell.tsx
@@ -269,6 +269,9 @@ export function SidebarShell({
 
           {PRIMARY_NAV.map((item) => {
             const active = pathname.startsWith(item.href);
+            const tooltipProps = item.tooltipKey
+              ? { description: t(item.tooltipKey) }
+              : {};
             const hasSessionsBelow =
               item.href === "/chat" &&
               showSessions &&
@@ -277,35 +280,42 @@ export function SidebarShell({
               onDeleteSession;
             const hasBots = item.href === "/agents";
             return (
-              <div key={item.href}>
-                <Link
-                  href={item.href}
-                  className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-[13.5px] transition-colors ${
-                    active
-                      ? "bg-[var(--background)]/70 font-medium text-[var(--foreground)]"
-                      : "text-[var(--muted-foreground)] hover:bg-[var(--background)]/50 hover:text-[var(--foreground)]"
-                  }`}
-                >
-                  <item.icon size={16} strokeWidth={active ? 1.9 : 1.5} />
-                  <span>{t(item.label)}</span>
-                </Link>
-                {hasSessionsBelow && (
-                  <div
-                    className={`${sessionViewportClassName} overflow-y-auto`}
+              <Tooltip
+                key={item.href}
+                label={t(item.label)}
+                side="bottom"
+                {...tooltipProps}
+              >
+                <div key={item.href}>
+                  <Link
+                    href={item.href}
+                    className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-[13.5px] transition-colors ${
+                      active
+                        ? "bg-[var(--background)]/70 font-medium text-[var(--foreground)]"
+                        : "text-[var(--muted-foreground)] hover:bg-[var(--background)]/50 hover:text-[var(--foreground)]"
+                    }`}
                   >
-                    <SessionList
-                      sessions={sessions}
-                      activeSessionId={activeSessionId}
-                      loading={loadingSessions}
-                      onSelect={onSelectSession}
-                      onRename={onRenameSession}
-                      onDelete={onDeleteSession}
-                      compact
-                    />
-                  </div>
-                )}
-                {hasBots && <TutorBotRecent />}
-              </div>
+                    <item.icon size={16} strokeWidth={active ? 1.9 : 1.5} />
+                    <span>{t(item.label)}</span>
+                  </Link>
+                  {hasSessionsBelow && (
+                    <div
+                      className={`${sessionViewportClassName} overflow-y-auto`}
+                    >
+                      <SessionList
+                        sessions={sessions}
+                        activeSessionId={activeSessionId}
+                        loading={loadingSessions}
+                        onSelect={onSelectSession}
+                        onRename={onRenameSession}
+                        onDelete={onDeleteSession}
+                        compact
+                      />
+                    </div>
+                  )}
+                  {hasBots && <TutorBotRecent />}
+                </div>
+              </Tooltip>
             );
           })}
         </div>

--- a/web/components/ui/Tooltip.tsx
+++ b/web/components/ui/Tooltip.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { ReactNode } from "react";
+
+interface TooltipProps {
+  label: string;
+  description?: string;
+  children: ReactNode;
+  side?: "right" | "bottom";
+}
+
+export function Tooltip({
+  label,
+  description,
+  children,
+  side = "right",
+}: TooltipProps) {
+  const sideStyles = {
+    right: "left-full top-1/2 -translate-y-1/2 ml-2",
+    bottom: "top-full left-1/2 -translate-x-1/2 mt-2",
+  };
+
+  return (
+    <div className="group relative inline-flex">
+      {children}
+      <div
+        className={`
+          absolute z-50 whitespace-nowrap rounded-lg bg-[var(--popover)] px-3 py-1.5 text-xs text-[var(--popover-foreground)] shadow-md
+          opacity-0 group-hover:opacity-100 transition-opacity duration-200
+          pointer-events-none
+          ${sideStyles[side]}
+        `}
+      >
+        <div className="font-medium">{label}</div>
+        {description && (
+          <div className="mt-0.5 text-[var(--muted-foreground)] text-[11px]">
+            {description}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/components/ui/Tooltip.tsx
+++ b/web/components/ui/Tooltip.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ReactNode, useState, useCallback, useRef, useId } from "react";
+import {
+  ReactNode,
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  useId,
+} from "react";
 
 interface TooltipProps {
   label: string;
@@ -24,9 +31,20 @@ export function Tooltip({
     timeoutRef.current = setTimeout(() => setVisible(true), 300);
   }, []);
 
+  const showNow = useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    setVisible(true);
+  }, []);
+
   const hideTooltip = useCallback(() => {
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
     setVisible(false);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
   }, []);
 
   return (
@@ -34,7 +52,7 @@ export function Tooltip({
       className="tooltip-wrapper"
       onMouseEnter={showTooltip}
       onMouseLeave={hideTooltip}
-      onFocus={showTooltip}
+      onFocus={showNow}
       onBlur={hideTooltip}
       aria-describedby={visible ? tooltipId : undefined}
     >

--- a/web/components/ui/Tooltip.tsx
+++ b/web/components/ui/Tooltip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode } from "react";
+import { ReactNode, useState, useCallback, useRef, useId } from "react";
 
 interface TooltipProps {
   label: string;
@@ -15,29 +15,41 @@ export function Tooltip({
   children,
   side = "right",
 }: TooltipProps) {
-  const sideStyles = {
-    right: "left-full top-1/2 -translate-y-1/2 ml-2",
-    bottom: "top-full left-1/2 -translate-x-1/2 mt-2",
-  };
+  const [visible, setVisible] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tooltipId = useId();
+
+  const showTooltip = useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setVisible(true), 300);
+  }, []);
+
+  const hideTooltip = useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    setVisible(false);
+  }, []);
 
   return (
-    <div className="group relative inline-flex">
+    <div
+      className="tooltip-wrapper"
+      onMouseEnter={showTooltip}
+      onMouseLeave={hideTooltip}
+      onFocus={showTooltip}
+      onBlur={hideTooltip}
+      aria-describedby={visible ? tooltipId : undefined}
+    >
       {children}
-      <div
-        className={`
-          absolute z-50 whitespace-nowrap rounded-lg bg-[var(--popover)] px-3 py-1.5 text-xs text-[var(--popover-foreground)] shadow-md
-          opacity-0 group-hover:opacity-100 transition-opacity duration-200
-          pointer-events-none
-          ${sideStyles[side]}
-        `}
-      >
-        <div className="font-medium">{label}</div>
-        {description && (
-          <div className="mt-0.5 text-[var(--muted-foreground)] text-[11px]">
-            {description}
-          </div>
-        )}
-      </div>
+      {visible && (
+        <div
+          id={tooltipId}
+          className="tooltip-content"
+          data-side={side}
+          role="tooltip"
+        >
+          <div className="tooltip-label">{label}</div>
+          {description && <div className="tooltip-desc">{description}</div>}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -1597,5 +1597,11 @@
   "Please use the attached file(s) and this chapter as context.": "Please use the attached file(s) and this chapter as context.",
   "Context": "Context",
   "Ask a question about this page. The current chapter content is sent to the assistant automatically.": "Ask a question about this page. The current chapter content is sent to the assistant automatically.",
-  "Ask about this page...": "Ask about this page..."
+  "Ask about this page...": "Ask about this page...",
+  "Chat tooltip": "This is the Chat tooltip.",
+  "TutorBot tooltip": "This is the TutorBot tooltip.",
+  "Co-Writer tooltip": "This is the Co-Writer tooltip.",
+  "Book tooltip": "This is the Book tooltip.",
+  "Knowledge tooltip": "This is the Knowledge tooltip.",
+  "Space tooltip": "This is the Space tooltip."
 }

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -1598,10 +1598,10 @@
   "Context": "Context",
   "Ask a question about this page. The current chapter content is sent to the assistant automatically.": "Ask a question about this page. The current chapter content is sent to the assistant automatically.",
   "Ask about this page...": "Ask about this page...",
-  "Chat tooltip": "This is the Chat tooltip.",
-  "TutorBot tooltip": "This is the TutorBot tooltip.",
-  "Co-Writer tooltip": "This is the Co-Writer tooltip.",
-  "Book tooltip": "This is the Book tooltip.",
-  "Knowledge tooltip": "This is the Knowledge tooltip.",
-  "Space tooltip": "This is the Space tooltip."
+  "Chat tooltip": "Multi-tool AI chat and search.",
+  "TutorBot tooltip": "Persistent, specialized AI agents.",
+  "Co-Writer tooltip": "AI-powered document editor.",
+  "Book tooltip": "Create AI-powered books.",
+  "Knowledge tooltip": "Manage learning personas.",
+  "Space tooltip": "Your personal learning library."
 }

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -1597,5 +1597,11 @@
   "Please use the attached file(s) and this chapter as context.": "请结合附件文件和本章节上下文回答。",
   "Context": "上下文",
   "Ask a question about this page. The current chapter content is sent to the assistant automatically.": "可以询问本页内容。当前章节内容会自动发送给助手。",
-  "Ask about this page...": "询问本页内容…"
+  "Ask about this page...": "询问本页内容…",
+  "Chat tooltip": "This is the Chat tooltip.",
+  "TutorBot tooltip": "This is the TutorBot tooltip.",
+  "Co-Writer tooltip": "This is the Co-Writer tooltip.",
+  "Book tooltip": "This is the Book tooltip.",
+  "Knowledge tooltip": "This is the Knowledge tooltip.",
+  "Space tooltip": "This is the Space tooltip."
 }

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -1598,10 +1598,10 @@
   "Context": "上下文",
   "Ask a question about this page. The current chapter content is sent to the assistant automatically.": "可以询问本页内容。当前章节内容会自动发送给助手。",
   "Ask about this page...": "询问本页内容…",
-  "Chat tooltip": "This is the Chat tooltip (zh).",
-  "TutorBot tooltip": "This is the TutorBot tooltip (zh).",
-  "Co-Writer tooltip": "This is the Co-Writer tooltip (zh).",
-  "Book tooltip": "This is the Book tooltip (zh).",
-  "Knowledge tooltip": "This is the Knowledge tooltip (zh).",
-  "Space tooltip": "This is the Space tooltip (zh)."
+  "Chat tooltip": "多工具 AI 对话与搜索。",
+  "TutorBot tooltip": "常驻的专业 AI 智能体。",
+  "Co-Writer tooltip": "AI 驱动的协作文档编辑器。",
+  "Book tooltip": "生成交互式 AI 书籍。",
+  "Knowledge tooltip": "管理文档与教学人设。",
+  "Space tooltip": "你的个人学习空间。"
 }

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -1598,10 +1598,10 @@
   "Context": "上下文",
   "Ask a question about this page. The current chapter content is sent to the assistant automatically.": "可以询问本页内容。当前章节内容会自动发送给助手。",
   "Ask about this page...": "询问本页内容…",
-  "Chat tooltip": "This is the Chat tooltip.",
-  "TutorBot tooltip": "This is the TutorBot tooltip.",
-  "Co-Writer tooltip": "This is the Co-Writer tooltip.",
-  "Book tooltip": "This is the Book tooltip.",
-  "Knowledge tooltip": "This is the Knowledge tooltip.",
-  "Space tooltip": "This is the Space tooltip."
+  "Chat tooltip": "This is the Chat tooltip (zh).",
+  "TutorBot tooltip": "This is the TutorBot tooltip (zh).",
+  "Co-Writer tooltip": "This is the Co-Writer tooltip (zh).",
+  "Book tooltip": "This is the Book tooltip (zh).",
+  "Knowledge tooltip": "This is the Knowledge tooltip (zh).",
+  "Space tooltip": "This is the Space tooltip (zh)."
 }

--- a/web/tests/skill-slug.test.ts
+++ b/web/tests/skill-slug.test.ts
@@ -8,7 +8,10 @@ import {
 } from "../lib/skill-slug";
 
 test("slugifySkillName normalizes common free-text names", () => {
-  assert.equal(slugifySkillName("Socratic Math Mentor"), "socratic-math-mentor");
+  assert.equal(
+    slugifySkillName("Socratic Math Mentor"),
+    "socratic-math-mentor",
+  );
   assert.equal(slugifySkillName("My  Skill__v2"), "my-skill-v2");
   assert.equal(slugifySkillName("___Tutor!! 2026"), "tutor-2026");
 });


### PR DESCRIPTION
<!-- Thank you for contributing to DeepTutor! 🚀 Please ensure your PR is ready for review and follows our contribution guidelines. For more details, see our [CONTRIBUTING.md](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md). -->

### Description

Tooltips are now available when hovering over the items on the sidebar. These include:
- Chat
- TutorBot
- Co-Writer
- Book
- Knowledge
- Space

Tooltips only appear when the sidebar is collapsed.
Additionally, new documentation has been added for these tooltips.
### Related Issues
- Closes #448
- Related to #448
### Module(s) Affected
- [x] `web` (Frontend)
- [x] `docs` (Documentation)
    

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.
    

### Additional Notes
Verified by checking if tooltips appear in both locales
