### PR TITLE
fix(visualize): unblock Gemini 2.5+ and harden Visualize pipeline

### DIFF
--- a/deeptutor/agents/visualize/agents/code_generator_agent.py
+++ b/deeptutor/agents/visualize/agents/code_generator_agent.py
@@ -84,4 +84,25 @@ class CodeGeneratorAgent(BaseAgent):
             if lowered.startswith("<!doctype") or lowered.startswith("<html"):
                 return stripped
 
+        # The renderers expect their payload to start cleanly with the right
+        # root tag. Models often wrap output with prose ("Here you go: <svg>…")
+        # or emit a code fence on the same line as the closing tag, which
+        # `extract_code_block`'s regex (requiring a leading \n before ```) does
+        # not strip. Trim to the outermost root tags as a defensive net.
+        if extracted:
+            if analysis.render_type == "svg":
+                lower = extracted.lower()
+                start = lower.find("<svg")
+                end = lower.rfind("</svg>")
+                if start != -1 and end != -1 and end > start:
+                    extracted = extracted[start : end + len("</svg>")]
+            elif analysis.render_type == "html":
+                lower = extracted.lower()
+                start = lower.find("<!doctype")
+                if start == -1:
+                    start = lower.find("<html")
+                end = lower.rfind("</html>")
+                if start != -1 and end != -1 and end > start:
+                    extracted = extracted[start : end + len("</html>")]
+
         return extracted

--- a/deeptutor/capabilities/visualize.py
+++ b/deeptutor/capabilities/visualize.py
@@ -8,6 +8,7 @@ Produces SVG or Chart.js code from user requests and conversation context.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from deeptutor.capabilities.request_contracts import get_capability_request_schema
@@ -15,6 +16,8 @@ from deeptutor.core.capability_protocol import BaseCapability, CapabilityManifes
 from deeptutor.core.context import UnifiedContext
 from deeptutor.core.stream_bus import StreamBus
 from deeptutor.core.trace import merge_trace_metadata
+
+logger = logging.getLogger(__name__)
 
 
 class VisualizeCapability(BaseCapability):
@@ -135,24 +138,47 @@ class VisualizeCapability(BaseCapability):
                     source=self.name,
                     stage="reviewing",
                 )
-                review = await pipeline.run_review(
-                    user_input=context.user_message,
-                    analysis=analysis,
-                    code=code,
-                )
-                final_code = review.optimized_code
-                if review.changed:
+                from deeptutor.agents.visualize.models import ReviewResult
+
+                try:
+                    review = await pipeline.run_review(
+                        user_input=context.user_message,
+                        analysis=analysis,
+                        code=code,
+                    )
+                except Exception as exc:
+                    # Review wraps generated code inside a JSON string field;
+                    # large/complex SVGs trip JSON-mode escaping and crash the
+                    # whole turn. Fall back to the unreviewed draft so the user
+                    # still gets a rendered result.
+                    logger.warning(
+                        "Visualize review failed (%s); using unreviewed draft.", exc
+                    )
+                    review = ReviewResult(
+                        optimized_code=code,
+                        changed=False,
+                        review_notes=f"Review skipped due to error: {exc}",
+                    )
+                    final_code = code
                     await stream.progress(
-                        message=f"Code optimized: {review.review_notes}",
+                        message="Review skipped — using draft as-is.",
                         source=self.name,
                         stage="reviewing",
                     )
                 else:
-                    await stream.progress(
-                        message="Code looks good — no changes needed.",
-                        source=self.name,
-                        stage="reviewing",
-                    )
+                    final_code = review.optimized_code
+                    if review.changed:
+                        await stream.progress(
+                            message=f"Code optimized: {review.review_notes}",
+                            source=self.name,
+                            stage="reviewing",
+                        )
+                    else:
+                        await stream.progress(
+                            message="Code looks good — no changes needed.",
+                            source=self.name,
+                            stage="reviewing",
+                        )
 
         # Emit final content as a fenced code block for the chat area
         if analysis.render_type == "svg":

--- a/deeptutor/services/config/loader.py
+++ b/deeptutor/services/config/loader.py
@@ -231,6 +231,7 @@ def get_agent_params(module_name: str) -> dict:
         "research": ("capabilities", "research"),
         "question": ("capabilities", "question"),
         "co_writer": ("capabilities", "co_writer"),
