### PR TITLE
fix: surface bad-login error inline instead of silent page reload

### DIFF
--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -136,14 +136,25 @@ const AUTH_ENABLED = process.env.NEXT_PUBLIC_AUTH_ENABLED === "true";
 /**
  * Authenticated fetch wrapper. Behaves identically to `fetch` but automatically
  * redirects to /login when the backend returns 401 (expired / invalid token).
+ *
+ * Pass `skipAuthRedirect: true` for endpoints where a 401 is an expected,
+ * recoverable response that the caller wants to handle inline — most notably
+ * the login/register endpoints, where 401 means "wrong credentials" and must
+ * surface as a form error rather than reload the page.
  */
 export async function apiFetch(
   input: RequestInfo | URL,
-  init?: RequestInit,
+  init?: RequestInit & { skipAuthRedirect?: boolean },
 ): Promise<Response> {
-  const res = await fetch(input, { credentials: "include", ...init });
+  const { skipAuthRedirect, ...fetchInit } = init ?? {};
+  const res = await fetch(input, { credentials: "include", ...fetchInit });
 
-  if (res.status === 401 && AUTH_ENABLED && typeof window !== "undefined") {
+  if (
+    res.status === 401 &&
+    AUTH_ENABLED &&
+    !skipAuthRedirect &&
+    typeof window !== "undefined"
+  ) {
     const next = encodeURIComponent(window.location.pathname);
     window.location.href = `/login?next=${next}`;
     return new Promise(() => {});

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -37,6 +37,9 @@ export async function login(
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username, password }),
+      // A 401 here means "wrong credentials", not an expired session — handle it
+      // inline as a form error instead of triggering the global login redirect.
+      skipAuthRedirect: true,
     });
 
     if (res.ok) return { ok: true };
@@ -80,6 +83,9 @@ export async function register(
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username, password }),
+      // Registration validation failures (e.g. 400/401) should surface inline
+      // rather than bounce the user through the global login redirect.
+      skipAuthRedirect: true,
     });
 
     const data = await res.json().catch(() => ({}));

