### PR TITLE
feat(visualize): replace free-form HTML generation with standardized JSON widget spec framework

### DIFF
--- a/deeptutor/agents/visualize/agents/code_generator_agent.py
+++ b/deeptutor/agents/visualize/agents/code_generator_agent.py
@@ -8,7 +8,7 @@ from deeptutor.agents.base_agent import BaseAgent
 from deeptutor.core.trace import build_trace_metadata, new_call_id
 
 from ..models import VisualizationAnalysis
-from ..utils import extract_code_block
+from ..utils import build_widget_from_spec, extract_code_block, extract_json_object, is_widget_spec
 
 
 class CodeGeneratorAgent(BaseAgent):
@@ -73,15 +73,23 @@ class CodeGeneratorAgent(BaseAgent):
         else:
             lang_hint = "javascript"
 
-        extracted = extract_code_block(response, lang_hint) or extract_code_block(response)
-
-        # For html, the model sometimes returns the full document with no fence.
-        # `extract_code_block` will then return the trimmed raw response — accept
-        # it as long as it looks like an HTML document.
-        if analysis.render_type == "html" and not extracted:
+        # ── HTML: try JSON widget spec first, then fall back to raw HTML ──────
+        if analysis.render_type == "html":
+            try:
+                spec = extract_json_object(response)
+                if is_widget_spec(spec):
+                    return build_widget_from_spec(spec)
+            except Exception:
+                pass
+            # Fallback: accept raw HTML document if LLM returned one directly
             stripped = (response or "").strip()
             lowered = stripped.lower()
             if lowered.startswith("<!doctype") or lowered.startswith("<html"):
                 return stripped
+            extracted = extract_code_block(response, "html")
+            if extracted:
+                return extracted
+            return stripped
 
+        extracted = extract_code_block(response, lang_hint) or extract_code_block(response)
         return extracted

--- a/deeptutor/agents/visualize/prompts/en/answer_now.yaml
+++ b/deeptutor/agents/visualize/prompts/en/answer_now.yaml
@@ -1,8 +1,29 @@
 system: |
   You are DeepTutor's visualization code generator. The user is waiting,
   so emit the final renderable code in one shot. Output strictly the JSON
-  {"render_type": "svg|chartjs|mermaid", "code": "..."}, where ``code`` is
-  the renderable source (SVG markup, Chart.js JS, or Mermaid DSL).
+  {"render_type": "svg|chartjs|mermaid|html", "code": "..."}, where ``code`` is
+  the renderable source (SVG markup, Chart.js JS, Mermaid DSL).
+
+  EXCEPTION for html: when render_type is "html", set "code" to a JSON STRING
+  containing a widget spec object (not a full HTML document). The host app has a
+  fixed Google-style shell; you only provide data + logic:
+
+  {
+    "render_type": "html",
+    "code": "{\"metrics\":[{\"id\":\"m1\",\"label\":\"K-Speed\",\"value\":\"50\",\"unit\":\"km/h\"},...],
+              \"canvas_type\":\"svg\",
+              \"canvas_html\":\"<svg id=\\\"dt-svg\\\" viewBox=\\\"0 0 800 280\\\">...</svg>\",
+              \"controls\":[{\"type\":\"slider\",\"id\":\"spd\",\"label\":\"Speed (km/h)\",
+                            \"min\":10,\"max\":100,\"step\":1,\"value\":50}],
+              \"update_js\":\"var d=values.spd*10; updateMetric('m1',d+' km'); dtSvg.getElementById('bar').setAttribute('width',d/800*760);\"}"
+  }
+
+  Widget spec rules:
+  - metrics: 3–5 entries. IDs unique.
+  - canvas_html: complete SVG with id="dt-svg" and all shapes having unique IDs.
+  - controls: sliders for numbers, toggles for booleans.
+  - update_js: must call updateMetric() for every metric AND update SVG/canvas.
+  - NO titles, headings, solution text, or explanations anywhere in the spec.
 
 user_template: |
   User request: {original}

--- a/deeptutor/agents/visualize/prompts/en/code_generator_agent.yaml
+++ b/deeptutor/agents/visualize/prompts/en/code_generator_agent.yaml
@@ -5,36 +5,76 @@ system: |
   Rules:
   - If render_type is "svg", output a complete, self-contained SVG string.
     The SVG must include the xmlns attribute and be well-formed XML.
-    Use viewBox for responsive sizing. Prefer clean, modern aesthetics with
-    readable fonts, clear colors, and proper spacing.
+    Use viewBox="0 0 900 480" unless the user explicitly needs another ratio.
+    Design it as a compact in-answer diagram, not a poster or full lesson page:
+      * Everything must fit inside the viewBox with 32px margins.
+      * Use one primary diagram area, not multiple large cards or sections.
+      * Keep labels short and tied to the written solution (same names/quantities).
+      * Use at most 6 prominent labels and at most 2 accent colors.
+      * Avoid large title banners, huge headings, explanatory paragraphs, and
+        dark formula blocks inside the SVG; the app renders the derivation below.
+      * Prefer the Google-style pattern: a small metric strip only when useful,
+        a simple axis/lane/geometry, direct annotations, and generous empty space.
+      * Text must never be clipped or placed outside the viewBox.
+    Prefer clean, minimal aesthetics with readable fonts, clear colors, and proper spacing.
   - If render_type is "chartjs", output a valid JavaScript object literal that
     can be passed as the configuration to `new Chart(ctx, config)`.
     The config must include `type`, `data`, and `options` fields.
-    Use modern color palettes and ensure labels are readable.
+    Set options.maintainAspectRatio=false and keep labels readable in a compact panel.
   - If render_type is "mermaid", output valid Mermaid.js diagram code.
     The code must start with a valid diagram type keyword (graph, flowchart,
     sequenceDiagram, classDiagram, stateDiagram-v2, erDiagram, gantt, mindmap, etc.).
     Use clear node labels and readable edge descriptions. Do NOT use spaces in
     node IDs — use camelCase or underscores. Avoid reserved keywords as node IDs.
