### PR TITLE
fix: keep NEXT_PUBLIC_AUTH_ENABLED out of the minifier constant-fold

### DIFF
--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -131,12 +131,22 @@ export function wsUrl(path: string): string {
   return `${normalizedBase}${normalizedPath}`;
 }
 
-// Evaluate the build-time flag at runtime (not a ``=== "true"`` compare) so the
-// Docker ``__NEXT_PUBLIC_AUTH_ENABLED_PLACEHOLDER__`` token survives minification
-// and ``start-frontend.sh`` can rewrite it on startup. See lib/auth.ts.
-const AUTH_ENABLED = /^(1|true|yes|on)$/i.test(
-  (process.env.NEXT_PUBLIC_AUTH_ENABLED ?? "").trim(),
-);
+/**
+ * Parse a ``NEXT_PUBLIC_AUTH_ENABLED``-style flag at runtime.
+ *
+ * The value is inlined at build time and, in the Docker image, baked as the
+ * ``__NEXT_PUBLIC_AUTH_ENABLED_PLACEHOLDER__`` token that ``start-frontend.sh``
+ * rewrites on container start. Evaluating it with a runtime regex — instead of
+ * a ``=== "true"`` literal comparison the minifier would constant-fold — keeps
+ * the placeholder in the bundle so it survives minification (the same approach
+ * used for the API base placeholder above). An unsubstituted placeholder
+ * therefore parses as "disabled".
+ */
+export function parseAuthEnabled(raw: string | undefined): boolean {
+  return /^(1|true|yes|on)$/i.test((raw ?? "").trim());
+}
+
+const AUTH_ENABLED = parseAuthEnabled(process.env.NEXT_PUBLIC_AUTH_ENABLED);
 
 /**
  * Authenticated fetch wrapper. Behaves identically to `fetch` but automatically

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -131,7 +131,12 @@ export function wsUrl(path: string): string {
   return `${normalizedBase}${normalizedPath}`;
 }
 
-const AUTH_ENABLED = process.env.NEXT_PUBLIC_AUTH_ENABLED === "true";
+// Evaluate the build-time flag at runtime (not a ``=== "true"`` compare) so the
+// Docker ``__NEXT_PUBLIC_AUTH_ENABLED_PLACEHOLDER__`` token survives minification
+// and ``start-frontend.sh`` can rewrite it on startup. See lib/auth.ts.
+const AUTH_ENABLED = /^(1|true|yes|on)$/i.test(
+  (process.env.NEXT_PUBLIC_AUTH_ENABLED ?? "").trim(),
+);
 
 /**
  * Authenticated fetch wrapper. Behaves identically to `fetch` but automatically

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -1,14 +1,13 @@
-import { apiFetch, apiUrl } from "@/lib/api";
+import { apiFetch, apiUrl, parseAuthEnabled } from "@/lib/api";
 
 // ``NEXT_PUBLIC_AUTH_ENABLED`` is inlined at build time and, in the Docker
 // image, baked as the ``__NEXT_PUBLIC_AUTH_ENABLED_PLACEHOLDER__`` token that
-// ``start-frontend.sh`` rewrites on container start. A ``=== "true"`` literal
-// comparison gets constant-folded by the minifier to ``false`` — which strips
-// the placeholder and permanently breaks the runtime rewrite. Evaluating the
-// raw value with a runtime regex keeps the placeholder string in the bundle
-// (mirroring how ``lib/api.ts`` handles the API base placeholder).
-export const AUTH_ENABLED = /^(1|true|yes|on)$/i.test(
-  (process.env.NEXT_PUBLIC_AUTH_ENABLED ?? "").trim(),
+// ``start-frontend.sh`` rewrites on container start. ``parseAuthEnabled``
+// evaluates it at runtime (not a ``=== "true"`` literal comparison) so the
+// minifier cannot constant-fold the check and strip the placeholder, which
+// would permanently break the runtime rewrite. See lib/api.ts.
+export const AUTH_ENABLED = parseAuthEnabled(
+  process.env.NEXT_PUBLIC_AUTH_ENABLED,
 );
 
 export interface AuthStatus {

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -1,6 +1,15 @@
 import { apiFetch, apiUrl } from "@/lib/api";
 
-export const AUTH_ENABLED = process.env.NEXT_PUBLIC_AUTH_ENABLED === "true";
+// ``NEXT_PUBLIC_AUTH_ENABLED`` is inlined at build time and, in the Docker
+// image, baked as the ``__NEXT_PUBLIC_AUTH_ENABLED_PLACEHOLDER__`` token that
+// ``start-frontend.sh`` rewrites on container start. A ``=== "true"`` literal
+// comparison gets constant-folded by the minifier to ``false`` — which strips
+// the placeholder and permanently breaks the runtime rewrite. Evaluating the
+// raw value with a runtime regex keeps the placeholder string in the bundle
+// (mirroring how ``lib/api.ts`` handles the API base placeholder).
+export const AUTH_ENABLED = /^(1|true|yes|on)$/i.test(
+  (process.env.NEXT_PUBLIC_AUTH_ENABLED ?? "").trim(),
+);
 
 export interface AuthStatus {
   enabled: boolean;

--- a/web/tests/auth-enabled.test.ts
+++ b/web/tests/auth-enabled.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { parseAuthEnabled } from "../lib/api";
+
+test("parseAuthEnabled is true for accepted truthy flags", () => {
+  for (const value of ["true", "1", "yes", "on", "TRUE", " true "]) {
+    assert.equal(
+      parseAuthEnabled(value),
+      true,
+      `expected ${JSON.stringify(value)} -> true`,
+    );
+  }
+});
+
+test("parseAuthEnabled is false for falsy / empty / undefined", () => {
+  for (const value of ["false", "0", "no", "off", "", undefined]) {
+    assert.equal(
+      parseAuthEnabled(value),
+      false,
+      `expected ${JSON.stringify(value)} -> false`,
+    );
+  }
+});
+
+// Guards the failure mode this flag was hardened against: if the Docker
+// placeholder is ever served unsubstituted, it must read as "disabled" rather
+// than throwing or accidentally enabling auth.
+test("parseAuthEnabled treats an unsubstituted Docker placeholder as disabled", () => {
+  assert.equal(
+    parseAuthEnabled("__NEXT_PUBLIC_AUTH_ENABLED_PLACEHOLDER__"),
+    false,
+  );
+});


### PR DESCRIPTION
### Description
With auth enabled, none of the auth UI shows up in the Docker image — no Admin
link, no Sign out, and the 401 → /login redirect never fires — even though the
backend auth works fine.

The problem is how the build-time flag is read. Both `lib/auth.ts` and
`lib/api.ts` do:

    const AUTH_ENABLED = process.env.NEXT_PUBLIC_AUTH_ENABLED === "true";

In the Docker build the value is injected as the literal
`__NEXT_PUBLIC_AUTH_ENABLED_PLACEHOLDER__`, and `start-frontend.sh` rewrites it
on container start. But since this is a `"<literal>" === "true"` comparison, the
minifier folds it down to `false` at build time and drops the placeholder
completely. By the time the startup script runs there's nothing left to
substitute, so the client flag is stuck at `false`.

`NEXT_PUBLIC_API_BASE` avoids this because it's used as a plain string and never
compared against a literal, so its placeholder survives minification.

The fix reads the raw value and evaluates it at runtime, which keeps the
placeholder in the bundle:

    const AUTH_ENABLED = /^(1|true|yes|on)$/i.test(
      (process.env.NEXT_PUBLIC_AUTH_ENABLED ?? "").trim(),
    );

After this, `start-frontend.sh` can substitute the placeholder as intended and
the auth UI appears when auth is on.

How to reproduce on `dev`: build the image, enable auth (`auth.json`
`enabled: true` or `AUTH_ENABLED=true`), start the container, and grep the built
bundle — `AUTH_ENABLED` is baked as `false` and the placeholder is gone. With
this change the placeholder is preserved and rewritten to `true` at startup.

---

Notes:
- Ran `pre-commit run --all-files`; my changes pass. Two unrelated failures
  already exist on `dev` and are left untouched as out of scope: a duplicate key
  in `web/locales/{en,zh}/app.json` (check-json), and Unix-only `os.getpgid` /
  `killpg` in `runtime/launcher.py` that mypy flags on Windows.
- Added unit tests (`web/tests/auth-enabled.test.ts`, node:test) for the flag
  parsing — accepted truthy values, falsy/empty/undefined, and that an
  unsubstituted Docker placeholder reads as disabled. After extracting the
  shared `parseAuthEnabled` helper, the placeholder still survives minification
  (verified with a production build), so the runtime rewrite is unaffected.

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.