### PR TITLE
fix(chat): enable native tool calling for reasoning models via OpenAI-compatible endpoints

### DIFF
--- a/deeptutor/agents/chat/agentic_pipeline.py
+++ b/deeptutor/agents/chat/agentic_pipeline.py
@@ -380,6 +380,7 @@ class AgenticChatPipeline:
 
         enabled_tools = self._compose_enabled_tools(context)
         use_native_tools = bool(enabled_tools) and self._can_use_native_tool_calling()
+        _is_reasoner = has_thinking_tags(self.binding, self.model)
         tool_schemas = (
             self._build_llm_tool_schemas(enabled_tools, context) if use_native_tools else None
         )
@@ -426,7 +427,6 @@ class AgenticChatPipeline:
         # and each tool call below allocate their own call_id and surface as
         # individual sub-traces in CallTracePanel.
         completion_kwargs = self._completion_kwargs(max_tokens=self._responding_max_tokens)
-        _is_reasoner = has_thinking_tags(self.binding, self.model)
 
         # Reasoning models (e.g. Qwen3.6-Plus) need ``enable_thinking``
         # explicitly set so the API correctly handles thinking + tool_calls.

--- a/deeptutor/agents/chat/agentic_pipeline.py
+++ b/deeptutor/agents/chat/agentic_pipeline.py
@@ -73,6 +73,7 @@ from deeptutor.services.llm import (
     clean_thinking_tags,
     get_llm_config,
     get_token_limit_kwargs,  # noqa: F401  (re-exported for tests)
+    has_thinking_tags,
     prepare_multimodal_messages,
     supports_tools,  # noqa: F401  (re-exported for tests)
 )
@@ -421,13 +422,14 @@ class AgenticChatPipeline:
         # call_id so it does NOT spawn its own sub-trace; each LLM iteration
         # and each tool call below allocate their own call_id and surface as
         # individual sub-traces in CallTracePanel.
-        # When native tool calling is active, disable thinking mode for
-        # reasoning models (e.g. Qwen3.6-Plus via DashScope).  These models
-        # emit tool calls inside ``reasoning_content`` instead of the
-        # ``tool_calls`` field when thinking is enabled, causing
-        # ``tool_without_calls`` protocol violations and infinite retries.
         completion_kwargs = self._completion_kwargs(max_tokens=self._responding_max_tokens)
-        if use_native_tools:
+        # Reasoning models (has_thinking_tags=True, e.g. Qwen3.6-Plus via
+        # DashScope) emit tool calls inside ``reasoning_content`` instead of
+        # the ``tool_calls`` field when thinking is enabled, causing
+        # ``tool_without_calls`` protocol violations and infinite retries.
+        # Disable thinking only when the model is a known reasoner AND native
+        # tool calling is active.  Non-reasoning models ignore the parameter.
+        if use_native_tools and has_thinking_tags(self.binding, self.model):
             completion_kwargs.setdefault("extra_body", {})["enable_thinking"] = False
 
         # When native tool calling is unavailable (no tool schemas), strip