+        "visualize": ("capabilities", "visualize"),
         "brainstorm": ("tools", "brainstorm"),
         "vision_solver": ("plugins", "vision_solver"),
         "math_animator": ("plugins", "math_animator"),

--- a/deeptutor/services/llm/cloud_provider.py
+++ b/deeptutor/services/llm/cloud_provider.py
@@ -349,6 +349,14 @@ async def _openai_complete(
             effort.lower() == "minimal" and binding.lower() in _BINDINGS_WITH_EXTRA_BODY_THINKING
         ):
             data["reasoning_effort"] = effort
+    elif (binding or "").lower() == "gemini" and any(
+        (model or "").lower().startswith(p) for p in ("gemini-2.5", "gemini-3")
+    ):
+        # Gemini 2.5+ models burn most of `max_tokens` on internal thinking by
+        # default, leaving too little headroom for the actual response and
+        # truncating with finish_reason=length. Disable thinking unless the
+        # caller explicitly asked for it.
+        data["reasoning_effort"] = "none"
 
     timeout = aiohttp.ClientTimeout(total=120)
     connector = _get_aiohttp_connector()
@@ -518,6 +526,14 @@ async def _openai_stream(
             effort.lower() == "minimal" and binding.lower() in _BINDINGS_WITH_EXTRA_BODY_THINKING
         ):
             data["reasoning_effort"] = effort
+    elif (binding or "").lower() == "gemini" and any(
+        (model or "").lower().startswith(p) for p in ("gemini-2.5", "gemini-3")
+    ):
+        # Gemini 2.5+ models burn most of `max_tokens` on internal thinking by
+        # default, leaving too little headroom for the actual response and
+        # truncating with finish_reason=length. Disable thinking unless the
+        # caller explicitly asked for it.
+        data["reasoning_effort"] = "none"
 
     timeout = aiohttp.ClientTimeout(total=300)
     connector = _get_aiohttp_connector()