-  - If render_type is "html", output one complete, self-contained single-file HTML
-    learning page.
-    Technical constraints:
-      * Must include everything from <!DOCTYPE html> to </html>.
-      * Put all CSS inside <style>; put all JavaScript inside <script> before </body>.
-      * Do NOT rely on external CDNs, fonts, or other resources (KaTeX is injected
-        by the host page; use $...$ for inline math, $$...$$ for block math).
-      * The page will render inside an iframe — use max-width: 100% and
-        box-sizing: border-box, avoid fixed widths.
-      * For long content use overflow-x: auto when needed; never let content be
-        clipped.
-      * Wrap all interactions inside DOMContentLoaded and use addEventListener;
-        do NOT use inline onclick handlers.
-      * Always check that an element exists before manipulating it.
-    Within these constraints, freely choose layout, colors, visual style, and
-    interaction patterns to make the page clear, beautiful, and easy to learn from.
+  - If render_type is "html", output a JSON widget spec (NOT a full HTML page).
+    The host app has a fixed Google-style shell that handles all layout, CSS, and
+    controls wiring. You only provide the DATA and LOGIC.
+
+    Output a ```json code block containing exactly this schema:
+
+    {
+      "metrics": [
+        {"id": "unique_id", "label": "SHORT LABEL", "value": "50", "unit": "km/h"},
+        ... (3–5 entries)
+      ],
+      "canvas_type": "svg",
+      "canvas_html": "<svg viewBox=\"0 0 800 280\" xmlns=\"...\" id=\"dt-svg\">
+                        ... complete SVG content with all shapes/labels ...
+                      </svg>",
+      "controls": [
+        {"type": "slider", "id": "ctrl_id", "label": "Label (unit)",
+         "min": 10, "max": 100, "step": 1, "value": 50},
+        {"type": "toggle", "id": "ctrl_id", "label": "Label", "value": false}
+      ],
+      "update_js": "// Plain JS that runs on every control change.
+                    // Available: values (object of {id: currentValue}),
+                    //            updateMetric(id, text) to update metric pills,
+                    //            dtSvg (the SVG element, for svg canvas_type).
+                    // Example for svg:
+                    //   var dist = values.speed * values.time;
+                    //   updateMetric('m_dist', dist.toFixed(1) + ' km');
+                    //   dtSvg.getElementById('bar').setAttribute('width', dist/800*760);
+                    "
+    }
+
+    For canvas2d instead of svg, use:
+      "canvas_type": "canvas2d",
+      "canvas_html": "",
+      "draw_js": "// Body of: function dtDraw(values) { var w=..., h=...
+                  //   dtCtx.clearRect(0,0,w,h); ... draw here ... }"
+
+    Rules for the spec:
+    - metrics: 3–5 short-label, live-updating key metrics. IDs must be unique.
+    - canvas_html: complete SVG with all initial shapes. Give interactive
+      elements unique id attributes so update_js can target them.
+    - controls: sliders for numeric variables, toggles for boolean flags.
+    - update_js: must call updateMetric() for EVERY metric on every change.
+      Must also update SVG attributes or call redraw for canvas2d.
+    - No titles, headings, explanations, or solution text anywhere in the spec.
+
   - Do NOT include any explanation outside the code fence.
   - Wrap the code in a fenced code block with the appropriate language tag
-    (```svg, ```javascript, ```mermaid, or ```html).
+    (```svg, ```javascript, ```mermaid, or ```json for html).
 
 user_template: |
   User request:
@@ -52,4 +92,4 @@ user_template: |
   - For SVG: ```svg ... ```
   - For Chart.js: ```javascript ... ```
   - For Mermaid: ```mermaid ... ```
-  - For HTML: ```html ... ```
+  - For HTML widget spec: ```json ... ```

--- a/deeptutor/agents/visualize/prompts/zh/answer_now.yaml
+++ b/deeptutor/agents/visualize/prompts/zh/answer_now.yaml
@@ -1,9 +1,28 @@
 system: |
   你是 DeepTutor 的可视化代码生成器。用户已经在等待，
   请直接输出最终可渲染的代码。
-  严格输出 JSON：{"render_type": "svg|chartjs|mermaid",
+  严格输出 JSON：{"render_type": "svg|chartjs|mermaid|html",
   "code": "..."}。
-  code 字段是可直接渲染的源代码（SVG 标签 / Chart.js JS 代码 / Mermaid 文本）。
+  code 字段是可直接渲染的源代码（SVG 标签 / Chart.js JS 代码 / Mermaid 文本 / 完整 HTML）。
+
+  如果 render_mode 是 html，请生成达到 Google AI Mode 品质的交互组件：
+
+  禁止：不输出推理文字、不输出评论、不输出大标题、不做多章节布局、
+  不使用外部资源、不使用 inline onclick、不硬编码白色背景。
+  绝不在组件内包含分步解题、推导、方程或教学文字——宿主应用会在组件下方渲染这些内容。
+
+  结构——一个全宽卡片填满 ~900×420px，包含三个分区：
+  1. 指标条（顶部 ~48px）：3–5 个关键数值药丸，flex 行排列。
+  2. 图示（中间，flex:1）：内联 SVG 或 Canvas 2D，带标注标签。
+     路程/距离问题：水平轨道 + 彩色位置条 + 车辆标记 + 距离标签 + "差距: Xkm"。
+  3. 控件（底部 ~56px）：styled range 滑块和/或药丸切换。
+
+  CSS：使用 :root 自定义属性 + @media (prefers-color-scheme: dark) 双调色板。
+  字体：system-ui。滑块：自定义 thumb/track 样式。
+  html,body { width:100%; height:100vh; margin:0; box-sizing:border-box; }
+
+  JS：所有逻辑在 DOMContentLoaded 中。控件用 "input" 事件实时更新指标+图示。
+  操作 DOM 前检查元素是否存在。
 
 user_template: |
   用户请求：{original}

--- a/deeptutor/agents/visualize/prompts/zh/code_generator_agent.yaml
+++ b/deeptutor/agents/visualize/prompts/zh/code_generator_agent.yaml
@@ -4,31 +4,71 @@ system: |
   规则：
   - 如果 render_type 是 "svg"，输出完整的、自包含的 SVG 字符串。
     SVG 必须包含 xmlns 属性并且是格式良好的 XML。
-    使用 viewBox 实现响应式尺寸。优先使用简洁现代的美学风格，
-    确保字体可读、颜色清晰、间距合适。
+    除非用户明确需要其它比例，否则使用 viewBox="0 0 900 480"。
+    请把它设计成答案中的紧凑图示，而不是海报或完整课程页面：
+      * 所有内容必须在 viewBox 内，并保留约 32px 边距
+      * 只保留一个主要图示区域，不要做多个大卡片/大章节
+      * 标签要短，并与下方解题文字使用同一组名称/数量
+      * 最多使用 6 个突出标签、最多 2 个强调色
+      * 避免大标题横幅、巨型标题、解释段落、深色公式块；推导由宿主页面在图下方渲染
+      * 优先采用类似 Google 的简洁模式：必要时一个小指标条 + 简单轴线/车道/几何图 + 直接标注 + 足够留白
+      * 文本绝不能被裁剪或超出 viewBox
+    优先使用简洁现代的美学风格，确保字体可读、颜色清晰、间距合适。
   - 如果 render_type 是 "chartjs"，输出一个有效的 JavaScript 对象字面量，
     可以作为配置传递给 `new Chart(ctx, config)`。
     配置必须包含 `type`、`data` 和 `options` 字段。
-    使用现代配色方案并确保标签可读。
+    设置 options.maintainAspectRatio=false，并确保在紧凑面板中标签可读。
   - 如果 render_type 是 "mermaid"，输出有效的 Mermaid.js 图表代码。
     代码必须以有效的图表类型关键词开头（graph、flowchart、sequenceDiagram、
     classDiagram、stateDiagram-v2、erDiagram、gantt、mindmap 等）。
     使用清晰的节点标签和可读的边描述。节点 ID 不要使用空格——使用
     camelCase 或下划线。避免使用保留关键词作为节点 ID。
-  - 如果 render_type 是 "html"，输出一个完整的、自包含的单文件 HTML 学习页面。
-    技术约束：
-      * 必须从 <!DOCTYPE html> 写到 </html>
-      * 所有 CSS 写在 <style> 中，所有 JavaScript 写在 </body> 前的 <script> 中
-      * 不依赖外部 CDN、字体或其他资源（KaTeX 会由宿主页面自动注入；行内公式用
-        $...$，块级公式用 $$...$$）
-      * 页面会渲染在 iframe 中，必须响应式适配：使用 max-width: 100%、
-        box-sizing: border-box，避免固定宽度
-      * 长内容必要时用 overflow-x: auto，避免被截断
-      * 所有交互必须包在 DOMContentLoaded 中，使用 addEventListener，禁止 onclick
-      * 操作 DOM 前检查元素是否存在
-    在以上约束内自由决定布局、配色、视觉风格和交互形式，让页面清晰、美观、易学。
+  - 如果 render_type 是 "html"，输出一个 JSON 组件规格（不是完整的 HTML 页面）。
+    宿主应用有固定的 Google 风格外壳，处理所有布局、CSS 和控件绑定。
+    你只需提供数据和逻辑。
+
+    输出一个 ```json 代码块，严格遵循此 schema：
+
+    {
+      "metrics": [
+        {"id": "唯一id", "label": "简短标签", "value": "50", "unit": "km/h"},
+        ... （3–5 个）
+      ],
+      "canvas_type": "svg",
+      "canvas_html": "<svg viewBox=\"0 0 800 280\" xmlns=\"...\" id=\"dt-svg\">
+                        ... 完整 SVG 内容，包含所有形状和标签 ...
+                      </svg>",
+      "controls": [
+        {"type": "slider", "id": "ctrl_id", "label": "标签（单位）",
+         "min": 10, "max": 100, "step": 1, "value": 50},
+        {"type": "toggle", "id": "ctrl_id", "label": "标签", "value": false}
+      ],
+      "update_js": "// 每次控件变化时运行的纯 JS。
+                    // 可用：values（{id: 当前值} 对象）、
+                    //       updateMetric(id, text) 更新指标药丸、
+                    //       dtSvg（SVG 元素，适用于 svg canvas_type）。
+                    // 示例：
+                    //   var dist = values.speed * values.time;
+                    //   updateMetric('m_dist', dist.toFixed(1) + ' km');
+                    //   dtSvg.getElementById('bar').setAttribute('width', dist/800*760);
+                    "
+    }
+
+    对于 canvas2d（而非 svg），使用：
+      "canvas_type": "canvas2d",
+      "canvas_html": "",
+      "draw_js": "// function dtDraw(values) 的函数体：var w=..., h=...
+                  //   dtCtx.clearRect(0,0,w,h); ... 在此绘制 ..."
+
+    规格规则：
+    - metrics：3–5 个短标签的实时更新关键指标，id 必须唯一。
+    - canvas_html：完整 SVG，包含所有初始形状。交互元素必须有唯一 id 属性。
+    - controls：数值变量用 slider，布尔标志用 toggle。
+    - update_js：每次变化必须调用 updateMetric() 更新每个指标，并更新 SVG 属性。
+    - 规格中任何地方都不要包含标题、标题区域、解释或解题文字。
+
   - 不要在代码块之外包含任何解释。
