### PR TITLE
弃用

### DIFF
--- a/deeptutor/tutorbot/channels/zulip.py
+++ b/deeptutor/tutorbot/channels/zulip.py
@@ -157,6 +157,9 @@ class ZulipChannel(BaseChannel):
             logger.warning("Zulip client not running")
             return
 
+        if msg.metadata.get("_tool_hint"):
+            return
+
         if not msg.metadata.get("msg_type"):
             stored = self._recipient_map.get(msg.chat_id)
             if stored:

--- a/deeptutor/tutorbot/channels/zulip.py
+++ b/deeptutor/tutorbot/channels/zulip.py
@@ -537,15 +537,16 @@ class ZulipChannel(BaseChannel):
         if not client:
             return
         loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(
-            None,
-            lambda: self._call_with_retry(
-                client.call_endpoint,
-                url="user_uploads",
-                files=[media_path],
-                timeout=self.config.timeout,
-            ),
-        )
+        with open(media_path, "rb") as f:
+            result = await loop.run_in_executor(
+                None,
+                lambda: self._call_with_retry(
+                    client.call_endpoint,
+                    url="user_uploads",
+                    files=[f],
+                    timeout=self.config.timeout,
+                ),
+            )
         if result.get("result") != "success":
             logger.error("Zulip upload failed: {}", result.get("msg", "unknown"))
             return

--- a/deeptutor/tutorbot/channels/zulip.py
+++ b/deeptutor/tutorbot/channels/zulip.py
@@ -532,12 +532,55 @@ class ZulipChannel(BaseChannel):
         if result.get("result") != "success":
             logger.error("Zulip send failed: {}", result.get("msg", "unknown"))
 
+    def _resolve_media_path(self, media_path: str) -> str | None:
+        if Path(media_path).exists():
+            return media_path
+
+        path_id: str | None = None
+        if media_path.startswith("/user_uploads/"):
+            path_id = media_path
+        elif self.config.site and media_path.startswith(self.config.site):
+            stripped = media_path[len(self.config.site.rstrip("/")):]
+            if stripped.startswith("/user_uploads/"):
+                path_id = stripped
+
+        if not path_id:
+            return None
+
+        media_dir = get_media_dir("zulip")
+        name = Path(unquote(path_id)).name
+        dest = self._attachment_destination(media_dir, name, path_id, 0)
+
+        if dest.exists():
+            return str(dest)
+
+        url = f"{self.config.site.rstrip('/')}{path_id}"
+        try:
+            resp = requests.get(
+                url,
+                auth=(self.config.email, self.config.api_key),
+                timeout=self.config.timeout,
+            )
+            resp.raise_for_status()
+            dest.write_bytes(resp.content)
+            logger.debug("Downloaded Zulip attachment for re-upload: {}", name)
+            return str(dest)
+        except Exception as e:
+            logger.warning("Failed to download Zulip attachment {}: {}", name, e)
+            return None
+
     async def _upload_and_send(self, chat_id: str, media_path: str, metadata: dict) -> None:
         client = self._client
         if not client:
             return
+
+        local_path = self._resolve_media_path(media_path)
+        if not local_path:
+            logger.error("Cannot resolve media path: {}", media_path)
+            return
+
         loop = asyncio.get_running_loop()
-        with open(media_path, "rb") as f:
+        with open(local_path, "rb") as f:
             result = await loop.run_in_executor(
                 None,
                 lambda: self._call_with_retry(

--- a/deeptutor/tutorbot/channels/zulip.py
+++ b/deeptutor/tutorbot/channels/zulip.py
@@ -157,6 +157,11 @@ class ZulipChannel(BaseChannel):
             logger.warning("Zulip client not running")
             return
 
+        if not msg.metadata.get("msg_type"):
+            stored = self._recipient_map.get(msg.chat_id)
+            if stored:
+                msg.metadata = {**stored, **msg.metadata}
+
         if not msg.metadata.get("_progress", False):
             self._stop_typing(msg.chat_id)
 


### PR DESCRIPTION
### Description

修复 Zulip 通道在处理附件上传和发送时存在的四个 BUG，涉及文件对象传递、路径解析、路由元数据补全和进度消息过滤。

#### BUG 1: 附件上传报错 `str object has no attribute name`
- **根因**: `_upload_and_send` 将文件路径字符串直接传入 `client.call_endpoint(files=...)`，但 Zulip Python 客户端期望文件对象列表（内部执行 `f.name`），导致 `AttributeError`
- **修复**: 使用 `open(media_path, "rb")` 打开文件后传入文件对象

#### BUG 2: 附件重发时 Zulip 上传路径被当作本地文件路径
- **根因**: LLM 回复时使用消息内容中的 Zulip 服务器路径（如 `/user_uploads/...`）作为 `media` 参数，而非本地已下载的文件路径，导致 `open()` 报错 `No such file or directory`
- **修复**: 新增 `_resolve_media_path` 方法，将 Zulip 上传路径解析为本地文件路径（优先查找已下载副本，否则重新下载）

#### BUG 3: 附件发送报错 `Message must have recipients`
- **根因**: `MessageTool` 创建的 `OutboundMessage` 只包含 `{"message_id": ...}`，缺少 `msg_type`/`stream`/`topic`/`recipient_user_id` 等 Zulip 路由字段，导致 `_build_send_request` 生成空收件人列表。`_recipient_map` 在收到消息时已存储完整路由元数据，但从未被读取使用
- **修复**: 在 `send()` 中，当 metadata 缺少 `msg_type` 时，从 `_recipient_map` 查找对应 `chat_id` 的路由信息并合并

#### BUG 4: 附件发送时产生重复的 `message("...")` 格式文本
- **根因**: LLM 调用 `message` 工具时，agent loop 先发送 `_tool_hint` 进度消息（如 `message("内容")`），然后 `MessageTool` 才发送真正的消息。配置中 `send_tool_hints` 默认为 `False`，但 `_outbound_router` 未检查该标志
- **修复**: 在 `send()` 入口处过滤 `_tool_hint` 消息，直接返回不发送

### Related Issues
- Related to Zulip channel attachment handling

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `channels`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

所有修复仅涉及 `deeptutor/tutorbot/channels/zulip.py` 一个文件，改动最小化，不影响其他通道（Matrix、飞书等）的行为。