### PR TITLE
feat: add pluggable TTS tool with multi-provider support

### DIFF
--- a/deeptutor/api/main.py
+++ b/deeptutor/api/main.py
@@ -314,6 +314,9 @@ from deeptutor.api.routers import (
     voice,
 )
 from deeptutor.api.routers import (
+    audio as audio_router,
+)
+from deeptutor.api.routers import (
     tools as tools_router,
 )
 from deeptutor.multi_user.router import router as multi_user_router  # noqa: E402
@@ -397,6 +400,7 @@ app.include_router(
 app.include_router(tools_router.router, prefix="/api/v1/tools", tags=["tools"], dependencies=_auth)
 app.include_router(system.router, prefix="/api/v1/system", tags=["system"], dependencies=_auth)
 app.include_router(voice.router, prefix="/api/v1/voice", tags=["voice"], dependencies=_auth)
+app.include_router(audio_router.router, prefix="/api/v1/audio", tags=["audio"], dependencies=_auth)
 app.include_router(
     plugins_api.router, prefix="/api/v1/plugins", tags=["plugins"], dependencies=_auth
 )

--- a/deeptutor/api/routers/audio.py
+++ b/deeptutor/api/routers/audio.py
@@ -1,0 +1,41 @@
+"""Audio file serving endpoint for TTS output."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
+
+from deeptutor.services.path_service import get_path_service
+
+router = APIRouter()
+
+
+@router.get("/{session_id}/{filename}")
+async def serve_audio(session_id: str, filename: str) -> FileResponse:
+    """Serve a generated TTS audio file.
+
+    Args:
+        session_id: The chat session identifier.
+        filename: The audio file name (UUID-based).
+
+    Returns:
+        The audio file as a streaming response.
+
+    Raises:
+        HTTPException: If the file does not exist or the path is invalid.
+    """
+    # Validate filename to prevent path traversal
+    if "/" in filename or "\\" in filename or ".." in filename:
+        raise HTTPException(status_code=400, detail="Invalid filename.")
+    if "/" in session_id or "\\" in session_id or ".." in session_id:
+        raise HTTPException(status_code=400, detail="Invalid session ID.")
+
+    audio_path = get_path_service().workspace_root / "chat" / "audio" / session_id / filename
+    if not audio_path.is_file():
+        raise HTTPException(status_code=404, detail="Audio file not found.")
+
+    return FileResponse(
+        path=str(audio_path),
+        media_type="audio/mpeg",
+        filename=filename,
+    )

--- a/deeptutor/services/tts/__init__.py
+++ b/deeptutor/services/tts/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+"""TTS service package exports."""
+
+from .config import TTSConfig
+from .providers import get_tts_provider
+
+__all__ = ["TTSConfig", "get_tts_provider"]

--- a/deeptutor/services/tts/base.py
+++ b/deeptutor/services/tts/base.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Base abstractions for TTS providers."""
+
+from abc import ABC, abstractmethod
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class BaseTTSProvider(ABC):
+    """Abstract TTS provider interface."""
+
+    @abstractmethod
+    async def synthesize(
+        self,
+        text: str,
+        *,
+        voice: str | None = None,
+        model: str | None = None,
+    ) -> bytes:
+        """Synthesize text to MP3 audio bytes.
+
+        Args:
+            text: Input text to synthesize.
+            voice: Optional provider voice override.
+            model: Optional provider model override.
+
+        Returns:
+            MP3 audio bytes.
+        """
+
+    def detect_voice(self, text: str, voices: dict[str, str]) -> str:
+        """Auto-detect language from text and choose a configured voice.
+
+        Args:
+            text: Input text.
+            voices: Language-to-voice mapping.
+
+        Returns:
+            Selected voice name, preferring ``zh`` when CJK ratio exceeds 30%,
+            otherwise ``en``.
+        """
+        if not voices:
+            return ""
+
+        cjk_count = 0
+        total = 0
+        for char in text:
+            if char.isspace():
+                continue
+            total += 1
+            code = ord(char)
+            if (
+                0x4E00 <= code <= 0x9FFF
+                or 0x3400 <= code <= 0x4DBF
+                or 0x3040 <= code <= 0x30FF
+                or 0xAC00 <= code <= 0xD7AF
+            ):
+                cjk_count += 1
+
+        ratio = (cjk_count / total) if total else 0.0
+        lang = "zh" if ratio > 0.30 else "en"
+
+        selected = voices.get(lang) or voices.get("en") or next(iter(voices.values()), "")
+        logger.debug("Detected voice language=%s ratio=%.3f selected=%s", lang, ratio, selected)
+        return selected
+
+
+__all__ = ["BaseTTSProvider"]

--- a/deeptutor/services/tts/config.py
+++ b/deeptutor/services/tts/config.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+"""TTS configuration loading and defaults."""
+
+from dataclasses import dataclass, field
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from deeptutor.services.path_service import get_path_service
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TTSConfig:
+    """Runtime configuration for text-to-speech providers.
+
+    Attributes:
+        provider: TTS provider name, one of ``dashscope``, ``openai``, or ``edge``.
+        model: Provider-specific model name.
+        voice: Explicit voice override.
+        voices: Language-to-voice mapping, for example ``{"zh": "...", "en": "..."}``.
+        api_key: Provider API key when required.
+        base_url: Optional custom API endpoint for compatible providers.
+    """
+
+    provider: str = "dashscope"
+    model: str = ""
+    voice: str = ""
+    voices: dict[str, str] = field(default_factory=dict)
+    api_key: str = ""
+    base_url: str = ""
+
+
+def _settings_file() -> Path:
+    """Return the TTS settings file path."""
+    return get_path_service().get_settings_file("tts")
+
+
+def _read_json_file(path: Path) -> dict[str, Any]:
+    """Read a JSON file safely.
+
+    Args:
+        path: JSON file path.
+
+    Returns:
+        Parsed dictionary, or an empty dict when unavailable/invalid.
+    """
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.warning("Failed to parse JSON config: %s", path, exc_info=True)
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _normalize_provider(value: str | None) -> str:
+    """Normalize provider aliases.
+
+    Args:
+        value: Raw provider value.
+
+    Returns:
+        Canonical provider name.
+    """
+    provider = (value or "").strip().lower()
+    alias_map = {
+        "azure": "openai",
+        "azure_openai": "openai",
+        "openai-compatible": "openai",
+        "openai_compatible": "openai",
+        "ms": "edge",
+        "edge_tts": "edge",
+    }
+    normalized = alias_map.get(provider, provider)
+    if normalized in {"dashscope", "openai", "edge"}:
+        return normalized
+    return "dashscope"
+
+
+def _load_default_from_model_catalog() -> TTSConfig:
+    """Build a default TTS config from model catalog active LLM profile.
+
+    Returns:
+        Baseline TTS config inferred from ``model_catalog.json``.
+    """
+    catalog = _read_json_file(get_path_service().get_settings_file("model_catalog"))
+    services = catalog.get("services") if isinstance(catalog, dict) else {}
+    llm_service = services.get("llm") if isinstance(services, dict) else {}
+    profiles = llm_service.get("profiles") if isinstance(llm_service, dict) else []
+    active_profile_id = (
+        llm_service.get("active_profile_id") if isinstance(llm_service, dict) else None
+    )
+
+    profile: dict[str, Any] = {}
+    if isinstance(profiles, list):
+        for item in profiles:
+            if isinstance(item, dict) and item.get("id") == active_profile_id:
+                profile = item
+                break
+        if not profile:
+            for item in profiles:
+                if isinstance(item, dict):
+                    profile = item
+                    break
+
+    binding = _normalize_provider(str(profile.get("binding") or "")) if profile else "dashscope"
+
+    if binding == "openai":
+        return TTSConfig(
+            provider="openai",
+            model="tts-1",
+            voices={"zh": "alloy", "en": "nova"},
+            api_key=str(profile.get("api_key") or ""),
+            base_url=str(profile.get("base_url") or "https://api.openai.com/v1"),
+        )
+
+    if binding == "edge":
+        return TTSConfig(
+            provider="edge",
+            model="",
+            voices={"zh": "zh-CN-XiaoxiaoNeural", "en": "en-US-JennyNeural"},
+            api_key="",
+            base_url="",
+        )
+
+    return TTSConfig(
+        provider="dashscope",
+        model="cosyvoice-v3-flash",
+        voices={"zh": "longxiaochun_v3", "en": "loongbella_v3"},
+        api_key=str(profile.get("api_key") or ""),
+        base_url=str(profile.get("base_url") or ""),
+    )
+
+
+def _resolve_api_key_with_fallback(config: TTSConfig) -> str:
+    """Resolve API key with fallback ordering.
+
+    Resolution order follows project requirements:
+    ``tts.json`` -> ``model_catalog.json`` (already included in defaults) -> environment.
+
+    Args:
+        config: Current merged config.
+
+    Returns:
+        Resolved API key string.
+    """
+    if config.api_key:
+        return config.api_key
+
+    env_name = "DASHSCOPE_API_KEY" if config.provider == "dashscope" else "OPENAI_API_KEY"
+    return os.environ.get(env_name, "") if config.provider in {"dashscope", "openai"} else ""
+
+
+def load_tts_config() -> TTSConfig:
+    """Load TTS configuration from settings with provider-aware defaults.
+
+    Returns:
+        Resolved ``TTSConfig`` instance.
+    """
+    defaults = _load_default_from_model_catalog()
+    raw = _read_json_file(_settings_file())
+
+    provider = _normalize_provider(str(raw.get("provider") or defaults.provider))
+    model = str(raw.get("model") or defaults.model)
+    voice = str(raw.get("voice") or "")
+    base_url = str(raw.get("base_url") or defaults.base_url)
+
+    voices_payload = raw.get("voices", defaults.voices)
+    voices: dict[str, str] = {}
+    if isinstance(voices_payload, dict):
+        voices = {
+            str(language).strip().lower(): str(v)
+            for language, v in voices_payload.items()
+            if str(language).strip() and str(v).strip()
+        }
+
+    config = TTSConfig(
+        provider=provider,
+        model=model,
+        voice=voice,
+        voices=voices or defaults.voices,
+        api_key=str(raw.get("api_key") or defaults.api_key),
+        base_url=base_url,
+    )
+    config.api_key = _resolve_api_key_with_fallback(config)
+    return config
+
+
+__all__ = ["TTSConfig", "load_tts_config"]

--- a/deeptutor/services/tts/providers/__init__.py
+++ b/deeptutor/services/tts/providers/__init__.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""TTS provider factory."""
+
+from deeptutor.services.tts.base import BaseTTSProvider
+from deeptutor.services.tts.config import TTSConfig
+
+
+def get_tts_provider(config: TTSConfig) -> BaseTTSProvider:
+    """Return a concrete TTS provider from config.
+
+    Args:
+        config: Runtime TTS config.
+
+    Returns:
+        Provider instance implementing ``BaseTTSProvider``.
+
+    Raises:
+        ValueError: If provider is unsupported.
+    """
+    match config.provider:
+        case "dashscope":
+            from .dashscope import DashScopeTTSProvider
+
+            return DashScopeTTSProvider(config)
+        case "openai":
+            from .openai_tts import OpenAITTSProvider
+
+            return OpenAITTSProvider(config)
+        case "edge":
+            from .edge import EdgeTTSProvider
+
+            return EdgeTTSProvider(config)
+        case _:
+            raise ValueError(
+                f"Unknown TTS provider: '{config.provider}'. Supported: dashscope, openai, edge"
+            )
+
+
+__all__ = ["get_tts_provider"]

--- a/deeptutor/services/tts/providers/dashscope.py
+++ b/deeptutor/services/tts/providers/dashscope.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""DashScope CosyVoice TTS provider."""
+
+import asyncio
+from importlib import import_module
+import logging
+import os
+
+from deeptutor.services.tts.base import BaseTTSProvider
+from deeptutor.services.tts.config import TTSConfig
+
+logger = logging.getLogger(__name__)
+
+
+class DashScopeTTSProvider(BaseTTSProvider):
+    """DashScope TTS provider using CosyVoice models."""
+
+    _DEFAULT_MODEL = "cosyvoice-v3-flash"
+    _DEFAULT_VOICES = {"zh": "longxiaochun_v3", "en": "loongbella_v3"}
+
+    def __init__(self, config: TTSConfig) -> None:
+        """Initialize provider with runtime config.
+
+        Args:
+            config: Resolved TTS configuration.
+        """
+        self.config = config
+
+    def _resolve_api_key(self) -> str:
+        """Resolve DashScope API key with provider-specific precedence."""
+        return os.environ.get("DASHSCOPE_API_KEY") or self.config.api_key
+
+    def _resolve_voice(self, text: str, voice: str | None) -> str:
+        """Resolve final voice name for synthesis."""
+        if voice:
+            return voice
+        if self.config.voice:
+            return self.config.voice
+        merged = dict(self._DEFAULT_VOICES)
+        merged.update(self.config.voices)
+        return self.detect_voice(text, merged)
+
+    async def synthesize(
+        self,
+        text: str,
+        *,
+        voice: str | None = None,
+        model: str | None = None,
+    ) -> bytes:
+        """Synthesize text with DashScope and return MP3 bytes.
+
+        Args:
+            text: Text to synthesize.
+            voice: Optional voice override.
+            model: Optional model override.
+
+        Returns:
+            MP3 audio bytes.
+        """
+        api_key = self._resolve_api_key()
+        if not api_key:
+            raise ValueError("DashScope TTS requires an API key.")
+
+        selected_voice = self._resolve_voice(text, voice)
+        selected_model = model or self.config.model or self._DEFAULT_MODEL
+
+        def _synthesize_sync() -> bytes:
+            dashscope = import_module("dashscope")
+            tts_module = import_module("dashscope.audio.tts_v2")
+            speech_synthesizer = getattr(tts_module, "SpeechSynthesizer")
+
+            setattr(dashscope, "api_key", api_key)
+            synthesizer = speech_synthesizer(model=selected_model, voice=selected_voice)
+            result = synthesizer.call(text)
+            if isinstance(result, bytes):
+                return result
+            raise RuntimeError("DashScope TTS returned non-bytes audio payload.")
+
+        loop = asyncio.get_event_loop()
+        logger.debug("DashScope TTS synthesize model=%s voice=%s", selected_model, selected_voice)
+        return await loop.run_in_executor(None, _synthesize_sync)
+
+
+__all__ = ["DashScopeTTSProvider"]

--- a/deeptutor/services/tts/providers/edge.py
+++ b/deeptutor/services/tts/providers/edge.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Edge TTS provider implementation."""
+
+from importlib import import_module
+import logging
+
+from deeptutor.services.tts.base import BaseTTSProvider
+from deeptutor.services.tts.config import TTSConfig
+
+logger = logging.getLogger(__name__)
+
+
+class EdgeTTSProvider(BaseTTSProvider):
+    """Microsoft Edge TTS provider."""
+
+    _DEFAULT_VOICES = {"zh": "zh-CN-XiaoxiaoNeural", "en": "en-US-JennyNeural"}
+
+    def __init__(self, config: TTSConfig) -> None:
+        """Initialize provider.
+
+        Args:
+            config: Resolved TTS configuration.
+        """
+        self.config = config
+
+    def _resolve_voice(self, text: str, voice: str | None) -> str:
+        """Resolve voice used for synthesis."""
+        if voice:
+            return voice
+        if self.config.voice:
+            return self.config.voice
+        merged = dict(self._DEFAULT_VOICES)
+        merged.update(self.config.voices)
+        return self.detect_voice(text, merged)
+
+    async def synthesize(
+        self,
+        text: str,
+        *,
+        voice: str | None = None,
+        model: str | None = None,
+    ) -> bytes:
+        """Synthesize text to MP3 bytes via Edge TTS.
+
+        Args:
+            text: Input text.
+            voice: Optional voice override.
+            model: Unused for edge-tts, accepted for API compatibility.
+
+        Returns:
+            MP3 audio bytes.
+        """
+        del model
+        selected_voice = self._resolve_voice(text, voice)
+        logger.debug("Edge TTS synthesize voice=%s", selected_voice)
+
+        edge_tts_module = import_module("edge_tts")
+        communicate = edge_tts_module.Communicate(text=text, voice=selected_voice)
+        chunks: list[bytes] = []
+        async for chunk in communicate.stream():
+            if chunk.get("type") == "audio":
+                data = chunk.get("data")
+                if isinstance(data, bytes):
+                    chunks.append(data)
+        return b"".join(chunks)
+
+
+__all__ = ["EdgeTTSProvider"]

--- a/deeptutor/services/tts/providers/openai_tts.py
+++ b/deeptutor/services/tts/providers/openai_tts.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""OpenAI-compatible HTTP TTS provider."""
+
+import logging
+
+import httpx
+
+from deeptutor.services.tts.base import BaseTTSProvider
+from deeptutor.services.tts.config import TTSConfig
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAITTSProvider(BaseTTSProvider):
+    """OpenAI speech synthesis provider."""
+
+    _DEFAULT_MODEL = "tts-1"
+    _DEFAULT_VOICES = {"zh": "alloy", "en": "nova"}
+    _DEFAULT_BASE_URL = "https://api.openai.com/v1"
+
+    def __init__(self, config: TTSConfig) -> None:
+        """Initialize provider.
+
+        Args:
+            config: Resolved TTS configuration.
+        """
+        self.config = config
+
+    def _resolve_voice(self, text: str, voice: str | None) -> str:
+        """Resolve voice used for synthesis."""
+        if voice:
+            return voice
+        if self.config.voice:
+            return self.config.voice
+        merged = dict(self._DEFAULT_VOICES)
+        merged.update(self.config.voices)
+        return self.detect_voice(text, merged)
+
+    async def synthesize(
+        self,
+        text: str,
+        *,
+        voice: str | None = None,
+        model: str | None = None,
+    ) -> bytes:
+        """Synthesize text to MP3 bytes via OpenAI-compatible endpoint.
+
+        Args:
+            text: Input text.
+            voice: Optional voice override.
+            model: Optional model override.
+
+        Returns:
+            MP3 audio bytes.
+        """
+        if not self.config.api_key:
+            raise ValueError("OpenAI TTS requires an API key.")
+
+        base_url = (self.config.base_url or self._DEFAULT_BASE_URL).rstrip("/")
+        url = f"{base_url}/audio/speech"
+        selected_model = model or self.config.model or self._DEFAULT_MODEL
+        selected_voice = self._resolve_voice(text, voice)
+
+        headers = {
+            "Authorization": f"Bearer {self.config.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "audio/mpeg",
+        }
+        payload = {
+            "model": selected_model,
+            "input": text,
+            "voice": selected_voice,
+            "format": "mp3",
+        }
+
+        logger.debug(
+            "OpenAI TTS synthesize url=%s model=%s voice=%s", url, selected_model, selected_voice
+        )
+        async with httpx.AsyncClient(timeout=60) as client:
+            response = await client.post(url, json=payload, headers=headers)
+            if response.status_code >= 400:
+                raise RuntimeError(
+                    f"OpenAI TTS request failed: status={response.status_code}, body={response.text[:500]}"
+                )
+            return response.content
+
+
+__all__ = ["OpenAITTSProvider"]

--- a/deeptutor/tools/builtin/__init__.py
+++ b/deeptutor/tools/builtin/__init__.py
@@ -36,7 +36,7 @@ class _PromptHintsMixin:
     """Shared prompt-hint loader for built-in tools."""
 
     def get_prompt_hints(self, language: str = "en"):
-        return load_prompt_hints(self.name, language=language)
+        return load_prompt_hints(str(getattr(self, "name", "")), language=language)
 
 
 class BrainstormTool(_PromptHintsMixin, BaseTool):
@@ -1284,6 +1284,75 @@ class ReadSkillTool(_PromptHintsMixin, BaseTool):
         )
 
 