-  - 用带有适当语言标签的代码块包裹代码（```svg、```javascript、```mermaid 或 ```html）。
+  - 用带有适当语言标签的代码块包裹代码（```svg、```javascript、```mermaid、html 用 ```json）。
 
 user_template: |
   用户请求：
@@ -46,4 +86,4 @@ user_template: |
   - SVG 使用：```svg ... ```
   - Chart.js 使用：```javascript ... ```
   - Mermaid 使用：```mermaid ... ```
-  - HTML 使用：```html ... ```
+  - HTML 组件规格使用：```json ... ```

--- a/deeptutor/agents/visualize/utils.py
+++ b/deeptutor/agents/visualize/utils.py
@@ -130,9 +130,400 @@ def build_fallback_html(*, title: str, summary: str = "", note: str = "") -> str
 </html>"""
 
 
+def is_widget_spec(data: Any) -> bool:
+    """Return True if *data* looks like a DeepTutor widget spec dict."""
+    if not isinstance(data, dict):
+        return False
+    return "metrics" in data or "controls" in data or "canvas_html" in data or "update_js" in data
+
+
+def build_widget_from_spec(spec: dict[str, Any]) -> str:
+    """Convert a structured widget spec into a complete, fixed-layout HTML page.
+
+    The spec schema:
+    {
+      "metrics": [{"id": str, "label": str, "value": str|num, "unit": str}],
+      "canvas_type": "svg" | "canvas2d",   # default "svg"
+      "canvas_html": str,                  # inner SVG markup OR empty for canvas2d
+      "draw_js":  str,                     # canvas2d only: body of draw(ctx,w,h,values)
+      "controls": [
+          {"type": "slider",  "id": str, "label": str,
+           "min": num, "max": num, "step": num, "value": num},
+          {"type": "toggle",  "id": str, "label": str, "value": bool},
+          {"type": "button",  "id": str, "label": str}
+      ],
+      "update_js": str   # JS body run after every control change; has access to
+                         #   values {id: currentValue}, updateMetric(id, text),
+                         #   and for svg: the SVG element as dtSvg
+                         #   and for canvas2d: redraw()
+    }
+    """
+    metrics = spec.get("metrics") or []
+    canvas_type = str(spec.get("canvas_type") or "svg").lower()
+    canvas_html = str(spec.get("canvas_html") or "").strip()
+    draw_js = str(spec.get("draw_js") or "").strip()
+    controls = spec.get("controls") or []
+    update_js = str(spec.get("update_js") or "").strip()
+
+    # ── Build metric strip HTML ──────────────────────────────────────────────
+    metric_items: list[str] = []
+    for m in metrics:
+        mid = str(m.get("id") or "").strip()
+        label = str(m.get("label") or "").strip()
+        value = str(m.get("value") if m.get("value") is not None else "").strip()
+        unit = str(m.get("unit") or "").strip()
+        display = f"{value}\u202f{unit}".strip() if unit else value
+        id_attr = f' id="{mid}"' if mid else ""
+        metric_items.append(
+            f'<div class="dt-metric">'
+            f'<span class="dt-metric-label">{label}</span>'
+            f'<span class="dt-metric-value"{id_attr}>{display}</span>'
+            f"</div>"
+        )
+    metrics_html = "\n      ".join(metric_items)
+
+    # ── Build canvas zone HTML ───────────────────────────────────────────────
+    if canvas_type == "canvas2d":
+        canvas_zone = '<canvas id="dt-cv"></canvas>'
+    else:
+        # SVG — wrap provided markup in a responsive container
+        inner = (
+            canvas_html
+            if canvas_html
+            else '<svg id="dt-svg" viewBox="0 0 800 300" xmlns="http://www.w3.org/2000/svg"></svg>'
+        )
+        if "<svg" not in inner.lower():
+            inner = f'<svg id="dt-svg" viewBox="0 0 800 300" xmlns="http://www.w3.org/2000/svg">{inner}</svg>'
+        elif 'id="dt-svg"' not in inner and "id='dt-svg'" not in inner:
+            inner = inner.replace("<svg", '<svg id="dt-svg"', 1)
+        # Strip full-coverage background rects with white/light fills that LLMs
+        # commonly inject — they hide our dark .dt-canvas background.
+        inner = re.sub(
+            r'<rect\b(?=[^>]*\bfill\s*=\s*["\'](?:#fff(?:fff)?|white|#f[0-9a-f]{5}'
+            r'|rgb\(\s*25[0-9]\s*,\s*25[0-9]\s*,\s*25[0-9]\s*\))["\'])[^>]*/?>',
+            "",
+            inner,
+            flags=re.IGNORECASE,
+        )
+        # Also strip rects that have style="...fill:white..." or style="background:white"
+        inner = re.sub(
+            r'<rect\b(?=[^>]*style\s*=\s*["\'][^"\'>]*?fill\s*:\s*(?:white|#fff)[^"\'>]*?["\'])[^>]*/?>',
+            "",
+            inner,
+            flags=re.IGNORECASE,
+        )
+        canvas_zone = inner
+
+    # ── Build controls HTML ──────────────────────────────────────────────────
+    control_items: list[str] = []
+    init_values: list[str] = []
+    for c in controls:
+        ctype = str(c.get("type") or "slider").lower()
+        cid = str(c.get("id") or "").strip()
+        clabel = str(c.get("label") or "").strip()
+        cval = c.get("value")
+
+        if ctype == "slider":
+            cmin = c.get("min", 0)
+            cmax = c.get("max", 100)
+            cstep = c.get("step", 1)
+            init_val = float(cval) if cval is not None else float(cmin)
+            init_values.append(f'values["{cid}"] = {init_val};')
+            # Format display: remove trailing .0 for whole numbers
+            disp = str(int(init_val)) if init_val == int(init_val) else str(init_val)
+            control_items.append(f"""
+      <div class="dt-control-group">
+        <span class="dt-control-label">{clabel}</span>
+        <div class="dt-slider-row">
+          <input type="range" id="ctrl-{cid}" min="{cmin}" max="{cmax}" step="{cstep}" value="{init_val}">
+          <span class="dt-slider-value" id="val-{cid}">{disp}</span>
+        </div>
+      </div>""")
+
+        elif ctype == "toggle":
+            checked = "checked" if cval else ""
+            init_bool = "true" if cval else "false"
+            init_values.append(f'values["{cid}"] = {init_bool};')
+            control_items.append(f"""
+      <div class="dt-toggle-row">
+        <label class="dt-toggle">
+          <input type="checkbox" id="ctrl-{cid}" {checked}>
+          <span class="dt-toggle-track"></span>
+          <span class="dt-toggle-thumb"></span>
+        </label>
+        <span class="dt-control-label">{clabel}</span>
+      </div>""")
+
+        elif ctype == "button":
+            control_items.append(f"""
+      <button class="dt-btn" id="ctrl-{cid}">{clabel}</button>""")
+
+    controls_html = "".join(control_items)
+    init_values_js = "\n    ".join(init_values)
+
+    # ── Canvas 2D setup ──────────────────────────────────────────────────────
+    if canvas_type == "canvas2d":
+        canvas_setup_js = f"""
+    var dtCv = document.getElementById('dt-cv');
+    dtCv.width  = dtCv.offsetWidth  || dtCv.parentElement.offsetWidth;
+    dtCv.height = dtCv.offsetHeight || dtCv.parentElement.offsetHeight;
+    var dtCtx = dtCv.getContext('2d');
+    function dtDraw(values) {{
+      var w = dtCv.width, h = dtCv.height;
+      dtCtx.clearRect(0, 0, w, h);
+      {draw_js}
+    }}
+    window.addEventListener('resize', function() {{
+      dtCv.width  = dtCv.parentElement.offsetWidth;
+      dtCv.height = dtCv.parentElement.offsetHeight;
+      dtDraw(values);
+    }});"""
+        update_canvas_call = "dtDraw(values);"
+    else:
+        canvas_setup_js = "    var dtSvg = document.getElementById('dt-svg');"
+        update_canvas_call = ""
+
+    # ── Wire up controls JS ──────────────────────────────────────────────────
+    wire_js_parts: list[str] = []
+    for c in controls:
+        ctype = str(c.get("type") or "slider").lower()
+        cid = str(c.get("id") or "").strip()
+        if ctype == "slider":
+            wire_js_parts.append(f"""
+    (function() {{
+      var el = document.getElementById('ctrl-{cid}');
+      var vl = document.getElementById('val-{cid}');
+      if (!el) return;
+      el.addEventListener('input', function() {{
+        var n = parseFloat(el.value);
+        values["{cid}"] = n;
+        if (vl) vl.textContent = Number.isInteger(n) ? n : n.toFixed(1);
+        runUpdate();
+      }});
+    }})();""")
+        elif ctype == "toggle":
+            wire_js_parts.append(f"""
+    (function() {{
+      var el = document.getElementById('ctrl-{cid}');
+      if (!el) return;
+      el.addEventListener('change', function() {{
+        values["{cid}"] = el.checked;
+        runUpdate();
+      }});
+    }})();""")
+
+    wire_js = "".join(wire_js_parts)
+
+    # ── Assemble full document ───────────────────────────────────────────────
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>
+  /* ── DeepTutor Widget Shell v1 — adapts to light & dark mode ── */
+  :root {{
+    color-scheme: light dark;
+    /* Light mode defaults */
+    --dt-text:         #111827;
+    --dt-muted:        #6b7280;
+    --dt-zone-bg:      rgba(0,0,0,0.04);
+    --dt-zone-border:  rgba(0,0,0,0.1);
+    --dt-divider:      rgba(0,0,0,0.1);
+    --dt-track:        #d1d5db;
+    --dt-thumb:        #3b82f6;
+    --dt-val-bg:       rgba(0,0,0,0.07);
+    --dt-val-border:   rgba(0,0,0,0.15);
+    --dt-btn-bg:       rgba(0,0,0,0.07);
+    --dt-btn-border:   rgba(0,0,0,0.15);
+    --dt-toggle-off:   #d1d5db;
+    --dt-svg-text:     #111827;
+  }}
+  @media (prefers-color-scheme: dark) {{
+    :root {{
+      --dt-text:         #e4e4e7;
+      --dt-muted:        #a1a1aa;
+      --dt-zone-bg:      rgba(255,255,255,0.05);
+      --dt-zone-border:  rgba(255,255,255,0.1);
+      --dt-divider:      rgba(255,255,255,0.1);
+      --dt-track:        #3f3f46;
+      --dt-thumb:        #3b82f6;
+      --dt-val-bg:       rgba(255,255,255,0.1);
+      --dt-val-border:   rgba(255,255,255,0.15);
+      --dt-btn-bg:       rgba(255,255,255,0.08);
+      --dt-btn-border:   rgba(255,255,255,0.15);
+      --dt-toggle-off:   #52525b;
+      --dt-svg-text:     #e4e4e7;
+    }}
+    /* Dark-only: nuke LLM-injected white backgrounds */
+    [style*="background: white"],[style*="background-color: white"],
+    [style*="background:#fff"],[style*="background: #fff"],
+    [style*="background:#ffffff"],[style*="background: #ffffff"],
+    [style*="background-color:#fff"],[style*="background-color: #fff"],
+    [style*="background-color:#ffffff"],[style*="background-color: #ffffff"] {{
+      background: transparent !important;
+      background-color: transparent !important;
+    }}
+    /* Dark-only: nuke LLM-injected black text */
+    [style*="color: black"],[style*="color:black"],
+    [style*="color: #000"],[style*="color:#000"],
+    [style*="color: #000000"],[style*="color:#000000"] {{
+      color: var(--dt-text) !important;
+    }}
+  }}
+  *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
+  html, body {{
+    width: 100%; height: 100vh; overflow: hidden;
+    background: transparent !important;
+    color: var(--dt-text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-size: 13px;
+  }}
+  /* Layout */
+  .dt-widget {{
+    display: flex; flex-direction: column;
+    height: 100vh; padding: 10px; gap: 8px;
+  }}
+  /* Zone 1 — Metric Strip */
+  .dt-metrics {{
+    display: flex; flex-shrink: 0;
+    background: var(--dt-zone-bg); border: 1px solid var(--dt-zone-border);
+    border-radius: 10px; overflow: hidden;
+  }}
+  .dt-metric {{
+    flex: 1; display: flex; flex-direction: column;
+    align-items: center; padding: 7px 10px; gap: 1px;
+  }}
+  .dt-metric + .dt-metric {{ border-left: 1px solid var(--dt-divider); }}
+  .dt-metric-label {{
+    font-size: 10px; text-transform: uppercase;
+    letter-spacing: 0.06em; color: var(--dt-muted);
+  }}
+  .dt-metric-value {{
+    font-size: 17px; font-weight: 600; color: var(--dt-text);
+    white-space: nowrap;
+  }}
+  /* Zone 2 — Diagram Canvas */
+  .dt-canvas {{
+    flex: 1; min-height: 0;
+    background: var(--dt-zone-bg); border: 1px solid var(--dt-zone-border);
+    border-radius: 10px; overflow: hidden; position: relative;
+    display: flex; align-items: center; justify-content: center;
+  }}
+  .dt-canvas svg {{
+    width: 100%; height: 100%; display: block;
+    background: transparent !important;
+  }}
+  /* SVG text inherits the theme text color by default */
+  .dt-canvas svg text {{ fill: var(--dt-svg-text); }}
+  .dt-canvas svg text[fill="#000"],
+  .dt-canvas svg text[fill="#000000"],
+  .dt-canvas svg text[fill="black"] {{ fill: var(--dt-svg-text) !important; }}
+  .dt-canvas canvas {{ width: 100%; height: 100%; display: block; }}
+  /* Zone 3 — Controls */
+  .dt-controls {{
+    flex-shrink: 0;
+    background: var(--dt-zone-bg); border: 1px solid var(--dt-zone-border);
+    border-radius: 10px; padding: 8px 12px;
+    display: flex; flex-direction: column; gap: 6px;
+  }}
+  .dt-control-group {{ display: flex; align-items: center; gap: 10px; }}
+  .dt-control-label {{
+    font-size: 12px; color: var(--dt-text); white-space: nowrap; min-width: 120px;
+  }}
+  .dt-slider-row {{ flex: 1; display: flex; align-items: center; gap: 8px; }}
+  input[type="range"] {{
+    flex: 1; -webkit-appearance: none; appearance: none;
+    height: 4px; border-radius: 2px; background: var(--dt-track);
+    accent-color: var(--dt-thumb); cursor: pointer; outline: none;
+  }}
+  input[type="range"]::-webkit-slider-thumb {{
+    -webkit-appearance: none; width: 16px; height: 16px;
+    border-radius: 50%; background: var(--dt-thumb); cursor: pointer;
+    box-shadow: 0 1px 4px rgba(0,0,0,.3);
+  }}
+  .dt-slider-value {{
+    font-size: 12px; font-weight: 500; color: var(--dt-text);
+    background: var(--dt-val-bg); border: 1px solid var(--dt-val-border);
+    border-radius: 5px; padding: 1px 7px; min-width: 38px; text-align: center;
+  }}
+  /* Toggle */
+  .dt-toggle-row {{ display: flex; align-items: center; gap: 8px; }}
+  .dt-toggle {{ position: relative; width: 38px; height: 20px; flex-shrink: 0; }}
+  .dt-toggle input {{ display: none; }}
+  .dt-toggle-track {{
+    position: absolute; inset: 0;
+    background: var(--dt-toggle-off); border-radius: 10px; cursor: pointer;
+    transition: background .2s;
+  }}
+  .dt-toggle input:checked + .dt-toggle-track {{ background: var(--dt-thumb); }}
+  .dt-toggle-thumb {{
+    position: absolute; top: 2px; left: 2px;
+    width: 16px; height: 16px; border-radius: 50%;
+    background: #fff; pointer-events: none; transition: left .2s;
+  }}
+  .dt-toggle input:checked ~ .dt-toggle-thumb {{ left: 20px; }}
+  /* Button */
+  .dt-btn {{
+    background: var(--dt-btn-bg); border: 1px solid var(--dt-btn-border);
+    color: var(--dt-text); border-radius: 7px; padding: 4px 14px;
+    font-size: 12px; cursor: pointer; transition: background .15s;
+  }}
+  .dt-btn:hover {{ filter: brightness(1.1); }}
+</style>
+</head>
+<body>
+<div class="dt-widget">
+  <!-- Zone 1: Metric Strip -->
+  <div class="dt-metrics">
+    {metrics_html}
+  </div>
+  <!-- Zone 2: Diagram Canvas -->
+  <div class="dt-canvas" id="dt-canvas-zone">
+    {canvas_zone}
+  </div>
+  <!-- Zone 3: Controls -->
+  <div class="dt-controls">
+    {controls_html}
+  </div>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {{
+  /* Control state */
+  var values = {{}};
+  {init_values_js}
+
+  /* Helper: update a metric pill text by id */
+  function updateMetric(id, text) {{
+    var el = document.getElementById(id);
+    if (el) el.textContent = text;
+  }}
+
+  /* Canvas setup */
+  {canvas_setup_js}
+
+  /* Wire controls */
+  {wire_js}
+
+  /* LLM-provided update logic */
+  function runUpdate() {{
+    {update_canvas_call}
+    {update_js}
+  }}
+
+  /* Initial render */
+  runUpdate();
+}});
+</script>
+</body>
+</html>"""
+
+
 __all__ = [
     "build_fallback_html",
+    "build_widget_from_spec",
     "extract_code_block",
     "extract_json_object",
     "is_valid_html_document",
+    "is_widget_spec",
 ]

