### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/tests/core/test_agentic_client_provider_kwargs.py
+++ b/tests/core/test_agentic_client_provider_kwargs.py
@@ -117,7 +117,7 @@ def test_build_openai_client_routes_anthropic_backend_through_adapter(monkeypatc
 
 def test_anthropic_backend_can_use_native_tool_calling() -> None:
     assert can_use_native_tool_calling(binding="custom_anthropic", model="claude-test") is True
-    assert can_use_native_tool_calling(binding="minimax_anthropic", model="MiniMax-M2") is True
+    assert can_use_native_tool_calling(binding="minimax_anthropic", model="MiniMax-M3") is True
 
 
 def test_custom_qwen_can_use_native_tool_calling() -> None:

--- a/tests/services/config/test_provider_runtime.py
+++ b/tests/services/config/test_provider_runtime.py
@@ -143,7 +143,7 @@ def test_llm_minimax_binding_uses_minimaxi_endpoint() -> None:
             "api_key": "minimax-key",
             "api_version": "",
             "extra_headers": {},
-            "models": [{"id": "llm-m", "name": "m", "model": "MiniMax-M2.7"}],
+            "models": [{"id": "llm-m", "name": "m", "model": "MiniMax-M3"}],
         }
     )
     resolved = resolve_llm_runtime_config(catalog=catalog)

--- a/tests/services/llm/test_capabilities.py
+++ b/tests/services/llm/test_capabilities.py
@@ -61,6 +61,12 @@ def test_moonshot_vision_models() -> None:
 def test_minimax_openai_compat_supports_tools_without_response_format() -> None:
     """MiniMax M-series models support OpenAI-compatible tool calls, but
     the provider still should not receive json_object response_format."""
+    # M3 is the current default model (512K context, image input support).
+    assert supports_tools("minimax", "MiniMax-M3") is True
+    assert supports_response_format("minimax", "MiniMax-M3") is False
+    # M2.7 and M2.7-highspeed remain as alternatives.
+    assert supports_tools("minimax", "MiniMax-M2.7") is True
+    assert supports_response_format("minimax", "MiniMax-M2.7") is False
     assert supports_tools("minimax", "MiniMax-M2.7-highspeed") is True
     assert supports_response_format("minimax", "MiniMax-M2.7-highspeed") is False
 


### PR DESCRIPTION
## Summary
Upgrade MiniMax model references in tests to use **MiniMax-M3** as the current default, while still asserting capability behavior for the M2.7 family that remains supported.

## Changes
- `tests/services/llm/test_capabilities.py` — extend `test_minimax_openai_compat_supports_tools_without_response_format` to cover `MiniMax-M3` and `MiniMax-M2.7` in addition to the existing `MiniMax-M2.7-highspeed` assertions.
- `tests/services/config/test_provider_runtime.py` — update the sample MiniMax model from `MiniMax-M2.7` to `MiniMax-M3` in `test_llm_minimax_binding_uses_minimaxi_endpoint` so the test exercises the new default model.
- `tests/core/test_agentic_client_provider_kwargs.py` — update the `minimax_anthropic` native-tool-calling assertion from `MiniMax-M2` to `MiniMax-M3`. (`MiniMax-M2` is no longer a first-class target on the MiniMax side.)

## Why
MiniMax-M3 is the current default model on the MiniMax platform. It introduces:
- 512K context window
- 128K max output
- Image input support on both OpenAI-compatible and Anthropic-compatible endpoints

DeepTutor's MiniMax / `minimax_anthropic` providers already accept arbitrary model strings, so the only meaningful in-tree change is to refresh the model identifiers used in tests so they match what users will actually configure today. The provider capability matrix (no `response_format`, tools enabled, etc.) is unchanged.

## Test Plan
- Existing tests still cover `MiniMax-M2.7-highspeed` behavior.
- New assertions confirm `MiniMax-M3` and `MiniMax-M2.7` get the same capability flags via the existing provider entry (`supports_tools=True`, `supports_response_format=False`).
- No production code paths were touched — provider registry, capabilities map, and reasoning params remain as-is.