### PR TITLE
fix: 将 Heartbeat 通知广播到所有已绑定的 Channel

### DIFF
--- a/deeptutor/services/tutorbot/manager.py
+++ b/deeptutor/services/tutorbot/manager.py
@@ -512,6 +512,28 @@ class TutorBotManager:
             )
 
         async def _hb_notify(response: str) -> None:
+            from deeptutor.tutorbot.bus.events import OutboundMessage
+
+            # 1. Broadcast to all bound channels (telegram, zulip, etc.)
+            for ch_name, ch_chat_id in dict(instance.channel_bindings).items():
+                if instance.channel_manager:
+                    channel = instance.channel_manager.get_channel(ch_name)
+                    if channel:
+                        try:
+                            await channel.send(
+                                OutboundMessage(
+                                    channel=ch_name,
+                                    chat_id=ch_chat_id,
+                                    content=response,
+                                )
+                            )
+                        except Exception:
+                            logger.exception(
+                                "Heartbeat: failed to send to channel %s for bot %s",
+                                ch_name,
+                                bot_id,
+                            )
+            # 2. Also deliver to web clients via notify_queue
             await instance.notify_queue.put(response)
 
         heartbeat = HeartbeatService(

--- a/deeptutor/services/tutorbot/manager.py
+++ b/deeptutor/services/tutorbot/manager.py
@@ -514,6 +514,19 @@ class TutorBotManager:
         async def _hb_notify(response: str) -> None:
             from deeptutor.tutorbot.bus.events import OutboundMessage
 
+            # Guard: if the agent decided to skip (e.g. outside active time
+            # window), do not push the skip rationale to any channel or web
+            # client.  This can happen when Phase 1 (_decide) returns "run"
+            # but the agent loop (Phase 2) still concludes it should skip.
+            lower = response.lower()
+            skip_keywords = ("skip", "不打扰", "不需要打扰", "无需打扰", "不需要通知")
+            if any(kw in lower for kw in skip_keywords):
+                logger.info(
+                    "Heartbeat: response contains skip decision, suppressing delivery for bot %s",
+                    bot_id,
+                )
+                return
+
             # 1. Broadcast to all bound channels (telegram, zulip, etc.)
             for ch_name, ch_chat_id in dict(instance.channel_bindings).items():
                 if instance.channel_manager:


### PR DESCRIPTION
转到 #556 重构 Heartbeat 广播


### Description

**Bug：Heartbeat 消息无法投递到外部 Channel**

TutorBot 的 Heartbeat 服务产生的响应仅投递到 `notify_queue`（Web Chat WebSocket 专用通道），外部 channel（Telegram、Zulip、Discord、WeCom 等）完全收不到 heartbeat 通知。

**根因分析：**

`_hb_execute` 硬编码 `channel="web", chat_id="web"`，产生的 `OutboundMessage` 经 `_outbound_router` 路由时，`get_channel("web")` 无法匹配任何已注册的外部 channel，消息被静默丢弃。Web Chat 能收到仅因为它通过 `notify_queue` 的第二条路径投递，与 channel 路由无关。

**修复方案：**

修改 `_hb_notify` 回调，在投递 `notify_queue` 之前，先遍历 `channel_bindings`（记录了所有活跃 channel→chat_id 的映射），构造 `OutboundMessage` 并通过对应 channel 的 `send()` 方法广播。具体措施：

1. 遍历 `dict(instance.channel_bindings)` 快照（避免与 `_outbound_router` 并发修改的竞态）
2. 对每个已绑定 channel 构造 `OutboundMessage` 并调用 `channel.send()`
3. 每个 channel 发送失败独立处理，不影响其他 channel
4. 最后仍投递 `notify_queue` 供 Web Chat 消费（保持原有行为）

**向后兼容：** 如果 Bot 尚未收到任何 channel 消息（`channel_bindings` 为空），则 heartbeat 仅推送到 Web Chat，行为与原来完全一致。



### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

**修改文件：** `deeptutor/services/tutorbot/manager.py` — `_hb_notify` 函数（+22 行）

**影响范围：** 仅影响 TutorBot Heartbeat 的通知投递路径，不影响正常的消息收发流程。

**已测试：** 在 Zulip channel 上验证通过——用户先通过 Zulip 发送消息建立 channel_binding 后，heartbeat 消息成功投递到 Zulip。