### PR TITLE
fix: sidebar footer items stay as text when the sidebar is collapsed

### DIFF
--- a/web/components/sidebar/SidebarShell.tsx
+++ b/web/components/sidebar/SidebarShell.tsx
@@ -98,7 +98,12 @@ interface SidebarShellProps {
   onSelectSession?: (sessionId: string) => void | Promise<void>;
   onRenameSession?: (sessionId: string, title: string) => void | Promise<void>;
   onDeleteSession?: (sessionId: string) => void | Promise<void>;
-  footerSlot?: ReactNode;
+  /**
+   * Footer content rendered below the nav. Pass a render function to receive
+   * the current ``collapsed`` state so footer items (e.g. Admin / Sign out) can
+   * switch to their icon-only variant when the rail is collapsed.
+   */
+  footerSlot?: ReactNode | ((collapsed: boolean) => ReactNode);
 }
 
 export function SidebarShell({
@@ -117,6 +122,8 @@ export function SidebarShell({
   const { t } = useTranslation();
   const { sidebarCollapsed: collapsed, setSidebarCollapsed: setCollapsed } =
     useAppShell();
+  const renderedFooter =
+    typeof footerSlot === "function" ? footerSlot(collapsed) : footerSlot;
   const [recentsCollapsed, setRecentsCollapsed] = useState(false);
 
   // Hydrate Recents collapse from localStorage after first render to stay SSR-safe.
@@ -236,7 +243,7 @@ export function SidebarShell({
               </Link>
             );
           })}
-          {footerSlot}
+          {renderedFooter}
           <a
             href={DOCS_URL}
             target="_blank"
@@ -389,7 +396,7 @@ export function SidebarShell({
             </Link>
           );
         })}
-        {footerSlot}
+        {renderedFooter}
         <div className="mt-0.5 flex items-center gap-0.5">
           <VersionBadge />
           <a

--- a/web/components/sidebar/UtilitySidebar.tsx
+++ b/web/components/sidebar/UtilitySidebar.tsx
@@ -90,12 +90,12 @@ export default function UtilitySidebar() {
       onSelectSession={handleSelectSession}
       onRenameSession={handleRenameSession}
       onDeleteSession={handleDeleteSession}
-      footerSlot={
+      footerSlot={(collapsed) => (
         <>
-          <AdminLink />
-          <LogoutButton />
+          <AdminLink collapsed={collapsed} />
+          <LogoutButton collapsed={collapsed} />
         </>
-      }
+      )}
     />
   );
 }

--- a/web/components/sidebar/WorkspaceSidebar.tsx
+++ b/web/components/sidebar/WorkspaceSidebar.tsx
@@ -132,12 +132,12 @@ export default function WorkspaceSidebar() {
       onSelectSession={handleSelectSession}
       onRenameSession={handleRenameSession}
       onDeleteSession={handleDeleteSession}
-      footerSlot={
+      footerSlot={(collapsed) => (
         <>
-          <AdminLink />
-          <LogoutButton />
+          <AdminLink collapsed={collapsed} />
+          <LogoutButton collapsed={collapsed} />
         </>
-      }
+      )}
     />
   );
 }


### PR DESCRIPTION
### Description
When auth is enabled and the sidebar is collapsed, the footer items (Admin and
Sign out) keep rendering as full-width text inside the narrow 60px rail instead
of shrinking to icons like the rest of the nav.

`AdminLink` and `LogoutButton` already have an icon-only mode behind a
`collapsed` prop, but `SidebarShell` renders `footerSlot` as a static node and
never passes the collapsed state down, so the prop stays `false` in both the
expanded and collapsed layouts.

This changes `footerSlot` to also accept a render function that receives the
current `collapsed` state, and updates both sidebars to forward it:

    footerSlot={(collapsed) => (
      <>
        <AdminLink collapsed={collapsed} />
        <LogoutButton collapsed={collapsed} />
      </>
    )}

Plain nodes are still accepted, so nothing else needs to change.

### Before / After (collapsed sidebar)

| Before | After |
|--------|-------|
|<img width="122" height="907" alt="image" src="https://github.com/user-attachments/assets/e72bb1e8-9b4b-4b11-8d9c-f5097d46d09e" /> | <img width="105" height="903" alt="image" src="https://github.com/user-attachments/assets/fdf313ef-7307-4323-91b8-5689ddb733b5" />|

### Reproducing

The footer items only render when auth is enabled, so reproduce with auth on
(e.g. `npm run dev` with auth configured), then collapse the sidebar — Admin and
Sign out overflow the rail as text.

In the Docker image you also need #549 for the footer to show up at all
(`NEXT_PUBLIC_AUTH_ENABLED` was being constant-folded to `false`), but the two
changes are independent — this one is purely the collapsed-rendering fix.

---

Notes:
- Ran `pre-commit run --all-files`; my changes pass. The only failures are
  pre-existing on `dev` and unrelated to this change (a duplicate key in
  `web/locales/{en,zh}/app.json`, and Unix-only `os` attributes in
  `runtime/launcher.py` flagged by mypy on Windows).
- No tests added: this is prop wiring for a presentational component. Can add a
  render test if you'd prefer.

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.
