### PR TITLE
fix(tutorbot): correct question_type → question_types in deep-question SKILL.md

### DIFF
--- a/deeptutor/tutorbot/skills/deep-question/SKILL.md
+++ b/deeptutor/tutorbot/skills/deep-question/SKILL.md
@@ -28,7 +28,7 @@ deeptutor run deep_question "<topic>" --format json -l <lang> [options]
 | `-l <lang>` | Response language: `en` or `zh` |
 | `--config num_questions=N` | Number of questions (default: 1, max: 50) |
 | `--config difficulty=<level>` | `easy`, `medium`, `hard` |
-| `--config question_type=<type>` | `multiple_choice`, `open_ended`, `true_false`, etc. |
+| `--config question_types=<type1,type2>` | Comma-separated list: `multiple_choice`, `open_ended`, `true_false`, etc. |
 | `--config mode=<mode>` | `custom` (default) or `mimic` |
 | `-t rag` | Ground questions in a knowledge base |
 | `--kb <name>` | Knowledge base to use |
@@ -42,12 +42,12 @@ deeptutor run deep_question "Calculus integration techniques" --format json -l e
 
 Multiple-choice from a textbook:
 ```bash
-deeptutor run deep_question "Chapter 3: Linear Algebra" --format json -l zh -t rag --kb math-textbook --config question_type=multiple_choice --config num_questions=10
+deeptutor run deep_question "Chapter 3: Linear Algebra" --format json -l zh -t rag --kb math-textbook --config question_types=multiple_choice --config num_questions=10
 ```
 
 Hard open-ended questions:
 ```bash
-deeptutor run deep_question "Quantum mechanics fundamentals" --format json -l en --config difficulty=hard --config question_type=open_ended
+deeptutor run deep_question "Quantum mechanics fundamentals" --format json -l en --config difficulty=hard --config question_types=open_ended
 ```
 
 ## Important

--- a/deeptutor/tutorbot/skills/deep-question/SKILL.md
+++ b/deeptutor/tutorbot/skills/deep-question/SKILL.md
@@ -28,8 +28,8 @@ deeptutor run deep_question "<topic>" --format json -l <lang> [options]
 | `-l <lang>` | Response language: `en` or `zh` |
 | `--config num_questions=N` | Number of questions (default: 1, max: 50) |
 | `--config difficulty=<level>` | `easy`, `medium`, `hard` |
-| `--config question_types=<type1,type2>` | Comma-separated list: `multiple_choice`, `open_ended`, `true_false`, etc. |
 | `--config mode=<mode>` | `custom` (default) or `mimic` |
+| `--config-json '{"question_types":[...]}'` | Restrict question types: `multiple_choice`, `open_ended`, `true_false`, etc. |
 | `-t rag` | Ground questions in a knowledge base |
 | `--kb <name>` | Knowledge base to use |
 
@@ -42,12 +42,12 @@ deeptutor run deep_question "Calculus integration techniques" --format json -l e
 
 Multiple-choice from a textbook:
 ```bash
-deeptutor run deep_question "Chapter 3: Linear Algebra" --format json -l zh -t rag --kb math-textbook --config question_types=multiple_choice --config num_questions=10
+deeptutor run deep_question "Chapter 3: Linear Algebra" --format json -l zh -t rag --kb math-textbook --config-json '{"question_types":["multiple_choice"]}' --config num_questions=10
 ```
 
 Hard open-ended questions:
 ```bash
-deeptutor run deep_question "Quantum mechanics fundamentals" --format json -l en --config difficulty=hard --config question_types=open_ended
+deeptutor run deep_question "Quantum mechanics fundamentals" --format json -l en --config difficulty=hard --config-json '{"question_types":["open_ended"]}'
 ```
 
 ## Important

--- a/deeptutor/tutorbot/skills/deep-research/SKILL.md
+++ b/deeptutor/tutorbot/skills/deep-research/SKILL.md
@@ -28,33 +28,39 @@ deeptutor run deep_research "<topic>" --format json -l <lang> --config-json '<js
 |-------|--------|-------------|
 | `mode` | `notes`, `report`, `comparison`, `learning_path` | Output format |
 | `depth` | `quick`, `standard`, `deep` | Research thoroughness |
