### PR TITLE
chore: add py313 and py314 to Black target-version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ include = ["deeptutor*", "deeptutor_cli*"]
 # ============================================
 [tool.black]
 line-length = 100
-target-version = ['py311', 'py312']
+target-version = ['py311', 'py312', 'py313', 'py314']
 include = '\.pyi?$'
 extend-exclude = '''
 /(


### PR DESCRIPTION
## Summary
- 更新 `[tool.black]` 的 `target-version` 以包含 `py313` 和 `py314`
- 项目 `requires-python = ">=3.11"`，现在 Python 3.13 & 3.14 已是稳定版本，Black 配置应同步纳入以正确识别支持的语法目标

## Test plan
- [x] `pyproject.toml` 语法检查正常
- [ ] CI pre-commit hooks 均通过（Black 配置变更不影响现有代码行为）

🤖 Generated with [Claude Code](https://claude.com/claude-code)