### PR TITLE
Fix TutorBot shell exec persistence

### DIFF
--- a/deeptutor/api/routers/tutorbot.py
+++ b/deeptutor/api/routers/tutorbot.py
@@ -84,6 +84,7 @@ class UpdateBotRequest(BaseModel):
     channels: dict | None = None
     model: str | None = None
     llm_selection: dict[str, str] | None = None
+    allow_shell_exec: bool | None = None
 
 
 class FileUpdateRequest(BaseModel):
@@ -339,6 +340,8 @@ def _apply_payload(target: BotConfig | TutorBotInstance, payload: UpdateBotReque
         cfg.model = payload.model
     if "llm_selection" in payload.model_fields_set:
         cfg.llm_selection = _validate_llm_selection_payload(payload.llm_selection)
+    if payload.allow_shell_exec is not None:
+        cfg.allow_shell_exec = payload.allow_shell_exec
 
 
 @router.patch("/{bot_id}")

--- a/deeptutor/services/tutorbot/manager.py
+++ b/deeptutor/services/tutorbot/manager.py
@@ -974,14 +974,9 @@ class TutorBotManager:
                 data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
                 if not data.get("auto_start", False):
                     continue
-                config = BotConfig(
-                    name=data.get("name", bid),
-                    description=data.get("description", ""),
-                    persona=data.get("persona", ""),
-                    channels=data.get("channels", {}),
-                    model=data.get("model"),
-                    llm_selection=data.get("llm_selection"),
-                )
+                config = self.load_bot_config(bid)
+                if config is None:
+                    continue
                 await self.start_bot(bid, config)
                 logger.info("Auto-started bot '%s'", bid)
             except Exception:

--- a/tests/api/test_tutorbot_router.py
+++ b/tests/api/test_tutorbot_router.py
@@ -642,6 +642,36 @@ class TestPatchBotStoppedAndRunning:
         assert saved_cfg[0].llm_selection is None
         assert resp.json()["llm_selection"] is None
 
+    def test_patch_stopped_can_update_shell_exec_flag(self, monkeypatch):
+        from deeptutor.services.tutorbot.manager import BotConfig
+
+        saved_cfg: list[BotConfig | None] = []
+
+        class FakeMgr:
+            def get_bot(self, bot_id: str):
+                return None
+
+            def load_bot_config(self, bot_id: str) -> BotConfig | None:
+                return BotConfig(name="b", allow_shell_exec=False)
+
+            def save_bot_config(
+                self, bot_id: str, config: BotConfig, *, auto_start: bool = True
+            ) -> None:
+                saved_cfg.append(config)
+
+        tutorbot_router_mod = importlib.import_module("deeptutor.api.routers.tutorbot")
+        monkeypatch.setattr(tutorbot_router_mod, "get_tutorbot_manager", lambda: FakeMgr())
+
+        app = FastAPI()
+        app.include_router(tutorbot_router_mod.router, prefix="/api/v1/tutorbot")
+        client = TestClient(app)
+
+        resp = client.patch("/api/v1/tutorbot/b", json={"allow_shell_exec": True})
+
+        assert resp.status_code == 200
+        assert saved_cfg[0].allow_shell_exec is True
+        assert resp.json()["allow_shell_exec"] is True
+
     def test_patch_running_channels_calls_reload(self, monkeypatch):
         from deeptutor.services.tutorbot.manager import BotConfig
 

--- a/tests/services/tutorbot/test_manager_config.py
+++ b/tests/services/tutorbot/test_manager_config.py
@@ -395,6 +395,29 @@ class TestAutoStartPersistence:
 
         assert self._config_data(manager, "manual-only-bot")["auto_start"] is False
 
+    def test_auto_start_preserves_shell_exec_opt_in(
+        self,
+        manager: TutorBotManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        cfg = BotConfig(name="shell-auto", allow_shell_exec=True)
+        manager.save_bot_config("shell-auto-bot", cfg, auto_start=True)
+        started: list[tuple[str, BotConfig | None]] = []
+
+        async def fake_start_bot(bot_id: str, config: BotConfig | None = None):
+            started.append((bot_id, config))
+            return TutorBotInstance(
+                bot_id=bot_id,
+                config=config or BotConfig(name=bot_id),
+            )
+
+        monkeypatch.setattr(manager, "start_bot", fake_start_bot)
+
+        asyncio.run(manager.auto_start_bots())
+
+        assert started == [("shell-auto-bot", cfg)]
+        assert started[0][1].allow_shell_exec is True
+
 
 def test_start_bot_passes_shared_memory_dir(
     manager: TutorBotManager,


### PR DESCRIPTION
## Summary
- allow TutorBot PATCH updates to persist allow_shell_exec
- preserve allow_shell_exec when auto-starting bots from saved config
- add regression coverage for PATCH and auto-start persistence

Fixes #534

## Tests
- uv run --extra dev pytest tests/api/test_tutorbot_router.py tests/services/tutorbot/test_manager_config.py tests/services/tutorbot/test_shell_exec_security.py