### PR TITLE
fix: prevent sed from corrupting API_BASE placeholder validation

### DIFF
--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -7,7 +7,12 @@
 // broken URL and the Settings page would render blank with no clue why.
 // Treating the placeholder as "not configured" surfaces the failure mode
 // instead of letting fetches die quietly.
-const API_BASE_PLACEHOLDER = "__NEXT_PUBLIC_API_BASE_PLACEHOLDER__";
+//
+// NOTE: The startup `sed` replaces `__NEXT_PUBLIC_API_BASE_PLACEHOLDER__` in
+// every JS file. We must NOT keep a matching sentinel constant here, because
+// sed would replace it too, making the validation check always fail.
+// Instead, we detect the un-substituted state by checking for the distinctive
+// prefix `__NEXT_PUBLIC_` which no valid URL would contain.
 
 // Get API base URL injected by the launcher from data/user/settings/system.json.
 // We deliberately do NOT throw at module-load time: the Docker build embeds the
@@ -17,10 +22,11 @@ const API_BASE_PLACEHOLDER = "__NEXT_PUBLIC_API_BASE_PLACEHOLDER__";
 export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE ?? "";
 
 function assertApiBaseConfigured(value: string): string {
-  if (!value || value === API_BASE_PLACEHOLDER) {
+  const isPlaceholder = value.startsWith && value.startsWith("__NEXT_PUBLIC_");
+  if (!value || isPlaceholder) {
     if (typeof window !== "undefined") {
       console.error(
-        value === API_BASE_PLACEHOLDER
+        isPlaceholder
           ? "NEXT_PUBLIC_API_BASE placeholder was not substituted at startup."
           : "NEXT_PUBLIC_API_BASE is not set.",
       );


### PR DESCRIPTION
The Docker startup script (start-frontend.sh) uses sed to replace __NEXT_PUBLIC_API_BASE_PLACEHOLDER__ with the actual API URL in all JS files at runtime. However, the validation constant API_BASE_PLACEHOLDER in web/lib/api.ts contained the exact same literal string, so sed replaced it too.

This caused the validation check (value === API_BASE_PLACEHOLDER) to compare the real URL against itself, always evaluating to true and throwing 'NEXT_PUBLIC_API_BASE is not configured'.

Fix: Replace the constant string comparison with a startsWith() prefix check for '__NEXT_PUBLIC_', which no valid URL would contain and which sed cannot corrupt since it's not the full placeholder literal.

<!--
Thank you for contributing to DeepTutor! 🚀
Please ensure your PR is ready for review and follows our contribution guidelines.
For more details, see our [CONTRIBUTING.md](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
-->

### Description
*A clear and concise description of the changes.*

### Related Issues
- Closes #...
- Related to #...

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [ ] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [ ] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
*Add any other context or screenshots about the pull request here.*
