### PR TITLE
fix(auth): make require_auth async so the user ContextVar reaches the endpoint

### DIFF
--- a/deeptutor/api/routers/auth.py
+++ b/deeptutor/api/routers/auth.py
@@ -157,7 +157,7 @@ def _extract_token(authorization: str | None, dt_token: str | None) -> str | Non
 # ---------------------------------------------------------------------------
 
 
-def require_auth(
+async def require_auth(
     authorization: str | None = Header(default=None, alias="Authorization"),
     dt_token: str | None = Cookie(default=None),
 ) -> TokenPayload | None:
@@ -168,11 +168,20 @@ def require_auth(
       - Authorization: Bearer <token> header
       - dt_token cookie
 
-    Works on both HTTP and WebSocket routes — ``Header`` and ``Cookie`` are
-    WS-compatible, while ``HTTPBearer`` (which we used to use here) is not.
+    ``Header`` and ``Cookie`` are kept here in place of ``HTTPBearer`` so the
+    function stays usable from WebSocket call sites that don't go through
+    FastAPI's standard HTTP request lifecycle.
 
     Returns the authenticated TokenPayload, or None if auth is disabled.
     Raises HTTP 401 if auth is enabled but the token is missing or invalid.
+
+    Declared ``async def`` so the ``set_current_user`` call runs in the same
+    asyncio context as the endpoint. A sync dependency is dispatched via
+    ``anyio.to_thread.run_sync``, which executes the function in a worker
+    thread under a *copy* of the request context; any ``ContextVar.set``
+    inside that thread is discarded when the thread returns, leaving the
+    endpoint to read the unset default. That regression was the root cause
+    of #481.
     """
     if not AUTH_ENABLED:
         from deeptutor.multi_user.context import set_current_user
@@ -248,7 +257,7 @@ async def ws_require_auth(ws: WebSocket) -> _CtxToken | _WsAuthFailed:
     return set_current_user(user_from_token_payload(payload))
 
 
-def require_admin(
+async def require_admin(
     payload: TokenPayload | None = Depends(require_auth),
 ) -> TokenPayload:
     """
@@ -256,6 +265,10 @@ def require_admin(
 
     Raises HTTP 403 if the authenticated user is not an admin.
     When AUTH_ENABLED=false, all requests are treated as admin.
+
+    ``async def`` mirrors ``require_auth`` so the dependency chain stays on
+    the event loop and the user ContextVar set by ``require_auth`` is visible
+    to the endpoint.
     """
     if not AUTH_ENABLED:
         from deeptutor.services.auth import TokenPayload as TP

--- a/tests/api/test_auth_contextvar.py
+++ b/tests/api/test_auth_contextvar.py
@@ -1,0 +1,134 @@
+"""Regression tests for #481.
+
+When ``require_auth`` was declared as a sync ``def``, FastAPI dispatched it
+through ``anyio.to_thread.run_sync``, which executes the function in a worker
+thread under a *copy* of the request context. Any ``ContextVar.set`` inside
+that thread is discarded when the thread returns, so the endpoint reads the
+unset default. The user-scoped path service then silently falls back to the
+admin workspace and non-admin users hit 404 on every session request.
+
+These tests pin two invariants:
+
+1. ``require_auth`` and ``require_admin`` are declared ``async``.
+2. With ``AUTH_ENABLED=true`` and a valid token, the user ContextVar set
+   inside ``require_auth`` is visible from inside the endpoint, so
+   ``get_path_service()`` resolves to the per-user workspace.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_require_auth_is_async_def() -> None:
+    from deeptutor.api.routers.auth import require_admin, require_auth
+
+    assert inspect.iscoroutinefunction(require_auth), (
+        "require_auth must be async — a sync dep is run in a threadpool whose "
+        "ContextVar mutations don't propagate back to the endpoint. See #481."
+    )
+    assert inspect.iscoroutinefunction(require_admin), (
+        "require_admin must be async for the same reason."
+    )
+
+
+def test_require_auth_propagates_user_contextvar_to_endpoint(monkeypatch) -> None:
+    """End-to-end: a valid token through require_auth makes the user
+    ContextVar visible to the endpoint."""
+    from deeptutor.api.routers import auth as auth_router
+    from deeptutor.multi_user.context import get_current_user_or_none
+    from deeptutor.services.auth import TokenPayload
+
+    monkeypatch.setattr(auth_router, "AUTH_ENABLED", True)
+    monkeypatch.setattr(
+        auth_router,
+        "decode_token",
+        lambda _t: TokenPayload(username="alice", role="user", user_id="u_alice"),
+    )
+
+    app = FastAPI()
+
+    @app.get("/whoami")
+    async def whoami(_=Depends(auth_router.require_auth)) -> dict:
+        user = get_current_user_or_none()
+        if user is None:
+            return {"seen": None}
+        return {"seen": user.username, "role": user.role, "scope_kind": user.scope.kind}
+
+    with TestClient(app) as client:
+        resp = client.get("/whoami", headers={"Authorization": "Bearer test-token"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["seen"] == "alice", (
+        "Endpoint should observe the user ContextVar set inside require_auth. "
+        "If this returns None the dependency is being run in a threadpool and "
+        "the ContextVar mutation is discarded — see #481."
+    )
+    assert body["role"] == "user"
+    assert body["scope_kind"] == "user"
+
+
+def test_require_auth_propagates_admin_contextvar_to_endpoint(monkeypatch) -> None:
+    from deeptutor.api.routers import auth as auth_router
+    from deeptutor.multi_user.context import get_current_user_or_none
+    from deeptutor.services.auth import TokenPayload
+
+    monkeypatch.setattr(auth_router, "AUTH_ENABLED", True)
+    monkeypatch.setattr(
+        auth_router,
+        "decode_token",
+        lambda _t: TokenPayload(username="root", role="admin", user_id="u_root"),
+    )
+
+    app = FastAPI()
+
+    @app.get("/whoami")
+    async def whoami(_=Depends(auth_router.require_auth)) -> dict:
+        user = get_current_user_or_none()
+        return {"role": None if user is None else user.role}
+
+    with TestClient(app) as client:
+        resp = client.get("/whoami", headers={"Authorization": "Bearer test-token"})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"role": "admin"}
+
+
+def test_path_service_resolves_per_user_workspace_through_dependency(monkeypatch, tmp_path) -> None:
+    """The full chain that the reporter exercised in #481: a non-admin
+    request lands on an endpoint that calls ``get_path_service()`` and
+    that path service must point at ``multi-user/<uid>/``, not the
+    admin fallback."""
+    from deeptutor.api.routers import auth as auth_router
+    from deeptutor.multi_user import paths as mu_paths
+    from deeptutor.services.auth import TokenPayload
+    from deeptutor.services.path_service import get_path_service
+
+    monkeypatch.setattr(auth_router, "AUTH_ENABLED", True)
+    monkeypatch.setattr(mu_paths, "MULTI_USER_ROOT", tmp_path / "multi-user")
+    monkeypatch.setattr(mu_paths, "_path_services", {})
+    monkeypatch.setattr(
+        auth_router,
+        "decode_token",
+        lambda _t: TokenPayload(username="alice", role="user", user_id="u_alice"),
+    )
+
+    app = FastAPI()
+
+    @app.get("/db-path")
+    async def db_path(_=Depends(auth_router.require_auth)) -> dict:
+        service = get_path_service()
+        return {"chat_db": str(service.get_chat_history_db())}
+
+    with TestClient(app) as client:
+        resp = client.get("/db-path", headers={"Authorization": "Bearer test-token"})
+
+    assert resp.status_code == 200
+    chat_db = resp.json()["chat_db"]
+    assert "multi-user/u_alice" in chat_db, (
+        f"Per-user request should resolve to multi-user/<uid>/ workspace, got: {chat_db}"
+    )


### PR DESCRIPTION
### Description

When `AUTH_ENABLED=true`, every non-admin HTTP request hits 404 because the user `ContextVar` set inside `require_auth` is invisible by the time the endpoint resolves the per-user path service.

`require_auth` is declared as a sync `def`. FastAPI dispatches sync deps via `anyio.to_thread.run_sync`, which captures the request context with `copy_context()` and runs the function in a worker thread under that copy. Mutations made inside the thread, including `ContextVar.set`, live on the copy and are discarded when the thread returns. The endpoint then runs in the original event-loop context with `_current_user` unset, so `get_current_path_service()` falls back to `PathService.get_instance()`, which points at `data/user/` — the admin workspace. Admin requests appear to work because the fallback coincides with their intended workspace; user requests resolve to the admin DB and 404 on every session lookup.

The user-context middleware that #474 introduced for exactly this case was removed in 8bae3ca on the assumption that `require_auth` was sufficient. With `require_auth` running in a threadpool, it was not.

Declaring `require_auth` (and `require_admin`, for symmetry) as `async def` keeps the dependency on the event loop; the `ContextVar` mutation now propagates to the endpoint and per-user path resolution works.

### Related Issues
- Closes #481

### Module(s) Affected
- [x] `api`
- [x] `tests`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

Regression coverage in `tests/api/test_auth_contextvar.py` pins two invariants:

1. `require_auth` and `require_admin` are declared `async`.
2. With `AUTH_ENABLED=true` and a valid token, the user `ContextVar` set inside `require_auth` is visible from inside the endpoint, so `get_path_service()` resolves to the per-user `multi-user/<uid>/` workspace.

Verified locally with `pytest tests/api/test_auth_contextvar.py` — all four cases pass on the fix and fail on the prior sync `def`.
