### PR TITLE
fix: prevent Document nodes from bypassing chunking pipeline

### DIFF
--- a/deeptutor/services/rag/pipelines/llamaindex/ingestion.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/ingestion.py
@@ -12,7 +12,7 @@ from typing import Any
 from llama_index.core import Settings, VectorStoreIndex
 from llama_index.core.ingestion import IngestionPipeline
 from llama_index.core.node_parser import SentenceSplitter
-from llama_index.core.schema import BaseNode
+from llama_index.core.schema import BaseNode, Document
 
 
 def build_ingestion_pipeline() -> IngestionPipeline:
@@ -34,14 +34,29 @@ def build_ingestion_pipeline() -> IngestionPipeline:
     )
 
 
+def _has_precomputed_embedding(node: Any) -> bool:
+    """Return True if node already carries an embedding vector.
+
+    LlamaIndex's Document class inherits from BaseNode, so a naive
+    ``isinstance(doc, BaseNode)`` check incorrectly classifies every
+    Document as pre-embedded, bypassing the chunking pipeline entirely.
+    This helper distinguishes genuinely pre-embedded nodes (e.g. ImageNode
+    produced by multimodal loaders) from regular Documents that still need
+    splitting and embedding.
+    """
+    if isinstance(node, Document):
+        return False
+    return isinstance(node, BaseNode) and bool(getattr(node, "embedding", None))
+
+
 def documents_to_nodes(documents: list[Any], *, show_progress: bool = True) -> list[Any]:
     """Convert LlamaIndex documents into embedded nodes.
 
     Pre-embedded nodes, such as ImageNode instances produced by the document
     loader, pass through unchanged so they are not re-embedded as text.
     """
-    text_documents = [document for document in documents if not isinstance(document, BaseNode)]
-    preembedded_nodes = [document for document in documents if isinstance(document, BaseNode)]
+    text_documents = [doc for doc in documents if not _has_precomputed_embedding(doc)]
+    preembedded_nodes = [doc for doc in documents if _has_precomputed_embedding(doc)]
 
     nodes: list[Any] = []
     if text_documents:


### PR DESCRIPTION
## Summary

Fixes a bug where all documents bypass `SentenceSplitter` during KB indexing, causing full-document text (1M+ chars) to be sent to the embedding API and triggering HTTP 400 input-length errors.

## Root Cause

LlamaIndex's `Document` class inherits from `BaseNode`. The previous filtering logic:

```python
text_documents = [doc for doc in documents if not isinstance(doc, BaseNode)]
```

classified **every** Document as a pre-embedded node, skipping the chunking pipeline entirely.

## Fix

Replace the naive `isinstance(doc, BaseNode)` check with `_has_precomputed_embedding()` that:
1. Always treats `Document` instances as needing chunking
2. Only skips nodes that are non-Document `BaseNode` subclasses **and** already carry an embedding vector (e.g. `ImageNode` from multimodal loaders)

## Testing

Verified end-to-end: KB creation with a 1M+ char PDF now correctly chunks into 512-token segments and embeds successfully via DashScope `text-embedding-v3`.