--- a/web/tests/api-auth-redirect.test.ts
+++ b/web/tests/api-auth-redirect.test.ts
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// AUTH_ENABLED and API_BASE_URL are read at module-load time, so the environment
+// must be configured before the module under test is imported.
+process.env.NEXT_PUBLIC_API_BASE = "http://localhost:8001/api";
+process.env.NEXT_PUBLIC_AUTH_ENABLED = "true";
+
+let apiModulePromise: Promise<typeof import("../lib/api")> | null = null;
+
+async function loadApiModule(): Promise<typeof import("../lib/api")> {
+  apiModulePromise ??= import("../lib/api");
+  return apiModulePromise;
+}
+
+// Install a fake `window` whose `location.href` assignment is recorded instead
+// of triggering a real navigation, so we can assert whether apiFetch redirected.
+function installWindow(pathname: string): {
+  redirectedTo: () => string | null;
+} {
+  let redirect: string | null = null;
+  const location = { pathname, href: "" };
+  Object.defineProperty(location, "href", {
+    get: () => redirect ?? "",
+    set: (value: string) => {
+      redirect = value;
+    },
+    configurable: true,
+  });
+  (globalThis as { window?: unknown }).window = { location };
+  return { redirectedTo: () => redirect };
+}
+
+function clearWindow(): void {
+  delete (globalThis as { window?: unknown }).window;
+}
+
+// Replace global fetch with one that always yields the given response.
+function stubFetch(response: Response): () => void {
+  const original = globalThis.fetch;
+  (globalThis as { fetch: typeof fetch }).fetch = async () => response;
+  return () => {
+    (globalThis as { fetch: typeof fetch }).fetch = original;
+  };
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Let pending microtasks run so apiFetch's async body reaches the redirect
+// branch. The call itself must NOT be awaited there: on redirect apiFetch
+// returns a promise that never resolves.
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test("apiFetch redirects to /login on 401 when auth is enabled and no opt-out", async () => {
+  const { apiFetch } = await loadApiModule();
+  const win = installWindow("/dashboard");
+  const restore = stubFetch(jsonResponse(401, { detail: "unauthorized" }));
+  try {
+    // Do not await: apiFetch returns a never-resolving promise once it redirects.
+    void apiFetch("http://localhost:8001/api/v1/knowledge/list");
+    await tick();
+    assert.equal(win.redirectedTo(), "/login?next=%2Fdashboard");
+  } finally {
+    restore();
+    clearWindow();
+  }
+});
+
+test("apiFetch does NOT redirect on 401 when skipAuthRedirect is set", async () => {
+  // Regression guard: the login endpoint returns 401 for wrong credentials, and
+  // that must reach the caller as an inline error instead of reloading the page.
+  const { apiFetch } = await loadApiModule();
+  const win = installWindow("/login");
+  const restore = stubFetch(
+    jsonResponse(401, { detail: "Incorrect username or password" }),
+  );
+  try {
+    const res = await apiFetch("http://localhost:8001/api/v1/auth/login", {
+      method: "POST",
+      skipAuthRedirect: true,
+    });
+    assert.equal(res.status, 401);
+    assert.equal(win.redirectedTo(), null);
+    const data = (await res.json()) as { detail?: string };
+    assert.equal(data.detail, "Incorrect username or password");
+  } finally {
+    restore();
+    clearWindow();
+  }
+});
+
+test("apiFetch passes successful responses through without redirecting", async () => {
+  const { apiFetch } = await loadApiModule();
+  const win = installWindow("/dashboard");
+  const restore = stubFetch(jsonResponse(200, { ok: true }));
+  try {
+    const res = await apiFetch("http://localhost:8001/api/v1/auth/status");
+    assert.equal(res.status, 200);
+    assert.equal(win.redirectedTo(), null);
+  } finally {
+    restore();
+    clearWindow();
+  }
+});


### PR DESCRIPTION
### Description
When auth is enabled, submitting **wrong credentials** on the login form gave the
user no feedback: the page silently reloaded and the only trace was a `401` in the
console.

**Root cause.** The global 401 interceptor in `apiFetch` (`web/lib/api.ts`) redirects
to `/login` and returns a never-resolving promise on **every** 401. The login and
register requests go through `apiFetch` too, so a 401 from wrong credentials triggered
a full-page reload back to `/login`, and `login()` never resolved — `handleSubmit`
never reached `setError`, so no inline error was ever shown.

**Fix.** Add an opt-out `skipAuthRedirect` flag to `apiFetch` and pass it from the
`login()` and `register()` calls, so their `401`/`400` responses are returned to the
caller and rendered as inline form errors. The expired-session redirect still applies
to every other endpoint, unchanged.

### Related Issues
- N/A — no existing issue; this was unreported.

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the contribution guidelines.
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit` and fixed any issues. <!-- run on the changed files; all hooks pass -->
- [x] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary). <!-- not needed -->
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

**Behavior**
| | Before | After |
|---|---|---|
| Wrong credentials | page silently reloads, only a `401` in console, no message | inline error **“Incorrect username or password”** shown under the form |

_After:_

<img width="448" height="571" alt="image" src="https://github.com/user-attachments/assets/d0944ae5-aa3b-4c3e-b267-bb2ba76e565b" />

**Tests** — `web/tests/api-auth-redirect.test.ts` (run with `npm run test:node`):
- `apiFetch` redirects to `/login` on 401 by default.
- `apiFetch` does **not** redirect on 401 when `skipAuthRedirect` is set, and returns
  the 401 + `detail` to the caller — the regression guard for this bug.
- successful (200) responses pass through untouched.

**Verification**
- `tsc` clean; node test suite **3/3 pass**.
- Mutation check: removing the `!skipAuthRedirect` guard makes the regression test
  fail as expected, confirming the test actually catches the regression.
- `pre-commit run --files <changed files>` — all applicable hooks pass.
- Rebuilt the Docker image and confirmed `POST /api/v1/auth/login` with bad credentials
  returns `401 {"detail":"Incorrect username or password"}` — the text now rendered
  inline (see screenshot).