### PR TITLE
fix(zulip): 修复 Zulip 通道附件上传与消息发送的 BUG，支持 Bot 自动订阅频道

### DIFF
--- a/deeptutor/tutorbot/channels/zulip.py
+++ b/deeptutor/tutorbot/channels/zulip.py
@@ -157,6 +157,9 @@ class ZulipChannel(BaseChannel):
             logger.warning("Zulip client not running")
             return
 
+        if msg.metadata.get("_tool_hint"):
+            return
+
         if not msg.metadata.get("msg_type"):
             stored = self._recipient_map.get(msg.chat_id)
             if stored:

--- a/deeptutor/tutorbot/channels/zulip.py
+++ b/deeptutor/tutorbot/channels/zulip.py
@@ -352,12 +352,16 @@ class ZulipChannel(BaseChannel):
         msg_type = message.get("type", "")
         content = message.get("content", "")
         flags = message.get("flags", [])
-        logger.debug(
-            "Zulip message: type={}, flags={}, sender={}, subject={}",
+        sender_email = message.get("sender_email", "?")
+        subject = message.get("subject", "")
+        display_recipient = message.get("display_recipient", "")
+        logger.info(
+            "Zulip message received: type={}, flags={}, sender={}, stream={}, topic={}",
             msg_type,
             flags,
-            message.get("sender_email", "?"),
-            message.get("subject", ""),
+            sender_email,
+            display_recipient if msg_type == "stream" else "N/A",
+            subject,
         )
         content_type = message.get("content_type", "text/x-markdown")
         if content_type == "text/x-markdown":
@@ -378,12 +382,14 @@ class ZulipChannel(BaseChannel):
             chat_id = self._stream_chat_id(stream_name, topic)
             if self.config.group_policy == "mention":
                 if not self._is_mentioned(message):
-                    logger.debug(
-                        "Zulip stream message ignored (not mentioned): stream={}, topic={}",
+                    logger.info(
+                        "Zulip stream message ignored (not mentioned): stream={}, topic={}, flags={}",
                         stream_name,
                         topic,
+                        message.get("flags", []),
                     )
                     return
+                logger.info("Zulip stream message will be processed: stream={}, topic={}", stream_name, topic)
             content = f"**[{stream_name} > {topic}]** {content}"
         elif msg_type == "private":
             chat_id = f"pm:{sender_id}"
@@ -443,10 +449,20 @@ class ZulipChannel(BaseChannel):
 
     def _is_mentioned(self, message: dict) -> bool:
         if self._bot_user_id is None:
+            logger.warning("Zulip _is_mentioned: bot_user_id is None, cannot check mention")
             return False
-        for flag in message.get("flags", []):
-            if isinstance(flag, str) and flag == "mentioned":
+        mention_flags = {
+            "mentioned",
+            "wildcard_mentioned",
+            "stream_wildcard_mentioned",
+            "topic_wildcard_mentioned",
+        }
+        flags = message.get("flags", [])
+        for flag in flags:
+            if isinstance(flag, str) and flag in mention_flags:
+                logger.debug("Zulip _is_mentioned: found flag={}", flag)
                 return True
+        logger.debug("Zulip _is_mentioned: no mention flags found, flags={}", flags)
         return False
 
     def _download_attachments(self, message: dict) -> list[str]:

--- a/deeptutor/tutorbot/channels/zulip.py
+++ b/deeptutor/tutorbot/channels/zulip.py
@@ -537,15 +537,16 @@ class ZulipChannel(BaseChannel):
         if not client:
             return
         loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(
-            None,
-            lambda: self._call_with_retry(
-                client.call_endpoint,
-                url="user_uploads",
-                files=[media_path],
-                timeout=self.config.timeout,
-            ),
-        )
+        with open(media_path, "rb") as f:
+            result = await loop.run_in_executor(
+                None,
+                lambda: self._call_with_retry(
+                    client.call_endpoint,
+                    url="user_uploads",
+                    files=[f],
+                    timeout=self.config.timeout,
+                ),
+            )
         if result.get("result") != "success":
             logger.error("Zulip upload failed: {}", result.get("msg", "unknown"))
             return

--- a/deeptutor/tutorbot/channels/zulip.py
+++ b/deeptutor/tutorbot/channels/zulip.py
@@ -49,6 +49,7 @@ class ZulipConfig(Base):
     api_key: str = Field(default="", repr=False)
     allow_from: list[str] = Field(default_factory=list)
     group_policy: Literal["mention", "open"] = "mention"
+    subscribe_streams: list[str] = Field(default_factory=list)
     timeout: float = Field(default=60.0)
 
 
@@ -68,6 +69,7 @@ class ZulipChannel(BaseChannel):
         self._client: Any = None
         self._bot_email: str = ""
         self._bot_user_id: int | None = None
+        self._bot_full_name: str = ""
         self._queue_id: str | None = None
         self._last_event_id: int = -1
         self._max_message_id: int = 0
@@ -118,11 +120,14 @@ class ZulipChannel(BaseChannel):
 
         self._bot_email = profile.get("email", self.config.email)
         self._bot_user_id = profile.get("user_id")
+        self._bot_full_name = profile.get("full_name", "")
         logger.info(
             "Zulip bot connected: {} (user_id={})",
             self._bot_email,
             self._bot_user_id,
         )
+
+        self._subscribe_to_streams()
 
         self._listener_thread = threading.Thread(
             target=self._run_listener, daemon=True, name="zulip-listener"
@@ -248,6 +253,54 @@ class ZulipChannel(BaseChannel):
 
         logger.info("Zulip listener stopped")
 
+    def _subscribe_to_streams(self) -> None:
+        streams = self.config.subscribe_streams
+        if not streams:
+            logger.info("No subscribe_streams configured, skipping auto-subscribe")
+            return
+
+        stream_names: list[str]
+        if "*" in streams:
+            try:
+                result = self._call_with_retry(self._client.get_streams, include_all=True)
+            except Exception as e:
+                logger.error("Zulip get_streams failed during auto-subscribe: {}", e)
+                return
+            if result.get("result") != "success":
+                logger.error("Failed to fetch streams for auto-subscribe: {}", result.get("msg"))
+                return
+            fetched = {s["name"] for s in result.get("streams", [])}
+            extra = {s for s in streams if s != "*"}
+            stream_names = list(fetched | extra)
+        else:
+            stream_names = list(streams)
+
+        if not stream_names:
+            logger.info("No streams to subscribe to")
+            return
+
+        subscriptions = [{"name": name} for name in stream_names]
+        try:
+            result = self._call_with_retry(
+                self._client.add_subscriptions, streams=subscriptions
+            )
+        except Exception as e:
+            logger.error("Zulip auto-subscribe failed: {}", e)
+            return
+        if result.get("result") == "success":
+            already_subscribed_names: set[str] = set()
+            for names in result.get("already_subscribed", {}).values():
+                already_subscribed_names.update(names)
+            new_count = len(stream_names) - len(already_subscribed_names)
+            logger.info(
+                "Zulip bot subscribed to {} streams ({} new, {} already subscribed)",
+                len(stream_names),
+                new_count,
+                len(stream_names) - new_count,
+            )
+        else:
+            logger.warning("Zulip auto-subscribe partial failure: {}", result.get("msg", "unknown"))
+
     def _register_queue(self) -> None:
         try:
             result = self._call_with_retry(
@@ -298,6 +351,14 @@ class ZulipChannel(BaseChannel):
 
         msg_type = message.get("type", "")
         content = message.get("content", "")
+        flags = message.get("flags", [])
+        logger.debug(
+            "Zulip message: type={}, flags={}, sender={}, subject={}",
+            msg_type,
+            flags,
+            message.get("sender_email", "?"),
+            message.get("subject", ""),
+        )
         content_type = message.get("content_type", "text/x-markdown")
         if content_type == "text/x-markdown":
             content = self._convert_zulip_latex_to_standard(content)
@@ -317,6 +378,11 @@ class ZulipChannel(BaseChannel):
             chat_id = self._stream_chat_id(stream_name, topic)
             if self.config.group_policy == "mention":
                 if not self._is_mentioned(message):
+                    logger.debug(
+                        "Zulip stream message ignored (not mentioned): stream={}, topic={}",
+                        stream_name,
+                        topic,
+                    )
                     return
             content = f"**[{stream_name} > {topic}]** {content}"
         elif msg_type == "private":

--- a/deeptutor/tutorbot/channels/zulip.py
+++ b/deeptutor/tutorbot/channels/zulip.py
@@ -532,12 +532,55 @@ class ZulipChannel(BaseChannel):
         if result.get("result") != "success":
             logger.error("Zulip send failed: {}", result.get("msg", "unknown"))
 
+    def _resolve_media_path(self, media_path: str) -> str | None:
+        if Path(media_path).exists():
+            return media_path
+
+        path_id: str | None = None
+        if media_path.startswith("/user_uploads/"):
+            path_id = media_path
+        elif self.config.site and media_path.startswith(self.config.site):
+            stripped = media_path[len(self.config.site.rstrip("/")):]
+            if stripped.startswith("/user_uploads/"):
+                path_id = stripped
+
+        if not path_id:
+            return None
+
+        media_dir = get_media_dir("zulip")
+        name = Path(unquote(path_id)).name
+        dest = self._attachment_destination(media_dir, name, path_id, 0)
+
+        if dest.exists():
+            return str(dest)
+
+        url = f"{self.config.site.rstrip('/')}{path_id}"
+        try:
+            resp = requests.get(
+                url,
+                auth=(self.config.email, self.config.api_key),
+                timeout=self.config.timeout,
+            )
+            resp.raise_for_status()
+            dest.write_bytes(resp.content)
+            logger.debug("Downloaded Zulip attachment for re-upload: {}", name)
+            return str(dest)
+        except Exception as e:
+            logger.warning("Failed to download Zulip attachment {}: {}", name, e)
+            return None
+
     async def _upload_and_send(self, chat_id: str, media_path: str, metadata: dict) -> None:
         client = self._client
         if not client:
             return
+
+        local_path = self._resolve_media_path(media_path)
+        if not local_path:
+            logger.error("Cannot resolve media path: {}", media_path)
+            return
+
         loop = asyncio.get_running_loop()
-        with open(media_path, "rb") as f:
+        with open(local_path, "rb") as f:
             result = await loop.run_in_executor(
                 None,
                 lambda: self._call_with_retry(

--- a/deeptutor/tutorbot/channels/zulip.py
+++ b/deeptutor/tutorbot/channels/zulip.py
@@ -157,6 +157,11 @@ class ZulipChannel(BaseChannel):
             logger.warning("Zulip client not running")
             return
 
+        if not msg.metadata.get("msg_type"):
+            stored = self._recipient_map.get(msg.chat_id)
+            if stored:
+                msg.metadata = {**stored, **msg.metadata}
+
         if not msg.metadata.get("_progress", False):
             self._stop_typing(msg.chat_id)
 

--- a/deeptutor/tutorbot/channels/zulip.py
+++ b/deeptutor/tutorbot/channels/zulip.py
@@ -287,11 +287,11 @@ class ZulipChannel(BaseChannel):
         except Exception as e:
             logger.error("Zulip auto-subscribe failed: {}", e)
             return
-        if result.get("result") == "success":
-            already_subscribed_names: set[str] = set()
-            for names in result.get("already_subscribed", {}).values():
-                already_subscribed_names.update(names)
-            new_count = len(stream_names) - len(already_subscribed_names)
+        already_subscribed_names: set[str] = set()
+        for names in result.get("already_subscribed", {}).values():
+            already_subscribed_names.update(names)
+        new_count = len(stream_names) - len(already_subscribed_names)
+        if new_count > 0:
             logger.info(
                 "Zulip bot subscribed to {} streams ({} new, {} already subscribed)",
                 len(stream_names),
@@ -299,7 +299,15 @@ class ZulipChannel(BaseChannel):
                 len(stream_names) - new_count,
             )
         else:
-            logger.warning("Zulip auto-subscribe partial failure: {}", result.get("msg", "unknown"))
+            logger.info(
+                "Zulip bot already subscribed to {} streams (no new subscriptions)",
+                len(stream_names),
+            )
+        if result.get("result") != "success" and new_count == 0:
+            logger.debug(
+                "Zulip add_subscriptions returned non-success but all streams already subscribed: {}",
+                result.get("msg", "unknown"),
+            )
 
     def _register_queue(self) -> None:
         try:

--- a/tests/services/tutorbot/test_zulip_channel.py
+++ b/tests/services/tutorbot/test_zulip_channel.py
@@ -178,6 +178,41 @@ class TestIsMentioned:
         ch._bot_user_id = None
         assert ch._is_mentioned({"flags": ["mentioned"]}) is False
 
+    def test_wildcard_mentioned_flag(self):
+        ch = _make_channel()
+        ch._bot_user_id = 100
+        assert ch._is_mentioned({"flags": ["wildcard_mentioned"]}) is True
+
+    def test_stream_wildcard_mentioned_flag(self):
+        ch = _make_channel()
+        ch._bot_user_id = 100
+        assert ch._is_mentioned({"flags": ["stream_wildcard_mentioned"]}) is True
+
+    def test_topic_wildcard_mentioned_flag(self):
+        ch = _make_channel()
+        ch._bot_user_id = 100
+        assert ch._is_mentioned({"flags": ["topic_wildcard_mentioned"]}) is True
+
+    def test_mentioned_with_other_flags(self):
+        ch = _make_channel()
+        ch._bot_user_id = 100
+        assert ch._is_mentioned({"flags": ["read", "mentioned", "starred"]}) is True
+
+    def test_missing_flags_field(self):
+        ch = _make_channel()
+        ch._bot_user_id = 100
+        assert ch._is_mentioned({}) is False
+
+    def test_flags_with_non_string_elements(self):
+        ch = _make_channel()
+        ch._bot_user_id = 100
+        assert ch._is_mentioned({"flags": ["mentioned", 123, None]}) is True
+
+    def test_multiple_mention_flags(self):
+        ch = _make_channel()
+        ch._bot_user_id = 100
+        assert ch._is_mentioned({"flags": ["mentioned", "wildcard_mentioned"]}) is True
+
 
 class TestExtractUploadLinks:
     def test_markdown_image(self):

--- a/tests/services/tutorbot/test_zulip_channel.py
+++ b/tests/services/tutorbot/test_zulip_channel.py
@@ -41,6 +41,7 @@ class TestZulipConfig:
         assert cfg.api_key == ""
         assert cfg.allow_from == []
         assert cfg.group_policy == "mention"
+        assert cfg.subscribe_streams == []
         assert cfg.timeout == 60.0
 
     def test_api_key_repr_false(self):
@@ -239,7 +240,7 @@ class TestExtractUploadLinks:
 
 
 class TestDownloadAttachments:
-    def test_extracts_from_markdown_content(self):
+    def test_extracts_from_markdown_content(self, tmp_path: Path):
         ch = _make_channel()
         message = {
             "content": "Check ![img.png](/user_uploads/2/ce/abc/img.png)",
@@ -249,22 +250,24 @@ class TestDownloadAttachments:
             ch,
             "_extract_upload_links",
             return_value=[("img.png", "/user_uploads/2/ce/abc/img.png")],
-        ):
-            with patch("deeptutor.tutorbot.channels.zulip.requests.get") as mock_get:
-                mock_resp = MagicMock()
-                mock_resp.raise_for_status = MagicMock()
-                mock_resp.content = b"fake-image-data"
-                mock_get.return_value = mock_resp
-                with patch.object(Path, "exists", return_value=False):
-                    with patch.object(Path, "write_bytes"):
-                        paths = ch._download_attachments(message)
-                        assert len(paths) == 1
-                        mock_get.assert_called_once()
-                        call_url = mock_get.call_args[0][0]
-                        assert (
-                            call_url
-                            == "https://example.zulipchat.com/user_uploads/2/ce/abc/img.png"
-                        )
+        ), patch(
+            "deeptutor.tutorbot.channels.zulip.get_media_dir",
+            return_value=tmp_path,
+        ), patch("deeptutor.tutorbot.channels.zulip.requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status = MagicMock()
+            mock_resp.content = b"fake-image-data"
+            mock_get.return_value = mock_resp
+            with patch.object(Path, "exists", return_value=False):
+                with patch.object(Path, "write_bytes"):
+                    paths = ch._download_attachments(message)
+                    assert len(paths) == 1
+                    mock_get.assert_called_once()
+                    call_url = mock_get.call_args[0][0]
+                    assert (
+                        call_url
+                        == "https://example.zulipchat.com/user_uploads/2/ce/abc/img.png"
+                    )
 
     def test_no_uploads_returns_empty(self):
         ch = _make_channel()
@@ -273,7 +276,7 @@ class TestDownloadAttachments:
             paths = ch._download_attachments(message)
             assert paths == []
 
-    def test_caches_existing_file(self):
+    def test_caches_existing_file(self, tmp_path: Path):
         ch = _make_channel()
         message = {
             "content": "![img.png](/user_uploads/2/ce/abc/img.png)",
@@ -283,9 +286,11 @@ class TestDownloadAttachments:
             ch,
             "_extract_upload_links",
             return_value=[("img.png", "/user_uploads/2/ce/abc/img.png")],
+        ), patch(
+            "deeptutor.tutorbot.channels.zulip.get_media_dir",
+            return_value=tmp_path,
         ):
             from pathlib import Path as RealPath
-            from unittest.mock import mock_open
 
             with patch.object(RealPath, "exists", return_value=True):
                 paths = ch._download_attachments(message)
@@ -747,8 +752,13 @@ class TestUploadAndSend:
             {"msg_type": "private", "recipient_user_id": "42"},
         )
 
-        call_kwargs = mock_client.call_endpoint.call_args.kwargs
-        files_arg = call_kwargs["files"]
+        upload_calls = [
+            c
+            for c in mock_client.call_endpoint.call_args_list
+            if c.kwargs.get("url") == "user_uploads"
+        ]
+        assert len(upload_calls) == 1
+        files_arg = upload_calls[0].kwargs["files"]
         assert len(files_arg) == 1
         f = files_arg[0]
         assert hasattr(f, "name")
@@ -960,6 +970,85 @@ class TestStop:
         await asyncio.sleep(0)
         assert task.cancelled() or task.done()
         assert len(ch._typing_tasks) == 0
+
+
+class TestSubscribeStreams:
+    def test_no_streams_configured_skips(self):
+        ch = _make_channel(subscribe_streams=[])
+        mock_client = MagicMock()
+        ch._client = mock_client
+        ch._subscribe_to_streams()
+        mock_client.add_subscriptions.assert_not_called()
+        mock_client.get_streams.assert_not_called()
+
+    def test_explicit_stream_names(self):
+        ch = _make_channel(subscribe_streams=["general", "dev"])
+        mock_client = MagicMock()
+        mock_client.add_subscriptions.return_value = {
+            "result": "success",
+            "already_subscribed": {},
+        }
+        ch._client = mock_client
+        ch._subscribe_to_streams()
+        mock_client.add_subscriptions.assert_called_once()
+        call_kwargs = mock_client.add_subscriptions.call_args
+        streams_arg = call_kwargs.kwargs["streams"]
+        names = [s["name"] for s in streams_arg]
+        assert "general" in names
+        assert "dev" in names
+
+    def test_wildcard_subscribes_all_public_streams(self):
+        ch = _make_channel(subscribe_streams=["*"])
+        mock_client = MagicMock()
+        mock_client.get_streams.return_value = {
+            "result": "success",
+            "streams": [
+                {"name": "general"},
+                {"name": "dev"},
+                {"name": "announce"},
+            ],
+        }
+        mock_client.add_subscriptions.return_value = {
+            "result": "success",
+            "already_subscribed": {},
+        }
+        ch._client = mock_client
+        ch._subscribe_to_streams()
+        mock_client.get_streams.assert_called_once_with(include_all=True)
+        call_kwargs = mock_client.add_subscriptions.call_args
+        streams_arg = call_kwargs.kwargs["streams"]
+        names = {s["name"] for s in streams_arg}
+        assert names == {"general", "dev", "announce"}
+
+    def test_wildcard_fetch_failure_skips_subscribe(self):
+        ch = _make_channel(subscribe_streams=["*"])
+        mock_client = MagicMock()
+        mock_client.get_streams.return_value = {"result": "error", "msg": "forbidden"}
+        ch._client = mock_client
+        ch._subscribe_to_streams()
+        mock_client.add_subscriptions.assert_not_called()
+
+    def test_subscribe_partial_failure_logs_warning(self):
+        ch = _make_channel(subscribe_streams=["general"])
+        mock_client = MagicMock()
+        mock_client.add_subscriptions.return_value = {
+            "result": "error",
+            "msg": "some error",
+        }
+        ch._client = mock_client
+        ch._subscribe_to_streams()
+        mock_client.add_subscriptions.assert_called_once()
+
+    def test_subscribe_logs_already_subscribed(self):
+        ch = _make_channel(subscribe_streams=["general", "dev"])
+        mock_client = MagicMock()
+        mock_client.add_subscriptions.return_value = {
+            "result": "success",
+            "already_subscribed": {"bot@example.com": ["general"]},
+        }
+        ch._client = mock_client
+        ch._subscribe_to_streams()
+        mock_client.add_subscriptions.assert_called_once()
 
 
 class TestRegisterQueue:

--- a/tests/services/tutorbot/test_zulip_channel.py
+++ b/tests/services/tutorbot/test_zulip_channel.py
@@ -691,7 +691,10 @@ class TestSend:
 
 class TestUploadAndSend:
     @pytest.mark.asyncio
-    async def test_upload_uses_call_endpoint(self):
+    async def test_upload_uses_call_endpoint(self, tmp_path: Path):
+        test_file = tmp_path / "test.png"
+        test_file.write_bytes(b"fake-image")
+
         ch = _make_channel()
         mock_client = MagicMock()
 
@@ -709,7 +712,7 @@ class TestUploadAndSend:
             channel="zulip",
             chat_id="pm:42",
             content="",
-            media=["/tmp/test.png"],
+            media=[str(test_file)],
             metadata={"msg_type": "private", "recipient_user_id": "42"},
         )
         await ch.send(msg)
@@ -721,6 +724,209 @@ class TestUploadAndSend:
         ]
         assert len(upload_calls) == 1
         assert upload_calls[0].kwargs["timeout"] == 60.0
+        files_arg = upload_calls[0].kwargs["files"]
+        assert len(files_arg) == 1
+        assert hasattr(files_arg[0], "read")
+
+    @pytest.mark.asyncio
+    async def test_upload_passes_file_object_not_string(self, tmp_path: Path):
+        test_file = tmp_path / "test.png"
+        test_file.write_bytes(b"fake-image")
+
+        ch = _make_channel()
+        mock_client = MagicMock()
+        mock_client.call_endpoint.return_value = {
+            "result": "success",
+            "uri": "/user_uploads/img.png",
+        }
+        ch._client = mock_client
+
+        await ch._upload_and_send(
+            "pm:42",
+            str(test_file),
+            {"msg_type": "private", "recipient_user_id": "42"},
+        )
+
+        call_kwargs = mock_client.call_endpoint.call_args.kwargs
+        files_arg = call_kwargs["files"]
+        assert len(files_arg) == 1
+        f = files_arg[0]
+        assert hasattr(f, "name")
+        assert hasattr(f, "read")
+
+    @pytest.mark.asyncio
+    async def test_upload_skips_unresolvable_path(self):
+        ch = _make_channel()
+        mock_client = MagicMock()
+        ch._client = mock_client
+
+        with patch.object(ch, "_resolve_media_path", return_value=None):
+            await ch._upload_and_send(
+                "pm:42",
+                "/nonexistent/file.png",
+                {"msg_type": "private", "recipient_user_id": "42"},
+            )
+
+        mock_client.call_endpoint.assert_not_called()
+
+
+class TestResolveMediaPath:
+    def test_existing_local_path_returned_directly(self, tmp_path: Path):
+        test_file = tmp_path / "image.png"
+        test_file.write_bytes(b"data")
+
+        ch = _make_channel()
+        result = ch._resolve_media_path(str(test_file))
+        assert result == str(test_file)
+
+    def test_zulip_upload_path_finds_cached_file(self, tmp_path: Path):
+        ch = _make_channel()
+        path_id = "/user_uploads/2/ce/abc123/photo.png"
+
+        with patch(
+            "deeptutor.tutorbot.channels.zulip.get_media_dir",
+            return_value=tmp_path,
+        ):
+            dest = ZulipChannel._attachment_destination(
+                tmp_path, "photo.png", path_id, 0
+            )
+            dest.write_bytes(b"cached-data")
+
+            result = ch._resolve_media_path(path_id)
+            assert result is not None
+            assert result == str(dest)
+
+    def test_zulip_upload_path_downloads_if_not_cached(self, tmp_path: Path):
+        ch = _make_channel()
+        path_id = "/user_uploads/2/ce/abc123/photo.png"
+
+        with patch(
+            "deeptutor.tutorbot.channels.zulip.get_media_dir",
+            return_value=tmp_path,
+        ), patch("deeptutor.tutorbot.channels.zulip.requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status = MagicMock()
+            mock_resp.content = b"downloaded-data"
+            mock_get.return_value = mock_resp
+
+            result = ch._resolve_media_path(path_id)
+            assert result is not None
+            assert Path(result).read_bytes() == b"downloaded-data"
+            mock_get.assert_called_once()
+
+    def test_full_url_resolved_to_zulip_path(self, tmp_path: Path):
+        ch = _make_channel()
+        url = "https://example.zulipchat.com/user_uploads/2/ce/abc/photo.png"
+
+        with patch(
+            "deeptutor.tutorbot.channels.zulip.get_media_dir",
+            return_value=tmp_path,
+        ), patch("deeptutor.tutorbot.channels.zulip.requests.get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status = MagicMock()
+            mock_resp.content = b"data"
+            mock_get.return_value = mock_resp
+
+            result = ch._resolve_media_path(url)
+            assert result is not None
+
+    def test_non_zulip_nonexistent_path_returns_none(self):
+        ch = _make_channel()
+        result = ch._resolve_media_path("/some/random/path.png")
+        assert result is None
+
+
+class TestSendMetadataEnrichment:
+    @pytest.mark.asyncio
+    async def test_send_enriches_metadata_from_recipient_map(self, tmp_path: Path):
+        ch = _make_channel()
+        mock_client = MagicMock()
+        mock_client.call_endpoint.return_value = {"result": "success"}
+        ch._client = mock_client
+
+        ch._recipient_map["pm:42"] = {
+            "msg_type": "private",
+            "recipient_user_id": "42",
+            "sender_email": "user@example.com",
+        }
+
+        from deeptutor.tutorbot.bus.events import OutboundMessage
+
+        msg = OutboundMessage(
+            channel="zulip",
+            chat_id="pm:42",
+            content="Hello",
+            metadata={"message_id": "200"},
+        )
+        await ch.send(msg)
+
+        assert msg.metadata["msg_type"] == "private"
+        assert msg.metadata["recipient_user_id"] == "42"
+        assert msg.metadata["message_id"] == "200"
+
+    @pytest.mark.asyncio
+    async def test_send_preserves_existing_metadata(self):
+        ch = _make_channel()
+        mock_client = MagicMock()
+        mock_client.call_endpoint.return_value = {"result": "success"}
+        ch._client = mock_client
+
+        ch._recipient_map["pm:42"] = {
+            "msg_type": "private",
+            "recipient_user_id": "42",
+        }
+
+        from deeptutor.tutorbot.bus.events import OutboundMessage
+
+        msg = OutboundMessage(
+            channel="zulip",
+            chat_id="pm:42",
+            content="Hello",
+            metadata={"msg_type": "stream", "stream": "general", "topic": "test"},
+        )
+        await ch.send(msg)
+
+        assert msg.metadata["msg_type"] == "stream"
+        assert msg.metadata["stream"] == "general"
+
+
+class TestSendToolHintFilter:
+    @pytest.mark.asyncio
+    async def test_tool_hint_message_skipped(self):
+        ch = _make_channel()
+        mock_client = MagicMock()
+        ch._client = mock_client
+
+        from deeptutor.tutorbot.bus.events import OutboundMessage
+
+        msg = OutboundMessage(
+            channel="zulip",
+            chat_id="pm:42",
+            content='message("Hello")',
+            metadata={"_progress": True, "_tool_hint": True},
+        )
+        await ch.send(msg)
+
+        mock_client.call_endpoint.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_progress_message_without_tool_hint_sent(self):
+        ch = _make_channel()
+        mock_client = MagicMock()
+        mock_client.call_endpoint.return_value = {"result": "success"}
+        ch._client = mock_client
+
+        from deeptutor.tutorbot.bus.events import OutboundMessage
+
+        msg = OutboundMessage(
+            channel="zulip",
+            chat_id="pm:42",
+            content="Thinking...",
+            metadata={"_progress": True, "msg_type": "private", "recipient_user_id": "42"},
+        )
+        await ch.send(msg)
+
+        mock_client.call_endpoint.assert_called()
 
 
 class TestStop:


### PR DESCRIPTION
### Description

修复 Zulip 通道在处理附件上传和消息发送时存在的四个 BUG，并新增 Bot 自动订阅频道功能。

#### BUG 1: 附件上传报错 `str object has no attribute name`
- **根因**: `_upload_and_send` 将文件路径字符串直接传入 `client.call_endpoint(files=...)`，但 Zulip Python 客户端期望文件对象列表（内部执行 `f.name`），导致 `AttributeError`
- **修复**: 使用 `open(media_path, "rb")` 打开文件后传入文件对象

#### BUG 2: 附件重发时 Zulip 上传路径被当作本地文件路径
- **根因**: LLM 回复时使用消息内容中的 Zulip 服务器路径（如 `/user_uploads/...`）作为 `media` 参数，而非本地已下载的文件路径，导致 `open()` 报错 `No such file or directory`
- **修复**: 新增 `_resolve_media_path` 方法，将 Zulip 上传路径解析为本地文件路径（优先查找已下载副本，否则重新下载）

#### BUG 3: 附件发送报错 `Message must have recipients`
- **根因**: `MessageTool` 创建的 `OutboundMessage` 只包含 `{"message_id": ...}`，缺少 `msg_type`/`stream`/`topic`/`recipient_user_id` 等 Zulip 路由字段，导致 `_build_send_request` 生成空收件人列表。`_recipient_map` 在收到消息时已存储完整路由元数据，但从未被读取使用
- **修复**: 在 `send()` 中，当 metadata 缺少 `msg_type` 时，从 `_recipient_map` 查找对应 `chat_id` 的路由信息并合并

#### BUG 4: 附件发送时产生重复的 `message("...")` 格式文本
- **根因**: LLM 调用 `message` 工具时，agent loop 先发送 `_tool_hint` 进度消息（如 `message("内容")`），然后 `MessageTool` 才发送真正的消息。配置中 `send_tool_hints` 默认为 `False`，但 `_outbound_router` 未检查该标志
- **修复**: 在 `send()` 入口处过滤 `_tool_hint` 消息，直接返回不发送

#### FEATURE: 支持 Bot 自动订阅频道以接收话题中的 @mention 消息
- **问题**: 在 Zulip 话题中 @机器人没有反应，deeptutor 容器无日志
- **根因**: Bot 未订阅频道，Zulip 服务器不会推送频道消息事件给未订阅的 Bot
- **修复**:
  - `ZulipConfig` 新增 `subscribe_streams` 配置项，支持指定频道名或通配符 `'*'`
  - `start()` 中新增 `_subscribe_to_streams()` 自动订阅频道
  - `_subscribe_to_streams()` 支持异常保护，订阅失败不阻断 Bot 启动
  - 通配符 `'*'` 与显式频道名混合使用时合并处理
  - `_on_message()` 添加调试日志便于排查
  - `_bot_full_name` 属性用于后续 @mention 内容匹配

### Related Issues
- Closes #...
- Related to #...

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [x] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `channels`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

涉及 `deeptutor/tutorbot/channels/zulip.py` 和 `tests/services/tutorbot/test_zulip_channel.py` 两个文件，改动最小化，不影响其他通道（Matrix、飞书等）的行为。