### PR TITLE
fix: allow quiz answer textarea vertical resize

### DIFF
--- a/web/components/quiz/QuizViewer.tsx
+++ b/web/components/quiz/QuizViewer.tsx
@@ -814,7 +814,7 @@ export default function QuizViewer({
                   ? t("Write your code here...")
                   : t("Type your answer...")
               }
-              className={`w-full resize-none rounded-lg border px-3 py-2 text-[13px] outline-none transition-colors placeholder:text-[var(--muted-foreground)] ${
+              className={`w-full resize-y rounded-lg border px-3 py-2 text-[13px] outline-none transition-colors placeholder:text-[var(--muted-foreground)] ${
                 ans.submitted
                   ? "border-[var(--border)] bg-[var(--muted)] text-[var(--foreground)]"
                   : "border-[var(--border)] bg-[var(--background)] text-[var(--foreground)] focus:border-[var(--primary)]/40"


### PR DESCRIPTION
### Description
Allow vertical resizing for the quiz answer textarea in `QuizViewer` so users can expand the input area for longer written or coding answers.

### Related Issues
- Closes #475

### Module(s) Affected
- [x] `web` (Frontend)

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
Validated the changed file with:
- `uvx pre-commit run --files web/components/quiz/QuizViewer.tsx`
- `npx eslint components/quiz/QuizViewer.tsx`

This change is intentionally minimal: it only replaces `resize-none` with `resize-y` for the answer textarea in the quiz viewer.
