### PR TITLE
fix: accept username, not just email, on login and register forms

### DIFF
--- a/tests/multi_user/test_login_username_contract.py
+++ b/tests/multi_user/test_login_username_contract.py
@@ -1,0 +1,105 @@
+"""Contract: auth accepts a plain username, not just an email address.
+
+The admin "Add user" dialog and the login/register forms let an operator use a
+bare username (no ``@``). These tests lock the backend half of that contract so
+a future change (e.g. swapping the field for ``pydantic.EmailStr``) can't
+silently make username login impossible again — which is exactly the bug the
+frontend ``type="text"`` fix was paired with.
+"""
+
+from __future__ import annotations
+
+from pydantic import ValidationError
+import pytest
+
+from deeptutor.api.routers.auth import LoginRequest, RegisterRequest
+
+# ---------------------------------------------------------------------------
+# RegisterRequest.username — the real validator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "username",
+    [
+        "admin@admin.com",  # standard email (PocketBase mode)
+        "user.name@sub.example.co",  # email with dotted local/sub-domain
+        "admin",  # bare username (SQLite/JSON mode) — the regression guard
+        "john_doe",
+        "user.name",
+        "a-b-c",
+        "abc",  # minimum length (3)
+        "x" * 64,  # maximum length (64)
+    ],
+)
+def test_register_accepts_email_or_plain_username(username: str) -> None:
+    assert RegisterRequest(username=username, password="password1234").username == username
+
+
+@pytest.mark.parametrize(
+    "username",
+    [
+        "",  # empty
+        "   ",  # whitespace only
+        "ab",  # too short for a plain username and not an email
+        "x" * 65,  # too long
+        "has space",  # spaces allowed in neither form
+        "@nodomain",  # has '@' but is not a valid email
+        "bad@",  # malformed email, '@' disqualifies it as a plain username
+        "no-at-but-bad!",  # '!' is outside the plain-username charset
+    ],
+)
+def test_register_rejects_invalid_username(username: str) -> None:
+    with pytest.raises(ValidationError):
+        RegisterRequest(username=username, password="password1234")
+
+
+def test_register_username_is_trimmed() -> None:
+    assert RegisterRequest(username="  admin  ", password="password1234").username == "admin"
+
+
+@pytest.mark.parametrize("password", ["", "short", "1234567"])  # all < 8 chars
+def test_register_rejects_short_password(password: str) -> None:
+    with pytest.raises(ValidationError):
+        RegisterRequest(username="admin", password=password)
+
+
+def test_register_accepts_eight_char_password() -> None:
+    assert RegisterRequest(username="admin", password="12345678").password == "12345678"
+
+
+# ---------------------------------------------------------------------------
+# LoginRequest — must NOT impose email-only validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("username", ["admin", "admin@admin.com", "john_doe"])
+def test_login_accepts_plain_username(username: str) -> None:
+    """Login must accept whatever identity a user registered with — including a
+    bare username. It also must not re-validate the password length, or existing
+    accounts with legacy short passwords could no longer sign in."""
+    req = LoginRequest(username=username, password="x")
+    assert req.username == username
+    assert req.password == "x"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a user created with a plain username can authenticate
+# ---------------------------------------------------------------------------
+
+
+def test_authenticate_round_trip_with_plain_username(
+    monkeypatch: pytest.MonkeyPatch, seed_user
+) -> None:
+    pytest.importorskip("bcrypt")  # password hashing dep; present in CI/Docker
+    from deeptutor.services import auth as auth_service
+
+    monkeypatch.setattr(auth_service, "AUTH_ENABLED", True)
+    seed_user("plainuser", password="password1234")
+
+    payload = auth_service.authenticate("plainuser", "password1234")
+    assert payload is not None
+    assert payload.username == "plainuser"
+
+    assert auth_service.authenticate("plainuser", "wrong-password") is None
+    assert auth_service.authenticate("ghost", "password1234") is None

