### PR TITLE
Feature/heartbeat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,4 @@ celerybeat.pid
 *.wav
 *.ogg
 !demo/*.mp4
+.worktrees/

--- a/deeptutor/logging/formatters.py
+++ b/deeptutor/logging/formatters.py
@@ -46,4 +46,5 @@ class ConsoleFormatter(logging.Formatter):
         context = getattr(record, "log_context", {}) or {}
         stage = f" @{context['stage']}" if context.get("stage") else ""
         task = f" #{context['task_id']}" if context.get("task_id") else ""
-        return f"{record.levelname:<7} {record.name}{stage}{task} - {record.getMessage()}"
+        ts = datetime.fromtimestamp(record.created, timezone.utc).strftime("%H:%M:%S")
+        return f"{ts} {record.levelname:<7} {record.name}{stage}{task} - {record.getMessage()}"

--- a/deeptutor/services/tutorbot/manager.py
+++ b/deeptutor/services/tutorbot/manager.py
@@ -328,6 +328,7 @@ class TutorBotManager:
                 channels=data.get("channels", {}),
                 model=data.get("model"),
                 llm_selection=data.get("llm_selection"),
+                heartbeat_interval_s=data.get("heartbeat_interval_s", 30 * 60),
             )
         except Exception:
             logger.exception("Failed to load bot config %s", bot_id)
@@ -348,6 +349,7 @@ class TutorBotManager:
             "persona": config.persona,
             "channels": config.channels,
             "auto_start": auto_start,
+            "heartbeat_interval_s": config.heartbeat_interval_s,
         }
         if config.model:
             data["model"] = config.model

--- a/deeptutor/services/tutorbot/manager.py
+++ b/deeptutor/services/tutorbot/manager.py
@@ -533,11 +533,7 @@ class TutorBotManager:
         logger.info("Reloaded LLM for TutorBot '%s' (model=%s)", bot_id, llm_config.model)
 
     async def reload_heartbeat(self, bot_id: str) -> None:
-        """Apply the bot's current heartbeat_interval_s to the running instance.
-
-        Loads the latest config from disk and updates the heartbeat service
-        interval; resets adaptive state as well.
-        """
+        """Apply the bot's current heartbeat_interval_s to the running instance."""
         instance = self._bots.get(bot_id)
         if not instance or not instance.running or not instance.heartbeat:
             return
@@ -547,14 +543,12 @@ class TutorBotManager:
             return
 
         hb = instance.heartbeat
-        old_base = hb._base_interval_s
-        hb._base_interval_s = fresh.heartbeat_interval_s
+        old = hb.interval_s
         hb.interval_s = fresh.heartbeat_interval_s
-        hb._consecutive_skips = 0
         logger.info(
             "Reloaded heartbeat interval for TutorBot '%s' ({}s -> {}s)",
             bot_id,
-            old_base,
+            old,
             fresh.heartbeat_interval_s,
         )
 

--- a/deeptutor/services/tutorbot/manager.py
+++ b/deeptutor/services/tutorbot/manager.py
@@ -125,6 +125,7 @@ class BotConfig:
     channels: dict[str, Any] = field(default_factory=dict)
     model: str | None = None
     llm_selection: dict[str, str] | None = None
+    heartbeat_interval_s: int = 30 * 60
 
 
 @dataclass
@@ -493,7 +494,7 @@ class TutorBotManager:
             model=agent_loop.model,
             on_execute=_hb_execute,
             on_notify=_hb_notify,
-            interval_s=30 * 60,
+            interval_s=config.heartbeat_interval_s,
         )
         instance.heartbeat = heartbeat
         await heartbeat.start()

--- a/deeptutor/services/tutorbot/manager.py
+++ b/deeptutor/services/tutorbot/manager.py
@@ -966,6 +966,7 @@ class TutorBotManager:
                     channels=data.get("channels", {}),
                     model=data.get("model"),
                     llm_selection=data.get("llm_selection"),
+                    heartbeat_interval_s=data.get("heartbeat_interval_s", 30 * 60),
                 )
                 await self.start_bot(bid, config)
                 logger.info("Auto-started bot '%s'", bid)

--- a/deeptutor/services/tutorbot/manager.py
+++ b/deeptutor/services/tutorbot/manager.py
@@ -532,6 +532,32 @@ class TutorBotManager:
             instance.heartbeat.model = instance.agent_loop.model
         logger.info("Reloaded LLM for TutorBot '%s' (model=%s)", bot_id, llm_config.model)
 
+    async def reload_heartbeat(self, bot_id: str) -> None:
+        """Apply the bot's current heartbeat_interval_s to the running instance.
+
+        Loads the latest config from disk and updates the heartbeat service
+        interval; resets adaptive state as well.
+        """
+        instance = self._bots.get(bot_id)
+        if not instance or not instance.running or not instance.heartbeat:
+            return
+
+        fresh = self.load_bot_config(bot_id)
+        if not fresh:
+            return
+
+        hb = instance.heartbeat
+        old_base = hb._base_interval_s
+        hb._base_interval_s = fresh.heartbeat_interval_s
+        hb.interval_s = fresh.heartbeat_interval_s
+        hb._consecutive_skips = 0
+        logger.info(
+            "Reloaded heartbeat interval for TutorBot '%s' ({}s -> {}s)",
+            bot_id,
+            old_base,
+            fresh.heartbeat_interval_s,
+        )
+
     async def _outbound_router(self, bot_id: str, bus: Any, instance: TutorBotInstance) -> None:
         """Route outbound messages to channels, web notify_queue, and EventBus.
 

--- a/deeptutor/services/tutorbot/manager.py
+++ b/deeptutor/services/tutorbot/manager.py
@@ -497,6 +497,7 @@ class TutorBotManager:
             on_execute=_hb_execute,
             on_notify=_hb_notify,
             interval_s=config.heartbeat_interval_s,
+            bot_id=bot_id,
         )
         instance.heartbeat = heartbeat
         await heartbeat.start()
@@ -546,7 +547,7 @@ class TutorBotManager:
         old = hb.interval_s
         hb.interval_s = fresh.heartbeat_interval_s
         logger.info(
-            "Reloaded heartbeat interval for TutorBot '%s' ({}s -> {}s)",
+            "Heartbeat reloaded (bot={}, {}s -> {}s)",
             bot_id,
             old,
             fresh.heartbeat_interval_s,

--- a/deeptutor/tutorbot/heartbeat/service.py
+++ b/deeptutor/tutorbot/heartbeat/service.py
@@ -65,22 +65,46 @@ class HeartbeatService:
         self.model = model
         self.on_execute = on_execute
         self.on_notify = on_notify
+        self._base_interval_s = interval_s
         self.interval_s = interval_s
         self.enabled = enabled
         self._running = False
         self._task: asyncio.Task | None = None
+        self._last_mtime: float | None = None
+        self._last_content_hash: str | None = None
+        self._consecutive_skips: int = 0
 
     @property
     def heartbeat_file(self) -> Path:
         return self.workspace / "HEARTBEAT.md"
 
-    def _read_heartbeat_file(self) -> str | None:
+    def _read_heartbeat_file(self) -> tuple[str | None, float | None]:
+        """Returns (content, mtime) or (None, None) if missing/invalid."""
         if self.heartbeat_file.exists():
             try:
-                return self.heartbeat_file.read_text(encoding="utf-8")
+                stat = self.heartbeat_file.stat()
+                content = self.heartbeat_file.read_text(encoding="utf-8")
+                return content, stat.st_mtime
             except Exception:
-                return None
-        return None
+                return None, None
+        return None, None
+
+    def _apply_adaptive_interval(self) -> None:
+        """Double interval after consecutive skips, up to 4x the base."""
+        if self._consecutive_skips >= 2:
+            multiplier = min(2 ** (self._consecutive_skips - 1), 4)
+            self.interval_s = int(self._base_interval_s * multiplier)
+            logger.info(
+                "Heartbeat: {} consecutive skips, extending interval to {}s",
+                self._consecutive_skips,
+                self.interval_s,
+            )
+
+    def _reset_adaptive_interval(self) -> None:
+        """Reset to base interval."""
+        if self.interval_s != self._base_interval_s:
+            self.interval_s = self._base_interval_s
+            logger.info("Heartbeat: resetting interval to {}s", self._base_interval_s)
 
     async def _decide(self, content: str) -> tuple[str, str]:
         """Phase 1: ask LLM to decide skip/run via virtual tool call.
@@ -147,11 +171,22 @@ class HeartbeatService:
         """Execute a single heartbeat tick."""
         from deeptutor.tutorbot.utils.evaluator import evaluate_response
 
-        content = self._read_heartbeat_file()
+        content, mtime = self._read_heartbeat_file()
         if not content:
             logger.debug("Heartbeat: HEARTBEAT.md missing or empty")
+            self._reset_adaptive_interval()
             return
 
+        # Option 2: skip LLM if file hasn't changed since last tick
+        if mtime == self._last_mtime and self._last_content_hash is not None:
+            if content == self._last_content_hash:
+                logger.debug("Heartbeat: HEARTBEAT.md unchanged, skipping LLM")
+                self._consecutive_skips += 1
+                self._apply_adaptive_interval()
+                return
+
+        self._last_mtime = mtime
+        self._last_content_hash = content
         logger.info("Heartbeat: checking for tasks...")
 
         try:
@@ -159,7 +194,13 @@ class HeartbeatService:
 
             if action != "run":
                 logger.info("Heartbeat: OK (nothing to report)")
+                self._consecutive_skips += 1
+                self._apply_adaptive_interval()
                 return
+
+            # Reset on active work
+            self._reset_adaptive_interval()
+            self._consecutive_skips = 0
 
             logger.info("Heartbeat: tasks found, executing...")
             if self.on_execute:
@@ -182,7 +223,7 @@ class HeartbeatService:
 
     async def trigger_now(self) -> str | None:
         """Manually trigger a heartbeat."""
-        content = self._read_heartbeat_file()
+        content, _ = self._read_heartbeat_file()
         if not content:
             return None
         action, tasks = await self._decide(content)

--- a/deeptutor/tutorbot/heartbeat/service.py
+++ b/deeptutor/tutorbot/heartbeat/service.py
@@ -165,7 +165,7 @@ class HeartbeatService:
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.error("Heartbeat error: {}", e)
+                logger.error("Heartbeat (bot={}) error: {}", self.bot_id, e)
 
     async def _tick(self) -> None:
         """Execute a single heartbeat tick."""
@@ -173,23 +173,23 @@ class HeartbeatService:
 
         content = self._read_heartbeat_file()
         if not content:
-            logger.debug("Heartbeat: HEARTBEAT.md missing or empty")
+            logger.debug("Heartbeat (bot={}): HEARTBEAT.md missing or empty", self.bot_id)
             return
 
         if not self._has_active_tasks(content):
-            logger.debug("Heartbeat: no active tasks found, skipping LLM")
+            logger.debug("Heartbeat (bot={}): no active tasks found, skipping LLM", self.bot_id)
             return
 
-        logger.info("Heartbeat: checking for tasks...")
+        logger.info("Heartbeat (bot={}): checking for tasks...", self.bot_id)
 
         try:
             action, tasks = await self._decide(content)
 
             if action != "run":
-                logger.info("Heartbeat: OK (nothing to report)")
+                logger.info("Heartbeat (bot={}): OK (nothing to report)", self.bot_id)
                 return
 
-            logger.info("Heartbeat: tasks found, executing...")
+            logger.info("Heartbeat (bot={}): tasks found, executing...", self.bot_id)
             if self.on_execute:
                 response = await self.on_execute(tasks)
 
@@ -201,10 +201,10 @@ class HeartbeatService:
                         self.model,
                     )
                     if should_notify and self.on_notify:
-                        logger.info("Heartbeat: completed, delivering response")
+                        logger.info("Heartbeat (bot={}): completed, delivering response", self.bot_id)
                         await self.on_notify(response)
                     else:
-                        logger.info("Heartbeat: silenced by post-run evaluation")
+                        logger.info("Heartbeat (bot={}): silenced by post-run evaluation", self.bot_id)
         except Exception:
             logger.exception("Heartbeat execution failed")
 

--- a/deeptutor/tutorbot/heartbeat/service.py
+++ b/deeptutor/tutorbot/heartbeat/service.py
@@ -70,24 +70,20 @@ class HeartbeatService:
         self.enabled = enabled
         self._running = False
         self._task: asyncio.Task | None = None
-        self._last_mtime: float | None = None
-        self._last_content_hash: str | None = None
         self._consecutive_skips: int = 0
 
     @property
     def heartbeat_file(self) -> Path:
         return self.workspace / "HEARTBEAT.md"
 
-    def _read_heartbeat_file(self) -> tuple[str | None, float | None]:
-        """Returns (content, mtime) or (None, None) if missing/invalid."""
+    def _read_heartbeat_file(self) -> str | None:
+        """Returns file content or None if missing/invalid."""
         if self.heartbeat_file.exists():
             try:
-                stat = self.heartbeat_file.stat()
-                content = self.heartbeat_file.read_text(encoding="utf-8")
-                return content, stat.st_mtime
+                return self.heartbeat_file.read_text(encoding="utf-8")
             except Exception:
-                return None, None
-        return None, None
+                return None
+        return None
 
     def _apply_adaptive_interval(self) -> None:
         """Double interval after consecutive skips, up to 4x the base."""
@@ -113,6 +109,26 @@ class HeartbeatService:
                 old,
                 self._base_interval_s,
             )
+
+    def _has_active_tasks(self, content: str) -> bool:
+        """Return True if content has non-comment/empty lines under ## Active Tasks."""
+        import re
+
+        idx = content.lower().find("## active tasks")
+        if idx < 0:
+            return False
+        section = content[idx + len("## Active Tasks") :]
+        end = re.search(r"\n##\s", section)
+        if end:
+            section = section[: end.start()]
+        lines = [
+            line.strip()
+            for line in section.splitlines()
+            if line.strip()
+            and not line.strip().startswith("<!--")
+            and not line.strip().startswith("#")
+        ]
+        return bool(lines)
 
     async def _decide(self, content: str) -> tuple[str, str]:
         """Phase 1: ask LLM to decide skip/run via virtual tool call.
@@ -179,22 +195,19 @@ class HeartbeatService:
         """Execute a single heartbeat tick."""
         from deeptutor.tutorbot.utils.evaluator import evaluate_response
 
-        content, mtime = self._read_heartbeat_file()
+        content = self._read_heartbeat_file()
         if not content:
             logger.debug("Heartbeat: HEARTBEAT.md missing or empty")
             self._reset_adaptive_interval()
             return
 
-        # Option 2: skip LLM if file hasn't changed since last tick
-        if mtime == self._last_mtime and self._last_content_hash is not None:
-            if content == self._last_content_hash:
-                logger.debug("Heartbeat: HEARTBEAT.md unchanged, skipping LLM")
-                self._consecutive_skips += 1
-                self._apply_adaptive_interval()
-                return
+        if not self._has_active_tasks(content):
+            logger.debug("Heartbeat: no active tasks found, skipping LLM")
+            self._reset_adaptive_interval()
+            self._consecutive_skips += 1
+            self._apply_adaptive_interval()
+            return
 
-        self._last_mtime = mtime
-        self._last_content_hash = content
         logger.info("Heartbeat: checking for tasks...")
 
         try:
@@ -206,7 +219,6 @@ class HeartbeatService:
                 self._apply_adaptive_interval()
                 return
 
-            # Reset on active work
             self._reset_adaptive_interval()
             self._consecutive_skips = 0
 
@@ -231,7 +243,7 @@ class HeartbeatService:
 
     async def trigger_now(self) -> str | None:
         """Manually trigger a heartbeat."""
-        content, _ = self._read_heartbeat_file()
+        content = self._read_heartbeat_file()
         if not content:
             return None
         action, tasks = await self._decide(content)

--- a/deeptutor/tutorbot/heartbeat/service.py
+++ b/deeptutor/tutorbot/heartbeat/service.py
@@ -65,12 +65,10 @@ class HeartbeatService:
         self.model = model
         self.on_execute = on_execute
         self.on_notify = on_notify
-        self._base_interval_s = interval_s
         self.interval_s = interval_s
         self.enabled = enabled
         self._running = False
         self._task: asyncio.Task | None = None
-        self._consecutive_skips: int = 0
 
     @property
     def heartbeat_file(self) -> Path:
@@ -85,30 +83,6 @@ class HeartbeatService:
                 return None
         return None
 
-    def _apply_adaptive_interval(self) -> None:
-        """Double interval after consecutive skips, up to 4x the base."""
-        if self._consecutive_skips >= 2:
-            multiplier = min(2 ** (self._consecutive_skips - 1), 4)
-            new_interval = int(self._base_interval_s * multiplier)
-            if new_interval != self.interval_s:
-                self.interval_s = new_interval
-                logger.debug(
-                    "Heartbeat: {} consecutive skips, extended interval to {}s (base={}s)",
-                    self._consecutive_skips,
-                    self.interval_s,
-                    self._base_interval_s,
-                )
-
-    def _reset_adaptive_interval(self) -> None:
-        """Reset to base interval."""
-        if self.interval_s != self._base_interval_s:
-            old = self.interval_s
-            self.interval_s = self._base_interval_s
-            logger.debug(
-                "Heartbeat: reset interval from {}s to {}s",
-                old,
-                self._base_interval_s,
-            )
 
     def _has_active_tasks(self, content: str) -> bool:
         """Return True if content has non-comment/empty lines under ## Active Tasks."""
@@ -198,14 +172,10 @@ class HeartbeatService:
         content = self._read_heartbeat_file()
         if not content:
             logger.debug("Heartbeat: HEARTBEAT.md missing or empty")
-            self._reset_adaptive_interval()
             return
 
         if not self._has_active_tasks(content):
             logger.debug("Heartbeat: no active tasks found, skipping LLM")
-            self._reset_adaptive_interval()
-            self._consecutive_skips += 1
-            self._apply_adaptive_interval()
             return
 
         logger.info("Heartbeat: checking for tasks...")
@@ -215,12 +185,7 @@ class HeartbeatService:
 
             if action != "run":
                 logger.info("Heartbeat: OK (nothing to report)")
-                self._consecutive_skips += 1
-                self._apply_adaptive_interval()
                 return
-
-            self._reset_adaptive_interval()
-            self._consecutive_skips = 0
 
             logger.info("Heartbeat: tasks found, executing...")
             if self.on_execute:

--- a/deeptutor/tutorbot/heartbeat/service.py
+++ b/deeptutor/tutorbot/heartbeat/service.py
@@ -59,6 +59,7 @@ class HeartbeatService:
         on_notify: Callable[[str], Coroutine[Any, Any, None]] | None = None,
         interval_s: int = 30 * 60,
         enabled: bool = True,
+        bot_id: str | None = None,
     ):
         self.workspace = workspace
         self.provider = provider
@@ -67,6 +68,7 @@ class HeartbeatService:
         self.on_notify = on_notify
         self.interval_s = interval_s
         self.enabled = enabled
+        self.bot_id = bot_id
         self._running = False
         self._task: asyncio.Task | None = None
 
@@ -144,7 +146,7 @@ class HeartbeatService:
 
         self._running = True
         self._task = asyncio.create_task(self._run_loop())
-        logger.info("Heartbeat started (every {}s)", self.interval_s)
+        logger.info("Heartbeat started (bot={}, every {}s)", self.bot_id, self.interval_s)
 
     def stop(self) -> None:
         """Stop the heartbeat service."""

--- a/deeptutor/tutorbot/heartbeat/service.py
+++ b/deeptutor/tutorbot/heartbeat/service.py
@@ -93,18 +93,26 @@ class HeartbeatService:
         """Double interval after consecutive skips, up to 4x the base."""
         if self._consecutive_skips >= 2:
             multiplier = min(2 ** (self._consecutive_skips - 1), 4)
-            self.interval_s = int(self._base_interval_s * multiplier)
-            logger.info(
-                "Heartbeat: {} consecutive skips, extending interval to {}s",
-                self._consecutive_skips,
-                self.interval_s,
-            )
+            new_interval = int(self._base_interval_s * multiplier)
+            if new_interval != self.interval_s:
+                self.interval_s = new_interval
+                logger.debug(
+                    "Heartbeat: {} consecutive skips, extended interval to {}s (base={}s)",
+                    self._consecutive_skips,
+                    self.interval_s,
+                    self._base_interval_s,
+                )
 
     def _reset_adaptive_interval(self) -> None:
         """Reset to base interval."""
         if self.interval_s != self._base_interval_s:
+            old = self.interval_s
             self.interval_s = self._base_interval_s
-            logger.info("Heartbeat: resetting interval to {}s", self._base_interval_s)
+            logger.debug(
+                "Heartbeat: reset interval from {}s to {}s",
+                old,
+                self._base_interval_s,
+            )
 
     async def _decide(self, content: str) -> tuple[str, str]:
         """Phase 1: ask LLM to decide skip/run via virtual tool call.

--- a/tests/services/tutorbot/test_heartbeat.py
+++ b/tests/services/tutorbot/test_heartbeat.py
@@ -1,0 +1,195 @@
+"""Tests for HeartbeatService and heartbeat config."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from deeptutor.services.tutorbot.manager import BotConfig, TutorBotManager
+
+
+# ---------------------------------------------------------------------------
+# HeartbeatService._has_active_tasks
+# ---------------------------------------------------------------------------
+
+
+class TestHasActiveTasks:
+    """Unit tests for _has_active_tasks parsing logic."""
+
+    @pytest.fixture
+    def hs(self) -> object:
+        """Return a HeartbeatService instance with a dummy workspace."""
+        from deeptutor.tutorbot.heartbeat.service import HeartbeatService
+
+        return HeartbeatService(
+            workspace=Path("/dev/null"),
+            provider=MagicMock(),
+            model="test-model",
+            bot_id="test-bot",
+        )
+
+    def test_empty_content(self, hs: object) -> None:
+        assert hs._has_active_tasks("") is False
+
+    def test_only_headers_and_comments(self, hs: object) -> None:
+        content = """# Heartbeat Tasks
+## Active Tasks
+
+<!-- Add your periodic tasks below this line -->
+
+## Completed
+"""
+        assert hs._has_active_tasks(content) is False
+
+    def test_real_task_lines(self, hs: object) -> None:
+        content = """## Active Tasks
+
+### Daily Reminder
+**Status:** ACTIVE
+**Schedule:** Every day at 09:00
+"""
+        assert hs._has_active_tasks(content) is True
+
+    def test_real_task_with_html_comments(self, hs: object) -> None:
+        content = """# Heartbeat Tasks
+## Active Tasks
+
+<!-- Add your periodic tasks below this line -->
+### Morning Reminder
+**Status:** ACTIVE
+
+## Completed
+"""
+        assert hs._has_active_tasks(content) is True
+
+    def test_no_active_tasks_section(self, hs: object) -> None:
+        content = """# Heartbeat Tasks
+
+## Completed
+<!-- Move completed tasks here -->
+"""
+        assert hs._has_active_tasks(content) is False
+
+    def test_case_insensitive_section_detection(self, hs: object) -> None:
+        content = """## active tasks
+
+### Task
+**Status:** ACTIVE
+"""
+        assert hs._has_active_tasks(content) is True
+
+    def test_multiple_tasks(self, hs: object) -> None:
+        content = """## Active Tasks
+
+### Task 1
+**Status:** ACTIVE
+
+### Task 2
+**Status:** ACTIVE
+"""
+        assert hs._has_active_tasks(content) is True
+
+    def test_tasks_in_completed_section_not_counted(self, hs: object) -> None:
+        content = """## Active Tasks
+
+<!-- empty -->
+
+## Completed
+
+### Old Task
+**Status:** DONE
+"""
+        assert hs._has_active_tasks(content) is False
+
+
+# ---------------------------------------------------------------------------
+# BotConfig heartbeat_interval_s roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatIntervalRoundtrip:
+    """Test that heartbeat_interval_s survives save/load roundtrip."""
+
+    def test_save_load_preserves_heartbeat_interval(self, tmp_path: Path) -> None:
+        mgr = TutorBotManager()
+        mgr._path_service = SimpleNamespace(  # type: ignore[assignment]
+            project_root=tmp_path,
+            get_memory_dir=lambda: tmp_path / "memory",
+        )
+
+        cfg = BotConfig(
+            name="hb-bot",
+            heartbeat_interval_s=900,
+        )
+        mgr.save_bot_config("hb-bot", cfg)
+
+        loaded = mgr.load_bot_config("hb-bot")
+        assert loaded is not None
+        assert loaded.heartbeat_interval_s == 900
+
+    def test_save_load_uses_default_when_missing(self, tmp_path: Path) -> None:
+        mgr = TutorBotManager()
+        mgr._path_service = SimpleNamespace(  # type: ignore[assignment]
+            project_root=tmp_path,
+            get_memory_dir=lambda: tmp_path / "memory",
+        )
+
+        cfg = BotConfig(name="hb-bot-default")
+        mgr.save_bot_config("hb-bot-default", cfg)
+
+        # Simulate old config file without heartbeat_interval_s
+        bot_dir = mgr._bot_dir("hb-bot-default")
+        # Rewrite without heartbeat_interval_s
+        (bot_dir / "config.yaml").write_text(
+            f"name: {cfg.name}\ndescription: {cfg.description}\n"
+        )
+
+        loaded = mgr.load_bot_config("hb-bot-default")
+        assert loaded is not None
+        # Default value
+        assert loaded.heartbeat_interval_s == 30 * 60
+
+
+# ---------------------------------------------------------------------------
+# reload_heartbeat
+# ---------------------------------------------------------------------------
+
+
+class TestReloadHeartbeat:
+    """Test TutorBotManager.reload_heartbeat hot-update."""
+
+    def test_reload_updates_interval(self, tmp_path: Path) -> None:
+        mgr = TutorBotManager()
+        mgr._path_service = SimpleNamespace(  # type: ignore[assignment]
+            project_root=tmp_path,
+            get_memory_dir=lambda: tmp_path / "memory",
+        )
+
+        original_cfg = BotConfig(name="reload-bot", heartbeat_interval_s=1800)
+        mgr.save_bot_config("reload-bot", original_cfg)
+
+        # Create a running instance with a heartbeat service
+        class FakeHeartbeat:
+            interval_s = 1800
+
+        instance = SimpleNamespace()
+        instance.config = original_cfg
+        instance.running = True
+        instance.heartbeat = FakeHeartbeat()
+        instance.tasks = []
+        mgr._bots["reload-bot"] = instance
+
+        # Update config on disk
+        new_cfg = BotConfig(name="reload-bot", heartbeat_interval_s=600)
+        mgr.save_bot_config("reload-bot", new_cfg)
+
+        async def run() -> None:
+            await mgr.reload_heartbeat("reload-bot")
+
+        asyncio.run(run())
+
+        assert instance.heartbeat.interval_s == 600


### PR DESCRIPTION
<!--
Thank you for contributing to DeepTutor! 🚀
Please ensure your PR is ready for review and follows our contribution guidelines.
For more details, see our [CONTRIBUTING.md](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
-->

### Description
Problems Solved

1. Wasted LLM calls: LLM was invoked even when HEARTBEAT.md had no active tasks
2. Interval not configurable: hardcoded 30 minutes, no way to adjust dynamically
3. Config lost on restart: editing config.yaml had no effect after service restart
4. Logs lack bot identity: impossible to distinguish which bot a log line belongs to

Changes

HeartbeatService (deeptutor/tutorbot/heartbeat/service.py)
- New _has_active_tasks(): parses ## Active Tasks section of HEARTBEAT.md, skips LLM when no real task content (excluding comments/headers/blank lines)
- New bot_id field, all logs prefixed with (bot=xxx)
- Constructor accepts bot_id parameter

TutorBotManager (deeptutor/services/tutorbot/manager.py)
- BotConfig add heartbeat_interval_s: int = 1800 (default 30 min)
- load_bot_config / save_bot_config / auto_start_bots read/write this field
- New reload_heartbeat(bot_id) hot-update method — changes to config.yaml take effect immediately

### Related Issues
- Closes 
- Related to #451 

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [x] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [ ] My changes do not introduce any new security vulnerabilities.

### Additional Notes
*Add any other context or screenshots about the pull request here.*
