### PR TITLE
fix(chat): route OAuth backend through native provider

### DIFF
--- a/deeptutor/core/agentic/client.py
+++ b/deeptutor/core/agentic/client.py
@@ -50,14 +50,21 @@ def build_openai_client(config: LLMClientConfig) -> Any:
     if spec and spec.backend == "anthropic":
         from deeptutor.services.llm.provider_core import AnthropicProvider
 
-        provider = AnthropicProvider(
+        anthropic_provider = AnthropicProvider(
             api_key=config.api_key,
             api_base=config.base_url or spec.default_api_base or None,
             default_model=config.model or "claude-sonnet-4-20250514",
             extra_headers=config.extra_headers,
             supports_prompt_caching=spec.supports_prompt_caching,
         )
-        return _AnthropicOpenAIAdapter(provider)
+        return _AnthropicOpenAIAdapter(anthropic_provider)
+    if spec and spec.backend == "openai_codex":
+        from deeptutor.services.llm.provider_core import OpenAICodexProvider
+
+        oauth_provider = OpenAICodexProvider(
+            default_model=config.model or "openai-codex/gpt-5.1-codex",
+        )
+        return _AnthropicOpenAIAdapter(oauth_provider)
 
     http_client = None
     if load_system_settings()["disable_ssl_verify"]:

--- a/tests/core/test_agentic_client_provider_kwargs.py
+++ b/tests/core/test_agentic_client_provider_kwargs.py
@@ -115,6 +115,31 @@ def test_build_openai_client_routes_anthropic_backend_through_adapter(monkeypatc
     assert captured["extra_headers"] == {"X-Test": "1"}
 
 
+def test_build_openai_client_routes_oauth_backend_through_adapter(monkeypatch) -> None:
+    captured = {}
+
+    class FakeProvider:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "deeptutor.services.llm.provider_core.OpenAICodexProvider",
+        FakeProvider,
+    )
+
+    client = build_openai_client(
+        LLMClientConfig(
+            binding="openai_codex",
+            model="openai-codex/gpt-5.5",
+            api_key="unused",
+            base_url="https://chatgpt.com/backend-api",
+        )
+    )
+
+    assert isinstance(client, _AnthropicOpenAIAdapter)
+    assert captured["default_model"] == "openai-codex/gpt-5.5"
+
+
 def test_anthropic_backend_can_use_native_tool_calling() -> None:
     assert can_use_native_tool_calling(binding="custom_anthropic", model="claude-test") is True
     assert can_use_native_tool_calling(binding="minimax_anthropic", model="MiniMax-M2") is True


### PR DESCRIPTION
### Description
Fixes chat failures for the OAuth-backed LLM profile in the agentic client factory.

The provider registry already identifies this profile as a native OAuth backend, and the runtime provider factory routes it through the dedicated native provider. The agentic chat client factory missed that routing branch and fell through to a generic `AsyncOpenAI` client instead. With the Settings base URL set to `https://chatgpt.com/backend-api`, the Python backend attempted a generic chat-completions request and received an HTML browser challenge where JSON was expected.

This change routes that backend through the existing OpenAI-style adapter backed by the native provider, matching the routing used by the general LLM runtime.

### Related Issues

N/A (no existing issue found)

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [x] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

Root cause: `build_openai_client()` only special-cased the Anthropic backend before constructing a generic OpenAI-compatible SDK client. Native OAuth-backed chat needs the existing native provider path instead.

Files changed:
- `deeptutor/core/agentic/client.py`
- `tests/core/test_agentic_client_provider_kwargs.py`

Validation:
- `uv run --with pytest --with pytest-asyncio pytest tests/core/test_agentic_client_provider_kwargs.py -q` — 12 passed
- `uv run --with pre-commit pre-commit run --files deeptutor/core/agentic/client.py tests/core/test_agentic_client_provider_kwargs.py` — passed