--- a/web/components/visualize/VisualizationViewer.tsx
+++ b/web/components/visualize/VisualizationViewer.tsx
@@ -1,9 +1,18 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Code2, Copy, Check, ExternalLink, Maximize2, X } from "lucide-react";
+import {
+  Code2,
+  Copy,
+  Check,
+  ExternalLink,
+  Maximize2,
+  X,
+  Sparkles,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Mermaid } from "@/components/Mermaid";
+import MarkdownRenderer from "@/components/common/MarkdownRenderer";
 import { prepareIframeHtml } from "@/lib/iframe-html";
 import type { VisualizeResult } from "@/lib/visualize-types";
 
@@ -28,7 +37,6 @@ function ChartJsRenderer({ config }: { config: string }) {
           chartRef.current = null;
         }
 
-        // eslint-disable-next-line no-new-func
         const parsedConfig = new Function(
           `"use strict"; return (${config});`,
         )();
@@ -71,16 +79,42 @@ function ChartJsRenderer({ config }: { config: string }) {
   }
 
   return (
-    <div className="relative w-full" style={{ maxHeight: 480 }}>
+    <div className="relative h-full min-h-0 w-full">
       <canvas ref={canvasRef} />
     </div>
   );
 }
 
+function readIframeTheme(): "light" | "dark" {
+  if (typeof document === "undefined") return "light";
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
 function HtmlRenderer({ html }: { html: string }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [iframeTheme, setIframeTheme] = useState<"light" | "dark">(
+    readIframeTheme,
+  );
 
-  const prepared = useMemo(() => prepareIframeHtml(html || ""), [html]);
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    const htmlEl = document.documentElement;
+    const updateTheme = () => setIframeTheme(readIframeTheme());
+    const observer = new MutationObserver(updateTheme);
+    observer.observe(htmlEl, { attributes: true, attributeFilter: ["class"] });
+    window.addEventListener("storage", updateTheme);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("storage", updateTheme);
+    };
+  }, []);
+
+  const prepared = useMemo(
+    () => prepareIframeHtml(html || "", iframeTheme),
+    [html, iframeTheme],
+  );
 
   useEffect(() => {
     const iframe = iframeRef.current;
@@ -101,7 +135,7 @@ function HtmlRenderer({ html }: { html: string }) {
   };
 
   return (
-    <div className="relative w-full">
+    <div className="relative w-full" style={{ height: 420 }}>
       <button
         type="button"
         onClick={handleOpenInNewTab}
@@ -115,27 +149,74 @@ function HtmlRenderer({ html }: { html: string }) {
         ref={iframeRef}
         title="HTML visualization"
         sandbox="allow-scripts"
-        className="w-full rounded-lg border border-[var(--border)] bg-[var(--card)]"
-        style={{ minHeight: 480, height: 560 }}
+        allowtransparency="true"
+        className="h-full w-full rounded-[18px] border-0"
+        style={{ background: "transparent" }}
       />
     </div>
   );
 }
 
+function normalizeSvgMarkup(svg: string): {
+  markup: string;
+  error: string | null;
+} {
+  const trimmed = svg.trim();
+  if (!trimmed.startsWith("<svg")) {
+    return { markup: "", error: "Invalid SVG: does not start with <svg" };
+  }
+
+  if (typeof window === "undefined" || typeof DOMParser === "undefined") {
+    return {
+      markup: trimmed
+        .replace(/<svg\b/i, '<svg preserveAspectRatio="xMidYMid meet"')
+        .replace(/\s(width|height)="[^"]*"/gi, ""),
+      error: null,
+    };
+  }
+
+  try {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(trimmed, "image/svg+xml");
+    if (doc.querySelector("parsererror")) {
+      return { markup: "", error: "Invalid SVG markup" };
+    }
+    const root = doc.documentElement;
+    if (!root || root.tagName.toLowerCase() !== "svg") {
+      return { markup: "", error: "Invalid SVG document" };
+    }
+
+    const parseSize = (value: string | null): number | null => {
+      if (!value) return null;
+      const match = value.match(/-?\d+(?:\.\d+)?/);
+      if (!match) return null;
+      const parsed = Number(match[0]);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+    };
+
+    if (!root.getAttribute("viewBox")) {
+      const width = parseSize(root.getAttribute("width")) ?? 900;
+      const height = parseSize(root.getAttribute("height")) ?? 480;
+      root.setAttribute("viewBox", `0 0 ${width} ${height}`);
+    }
+    root.setAttribute("width", "100%");
+    root.setAttribute("height", "100%");
+    root.setAttribute("preserveAspectRatio", "xMidYMid meet");
+    root.setAttribute(
+      "style",
+      `${root.getAttribute("style") || ""};max-width:100%;max-height:100%;display:block;`,
+    );
+
+    return { markup: new XMLSerializer().serializeToString(root), error: null };
+  } catch {
+    return { markup: "", error: "Could not normalize SVG for preview" };
+  }
+}
+
 function SvgRenderer({ svg }: { svg: string }) {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  const sanitizedSvg = useMemo(() => {
-    const trimmed = svg.trim();
-    if (!trimmed.startsWith("<svg")) {
-      setError(t("Invalid SVG: does not start with <svg"));
-      return "";
-    }
-    setError(null);
-    return trimmed;
-  }, [svg, t]);
+  const { markup, error } = useMemo(() => normalizeSvgMarkup(svg), [svg]);
 
   if (error) {
     return (
@@ -144,7 +225,7 @@ function SvgRenderer({ svg }: { svg: string }) {
           {t("SVG rendering error")}
         </p>
         <pre className="mt-2 whitespace-pre-wrap text-xs text-red-500">
-          {error}
+          {t(error)}
         </pre>
       </div>
     );
@@ -153,8 +234,8 @@ function SvgRenderer({ svg }: { svg: string }) {
   return (
     <div
       ref={containerRef}
-      className="flex justify-center overflow-x-auto"
-      dangerouslySetInnerHTML={{ __html: sanitizedSvg }}
+      className="flex h-full min-h-0 w-full items-center justify-center overflow-hidden"
+      dangerouslySetInnerHTML={{ __html: markup }}
     />
   );
 }
@@ -172,6 +253,67 @@ function renderVisualization(result: VisualizeResult) {
   return <ChartJsRenderer config={result.code.content} />;
 }
 
+function labelForResult(result: VisualizeResult): string {
+  if (result.render_type === "svg") return "SVG";
+  if (result.render_type === "mermaid") {
+    return `Mermaid · ${result.analysis.chart_type || "diagram"}`;
+  }
+  if (result.render_type === "html") {
+    return `Interactive · ${result.analysis.chart_type || "visual"}`;
+  }
+  return `Chart.js · ${result.analysis.chart_type || "chart"}`;
+}
+
+/**
+ * Strip fenced code blocks from a response string so we only keep the
+ * prose explanation.  The `response` field often contains both a solution
+ * paragraph and a ```lang … ``` block — we want only the former.
+ */
+function stripCodeFences(value: string): string {
+  // Remove all fenced code blocks (```lang\n…\n```)
+  const stripped = value.replace(/```[\w-]*\s*[\s\S]*?```/g, "").trim();
+  return stripped;
+}
+
+/**
+ * Detect and discard text that looks like leaked LLM reasoning / chain-of-
+ * thought rather than an actual user-facing explanation.
+ */
+function looksLikeLeakedReasoning(text: string): boolean {
+  const lower = text.slice(0, 300).toLowerCase();
+  return (
+    lower.includes("we need to") ||
+    lower.includes("let me") ||
+    lower.includes("i need to") ||
+    lower.includes("the user wants") ||
+    lower.includes("based on the analysis") ||
+    lower.includes("let's design") ||
+    lower.includes("let's build") ||
+    lower.includes("as per the instructions")
+  );
+}
+
+function solutionForResult(result: VisualizeResult): string {
+  // 1. Prefer explicit solution field from the backend
+  const explicit = (result.solution || "").trim();
+  if (explicit && !looksLikeLeakedReasoning(explicit)) return explicit;
+
+  // 2. Try the response field, but strip code fences and leaked reasoning
+  const responseText = stripCodeFences(result.response || "");
+  if (responseText && !looksLikeLeakedReasoning(responseText))
+    return responseText;
+
+  // 3. Fall back to analysis metadata
+  const labels =
+    result.analysis.visual_elements?.filter(Boolean).slice(0, 6) ?? [];
+  const parts = [
+    result.analysis.description,
+    result.analysis.data_description,
+    labels.length ? `Diagram labels: ${labels.join(", ")}.` : "",
+  ].filter(Boolean);
+  return parts.join("\n\n");
+}
+
 export default function VisualizationViewer({
   result,
 }: {
@@ -181,6 +323,8 @@ export default function VisualizationViewer({
   const [showCode, setShowCode] = useState(false);
   const [copied, setCopied] = useState(false);
   const [fullscreen, setFullscreen] = useState(false);
+  const solution = useMemo(() => solutionForResult(result), [result]);
+  const resultLabel = labelForResult(result);
 
   // HTML iframe already provides its own "Open in new tab" affordance; the
   // sandboxed iframe also doesn't behave well inside a re-rendered modal.
@@ -211,31 +355,53 @@ export default function VisualizationViewer({
   };
 
   return (
-    <div className="space-y-3">
-      {/* Visualization area */}
-      <div
-        className={`relative ${
-          result.render_type === "html"
-            ? "overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)]"
-            : "overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)] p-4"
-        }`}
-      >
-        {supportsFullscreen && (
-          <button
-            type="button"
-            onClick={() => setFullscreen(true)}
-            title={t("Fullscreen")}
-            className="absolute right-2 top-2 z-10 inline-flex items-center gap-1 rounded-md border border-[var(--border)] bg-[var(--background)]/90 px-2 py-1 text-[10px] font-medium text-[var(--muted-foreground)] backdrop-blur transition-colors hover:text-[var(--foreground)]"
-          >
-            <Maximize2 size={10} strokeWidth={1.8} />
-            {t("Fullscreen")}
-          </button>
-        )}
-        {renderVisualization(result)}
+    <div className="dt-viz-shell overflow-hidden rounded-[22px] border border-[var(--border)] bg-[var(--card)] shadow-sm">
+      <div className="dt-viz-stage relative bg-[var(--background)]/55 px-4 py-4 sm:px-6">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div className="inline-flex min-w-0 items-center gap-2">
+            <Sparkles className="h-3.5 w-3.5 shrink-0 text-[var(--primary)]" />
+            <span className="truncate text-[12px] font-semibold text-[var(--muted-foreground)]">
+              {result.analysis.description || t("Visualization")}
+            </span>
+          </div>
+          {supportsFullscreen && (
+            <button
+              type="button"
+              onClick={() => setFullscreen(true)}
+              title={t("Fullscreen")}
+              className="inline-flex shrink-0 items-center gap-1 rounded-md border border-[var(--border)]/70 bg-[var(--card)]/80 px-2 py-1 text-[10px] font-medium text-[var(--muted-foreground)] backdrop-blur transition-colors hover:text-[var(--foreground)]"
+            >
+              <Maximize2 size={10} strokeWidth={1.8} />
+              {t("Open")}
+            </button>
+          )}
+        </div>
+        <div
+          className={`dt-viz-canvas relative mx-auto flex w-full items-center justify-center overflow-hidden rounded-[18px] border border-[var(--border)]/70 bg-[var(--card)]/80 ${
+            result.render_type === "html"
+              ? "p-0 min-h-[420px]"
+              : "p-3 sm:p-5 min-h-[300px]"
+          }`}
+        >
+          {renderVisualization(result)}
+        </div>
       </div>
 
+      {solution && (
+        <div className="border-t border-[var(--border)]/80 px-4 py-4 sm:px-6">
+          <div className="mb-3 text-[22px] font-semibold tracking-normal text-[var(--foreground)]">
+            {t("Step-by-Step Derivation")}
+          </div>
+          <MarkdownRenderer
+            content={solution}
+            variant="prose"
+            className="text-[14px] leading-[1.7] text-[var(--foreground)]"
+          />
+        </div>
+      )}
+
       {/* Toolbar */}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 border-t border-[var(--border)]/80 px-4 py-3 sm:px-6">
         <button
           type="button"
           onClick={() => setShowCode((prev) => !prev)}
@@ -259,25 +425,17 @@ export default function VisualizationViewer({
         </button>
 
         <span className="ml-auto text-[10px] uppercase tracking-wider text-[var(--muted-foreground)]/50">
-          {result.render_type === "svg"
-            ? "SVG"
-            : result.render_type === "mermaid"
-              ? `Mermaid · ${result.analysis.chart_type || "diagram"}`
-              : result.render_type === "html"
-                ? `HTML · ${result.analysis.chart_type || "interactive"}`
-                : `Chart.js · ${result.analysis.chart_type || "chart"}`}
+          {resultLabel}
         </span>
       </div>
 
-      {/* Code panel — matches the always-dark .md-code-block style used by the
-          markdown renderers so a "Show code" toggle inside a chart message
-          looks identical to a fenced code block in the assistant response. */}
+      {/* Code panel */}
       {showCode && (
-        <div className="md-code-block overflow-hidden rounded-xl border border-[var(--border)] bg-[#1f2937]">
+        <div className="mx-4 mb-4 overflow-hidden rounded-xl border border-[var(--border)] bg-[#1f2937] sm:mx-6">
           <div className="border-b border-white/10 px-3 py-2 text-[11px] font-medium uppercase tracking-wider text-[#9ca3af]">
             {result.code.language}
           </div>
-          <pre className="max-h-80 overflow-auto p-4 text-[13px] leading-relaxed text-[#e5e7eb]">
+          <pre className="max-h-80 overflow-auto p-4 text-[13px] leading-relaxed text-[#d1d5db]">
             <code>{result.code.content}</code>
           </pre>
         </div>
@@ -285,7 +443,7 @@ export default function VisualizationViewer({
 
       {/* Review notes */}
       {result.review.changed && result.review.review_notes && (
-        <p className="text-[11px] text-[var(--muted-foreground)]">
+        <p className="px-4 pb-4 text-[11px] text-[var(--muted-foreground)] sm:px-6">
           {t("Review")}: {result.review.review_notes}
         </p>
       )}
@@ -298,11 +456,7 @@ export default function VisualizationViewer({
         >
           <div className="mb-2 flex shrink-0 items-center justify-between text-white">
             <div className="text-xs uppercase tracking-wider opacity-80">
-              {result.render_type === "svg"
-                ? "SVG"
-                : result.render_type === "mermaid"
-                  ? `Mermaid · ${result.analysis.chart_type || "diagram"}`
-                  : `Chart.js · ${result.analysis.chart_type || "chart"}`}
+              {resultLabel}
             </div>
             <button
               type="button"
@@ -318,7 +472,7 @@ export default function VisualizationViewer({
             </button>
           </div>
           <div
-            className="flex flex-1 items-center justify-center overflow-auto rounded-xl bg-[var(--card)] p-6 shadow-2xl"
+            className="flex flex-1 items-center justify-center overflow-auto rounded-xl bg-white p-6 shadow-2xl"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="w-full max-w-[1600px]">

--- a/web/lib/iframe-html.ts
+++ b/web/lib/iframe-html.ts
@@ -17,7 +17,6 @@ const KATEX_RESOURCES = [
     "/script>",
 ].join("\n  ");
 
-// eslint-disable-next-line no-template-curly-in-string
 const KATEX_INIT_SCRIPT =
   "<script data-katex-init>" +
   'document.addEventListener("DOMContentLoaded",function(){var t=0,i=setInterval(function(){if(typeof renderMathInElement==="function"){clearInterval(i);try{renderMathInElement(document.body,{delimiters:[{left:"$$",right:"$$",display:true},{left:"$",right:"$",display:false},{left:"\\\\(",right:"\\\\)",display:false},{left:"\\\\[",right:"\\\\]",display:true}],throwOnError:false})}catch(e){console.error("[KaTeX] Error:",e)}}else if(++t>50){clearInterval(i);console.warn("[KaTeX] Timeout")}},100)});' +
@@ -25,6 +24,82 @@ const KATEX_INIT_SCRIPT =
   "/script>";
 
 const KATEX_HEAD = KATEX_RESOURCES + "\n  " + KATEX_INIT_SCRIPT;
+
+type IframeTheme = "light" | "dark";
+
+function buildThemeStyle(theme: IframeTheme): string {
+  if (theme !== "dark") {
+    return `<style data-deeptutor-theme>
+      :root { color-scheme: light; --dt-bg: #ffffff; --dt-panel: #f8fafc; --dt-card: #ffffff; --dt-border: #d8e0eb; --dt-text: #111827; --dt-muted: #667085; --dt-track: #d9e2ee; }
+      html, body { background: var(--dt-bg); color: var(--dt-text); }
+    </style>`;
+  }
+
+  // Dark mode: set CSS custom properties and override ONLY html/body.
+  // The generated widget's own @media (prefers-color-scheme: dark) block
+  // handles element-level styling. We avoid broad !important overrides on
+  // generic elements (div, section, main …) which broke custom layouts.
+  return `<style data-deeptutor-theme>
+    :root { color-scheme: dark; --dt-bg: transparent; --dt-panel: rgba(255,255,255,0.05); --dt-card: rgba(255,255,255,0.05); --dt-border: rgba(255,255,255,0.1); --dt-text: #f5f1eb; --dt-muted: #b8aea6; --dt-track: #5a514b; }
+    html, body { background: transparent !important; color: var(--dt-text) !important; }
+    body { scrollbar-color: #5f5650 var(--dt-bg); }
+    /* Expose a prefers-color-scheme override so widget CSS that checks the
+       media query still triggers in dark mode even inside a sandboxed iframe. */
+    @media (prefers-color-scheme: light) {
+      :root { color-scheme: dark; }
+    }
+    /* Override inline-style white/light backgrounds that LLMs hardcode on divs */
+    [style*="background: white"],
+    [style*="background-color: white"],
+    [style*="background:#fff"],
+    [style*="background: #fff"],
+    [style*="background:#ffffff"],
+    [style*="background: #ffffff"],
+    [style*="background-color:#fff"],
+    [style*="background-color: #fff"],
+    [style*="background-color:#ffffff"],
+    [style*="background-color: #ffffff"] {
+      background: transparent !important;
+      background-color: transparent !important;
+    }
+    /* Override inline-style black text for readability */
+    [style*="color: black"], [style*="color:black"],
+    [style*="color: #000"], [style*="color:#000"],
+    [style*="color: #000000"], [style*="color:#000000"] {
+      color: var(--dt-text) !important;
+    }
+    /* Minimal fallback for widgets that don't handle dark mode themselves —
+       only target inputs and SVG text, not layout containers. */
+    input[type="range"] { color-scheme: dark; }
+    svg text, svg tspan { fill: currentColor; }
+    svg { background: transparent !important; }
+  </style>`;
+}
+
+function injectThemeStyle(html: string, theme: IframeTheme): string {
+  const themeStyle = buildThemeStyle(theme);
+  if (html.includes("</head>")) {
+    return html.replace("</head>", themeStyle + "\n</head>");
+  }
+  if (html.includes("<head>")) {
+    return html.replace(/<head([^>]*)>/i, "<head$1>\n" + themeStyle);
+  }
+  if (html.includes("<html")) {
+    return html.replace(
+      /(<html[^>]*>)/i,
+      '$1\n<head>\n  <meta charset="UTF-8">\n  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n' +
+        themeStyle +
+        "\n</head>",
+    );
+  }
+  return (
+    '<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="UTF-8">\n  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n' +
+    themeStyle +
+    "\n</head>\n<body>\n" +
+    html +
+    "\n</body>\n</html>"
+  );
+}
 
 /**
  * Inject KaTeX (CSS + JS + auto-render init) into the document's `<head>`.
@@ -87,6 +162,9 @@ export function sanitizeIframeHtml(html: string): string {
  * Convenience: inject KaTeX, then sanitize. Suitable for a one-shot iframe
  * `srcdoc` write.
  */
-export function prepareIframeHtml(html: string): string {
-  return sanitizeIframeHtml(injectKaTeX(html));
+export function prepareIframeHtml(
+  html: string,
+  theme: IframeTheme = "light",
+): string {
+  return sanitizeIframeHtml(injectThemeStyle(injectKaTeX(html), theme));
 }


### PR DESCRIPTION

### Description

This PR introduces a **standardized widget framework** for the `visualize` capability, replacing free-form LLM-generated HTML with a structured, template-driven architecture that guarantees consistent, high-quality interactive widgets regardless of which LLM is used.

**Problem:** The previous approach asked LLMs to generate a complete HTML document for every visualization. This caused layout inconsistency across models, dark mode breakage (hardcoded white backgrounds), LLM reasoning text leaking into the rendered widget, and content overflowing the iframe height.

**Solution:** The LLM now outputs a structured **JSON widget spec** (metrics, SVG/canvas, controls, JS update function). A fixed Python shell `build_widget_from_spec()` in `utils.py` assembles this into a guaranteed 3-zone layout — **Metric Strip → Diagram Canvas → Controls** — with a full CSS design system that cannot drift with LLM output. The iframe is made transparent so widgets inherit the app's background, and `@media (prefers-color-scheme)` tokens ensure automatic light/dark adaptation. A graceful HTML fallback is preserved for resilience.

### Related Issues
- Related to #78

### Module(s) Affected
- [x] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [x] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

**Files changed (8 files, 865 insertions, 114 deletions):**
- `deeptutor/agents/visualize/utils.py` — Added `build_widget_from_spec()` fixed shell + `is_widget_spec()` detection
- `deeptutor/agents/visualize/agents/code_generator_agent.py` — JSON spec routing with HTML fallback
- `deeptutor/agents/visualize/prompts/en|zh/code_generator_agent.yaml` — Spec-first prompt with strict output schema
- `deeptutor/agents/visualize/prompts/en|zh/answer_now.yaml` — Fast-path updated to request JSON spec
- `web/components/visualize/VisualizationViewer.tsx` — Transparent iframe, reasoning leak guard
- `web/lib/iframe-html.ts` — Transparent dark mode injection, inline-style white/black overrides

All 14 pre-commit hooks passed (ruff, ruff-format, prettier, bandit, mypy, detect-secrets, trailing-whitespace, end-of-file-fixer, check-yaml, check-json, check-toml, check-merge-conflicts, check-case-conflict, check-added-large-files).

**New Design**
<img width="934" height="616" alt="Screenshot 2026-05-17 at 8 09 10 AM" src="https://github.com/user-attachments/assets/4999e3c9-a02a-4c23-8f21-391899f50146" />
**Old Design**
<img width="919" height="531" alt="Screenshot 2026-05-17 at 8 09 39 AM" src="https://github.com/user-attachments/assets/4cde95fb-6db4-431b-ad43-4907ce6eead9" />