+class TTSTool(_PromptHintsMixin, BaseTool):
+    def get_definition(self) -> ToolDefinition:
+        return ToolDefinition(
+            name="tts",
+            description="Convert text to speech audio using the configured TTS provider.",
+            parameters=[
+                ToolParameter(
+                    name="text",
+                    type="string",
+                    description="The text to synthesize into speech.",
+                ),
+                ToolParameter(
+                    name="language",
+                    type="string",
+                    description="Target language code, e.g. 'en' or 'zh'. Defaults to auto-detect.",
+                    required=False,
+                ),
+                ToolParameter(
+                    name="voice",
+                    type="string",
+                    description="Specific voice ID to use. Overrides the default for the language.",
+                    required=False,
+                ),
+            ],
+        )
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        from pathlib import Path
+        import uuid
+
+        from deeptutor.services.tts.config import load_tts_config
+        from deeptutor.services.tts.providers import get_tts_provider
+
+        text = kwargs.get("text", "")
+        if not text.strip():
+            return ToolResult(content="No text provided for synthesis.")
+
+        config = load_tts_config()
+        provider: Any = get_tts_provider(config)
+
+        language = kwargs.get("language") or ""
+        voice = kwargs.get("voice") or ""
+
+        # Resolve voice from language if not explicitly set
+        if not voice:
+            if language and config.voices.get(language):
+                voice = config.voices[language]
+            else:
+                voice = provider.detect_voice(text, config.voices)
+
+        audio_data = await provider.synthesize(text=text, voice=voice or None)
+
+        from deeptutor.services.path_service import get_path_service
+
+        session_id = kwargs.get("session_id", "default")
+        audio_dir = get_path_service().workspace_root / "chat" / "audio" / session_id
+        audio_dir.mkdir(parents=True, exist_ok=True)
+        filename = f"{uuid.uuid4().hex}.mp3"
+        audio_path: Path = audio_dir / filename
+        audio_path.write_bytes(audio_data)
+
+        relative_path = f"{session_id}/{filename}"
+        audio_url = f"/api/v1/audio/{relative_path}"
+        return ToolResult(
+            content=f"Audio generated successfully ({len(audio_data)} bytes).",
+            metadata={"audio_url": audio_url, "audio_path": str(audio_path)},
+        )
+
+
 class LoadToolsTool(_PromptHintsMixin, BaseTool):
     """Load deferred (Extended) tools' schemas into the current session.
 
@@ -1465,6 +1534,7 @@ BUILTIN_TOOL_TYPES: tuple[type[BaseTool], ...] = (
     # grant-gated; the chat pipeline only mounts them when a model is configured.
     ImagegenTool,
     VideogenTool,
+    TTSTool,
     # Mastery Path + Solve + Obsidian tools — globally registered so schemas/API
     # stay stable; the chat loop capabilities decide when to auto-mount them for
     # a turn. Obsidian is a knowledge capability: when its vault is selected it
@@ -1498,21 +1568,6 @@ COMING_SOON_TOOL_NAMES: tuple[str, ...] = tuple(
     tool_type().name for tool_type in COMING_SOON_TOOL_TYPES
 )
 
-# Tools the user can switch on/off from /settings/tools ("体验增强" /
-# Experience Enhancement). Everything else in BUILTIN_TOOL_NAMES is mounted
-# automatically by the chat pipeline under per-tool context gates and is
-# locked-on from the user's perspective. Ordering here is the canonical
-# display order for the settings page.
-USER_TOGGLEABLE_TOOL_NAMES: tuple[str, ...] = (
-    "brainstorm",
-    "web_search",
-    "paper_search",
-    "reason",
-    "geogebra_analysis",
-    "imagegen",
-    "videogen",
-)
-
 # Built-in tools the chat agent loop auto-mounts under context gates (a KB
 # attached, the sandbox enabled, the user having memory/notebooks, …) rather
 # than user toggles — "locked-on" in the product chat composer. Partners,
@@ -1538,6 +1593,22 @@ CONFIGURABLE_BUILTIN_TOOL_NAMES: tuple[str, ...] = (
     "load_tools",
     "cron",
     "ask_user",
+)
+
+# Tools the user can switch on/off from /settings/tools ("体验增强" /
+# Experience Enhancement). Everything else in BUILTIN_TOOL_NAMES is mounted
+# automatically by the chat pipeline under per-tool context gates and is
+# locked-on from the user's perspective. Ordering here is the canonical
+# display order for the settings page.
+USER_TOGGLEABLE_TOOL_NAMES: tuple[str, ...] = (
+    "brainstorm",
+    "web_search",
+    "paper_search",
+    "reason",
+    "geogebra_analysis",
+    "imagegen",
+    "videogen",
+    "tts",
 )
 
 TOOL_ALIASES: dict[str, tuple[str, dict[str, Any]]] = {

--- a/tests/api/test_tools_router.py
+++ b/tests/api/test_tools_router.py
@@ -47,6 +47,7 @@ async def test_list_builtin_tools_marks_toggleable_set(
         "geogebra_analysis",
         "imagegen",
         "videogen",
+        "tts",
     }
 
     # Locked-on (non-toggleable, non-coming-soon) tools always report


### PR DESCRIPTION
## Summary

Adds a general-purpose **TTS (Text-to-Speech) tool** to DeepTutor, enabling any capability (Chat, Solve, Research, etc.) to synthesize speech from text responses.

Relates to roadmap item: #498 (Voice I/O)

## What's included

- **TTS service layer** (`deeptutor/services/tts/`) with provider abstraction supporting:
  - **DashScope** (CosyVoice) — default
  - **OpenAI** TTS API
  - **Edge TTS** (free, no API key required)
- **TTSTool** registered as a user-toggleable built-in tool (`name="tts"`)
- **Audio serving endpoint** at `GET /api/v1/audio/{session_id}/{filename}` with path traversal protection
- **Auto language detection** for voice selection (CJK ratio heuristic), with explicit `language` and `voice` parameter overrides
- **Configuration** via `data/user/settings/tts.json`, falling back to the active LLM profile in `model_catalog.json`

## Architecture

```
LLM picks tts tool -> TTSTool.execute()
  -> load_tts_config() (tts.json -> model_catalog fallback)
  -> get_tts_provider(config) (DashScope/OpenAI/Edge)
  -> provider.synthesize(text, voice=...)
  -> saves to workspace/chat/audio/{session}/{uuid}.mp3
  -> returns ToolResult with audio_url metadata
```

## Testing

Verified locally with DashScope provider:
- English synthesis (35KB audio)
- Chinese auto-detection (45KB audio)
- Explicit voice override
- Empty text guard
- Full app import with audio router registered
- All files pass `python3.11 -m compileall`

## Future work (separate PR)

- Frontend audio player component in Chat UI
- TTS settings panel in Settings -> Tools
- Streaming synthesis for long text