--- a/deeptutor/services/llm/executors.py
+++ b/deeptutor/services/llm/executors.py
@@ -178,6 +178,14 @@ async def sdk_complete(
 
     if reasoning_effort:
         payload["reasoning_effort"] = reasoning_effort
+    elif (provider_name or "").lower() == "gemini" and any(
+        (resolved_model or "").lower().startswith(p) for p in ("gemini-2.5", "gemini-3")
+    ):
+        # Gemini 2.5+ models burn most of `max_tokens` on internal "thinking"
+        # by default, often leaving zero room for the actual response and
+        # truncating with finish_reason=length. Disable thinking unless the
+        # caller explicitly opted in.
+        payload["reasoning_effort"] = "none"
     payload.update(kwargs)
 
     response = await _create_with_format_fallback(
@@ -246,6 +254,14 @@ async def sdk_stream(
 
     if reasoning_effort:
         payload["reasoning_effort"] = reasoning_effort
+    elif (provider_name or "").lower() == "gemini" and any(
+        (resolved_model or "").lower().startswith(p) for p in ("gemini-2.5", "gemini-3")
+    ):
+        # Gemini 2.5+ models burn most of `max_tokens` on internal "thinking"
+        # by default, often leaving zero room for the actual response and
+        # truncating with finish_reason=length. Disable thinking unless the
+        # caller explicitly opted in.
+        payload["reasoning_effort"] = "none"
     payload.update(kwargs)
 
     stream_response = await _create_with_format_fallback(

--- a/deeptutor/services/llm/provider_core/openai_compat_provider.py
+++ b/deeptutor/services/llm/provider_core/openai_compat_provider.py
@@ -313,6 +313,15 @@ class OpenAICompatProvider(LLMProvider):
             if any(p.lower() in model_lower for p in spec.reasoning_model_patterns):
                 reasoning_effort = "high"
 
+        # Gemini 2.5+ models burn most of `max_tokens` on internal "thinking"
+        # by default, often leaving zero room for the actual response and
+        # truncating with finish_reason=length. Disable thinking unless the
+        # caller explicitly opted in.
+        if reasoning_effort is None and spec and spec.name == "gemini":
+            model_lower = model_name.lower()
+            if any(model_lower.startswith(p) for p in ("gemini-2.5", "gemini-3")):
+                reasoning_effort = "none"
+
         semantic_effort: str | None = None
         if isinstance(reasoning_effort, str):
             semantic_effort = reasoning_effort.lower()

--- a/deeptutor/services/setup/init.py
+++ b/deeptutor/services/setup/init.py
@@ -83,6 +83,7 @@ DEFAULT_AGENTS_SETTINGS = {
         "research": {"temperature": 0.5, "max_tokens": 12000},
         "question": {"temperature": 0.7, "max_tokens": 4096},
         "co_writer": {"temperature": 0.7, "max_tokens": 4096},
+        "visualize": {"temperature": 0.4, "max_tokens": 16384},
         "chat": {
             "temperature": 0.2,
             "responding": {"max_tokens": 8000},


### PR DESCRIPTION
Fixes #489.

## Summary

Six bugs that combined to break the Visualize capability on Gemini 2.5 Flash (and similar thinking-by-default models). Each is independently useful, but the user-visible symptom — Visualize output randomly truncated at ~370 chars — needs all of them.

### 1. Gemini 2.5/3.x reasoning-tokens default (root cause)

Gemini 2.5+ models burn most of `max_tokens` on internal "thinking" tokens by default. With `max_tokens=4096`, ~3900 tokens went to reasoning and ~160 came out as visible content, causing `finish_reason=length` on every multi-step pipeline (Visualize codegen + review, Deep Solve writing, etc.). See #489 for the reproducer with `curl` directly against Gemini's OpenAI-compat endpoint.

Default `reasoning_effort="none"` for Gemini 2.5/3.x when the caller doesn't specify, in all three execution paths:
- `provider_core/openai_compat_provider.py:_build_kwargs` (live path)
- `executors.py:sdk_complete` / `sdk_stream` (SDK path)
- `cloud_provider.py:_openai_complete` / `_openai_stream` (aiohttp fallback)

Callers that *want* thinking can still opt in via explicit `reasoning_effort`.

### 2. `visualize` capability had no `agents.yaml` entry

`get_agent_params("visualize")` silently fell through to the 4096-token default because there was no entry in `DEFAULT_AGENTS_SETTINGS` or `loader.py:section_map`. Added both, with a 16384-token budget appropriate for full HTML pages.

### 3. Review stage crashed hard on JSON parse failure

`ReviewAgent.process` does `ReviewResult.model_validate(extract_json_object(response))`. When the model returned prose instead of JSON (common with large SVGs that don't escape cleanly into a JSON string field), the parse raised and killed the entire Visualize turn — the user saw the streamed SVG draft and then a traceback. Wrapped `pipeline.run_review()` in try/except so a parse failure falls back to the unreviewed draft and the user still gets a rendered result.

### 4. Codegen output not trimmed to the root tag

Models often wrap SVG/HTML in prose ("Here you go: <svg>…</svg> Enjoy!") or emit a closing code fence on the same line as `</html>`, which `extract_code_block`'s regex (requiring a leading `\n` before the fence) doesn't strip. Added defensive root-tag trimming for `render_type=="svg"` and `render_type=="html"` so the renderer always sees a clean payload.

## Test plan

Verified end-to-end on Gemini 2.5 Flash via the CLI and via headless Playwright:
- Long-division HTML test prompt: 22 KB self-contained interactive page (was: 0 bytes / crash on `dev`).
- All step prompts read correctly (e.g. "How many whole times does 6 go into 7?" for the first digit).
- Walking the full 7852 ÷ 6 algorithm step by step terminates with `Quotient: 1308, Remainder: 4`.
- Wrong-answer retry preserves prior progress; 3 wrong attempts reveals the answer and auto-advances (graceful-fallback path exercised).
- Simple SVG (e.g. "draw 8 cookies") still renders unchanged — no regression on the happy path.
- The defensive root-tag trim is a no-op when codegen already returns a clean tag.

- [ ] Maintainer: please run `pre-commit run --all-files` and CI as a sanity check; my local environment doesn't have all the lint deps configured.