### PR TITLE
Fix GPT-5 token limit parameter in init wizard probe

### DIFF
--- a/deeptutor_cli/init_wizard.py
+++ b/deeptutor_cli/init_wizard.py
@@ -23,6 +23,7 @@ from rich.table import Table
 from rich.text import Text
 import typer
 
+from deeptutor.services.llm.config import get_token_limit_kwargs
 from deeptutor.services.provider_registry import PROVIDERS, ProviderSpec, find_by_name
 
 # --- Featured selection ------------------------------------------------------
@@ -794,7 +795,7 @@ def probe_llm(*, base_url: str, api_key: str, binding: str, model: str) -> tuple
             }
             body = {
                 "model": model,
-                "max_tokens": 1,
+                **get_token_limit_kwargs(model, 1),
                 "messages": [{"role": "user", "content": "ping"}],
             }
 


### PR DESCRIPTION
## Summary

Fix GPT-5 OpenAI compatibility during `deeptutor init`.

`probe_llm()` in `deeptutor_cli/init_wizard.py` still hardcoded `"max_tokens": 1` for OpenAI-compatible requests, which causes GPT-5 models to fail with:

`Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.`

This PR reuses the existing `get_token_limit_kwargs()` helper from `deeptutor.services.llm.config` to preserve compatibility logic already used elsewhere in the codebase.

## Scope

Minimal change:

* 1 file modified
* reuse existing helper
* no provider logic changes
* no model taxonomy changes