### PR TITLE
fix(web): preserve math before citation linkification

### DIFF
--- a/web/lib/markdown-display.ts
+++ b/web/lib/markdown-display.ts
@@ -138,6 +138,7 @@ const ALLOWED_HTML_TAGS = new Set<string>([
 const HTML_LIKE_TAG_REGEX = /<\/?([A-Za-z][A-Za-z0-9_-]*)\b[^<>]*?\/?>/g;
 const FENCED_CODE_BLOCK_REGEX = /```[\s\S]*?```/g;
 const INLINE_CODE_SPAN_REGEX = /`[^`\n]*`/g;
+const MATH_SPAN_REGEX = /\\\[[\s\S]*?\\\]|\\\([\s\S]*?\\\)|\$\$[\s\S]*?\$\$/g;
 const PROTECTED_SPAN_REGEX = /```[\s\S]*?```|`[^`\n]*`/g;
 const PROTECTED_PLACEHOLDER_REGEX = /\u0000PROTECTED_(\d+)\u0000/g;
 const HTML_ATTR_VALUE = /(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+)/.source;
@@ -468,13 +469,16 @@ function linkifyCitationsOutsideCode(content: string): string {
     FENCED_CODE_BLOCK_REGEX,
     "FENCED_CODE",
   );
-  const unwrapped = unwrapBacktickedCitations(fenced.masked);
+  const math = maskProtectedSpans(fenced.masked, MATH_SPAN_REGEX, "MATH");
+  const unwrapped = unwrapBacktickedCitations(math.masked);
   const inline = maskProtectedSpans(
     unwrapped,
     INLINE_CODE_SPAN_REGEX,
     "INLINE_CODE",
   );
-  return fenced.restore(inline.restore(linkifyCitations(inline.masked)));
+  return fenced.restore(
+    math.restore(inline.restore(linkifyCitations(inline.masked))),
+  );
 }
 
 export function normalizeMarkdownForDisplay(content: string): string {

--- a/web/tests/markdown-display.test.ts
+++ b/web/tests/markdown-display.test.ts
@@ -73,6 +73,20 @@ test("normalizeMarkdownForDisplay keeps array indexes inside inline code", () =>
   assert.equal(normalizeMarkdownForDisplay(input), input);
 });
 
+test("normalizeMarkdownForDisplay keeps bracketed vectors inside display math", () => {
+  const input = ["The row for `sat` is:", "", "\\[", "[1, 1, 2]", "\\]"].join(
+    "\n",
+  );
+  assert.equal(normalizeMarkdownForDisplay(input), input);
+});
+
+test("normalizeMarkdownForDisplay keeps bracketed vectors inside weighted math", () => {
+  const input = ["\\[", "0.212[1, 1] + 0.212[2, 0] + 0.576[0, 3]", "\\]"].join(
+    "\n",
+  );
+  assert.equal(normalizeMarkdownForDisplay(input), input);
+});
+
 test("normalizeMarkdownForDisplay unwraps explicit citation code spans outside code", () => {
   assert.equal(
     normalizeMarkdownForDisplay("See `[web-1]` for details."),


### PR DESCRIPTION
### Description
Fixes a markdown rendering regression where numeric arrays inside LaTeX math were treated as citations before KaTeX rendered them.

The citation normalizer already protected fenced and inline code, but it did not protect math spans. As a result, vectors such as `[1, 1, 2]` inside `\[...\]` were rewritten into reference links first. KaTeX then received markdown link syntax inside math and displayed a red parse error instead of the formula.

This change masks display and inline math spans before citation linkification, then restores them afterward. Citation links outside math still behave the same way.

### Related Issues

N/A (no existing issue found)

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

Root cause: `normalizeMarkdownForDisplay()` ran citation linkification before math rendering while protecting code spans only. Numeric vectors and weighted expressions are valid math content, but they also match the citation-link pattern.

Validation:
- `npm run test:node` — 108 passed
- `npm run build` — passed
- `uv run --with pre-commit pre-commit run --files web/lib/markdown-display.ts web/tests/markdown-display.test.ts` — passed
- `pre-commit run --all-files` was attempted via `uv run --with pre-commit pre-commit run --all-files`; it failed because hooks reformatted 34 unrelated files already present on the `dev` base (`end-of-file-fixer`, `ruff-format`, and `prettier`). Those unrelated hook changes were not included in this PR.