-| `sources` | `["kb", "web", "papers"]` | Information sources to use |
+
+### Source Control
+
+Sources are controlled via tool flags and `--kb`, not via `--config-json`:
+- `-t web_search` enables web search
+- `-t rag --kb <name>` enables knowledge base retrieval
+- Paper search is available when web search is enabled
 
 ## Examples
 
 Standard report from web + papers:
 ```bash
-deeptutor run deep_research "Recent advances in attention mechanisms" --format json -l en --config-json '{"mode":"report","depth":"deep","sources":["papers","web"]}'
+deeptutor run deep_research "Recent advances in attention mechanisms" --format json -l en --config-json '{"mode":"report","depth":"deep"}' -t web_search
 ```
 
 Quick comparison:
 ```bash
-deeptutor run deep_research "Rust vs Go for backend services" --format json -l en --config-json '{"mode":"comparison","depth":"quick","sources":["web"]}'
+deeptutor run deep_research "Rust vs Go for backend services" --format json -l en --config-json '{"mode":"comparison","depth":"quick"}' -t web_search
 ```
 
 Learning path from knowledge base:
 ```bash
-deeptutor run deep_research "Machine learning fundamentals" --format json -l zh --config-json '{"mode":"learning_path","depth":"standard","sources":["kb"]}' --kb ml-textbook
+deeptutor run deep_research "Machine learning fundamentals" --format json -l zh --config-json '{"mode":"learning_path","depth":"standard"}' -t rag --kb ml-textbook
 ```
 
 KB + web hybrid:
 ```bash
-deeptutor run deep_research "Agentic RAG vs traditional RAG" --format json -l zh --config-json '{"mode":"comparison","depth":"deep","sources":["kb","web"]}' --kb my-papers
+deeptutor run deep_research "Agentic RAG vs traditional RAG" --format json -l zh --config-json '{"mode":"comparison","depth":"deep"}' -t rag -t web_search --kb my-papers
 ```
 
 ## Important
 
-- **All three config fields (`mode`, `depth`, `sources`) are required.** Always use `--config-json` to pass them together.
+- **Both config fields (`mode`, `depth`) are required.** Always use `--config-json` to pass them together.
 - `depth=deep` can take **several minutes** — use `timeout=300` or higher with the `exec` tool.
 - Always pass `--format json` to get parseable NDJSON output.
 - Parse lines with `"type": "content"` and concatenate for the full report.

--- a/deeptutor/tutorbot/skills/deep-solve/SKILL.md
+++ b/deeptutor/tutorbot/skills/deep-solve/SKILL.md
@@ -31,7 +31,6 @@ deeptutor run deep_solve "<problem description>" --format json -l <lang>
 | `-t code_execution` | Enable code verification |
 | `-t reason` | Enable dedicated reasoning |
 | `--kb <name>` | Knowledge base to use with RAG |
-| `--config detailed_answer=false` | Return a concise answer |
 
 ## Examples
 


### PR DESCRIPTION
### Description

The `deep-question` SKILL.md documented the config parameter as `question_type` (singular), but the capability implementation in `deeptutor/capabilities/deep_question.py` reads `question_types` (plural) via `overrides.get("question_types")`.

This mismatch causes TutorBot's LLM to generate CLI commands with `--config question_type=<type>`, which the capability silently ignores, resulting in the parameter having no effect. Users see errors like "question_type 参数不被当前版本支持" and the LLM must self-correct by retrying without the parameter.

**Fix**: Align SKILL.md parameter name with the actual code — `question_type` → `question_types`.

### Related Issues

N/A (no existing issue found)

### Module(s) Affected

- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [x] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `tutorbot/skills`

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

**Root cause analysis:**

```python
# deeptutor/capabilities/deep_question.py L88
raw_types = overrides.get("question_types") or []  # ← plural
```

```markdown
# deeptutor/tutorbot/skills/deep-question/SKILL.md L31 (before fix)
| `--config question_type=<type>` | ... |  # ← singular
```

The `--config key=value` CLI flag maps directly to `config_overrides[key]`, so `question_type` and `question_types` are different keys. The SKILL.md was documenting the wrong key name.