--- a/deeptutor/agents/chat/agentic_pipeline.py
+++ b/deeptutor/agents/chat/agentic_pipeline.py
@@ -1266,7 +1266,7 @@ class AgenticChatPipeline:
             note = (
                 "\n\n# 推理模型特别说明\n"
                 "你是一个原生支持推理和工具调用的模型。"
-                "请**忽略上面"输出协议"中关于 ``TOOL``/``THINK``/``FINISH``/``PAUSE`` 标签的指示**。"
+                "请**忽略上面「输出协议」中关于 ``TOOL``/``THINK``/``FINISH``/``PAUSE`` 标签的指示**。"
                 "你不需要在回复中输出任何标签。"
                 "你的推理过程会自动在独立区域显示。"
                 "当你需要调用工具时，直接通过原生 tool_calls 功能发起调用，不要在文本中写 JSON。"
@@ -1276,7 +1276,7 @@ class AgenticChatPipeline:
             note = (
                 "\n\n# Reasoning Model Special Instructions\n"
                 "You are a model with native reasoning and tool-calling support. "
-                "Please **ignore the "Output Protocol" instructions above about "
+                "Please **ignore the 'Output Protocol' instructions above about "
                 "``TOOL``/``THINK``/``FINISH``/``PAUSE`` labels**. "
                 "You do NOT need to output any labels in your replies. "
                 "Your reasoning is automatically displayed in a separate area. "

--- a/deeptutor/agents/chat/agentic_pipeline.py
+++ b/deeptutor/agents/chat/agentic_pipeline.py
@@ -421,13 +421,35 @@ class AgenticChatPipeline:
         # call_id so it does NOT spawn its own sub-trace; each LLM iteration
         # and each tool call below allocate their own call_id and surface as
         # individual sub-traces in CallTracePanel.
+        # When native tool calling is active, disable thinking mode for
+        # reasoning models (e.g. Qwen3.6-Plus via DashScope).  These models
+        # emit tool calls inside ``reasoning_content`` instead of the
+        # ``tool_calls`` field when thinking is enabled, causing
+        # ``tool_without_calls`` protocol violations and infinite retries.
+        completion_kwargs = self._completion_kwargs(max_tokens=self._responding_max_tokens)
+        if use_native_tools:
+            completion_kwargs.setdefault("extra_body", {})["enable_thinking"] = False
+
+        # When native tool calling is unavailable (no tool schemas), strip
+        # the TOOL label from the protocol so the loop does not expect
+        # ``tool_calls`` deltas and trigger ``tool_without_calls`` violations.
+        protocol = _CHAT_PROTOCOL
+        if not use_native_tools and protocol.tool_label is not None:
+            protocol = LabelProtocol(
+                allowed=tuple(l for l in protocol.allowed if l != LABEL_TOOL),
+                terminal=protocol.terminal,
+                intermediate=protocol.intermediate,
+                final=protocol.final,
+                tool_label=None,
+            )
+
         async with stream.stage("responding", source="chat"):
             outcome = await run_agentic_loop(
                 initial_messages=messages,
-                protocol=_CHAT_PROTOCOL,
+                protocol=protocol,
                 client=client,
                 model=self.model,
-                completion_kwargs=self._completion_kwargs(max_tokens=self._responding_max_tokens),
+                completion_kwargs=completion_kwargs,
                 binding=self.binding,
                 tool_schemas=tool_schemas,
                 stream=stream,

--- a/deeptutor/agents/chat/agentic_pipeline.py
+++ b/deeptutor/agents/chat/agentic_pipeline.py
@@ -77,6 +77,7 @@ from deeptutor.services.llm import (
     prepare_multimodal_messages,
     supports_tools,  # noqa: F401  (re-exported for tests)
 )
+from deeptutor.services.provider_registry import find_by_name
 from deeptutor.services.llm import (
     stream as llm_stream,
 )
@@ -384,6 +385,8 @@ class AgenticChatPipeline:
         )
 
         system_prompt = self._build_system_prompt(enabled_tools, context)
+        if _is_reasoner and use_native_tools:
+            system_prompt = self._append_reasoner_protocol_note(system_prompt)
         user_content = self._t(
             "user_template",
             default=context.user_message,
@@ -423,14 +426,18 @@ class AgenticChatPipeline:
         # and each tool call below allocate their own call_id and surface as
         # individual sub-traces in CallTracePanel.
         completion_kwargs = self._completion_kwargs(max_tokens=self._responding_max_tokens)
-        # Reasoning models (has_thinking_tags=True, e.g. Qwen3.6-Plus via
-        # DashScope) emit tool calls inside ``reasoning_content`` instead of
-        # the ``tool_calls`` field when thinking is enabled, causing
-        # ``tool_without_calls`` protocol violations and infinite retries.
-        # Disable thinking only when the model is a known reasoner AND native
-        # tool calling is active.  Non-reasoning models ignore the parameter.
-        if use_native_tools and has_thinking_tags(self.binding, self.model):
-            completion_kwargs.setdefault("extra_body", {})["enable_thinking"] = False
+        _is_reasoner = has_thinking_tags(self.binding, self.model)
+
+        # Reasoning models (e.g. Qwen3.6-Plus) need ``enable_thinking``
+        # explicitly set so the API correctly handles thinking + tool_calls.
+        # When the binding already has a ``thinking_style`` (e.g. dashscope),
+        # ``build_provider_extra_kwargs`` handles this. But when the model is
+        # accessed via a generic binding (e.g. custom / OpenAI-compatible)
+        # that lacks ``thinking_style``, we must inject it here.
+        if _is_reasoner and use_native_tools:
+            _spec = find_by_name(self.binding)
+            if not (_spec and _spec.thinking_style):
+                completion_kwargs.setdefault("extra_body", {})["enable_thinking"] = True
 
         # When native tool calling is unavailable (no tool schemas), strip
         # the TOOL label from the protocol so the loop does not expect
@@ -460,12 +467,16 @@ class AgenticChatPipeline:
                 max_iterations=max(1, self._max_iterations),
                 host=host,
                 usage=self._usage,
-                # Reasoning models that natively emit ``<think>...</think>``
-                # without parroting back ``\`\`THINK\`\``` are gracefully
-                # accepted as a THINK iteration rather than treated as a
-                # protocol violation (which would burn budget on repair
-                # retries that the model can't actually satisfy).
-                implicit_think_label=LABEL_THINK,
+                # Reasoning models with native tool-calling support emit
+                # ``reasoning_content`` without parroting back
+                # ````THINK```` labels.  When the model is a reasoner
+                # AND native tool calling is active, use LABEL_FINISH so
+                # that a reply containing ``reasoning_content`` + answer
+                # text (but no explicit label) terminates the loop — the
+                # answer lives in ``content``, reasoning in
+                # ``reasoning_content``.  Non-reasoning models that emit
+                # ``<think/>`` tags get LABEL_THINK so the loop continues.
+                implicit_think_label=LABEL_FINISH if (_is_reasoner and use_native_tools) else LABEL_THINK,
             )
 
         if outcome.sources:
@@ -1240,6 +1251,40 @@ class AgenticChatPipeline:
             kb_note=self._kb_system_note(context),
         )
         return append_language_directive(system, self.language)
+
+    def _append_reasoner_protocol_note(self, system_prompt: str) -> str:
+        """Append a note for reasoning models that support native tool calling.
+
+        Reasoning models (e.g. Qwen3.6-Plus) emit reasoning via
+        ``reasoning_content`` and tool calls via native ``tool_calls``
+        deltas. The label protocol (TOOL/THINK/FINISH/PAUSE) confuses
+        them into writing tool-call JSON in ``content`` instead of using
+        the native mechanism. This note tells them to ignore labels and
+        use native tool calling directly.
+        """
+        if self.language == "zh":
+            note = (
+                "\n\n# 推理模型特别说明\n"
+                "你是一个原生支持推理和工具调用的模型。"
+                "请**忽略上面"输出协议"中关于 ``TOOL``/``THINK``/``FINISH``/``PAUSE`` 标签的指示**。"
+                "你不需要在回复中输出任何标签。"
+                "你的推理过程会自动在独立区域显示。"
+                "当你需要调用工具时，直接通过原生 tool_calls 功能发起调用，不要在文本中写 JSON。"
+                "当你准备好给出最终答案时，直接在回复正文中写出答案即可。"
+            )
+        else:
+            note = (
+                "\n\n# Reasoning Model Special Instructions\n"
+                "You are a model with native reasoning and tool-calling support. "
+                "Please **ignore the "Output Protocol" instructions above about "
+                "``TOOL``/``THINK``/``FINISH``/``PAUSE`` labels**. "
+                "You do NOT need to output any labels in your replies. "
+                "Your reasoning is automatically displayed in a separate area. "
+                "When you need to call a tool, use native tool_calls directly — "
+                "do NOT write JSON in your text output. "
+                "When you are ready to give the final answer, just write it in your reply body."
+            )
+        return system_prompt + note
 
     def _build_messages(
         self,

--- a/deeptutor/services/llm/capabilities.py
+++ b/deeptutor/services/llm/capabilities.py
@@ -105,6 +105,16 @@ PROVIDER_CAPABILITIES: dict[str, dict[str, object]] = {
         "supports_vision": True,
         "system_in_messages": True,
     },
+    # DashScope / Alibaba Cloud (Qwen family)
+    # Uses OpenAI-compatible API with native function calling support.
+    "dashscope": {
+        "supports_response_format": True,
+        "supports_streaming": True,
+        "supports_tools": True,
+        "supports_vision": False,  # Per-model; set True via MODEL_OVERRIDES
+        "system_in_messages": True,
+        "has_thinking_tags": True,  # Qwen reasoner models emit <think/> tags
+    },
     # Moonshot / Kimi — vision is per-model (see MODEL_OVERRIDES below).
     # Per the official docs the image input must be base64-encoded inline; URL
     # form is rejected. We therefore force the multimodal layer to resolve any

--- a/deeptutor/services/llm/capabilities.py
+++ b/deeptutor/services/llm/capabilities.py
@@ -36,7 +36,7 @@ PROVIDER_CAPABILITIES: dict[str, dict[str, object]] = {
         "supports_tools": True,  # Most OpenAI-compat endpoints support function calling
         "supports_vision": False,  # Per-model; set True via MODEL_OVERRIDES
         "system_in_messages": True,
-        "has_thinking_tags": True,  # Reasoning models (e.g. Qwen) may emit <think/> tags
+        "has_thinking_tags": False,  # Per-model; MODEL_OVERRIDES handles qwen/deepseek etc.
     },
     "azure_openai": {
         "supports_response_format": True,

--- a/deeptutor/services/llm/capabilities.py
+++ b/deeptutor/services/llm/capabilities.py
@@ -29,6 +29,15 @@ PROVIDER_CAPABILITIES: dict[str, dict[str, object]] = {
         "system_in_messages": True,  # System prompt goes in messages array
         "newer_models_use_max_completion_tokens": True,
     },
+    # Custom / user-defined OpenAI-compatible endpoints
+    "custom": {
+        "supports_response_format": True,
+        "supports_streaming": True,
+        "supports_tools": True,  # Most OpenAI-compat endpoints support function calling
+        "supports_vision": False,  # Per-model; set True via MODEL_OVERRIDES
+        "system_in_messages": True,
+        "has_thinking_tags": True,  # Reasoning models (e.g. Qwen) may emit <think/> tags
+    },
     "azure_openai": {
         "supports_response_format": True,
         "supports_streaming": True,


### PR DESCRIPTION
### Description
Fixes tool calling failures with reasoning models (Qwen 3.6 Plus, DeepSeek, etc.) when accessed through OpenAI-compatible endpoints. Resolves `UnboundLocalError` and enables proper native `tool_calls` support.

### Related Issues
- Closes #527

### Module(s) Affected
- [x] `agents`
- [x] `services`

### Changes Summary

| File | Change |
|------|--------|
| `deeptutor/agents/chat/agentic_pipeline.py` | Fix `_is_reasoner` variable order; add `enable_thinking` injection for reasoning models; add reasoner protocol note; adjust `implicit_think_label` logic |
| `deeptutor/services/llm/capabilities.py` | Add `custom` binding with `supports_tools: True`; add `dashscope` binding with full capabilities |

### Key Fixes

1. **Variable order fix**: Move `_is_reasoner = has_thinking_tags(...)` before first use
2. **Custom binding capabilities**: Enable `supports_tools` and per-model `has_thinking_tags` via MODEL_OVERRIDES
3. **DashScope binding**: Add official capability declaration
4. **Reasoning model handling**: Inject `enable_thinking=True` for reasoning models when binding lacks `thinking_style`
5. **Protocol adjustment**: Use `LABEL_FINISH` for reasoning models with native tool calling

### Tested
- [x] Qwen 3.6 Plus via custom OpenAI-compatible binding
- [x] RAG retrieval (tool calling) works correctly
- [x] Non-reasoning models (GPT-4o) unaffected via MODEL_OVERRIDES

### Checklist
- [x] I have read and followed the contribution guidelines
- [x] My code follows the project's coding standards
- [x] My changes do not introduce any new security vulnerabilities

### Commits
- `6f9af58` fix(chat): disable thinking mode for native tool calling and strip TOOL label when unavailable
- `b6a8183` fix(chat): only disable thinking for reasoning models when native tool calling is active
- `35ea0b1` fix: enable native tool_calls for reasoning models via custom OpenAI binding
- `4862185` fix: escape quotes in reasoner protocol note strings
- `2a0310a` fix(chat): fix Qwen 3.6 Plus tool call failures
- `551b98b` fix(capabilities): change custom binding has_thinking_tags to False