--- a/web/app/(auth)/login/page.tsx
+++ b/web/app/(auth)/login/page.tsx
@@ -70,18 +70,18 @@ function LoginPageContent() {
       {/* Card */}
       <div className="bg-[var(--card)] border border-[var(--border)] rounded-2xl shadow-sm px-8 py-8">
         <form onSubmit={handleSubmit} className="space-y-5">
-          {/* Email */}
+          {/* Email or username */}
           <div>
             <label
               htmlFor="username"
               className="block text-sm font-medium text-[var(--foreground)] mb-1.5"
             >
-              {t("Email")}
+              {t("Email or username")}
             </label>
             <input
               id="username"
-              type="email"
-              autoComplete="email"
+              type="text"
+              autoComplete="username"
               required
               value={username}
               onChange={(e) => setUsername(e.target.value)}

--- a/web/app/(auth)/register/page.tsx
+++ b/web/app/(auth)/register/page.tsx
@@ -76,18 +76,18 @@ export default function RegisterPage() {
       {/* Card */}
       <div className="bg-[var(--card)] border border-[var(--border)] rounded-2xl shadow-sm px-8 py-8">
         <form onSubmit={handleSubmit} className="space-y-5">
-          {/* Email */}
+          {/* Email or username */}
           <div>
             <label
               htmlFor="username"
               className="block text-sm font-medium text-[var(--foreground)] mb-1.5"
             >
-              {t("Email")}
+              {t("Email or username")}
             </label>
             <input
               id="username"
-              type="email"
-              autoComplete="email"
+              type="text"
+              autoComplete="username"
               required
               value={username}
               onChange={(e) => setUsername(e.target.value)}

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -373,7 +373,7 @@
   "Sign in to your account": "Sign in to your account",
   "Signing in…": "Signing in…",
   "Login failed": "Login failed",
-  "Email": "Email",
+  "Email or username": "Email or username",
   "Password": "Password",
   "Don't have an account?": "Don't have an account?",
   "Create one": "Create one",

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -373,7 +373,7 @@
   "Sign in to your account": "登录到你的账户",
   "Signing in…": "登录中…",
   "Login failed": "登录失败",
-  "Email": "邮箱",
+  "Email or username": "邮箱或用户名",
   "Password": "密码",
   "Don't have an account?": "还没有账户？",
   "Create one": "注册一个",


### PR DESCRIPTION
### Description

The admin **Add user** dialog lets an operator create an account with either an
email **or** a plain username, and the backend accepts both: the `/login` and
`/register` endpoints pass the value straight to `authenticate()` /
`RegisterRequest`, whose validator explicitly allows *"a standard email address
or a plain username"* (`deeptutor/api/routers/auth.py`).

But the **login and register forms hardcoded the identity field as
`type="email"`**, so the browser's native HTML5 validation rejected anything
without an `@` ("Please include an '@' in the email address"). The result: you
could create a username-only account from the admin panel, but never sign in
with it — the form blocked submission before the request was even sent.

This change makes the frontend match the admin dialog and the backend:

- `type="email"` → `type="text"` (drops the browser's email-only validation)
- `autoComplete="email"` → `autoComplete="username"`
- label `Email` → `Email or username` (added to both `en` and `zh` locales)

No backend changes — it already supported username login.

### Related Issues
- N/A — not previously tracked.

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the contribution guidelines.
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary). <!-- no docs impact -->
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

**Before / After**

| Before (`type="email"` blocks a username) | After (`Email or username`) |
| --- | --- |
| <img width="700" height="560" alt="image" src="https://github.com/user-attachments/assets/d1e339d4-35f4-4152-ac48-6007cd8b1a42" /> | <img width="538" height="538" alt="image" src="https://github.com/user-attachments/assets/48deaa7f-be60-42ef-9f30-43d1769f20d3" /> |

**Tests** — added `tests/multi_user/test_login_username_contract.py`, locking the
backend contract the form relies on so a future change (e.g. swapping the field
for `pydantic.EmailStr`) can't silently break username login again:
- `RegisterRequest` accepts an email or a bare username; rejects empty/garbage
  and passwords shorter than 8 chars.
- `LoginRequest` imposes no email-only or password-length validation.
- `authenticate()` round-trips a user created with a plain username.

**Note on `pre-commit`** — all hooks pass on the changed files **except**
`check-json`, which flags a **pre-existing** duplicate key (`"Space tooltip"`) in
`web/locales/{en,zh}/app.json`. That duplicate is already present on `dev` and is
unrelated to this PR; happy to fix it in a separate change if useful.