### PR TITLE
feat(partners): Partner 多用户隔离 — 按用户 scope 存储 partner 数据

### DIFF
--- a/deeptutor/api/main.py
+++ b/deeptutor/api/main.py
@@ -318,9 +318,10 @@ app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
 from deeptutor.api.routers.auth import require_admin, require_auth  # noqa: E402
 
 _auth = [Depends(require_auth)]
-# Partner data is anchored at the admin workspace (data/partners) and shared
-# process-wide, so management is admin-gated in multi-user deployments
-# (single-user local runs are implicitly admin — no behaviour change there).
+# Partners 使用 _auth（require_auth），ownership 校验在各端点内完成：
+# - /{partner_id} 端点通过 _check_partner_owner() 校验归属
+# - Soul library 端点（/souls/*）在端点内检查 admin 权限
+# 单机模式下 get_current_user() 返回 local_admin_user()，所有校验自动通过。
 _admin = [Depends(require_admin)]
 
 app.include_router(
@@ -394,7 +395,7 @@ app.include_router(
     vision_solver.router, prefix="/api/v1", tags=["vision-solver"], dependencies=_auth
 )
 app.include_router(
-    partners.router, prefix="/api/v1/partners", tags=["partners"], dependencies=_admin
+    partners.router, prefix="/api/v1/partners", tags=["partners"], dependencies=_auth
 )
 app.include_router(
     attachments.router,

--- a/deeptutor/api/routers/partners.py
+++ b/deeptutor/api/routers/partners.py
@@ -22,7 +22,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from deeptutor.core.i18n import t
-from deeptutor.partners.config.paths import get_partner_media_dir
+from deeptutor.partners.config.paths import get_partner_media_dir, resolve_owner_for_partner
 from deeptutor.partners.helpers import safe_filename
 from deeptutor.services.partners import get_partner_manager, slugify_partner_id
 from deeptutor.services.partners.manager import (
@@ -43,6 +43,38 @@ from deeptutor.services.partners.workspace import (
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+# ── Ownership 校验 ──────────────────────────────────────────────
+
+
+def _check_partner_owner(partner_id: str) -> str:
+    """校验当前用户是否有权操作该 partner。返回 owner_id。
+
+    - admin 用户可以操作任意 partner
+    - 普通用户只能操作 owner_id 等于自己 id 的 partner
+    - partner 不存在时返回 404（避免通过 403/404 差异确认 partner_id 是否存在）
+    - owner_id 为空串表示 admin owner，此时仅 admin 可操作
+    """
+    from deeptutor.multi_user.context import get_current_user
+
+    user = get_current_user()
+    owner_id = resolve_owner_for_partner(partner_id)
+
+    # partner 不存在时直接 404
+    mgr = get_partner_manager()
+    if not mgr.partner_exists(partner_id, owner_id=owner_id or None):
+        raise HTTPException(status_code=404, detail=t("api.partner_not_found"))
+
+    if user.is_admin:
+        return owner_id
+
+    if owner_id != user.id:
+        raise HTTPException(
+            status_code=403,
+            detail="你没有权限操作此 partner",
+        )
+    return owner_id
 
 
 # Per-partner async locks used to dedupe concurrent WebSocket-driven
@@ -67,7 +99,8 @@ async def _ensure_running_partner(partner_id: str) -> PartnerInstance:
     if instance and instance.running:
         return instance
 
-    config = mgr.load_config(partner_id)
+    owner_id = resolve_owner_for_partner(partner_id) or None
+    config = mgr.load_config(partner_id, owner_id=owner_id)
     if config is None:
         raise HTTPException(status_code=404, detail=t("api.partner_not_found"))
 
@@ -300,11 +333,23 @@ def _load_persona_markdown(name: str) -> str:
 
 @router.get("/souls")
 async def list_souls():
+    # 灵魂模板是共享资源，仅 admin 可管理
+    from deeptutor.multi_user.context import get_current_user
+
+    user = get_current_user()
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
     return get_partner_manager().list_souls()
 
 
 @router.post("/souls")
 async def create_soul(payload: SoulCreateRequest):
+    # 灵魂模板是共享资源，仅 admin 可管理
+    from deeptutor.multi_user.context import get_current_user
+
+    user = get_current_user()
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
     mgr = get_partner_manager()
     if mgr.get_soul(payload.id):
         raise HTTPException(status_code=409, detail=t("api.soul_already_exists", name=payload.id))
@@ -313,6 +358,12 @@ async def create_soul(payload: SoulCreateRequest):
 
 @router.get("/souls/{soul_id}")
 async def get_soul(soul_id: str):
+    # 灵魂模板是共享资源，仅 admin 可管理
+    from deeptutor.multi_user.context import get_current_user
+
+    user = get_current_user()
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
     soul = get_partner_manager().get_soul(soul_id)
     if not soul:
         raise HTTPException(status_code=404, detail=t("api.soul_not_found"))
@@ -321,6 +372,12 @@ async def get_soul(soul_id: str):
 
 @router.put("/souls/{soul_id}")
 async def update_soul(soul_id: str, payload: SoulTemplateUpdateRequest):
+    # 灵魂模板是共享资源，仅 admin 可管理
+    from deeptutor.multi_user.context import get_current_user
+
+    user = get_current_user()
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
     result = get_partner_manager().update_soul(soul_id, payload.name, payload.content)
     if not result:
         raise HTTPException(status_code=404, detail=t("api.soul_not_found"))
@@ -329,6 +386,12 @@ async def update_soul(soul_id: str, payload: SoulTemplateUpdateRequest):
 
 @router.delete("/souls/{soul_id}")
 async def delete_soul(soul_id: str):
+    # 灵魂模板是共享资源，仅 admin 可管理
+    from deeptutor.multi_user.context import get_current_user
+
+    user = get_current_user()
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
     if not get_partner_manager().delete_soul(soul_id):
         raise HTTPException(status_code=404, detail=t("api.soul_not_found"))
     return {"id": soul_id, "deleted": True}
@@ -412,19 +475,28 @@ async def tool_options():
 
 @router.post("")
 async def create_partner(payload: CreatePartnerRequest):
+    from deeptutor.multi_user.context import get_current_user
+
     mgr = get_partner_manager()
     partner_id = slugify_partner_id(payload.partner_id or payload.name)
+
+    # 全局唯一性检查：如果 partner_id 已被任何用户占用，自动加后缀
     if mgr.partner_exists(partner_id):
-        raise HTTPException(
-            status_code=409,
-            detail=t("api.partner_already_exists", name=partner_id),
-        )
+        base = partner_id
+        suffix = 2
+        while mgr.partner_exists(partner_id):
+            partner_id = f"{base}-{suffix}"
+            suffix += 1
 
     if payload.channels is not None:
         _validate_channels_payload(payload.channels)
     llm_selection = _validate_llm_selection_payload(payload.llm_selection)
     backup_llm_selection = _validate_llm_selection_payload(payload.backup_llm_selection)
     soul_content, soul_origin = _resolve_soul_content(payload.soul)
+
+    # 从当前用户获取 owner_id：admin 为空串，普通用户为 uid
+    current_user = get_current_user()
+    owner_id = "" if current_user.is_admin else current_user.id
 
     config = PartnerConfig(
         name=payload.name.strip(),
@@ -439,14 +511,16 @@ async def create_partner(payload: CreatePartnerRequest):
         soul_origin=soul_origin,
         enabled_tools=payload.enabled_tools,
         mcp_tools=payload.mcp_tools,
+        owner_id=owner_id,
     )
     mgr.save_config(partner_id, config, auto_start=True)
-    write_soul(partner_id, soul_content)
+    write_soul(partner_id, soul_content, owner_id=owner_id or None)
 
     provisioning: dict[str, Any] = {"copied": {}, "errors": []}
     if payload.assets is not None:
         provisioning = provision_assets(
             partner_id,
+            owner_id=owner_id or None,
             knowledge_bases=payload.assets.knowledge_bases,
             skills=payload.assets.skills,
             notebooks=payload.assets.notebooks,
@@ -492,6 +566,7 @@ def _stopped_partner_dict(
         "soul_origin": cfg.soul_origin,
         "enabled_tools": cfg.enabled_tools,
         "mcp_tools": cfg.mcp_tools,
+        "owner_id": cfg.owner_id,
         "running": False,
         "started_at": None,
         "last_reload_error": None,
@@ -509,6 +584,7 @@ async def get_partner(
         ),
     ),
 ):
+    _check_partner_owner(partner_id)
     mgr = get_partner_manager()
     instance = mgr.get_partner(partner_id)
     if instance:
@@ -516,7 +592,8 @@ async def get_partner(
             include_secrets=include_secrets,
             mask_secrets=not include_secrets,
         )
-    cfg = mgr.load_config(partner_id)
+    owner_id = resolve_owner_for_partner(partner_id) or None
+    cfg = mgr.load_config(partner_id, owner_id=owner_id)
     if cfg:
         return _stopped_partner_dict(partner_id, cfg, include_secrets=include_secrets)
     raise HTTPException(status_code=404, detail=t("api.partner_not_found"))
@@ -550,6 +627,7 @@ def _apply_update(cfg: PartnerConfig, payload: UpdatePartnerRequest) -> None:
 
 @router.patch("/{partner_id}")
 async def update_partner(partner_id: str, payload: UpdatePartnerRequest):
+    _check_partner_owner(partner_id)
     if payload.channels is not None:
         _validate_channels_payload(payload.channels)
 
@@ -574,7 +652,8 @@ async def update_partner(partner_id: str, payload: UpdatePartnerRequest):
         # llm_selection and tool config per turn from this same config object.
         return instance.to_dict(mask_secrets=True)
 
-    cfg = mgr.load_config(partner_id)
+    owner_id = resolve_owner_for_partner(partner_id) or None
+    cfg = mgr.load_config(partner_id, owner_id=owner_id)
     if not cfg:
         raise HTTPException(status_code=404, detail=t("api.partner_not_found"))
     _apply_update(cfg, payload)
@@ -584,12 +663,14 @@ async def update_partner(partner_id: str, payload: UpdatePartnerRequest):
 
 @router.post("/{partner_id}/start")
 async def start_partner(partner_id: str):
+    _check_partner_owner(partner_id)
     instance = await _ensure_running_partner(partner_id)
     return instance.to_dict(mask_secrets=True)
 
 
 @router.post("/{partner_id}/stop")
 async def stop_partner(partner_id: str):
+    _check_partner_owner(partner_id)
     stopped = await get_partner_manager().stop_partner(partner_id)
     if not stopped:
         raise HTTPException(status_code=404, detail=t("api.partner_not_found_or_not_running"))
@@ -598,6 +679,7 @@ async def stop_partner(partner_id: str):
 
 @router.delete("/{partner_id}")
 async def destroy_partner(partner_id: str):
+    _check_partner_owner(partner_id)
     destroyed = await get_partner_manager().destroy_partner(partner_id)
     if not destroyed:
         raise HTTPException(status_code=404, detail=t("api.partner_not_found"))
@@ -606,6 +688,7 @@ async def destroy_partner(partner_id: str):
 
 @router.post("/{partner_id}/channels/reload")
 async def reload_partner_channels(partner_id: str):
+    _check_partner_owner(partner_id)
     mgr = get_partner_manager()
     instance = mgr.get_partner(partner_id)
     if not instance or not instance.running:
@@ -625,18 +708,22 @@ async def reload_partner_channels(partner_id: str):
 
 @router.get("/{partner_id}/soul")
 async def get_partner_soul(partner_id: str):
+    _check_partner_owner(partner_id)
     mgr = get_partner_manager()
     if not mgr.partner_exists(partner_id):
         raise HTTPException(status_code=404, detail=t("api.partner_not_found"))
-    return {"partner_id": partner_id, "content": read_soul(partner_id)}
+    owner_id = resolve_owner_for_partner(partner_id) or None
+    return {"partner_id": partner_id, "content": read_soul(partner_id, owner_id=owner_id)}
 
 
 @router.put("/{partner_id}/soul")
 async def put_partner_soul(partner_id: str, payload: SoulUpdateBody):
+    _check_partner_owner(partner_id)
     mgr = get_partner_manager()
     if not mgr.partner_exists(partner_id):
         raise HTTPException(status_code=404, detail=t("api.partner_not_found"))
-    write_soul(partner_id, payload.content)
+    owner_id = resolve_owner_for_partner(partner_id) or None
+    write_soul(partner_id, payload.content, owner_id=owner_id)
     return {"partner_id": partner_id, "saved": True}
 
 
@@ -645,38 +732,45 @@ async def put_partner_soul(partner_id: str, payload: SoulUpdateBody):
 
 @router.get("/{partner_id}/assets")
 async def get_partner_assets(partner_id: str):
+    _check_partner_owner(partner_id)
     mgr = get_partner_manager()
     if not mgr.partner_exists(partner_id):
         raise HTTPException(status_code=404, detail=t("api.partner_not_found"))
-    return list_assets(partner_id)
+    owner_id = resolve_owner_for_partner(partner_id) or None
+    return list_assets(partner_id, owner_id=owner_id)
 
 
 @router.post("/{partner_id}/assets")
 async def add_partner_assets(partner_id: str, payload: AssetAddRequest):
+    _check_partner_owner(partner_id)
     mgr = get_partner_manager()
     if not mgr.partner_exists(partner_id):
         raise HTTPException(status_code=404, detail=t("api.partner_not_found"))
+    owner_id = resolve_owner_for_partner(partner_id) or None
     report = provision_assets(
         partner_id,
+        owner_id=owner_id,
         knowledge_bases=payload.knowledge_bases,
         skills=payload.skills,
         notebooks=payload.notebooks,
     )
-    return {"partner_id": partner_id, **report, "assets": list_assets(partner_id)}
+    return {"partner_id": partner_id, **report, "assets": list_assets(partner_id, owner_id=owner_id)}
 
 
 @router.delete("/{partner_id}/assets/{asset_type}/{name}")
 async def delete_partner_asset(partner_id: str, asset_type: str, name: str):
+    _check_partner_owner(partner_id)
     mgr = get_partner_manager()
     if not mgr.partner_exists(partner_id):
         raise HTTPException(status_code=404, detail=t("api.partner_not_found"))
+    owner_id = resolve_owner_for_partner(partner_id) or None
     try:
-        removed = remove_asset(partner_id, asset_type, name)
+        removed = remove_asset(partner_id, asset_type, name, owner_id=owner_id)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from None
     if not removed:
         raise HTTPException(status_code=404, detail="Asset not found")
-    return {"partner_id": partner_id, "removed": True, "assets": list_assets(partner_id)}
+    return {"partner_id": partner_id, "removed": True, "assets": list_assets(partner_id, owner_id=owner_id)}
 
 
 # ── History ────────────────────────────────────────────────────
@@ -688,15 +782,18 @@ async def get_partner_history(
     session_key: str | None = None,
     limit: int = 100,
 ):
+    _check_partner_owner(partner_id)
     return get_partner_manager().get_history(partner_id, session_key=session_key, limit=limit)
 
 
 @router.get("/{partner_id}/sessions")
 async def get_partner_sessions(partner_id: str):
+    _check_partner_owner(partner_id)
     mgr = get_partner_manager()
     if not mgr.partner_exists(partner_id):
         raise HTTPException(status_code=404, detail=t("api.partner_not_found"))
-    return mgr.session_store(partner_id).list_sessions()
+    owner_id = resolve_owner_for_partner(partner_id) or None
+    return mgr.session_store(partner_id, owner_id=owner_id).list_sessions()
 
 
 @router.get("/commands/palette")
@@ -749,7 +846,8 @@ def _materialize_partner_attachments(
     if not attachments:
         return []
 
-    media_dir = get_partner_media_dir(partner_id, "web")
+    owner_id = resolve_owner_for_partner(partner_id) or None
+    media_dir = get_partner_media_dir(partner_id, "web", owner_id=owner_id)
     total_bytes = 0
     media_paths: list[str] = []
     for item in attachments:
@@ -784,6 +882,7 @@ def _materialize_partner_attachments(
 @router.post("/{partner_id}/chat")
 async def partner_chat_http(partner_id: str, payload: ChatMessageRequest) -> dict[str, Any]:
     """Send one HTTP message to a partner with persistent session context."""
+    _check_partner_owner(partner_id)
     content = payload.content.strip()
     if not content and not payload.attachments:
         raise HTTPException(status_code=400, detail=t("api.content_required"))
@@ -873,6 +972,7 @@ async def _partner_chat_stream(
 @router.post("/{partner_id}/chat/execute-stream")
 async def partner_chat_http_stream(partner_id: str, payload: ChatMessageRequest):
     """Stream one HTTP message to a partner as server-sent events."""
+    _check_partner_owner(partner_id)
     if not payload.content.strip() and not payload.attachments:
         raise HTTPException(status_code=400, detail=t("api.content_required"))
     await _ensure_running_partner(partner_id)
@@ -904,6 +1004,15 @@ async def partner_chat_ws(ws: WebSocket, partner_id: str):
     if user_token is ws_auth_failed:
         return
 
+    # Ownership 校验：WebSocket 不能抛 HTTPException，需手动处理
+    from deeptutor.multi_user.context import get_current_user
+
+    ws_user = get_current_user()
+    ws_owner_id = resolve_owner_for_partner(partner_id)
+    if not ws_user.is_admin and ws_owner_id != ws_user.id:
+        await ws.close(code=4003, reason="你没有权限操作此 partner")
+        return
+
     disconnected = asyncio.Event()
 
     async def _safe_send(payload: dict) -> bool:
@@ -920,7 +1029,8 @@ async def partner_chat_ws(ws: WebSocket, partner_id: str):
     await ws.accept()
 
     if not instance or not instance.running:
-        config = mgr.load_config(partner_id)
+        owner_id = resolve_owner_for_partner(partner_id) or None
+        config = mgr.load_config(partner_id, owner_id=owner_id)
         if config is None:
             message = t("api.partner_not_found")
             await _safe_send({"type": "error", "content": message})

--- a/deeptutor/api/routers/partners.py
+++ b/deeptutor/api/routers/partners.py
@@ -485,11 +485,15 @@ async def create_partner(payload: CreatePartnerRequest):
     mgr = get_partner_manager()
     partner_id = slugify_partner_id(payload.partner_id or payload.name)
 
-    # 全局唯一性检查：如果 partner_id 已被任何用户占用，自动加后缀
-    if mgr.partner_exists(partner_id):
+    # 从当前用户获取 owner_id：admin 为空串，普通用户为 uid
+    current_user = get_current_user()
+    owner_id = "" if current_user.is_admin else current_user.id
+
+    # 同名唯一性检查：仅检查当前用户 scope 内是否已存在同名 partner
+    if mgr.partner_exists(partner_id, owner_id=owner_id or None):
         base = partner_id
         suffix = 2
-        while mgr.partner_exists(partner_id):
+        while mgr.partner_exists(partner_id, owner_id=owner_id or None):
             partner_id = f"{base}-{suffix}"
             suffix += 1
 
@@ -498,10 +502,6 @@ async def create_partner(payload: CreatePartnerRequest):
     llm_selection = _validate_llm_selection_payload(payload.llm_selection)
     backup_llm_selection = _validate_llm_selection_payload(payload.backup_llm_selection)
     soul_content, soul_origin = _resolve_soul_content(payload.soul)
-
-    # 从当前用户获取 owner_id：admin 为空串，普通用户为 uid
-    current_user = get_current_user()
-    owner_id = "" if current_user.is_admin else current_user.id
 
     config = PartnerConfig(
         name=payload.name.strip(),

--- a/deeptutor/api/routers/partners.py
+++ b/deeptutor/api/routers/partners.py
@@ -51,10 +51,10 @@ router = APIRouter()
 def _check_partner_owner(partner_id: str) -> str:
     """校验当前用户是否有权操作该 partner。返回 owner_id。
 
-    - admin 用户可以操作任意 partner
+    - admin 用户只能操作 admin 自己的 partner（owner_id 为空串）
     - 普通用户只能操作 owner_id 等于自己 id 的 partner
     - partner 不存在时返回 404（避免通过 403/404 差异确认 partner_id 是否存在）
-    - owner_id 为空串表示 admin owner，此时仅 admin 可操作
+    - owner_id 为空串表示 admin owner
     """
     from deeptutor.multi_user.context import get_current_user
 
@@ -67,6 +67,11 @@ def _check_partner_owner(partner_id: str) -> str:
         raise HTTPException(status_code=404, detail=t("api.partner_not_found"))
 
     if user.is_admin:
+        if owner_id:
+            raise HTTPException(
+                status_code=403,
+                detail="你没有权限操作此 partner",
+            )
         return owner_id
 
     if owner_id != user.id:
@@ -1009,7 +1014,11 @@ async def partner_chat_ws(ws: WebSocket, partner_id: str):
 
     ws_user = get_current_user()
     ws_owner_id = resolve_owner_for_partner(partner_id)
-    if not ws_user.is_admin and ws_owner_id != ws_user.id:
+    if ws_user.is_admin:
+        if ws_owner_id:
+            await ws.close(code=4003, reason="你没有权限操作此 partner")
+            return
+    elif ws_owner_id != ws_user.id:
         await ws.close(code=4003, reason="你没有权限操作此 partner")
         return
 

--- a/deeptutor/api/routers/partners.py
+++ b/deeptutor/api/routers/partners.py
@@ -759,7 +759,11 @@ async def add_partner_assets(partner_id: str, payload: AssetAddRequest):
         skills=payload.skills,
         notebooks=payload.notebooks,
     )
-    return {"partner_id": partner_id, **report, "assets": list_assets(partner_id, owner_id=owner_id)}
+    return {
+        "partner_id": partner_id,
+        **report,
+        "assets": list_assets(partner_id, owner_id=owner_id),
+    }
 
 
 @router.delete("/{partner_id}/assets/{asset_type}/{name}")
@@ -775,7 +779,11 @@ async def delete_partner_asset(partner_id: str, asset_type: str, name: str):
         raise HTTPException(status_code=422, detail=str(exc)) from None
     if not removed:
         raise HTTPException(status_code=404, detail="Asset not found")
-    return {"partner_id": partner_id, "removed": True, "assets": list_assets(partner_id, owner_id=owner_id)}
+    return {
+        "partner_id": partner_id,
+        "removed": True,
+        "assets": list_assets(partner_id, owner_id=owner_id),
+    }
 
 
 # ── History ────────────────────────────────────────────────────

--- a/deeptutor/partners/channels/base.py
+++ b/deeptutor/partners/channels/base.py
@@ -43,6 +43,7 @@ class BaseChannel(ABC):
         self.config = config
         self.bus = bus
         self._running = False
+        self.partner_id: str = ""  # 由 PartnerManager 在创建后注入
 
     async def transcribe_audio(self, file_path: str | Path) -> str:
         """Transcribe an audio file via Groq Whisper. Returns empty string on failure."""

--- a/deeptutor/partners/channels/discord.py
+++ b/deeptutor/partners/channels/discord.py
@@ -15,7 +15,7 @@ import websockets
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_media_dir
+from deeptutor.partners.config.paths import get_partner_media_dir
 from deeptutor.partners.config.schema import DeliveryOverrides, StreamingSupport
 from deeptutor.partners.helpers import split_message
 
@@ -415,7 +415,7 @@ class DiscordChannel(BaseChannel):
 
         content_parts = [content] if content else []
         media_paths: list[str] = []
-        media_dir = get_media_dir("discord")
+        media_dir = get_partner_media_dir(self.partner_id, "discord")
 
         for attachment in payload.get("attachments") or []:
             url = attachment.get("url")

--- a/deeptutor/partners/channels/feishu.py
+++ b/deeptutor/partners/channels/feishu.py
@@ -18,7 +18,7 @@ from pydantic import Field
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_media_dir
+from deeptutor.partners.config.paths import get_partner_media_dir
 from deeptutor.partners.config.schema import DeliveryOverrides, StreamingSupport
 
 FEISHU_AVAILABLE = importlib.util.find_spec("lark_oapi") is not None
@@ -854,7 +854,7 @@ class FeishuChannel(BaseChannel):
             (file_path, content_text) - file_path is None if download failed
         """
         loop = asyncio.get_running_loop()
-        media_dir = get_media_dir("feishu")
+        media_dir = get_partner_media_dir(self.partner_id, "feishu")
 
         data, filename = None, None
 

--- a/deeptutor/partners/channels/matrix.py
+++ b/deeptutor/partners/channels/matrix.py
@@ -47,7 +47,7 @@ else:
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_data_dir, get_media_dir
+from deeptutor.partners.config.paths import get_data_dir, get_partner_media_dir, get_partner_runtime_subdir
 from deeptutor.partners.config.schema import DeliveryOverrides
 from deeptutor.partners.helpers import safe_filename
 
@@ -244,7 +244,7 @@ class MatrixChannel(BaseChannel):
                 "sure libolm is available on your system."
             )
 
-        store_path = get_data_dir() / "matrix-store"
+        store_path = get_partner_runtime_subdir(self.partner_id, "matrix")
         store_path.mkdir(parents=True, exist_ok=True)
 
         self.client = AsyncClient(
@@ -603,7 +603,7 @@ class MatrixChannel(BaseChannel):
         return False
 
     def _media_dir(self) -> Path:
-        return get_media_dir("matrix")
+        return get_partner_media_dir(self.partner_id, "matrix")
 
     @staticmethod
     def _event_source_content(event: RoomMessage) -> dict[str, Any]:

--- a/deeptutor/partners/channels/matrix.py
+++ b/deeptutor/partners/channels/matrix.py
@@ -47,7 +47,10 @@ else:
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_data_dir, get_partner_media_dir, get_partner_runtime_subdir
+from deeptutor.partners.config.paths import (
+    get_partner_media_dir,
+    get_partner_runtime_subdir,
+)
 from deeptutor.partners.config.schema import DeliveryOverrides
 from deeptutor.partners.helpers import safe_filename
 

--- a/deeptutor/partners/channels/mochat.py
+++ b/deeptutor/partners/channels/mochat.py
@@ -7,6 +7,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 import json
+from pathlib import Path
 from typing import Any
 
 import httpx

--- a/deeptutor/partners/channels/mochat.py
+++ b/deeptutor/partners/channels/mochat.py
@@ -16,7 +16,7 @@ from pydantic import Field
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_runtime_subdir
+from deeptutor.partners.config.paths import get_partner_runtime_subdir
 from deeptutor.partners.config.schema import Base, DeliveryOverrides
 
 try:
@@ -293,8 +293,6 @@ class MochatChannel(BaseChannel):
         self._socket: Any = None
         self._ws_connected = self._ws_ready = False
 
-        self._state_dir = get_runtime_subdir("mochat")
-        self._cursor_path = self._state_dir / "session_cursors.json"
         self._session_cursor: dict[str, int] = {}
         self._cursor_save_task: asyncio.Task | None = None
 
@@ -314,6 +312,15 @@ class MochatChannel(BaseChannel):
         self._panel_fallback_tasks: dict[str, asyncio.Task] = {}
         self._refresh_task: asyncio.Task | None = None
         self._target_locks: dict[str, asyncio.Lock] = {}
+
+    @property
+    def _state_dir(self) -> Path:
+        """按 partner 隔离的运行时目录（延迟计算，依赖注入后的 partner_id）。"""
+        return get_partner_runtime_subdir(self.partner_id, "mochat")
+
+    @property
+    def _cursor_path(self) -> Path:
+        return self._state_dir / "session_cursors.json"
 
     # ---- lifecycle ---------------------------------------------------------
 

--- a/deeptutor/partners/channels/msteams.py
+++ b/deeptutor/partners/channels/msteams.py
@@ -19,6 +19,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import importlib.util
 import json
 import os
+from pathlib import Path
 import re
 import tempfile
 import threading

--- a/deeptutor/partners/channels/msteams.py
+++ b/deeptutor/partners/channels/msteams.py
@@ -38,7 +38,7 @@ from pydantic import Field
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_runtime_subdir
+from deeptutor.partners.config.paths import get_partner_runtime_subdir
 from deeptutor.partners.config.schema import DeliveryOverrides
 
 MSTEAMS_AVAILABLE = (
@@ -133,15 +133,35 @@ class MSTeamsChannel(BaseChannel):
         self._botframework_openid_config_expires_at: float = 0.0
         self._botframework_jwks: dict[str, Any] | None = None
         self._botframework_jwks_expires_at: float = 0.0
-        state_dir = get_runtime_subdir("msteams")
-        self._refs_path = state_dir / MSTEAMS_REF_FILENAME
-        self._refs_meta_path = state_dir / MSTEAMS_REF_META_FILENAME
-        self._refs_lock_path = state_dir / MSTEAMS_REF_LOCK_FILENAME
         self._refs_guard = threading.RLock()
-        self._conversation_refs: dict[str, ConversationRef] = self._load_refs()
-        with self._refs_guard:
-            if self._prune_conversation_refs():
-                self._save_refs_locked(prune=True)
+        self._conversation_refs: dict[str, ConversationRef] = {}
+        self._refs_loaded = False
+
+    @property
+    def _state_dir(self) -> Path:
+        """按 partner 隔离的运行时目录（延迟计算，依赖注入后的 partner_id）。"""
+        return get_partner_runtime_subdir(self.partner_id, "msteams")
+
+    @property
+    def _refs_path(self) -> Path:
+        return self._state_dir / MSTEAMS_REF_FILENAME
+
+    @property
+    def _refs_meta_path(self) -> Path:
+        return self._state_dir / MSTEAMS_REF_META_FILENAME
+
+    @property
+    def _refs_lock_path(self) -> Path:
+        return self._state_dir / MSTEAMS_REF_LOCK_FILENAME
+
+    def _ensure_refs_loaded(self) -> None:
+        """延迟加载 refs（首次访问时触发）。"""
+        if not self._refs_loaded:
+            self._refs_loaded = True
+            self._conversation_refs = self._load_refs()
+            with self._refs_guard:
+                if self._prune_conversation_refs():
+                    self._save_refs_locked(prune=True)
 
     async def start(self) -> None:
         """Start the Teams webhook listener."""
@@ -163,6 +183,7 @@ class MSTeamsChannel(BaseChannel):
         self._loop = asyncio.get_running_loop()
         self._http = httpx.AsyncClient(timeout=30.0)
         self._running = True
+        self._ensure_refs_loaded()
 
         channel = self
 

--- a/deeptutor/partners/channels/napcat.py
+++ b/deeptutor/partners/channels/napcat.py
@@ -27,7 +27,7 @@ from websockets.asyncio.client import connect as ws_connect
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_media_dir
+from deeptutor.partners.config.paths import get_partner_media_dir
 from deeptutor.partners.config.schema import DeliveryOverrides
 from deeptutor.partners.helpers import safe_filename
 from deeptutor.partners.network import validate_url_target
@@ -573,7 +573,7 @@ class NapcatChannel(BaseChannel):
             name = f"{int(time.time() * 1000)}.jpg"
         # Resolved lazily (not in __init__) so constructing the channel never
         # touches the partners data tree.
-        path = get_media_dir("napcat") / name
+        path = get_partner_media_dir(self.partner_id, "napcat") / name
         try:
             await asyncio.to_thread(path.write_bytes, data)
         except OSError as e:

--- a/deeptutor/partners/channels/telegram.py
+++ b/deeptutor/partners/channels/telegram.py
@@ -19,7 +19,7 @@ from telegram.request import HTTPXRequest
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_media_dir
+from deeptutor.partners.config.paths import get_partner_media_dir
 from deeptutor.partners.config.schema import DeliveryOverrides, StreamingSupport
 from deeptutor.partners.helpers import split_message
 from deeptutor.services.partners.commands import build_partner_help_text, partner_command_palette
@@ -795,7 +795,7 @@ class TelegramChannel(BaseChannel):
                 getattr(media_file, "mime_type", None),
                 getattr(media_file, "file_name", None),
             )
-            media_dir = get_media_dir("telegram")
+            media_dir = get_partner_media_dir(self.partner_id, "telegram")
             unique_id = getattr(media_file, "file_unique_id", media_file.file_id)
             file_path = media_dir / f"{unique_id}{ext}"
             await file.download_to_drive(str(file_path))

--- a/deeptutor/partners/channels/wecom.py
+++ b/deeptutor/partners/channels/wecom.py
@@ -12,7 +12,7 @@ from pydantic import Field
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_media_dir
+from deeptutor.partners.config.paths import get_partner_media_dir
 from deeptutor.partners.config.schema import DeliveryOverrides
 
 WECOM_AVAILABLE = importlib.util.find_spec("wecom_aibot_sdk") is not None
@@ -332,7 +332,7 @@ class WecomChannel(BaseChannel):
                 logger.warning("Failed to download media from WeCom")
                 return None
 
-            media_dir = get_media_dir("wecom")
+            media_dir = get_partner_media_dir(self.partner_id, "wecom")
             if not filename:
                 filename = fname or f"{media_type}_{hash(file_url) % 100000}"
             filename = os.path.basename(filename)

--- a/deeptutor/partners/channels/weixin.py
+++ b/deeptutor/partners/channels/weixin.py
@@ -31,7 +31,7 @@ from pydantic import Field
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_media_dir, get_runtime_subdir
+from deeptutor.partners.config.paths import get_partner_media_dir, get_partner_runtime_subdir
 from deeptutor.partners.config.schema import DeliveryOverrides
 from deeptutor.partners.helpers import safe_filename, split_message
 
@@ -183,7 +183,7 @@ class WeixinChannel(BaseChannel):
         if self.config.state_dir:
             d = Path(self.config.state_dir).expanduser()
         else:
-            d = get_runtime_subdir("weixin")
+            d = get_partner_runtime_subdir(self.partner_id, "weixin")
         d.mkdir(parents=True, exist_ok=True)
         self._state_dir = d
         return d
@@ -881,7 +881,7 @@ class WeixinChannel(BaseChannel):
             if not data:
                 return None
 
-            media_dir = get_media_dir("weixin")
+            media_dir = get_partner_media_dir(self.partner_id, "weixin")
             ext = _ext_for_type(media_type)
             if not filename:
                 ts = int(time.time())

--- a/deeptutor/partners/channels/zulip.py
+++ b/deeptutor/partners/channels/zulip.py
@@ -19,7 +19,7 @@ import requests
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_media_dir
+from deeptutor.partners.config.paths import get_partner_media_dir
 from deeptutor.partners.config.schema import DeliveryOverrides
 from deeptutor.partners.helpers import split_message
 
@@ -550,7 +550,7 @@ class ZulipChannel(BaseChannel):
         if not upload_links:
             return paths
 
-        media_dir = get_media_dir("zulip")
+        media_dir = get_partner_media_dir(self.partner_id, "zulip")
 
         for name, path_id in upload_links:
             local_path = self._download_upload_path(
@@ -635,7 +635,7 @@ class ZulipChannel(BaseChannel):
         name: str | None = None,
         index: int = 0,
     ) -> str | None:
-        media_dir = media_dir or get_media_dir("zulip")
+        media_dir = media_dir or get_partner_media_dir(self.partner_id, "zulip")
         filename = name or Path(unquote(path_id)).name
         dest = self._attachment_destination(media_dir, filename, path_id, index)
 

--- a/deeptutor/partners/config/__init__.py
+++ b/deeptutor/partners/config/__init__.py
@@ -5,9 +5,12 @@ from deeptutor.partners.config.paths import (
     get_media_dir,
     get_partner_dir,
     get_partner_media_dir,
+    get_partner_runtime_subdir,
     get_partner_sessions_dir,
     get_partner_workspace,
     get_runtime_subdir,
+    invalidate_owner_cache,
+    resolve_owner_for_partner,
 )
 from deeptutor.partners.config.schema import Base, ChannelsConfig
 
@@ -18,7 +21,10 @@ __all__ = [
     "get_media_dir",
     "get_partner_dir",
     "get_partner_media_dir",
+    "get_partner_runtime_subdir",
     "get_partner_sessions_dir",
     "get_partner_workspace",
     "get_runtime_subdir",
+    "invalidate_owner_cache",
+    "resolve_owner_for_partner",
 ]

--- a/deeptutor/partners/config/paths.py
+++ b/deeptutor/partners/config/paths.py
@@ -13,11 +13,10 @@ partner scope，会导致递归。
 
 from __future__ import annotations
 
-import warnings
 from pathlib import Path
+import warnings
 
 from deeptutor.partners.helpers import ensure_dir
-
 
 # ── Owner-resolved base dirs ─────────────────────────────────────
 
@@ -35,7 +34,7 @@ def _base_dir_for_owner(owner_id: str) -> Path:
     - 空 owner_id → admin workspace（data/user/partners/ 或 data/partners/）
     - 非空 owner_id → user workspace（data/users/<uid>/partners/）
     """
-    from deeptutor.multi_user.paths import ADMIN_WORKSPACE_ROOT, USERS_ROOT
+    from deeptutor.multi_user.paths import USERS_ROOT
 
     if owner_id:
         return ensure_dir(USERS_ROOT / owner_id / "partners")
@@ -139,9 +138,7 @@ def get_partner_sessions_dir(partner_id: str, *, owner_id: str | None = None) ->
     return ensure_dir(get_partner_dir(partner_id, owner_id=owner_id) / "sessions")
 
 
-def get_partner_runtime_subdir(
-    partner_id: str, name: str, *, owner_id: str | None = None
-) -> Path:
+def get_partner_runtime_subdir(partner_id: str, name: str, *, owner_id: str | None = None) -> Path:
     """Partner 级别的运行时子目录（如 media）。"""
     return ensure_dir(get_partner_dir(partner_id, owner_id=owner_id) / name)
 

--- a/deeptutor/partners/config/paths.py
+++ b/deeptutor/partners/config/paths.py
@@ -1,53 +1,153 @@
-"""Path helpers for the Partners data tree (``data/partners/``)."""
+"""Path helpers for the Partners data tree — per-owner isolation.
+
+Partner 数据按 owner 隔离存储：
+
+- Admin 的 partners: ``data/user/partners/``（单机模式为 ``data/partners/``）
+- 普通用户的 partners: ``data/users/<uid>/partners/``
+
+核心约束：``_base_dir_for_owner()`` 接受显式的 ``owner_id`` 参数，
+**不能**使用 ``get_current_user()`` 解析路径，因为 partner 运行时
+通过 ``user_context(partner_user(partner_id))`` 设置了 synthetic
+partner scope，会导致递归。
+"""
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 from deeptutor.partners.helpers import ensure_dir
 
 
-def _base_dir() -> Path:
-    # Anchored to the admin workspace root (data/partners), NOT the
-    # current-user path service: partner runtimes execute inside a synthetic
-    # partner scope whose workspace_root lives below this very tree, so
-    # resolving through the contextvar here would recurse the layout.
+# ── Owner-resolved base dirs ─────────────────────────────────────
+
+
+def _admin_base_dir() -> Path:
+    """Admin workspace partners dir — used by process-level operations."""
     from deeptutor.multi_user.paths import get_admin_path_service
 
     return ensure_dir(get_admin_path_service().workspace_root / "partners")
 
 
+def _base_dir_for_owner(owner_id: str) -> Path:
+    """按 owner_id 解析 partners 目录。
+
+    - 空 owner_id → admin workspace（data/user/partners/ 或 data/partners/）
+    - 非空 owner_id → user workspace（data/users/<uid>/partners/）
+    """
+    from deeptutor.multi_user.paths import ADMIN_WORKSPACE_ROOT, USERS_ROOT
+
+    if owner_id:
+        return ensure_dir(USERS_ROOT / owner_id / "partners")
+    return _admin_base_dir()
+
+
+# ── Owner resolution ─────────────────────────────────────────────
+
+# 缓存 partner_id → owner_id 映射，避免反复扫描磁盘
+_owner_cache: dict[str, str] = {}
+
+
+def _resolve_owner_id(partner_id: str) -> str:
+    """通过扫描已知位置查找 partner 的 owner_id。
+
+    先检查 admin 目录，再检查各用户目录。未找到时默认返回空串（admin）。
+    """
+    if partner_id in _owner_cache:
+        return _owner_cache[partner_id]
+
+    # 先检查 admin 目录
+    admin_cfg = _admin_base_dir() / partner_id / "config.yaml"
+    if admin_cfg.exists():
+        _owner_cache[partner_id] = ""
+        return ""
+
+    # 再检查各用户目录
+    from deeptutor.multi_user.paths import USERS_ROOT
+
+    if USERS_ROOT.exists():
+        for user_dir in USERS_ROOT.iterdir():
+            if user_dir.is_dir():
+                cfg = user_dir / "partners" / partner_id / "config.yaml"
+                if cfg.exists():
+                    _owner_cache[partner_id] = user_dir.name
+                    return user_dir.name
+
+    # fallback: 默认 admin
+    _owner_cache[partner_id] = ""
+    return ""
+
+
+def resolve_owner_for_partner(partner_id: str) -> str:
+    """公开接口：反查 partner 的 owner_id。空串表示 admin。"""
+    return _resolve_owner_id(partner_id)
+
+
+def invalidate_owner_cache(partner_id: str | None = None) -> None:
+    """清除 owner 缓存。partner_id 为 None 时清除全部。"""
+    if partner_id is None:
+        _owner_cache.clear()
+    else:
+        _owner_cache.pop(partner_id, None)
+
+
+# ── Deprecated global helpers ────────────────────────────────────
+
+
 def get_data_dir() -> Path:
-    return _base_dir()
+    """Admin partners 数据目录（仅用于兼容旧调用）。"""
+    return _admin_base_dir()
 
 
 def get_runtime_subdir(name: str) -> Path:
-    return ensure_dir(_base_dir() / name)
+    """已废弃：请使用 ``get_partner_runtime_subdir``。"""
+    warnings.warn(
+        "get_runtime_subdir() 已废弃，请使用 get_partner_runtime_subdir()",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return ensure_dir(_admin_base_dir() / name)
 
 
 def get_media_dir(channel: str | None = None) -> Path:
-    """Shared media download dir used by channel implementations."""
+    """已废弃：请使用 ``get_partner_media_dir``。"""
+    warnings.warn(
+        "get_media_dir() 已废弃，请使用 get_partner_media_dir()",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     base = get_runtime_subdir("media")
     return ensure_dir(base / channel) if channel else base
 
 
-# ── Per-partner path helpers ──────────────────────────────────────
+# ── Per-partner path helpers ─────────────────────────────────────
 
 
-def get_partner_dir(partner_id: str) -> Path:
-    """data/partners/{partner_id}/ — config, sessions, and workspace."""
-    return ensure_dir(_base_dir() / partner_id)
+def get_partner_dir(partner_id: str, *, owner_id: str | None = None) -> Path:
+    """data/[user|users/<uid>]/partners/{partner_id}/ — config, sessions, and workspace."""
+    if owner_id is None:
+        owner_id = _resolve_owner_id(partner_id)
+    return ensure_dir(_base_dir_for_owner(owner_id) / partner_id)
 
 
-def get_partner_workspace(partner_id: str) -> Path:
+def get_partner_workspace(partner_id: str, *, owner_id: str | None = None) -> Path:
     """The partner's scope root (chat user-workspace layout lives below it)."""
-    return ensure_dir(get_partner_dir(partner_id) / "workspace")
+    return ensure_dir(get_partner_dir(partner_id, owner_id=owner_id) / "workspace")
 
 
-def get_partner_sessions_dir(partner_id: str) -> Path:
-    return ensure_dir(get_partner_dir(partner_id) / "sessions")
+def get_partner_sessions_dir(partner_id: str, *, owner_id: str | None = None) -> Path:
+    return ensure_dir(get_partner_dir(partner_id, owner_id=owner_id) / "sessions")
 
 
-def get_partner_media_dir(partner_id: str, channel: str | None = None) -> Path:
-    base = ensure_dir(get_partner_dir(partner_id) / "media")
+def get_partner_runtime_subdir(
+    partner_id: str, name: str, *, owner_id: str | None = None
+) -> Path:
+    """Partner 级别的运行时子目录（如 media）。"""
+    return ensure_dir(get_partner_dir(partner_id, owner_id=owner_id) / name)
+
+
+def get_partner_media_dir(
+    partner_id: str, channel: str | None = None, *, owner_id: str | None = None
+) -> Path:
+    base = get_partner_runtime_subdir(partner_id, "media", owner_id=owner_id)
     return ensure_dir(base / channel) if channel else base

--- a/deeptutor/services/partners/manager.py
+++ b/deeptutor/services/partners/manager.py
@@ -260,17 +260,17 @@ class PartnerManager:
             return None
         try:
             data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-            # 已有数据迁移：无 owner_id 时自动补充 "local-admin" 并回写
+            # 已有数据迁移：无 owner_id 时自动补充空串（= admin）并回写
             loaded_owner_id = str(data.get("owner_id") or "")
             if "owner_id" not in data:
-                data["owner_id"] = "local-admin"
+                data["owner_id"] = ""
                 try:
                     tmp_path = path.with_suffix(path.suffix + ".tmp")
                     tmp_path.write_text(yaml.dump(data, allow_unicode=True), encoding="utf-8")
                     tmp_path.replace(path)
                 except Exception:
                     logger.warning("无法回写 owner_id 迁移到 %s", path, exc_info=True)
-                loaded_owner_id = "local-admin"
+                loaded_owner_id = ""
             return PartnerConfig(
                 name=data.get("name", partner_id),
                 description=data.get("description", ""),
@@ -641,8 +641,8 @@ class PartnerManager:
         result: dict[str, dict[str, Any]] = {}
 
         for inst in self._partners.values():
-            # 用磁盘位置（resolve_owner_for_partner）而非 config.owner_id 判断归属，
-            # 避免遗留迁移 partner（config.owner_id = "local-admin"）被错误过滤。
+            # 用磁盘位置（resolve_owner_for_partner）判断归属，
+            # 与 config.owner_id 语义一致（admin = 空串）。
             inst_oid = resolve_owner_for_partner(inst.partner_id)
             if current.is_admin:
                 if inst_oid:

--- a/deeptutor/services/partners/manager.py
+++ b/deeptutor/services/partners/manager.py
@@ -20,7 +20,6 @@ from typing import Any, Awaitable, Callable
 import yaml
 
 from deeptutor.partners.config.paths import (
-    get_data_dir,
     get_partner_dir,
     get_partner_sessions_dir,
     invalidate_owner_cache,
@@ -335,7 +334,9 @@ class PartnerManager:
         # 更新 owner 缓存
         invalidate_owner_cache(partner_id)
 
-    def _load_auto_start(self, partner_id: str, *, default: bool = False, owner_id: str | None = None) -> bool:
+    def _load_auto_start(
+        self, partner_id: str, *, default: bool = False, owner_id: str | None = None
+    ) -> bool:
         path = self._partner_dir(partner_id, owner_id=owner_id) / "config.yaml"
         if not path.exists():
             return default
@@ -474,7 +475,9 @@ class PartnerManager:
             return False
         owner_id = instance.config.owner_id or None
         auto_start = (
-            self._load_auto_start(partner_id, default=True, owner_id=owner_id) if preserve_auto_start else False
+            self._load_auto_start(partner_id, default=True, owner_id=owner_id)
+            if preserve_auto_start
+            else False
         )
 
         for task in instance.tasks:

--- a/deeptutor/services/partners/manager.py
+++ b/deeptutor/services/partners/manager.py
@@ -23,6 +23,8 @@ from deeptutor.partners.config.paths import (
     get_data_dir,
     get_partner_dir,
     get_partner_sessions_dir,
+    invalidate_owner_cache,
+    resolve_owner_for_partner,
 )
 from deeptutor.services.partners.runtime import PartnerRunner
 from deeptutor.services.partners.sessions import PartnerSessionStore
@@ -128,6 +130,8 @@ class PartnerConfig:
     enabled_tools: list[str] | None = None
     # Configured MCP tools the partner may load. None = all; [] = MCP off.
     mcp_tools: list[str] | None = None
+    # 数据归属：空串表示 admin，非空为用户 uid
+    owner_id: str = ""
 
 
 @dataclass
@@ -181,6 +185,7 @@ class PartnerInstance:
             "soul_origin": self.config.soul_origin,
             "enabled_tools": self.config.enabled_tools,
             "mcp_tools": self.config.mcp_tools,
+            "owner_id": self.config.owner_id,
             "running": self.running,
             "started_at": self.started_at.isoformat(),
             "last_reload_error": self.last_reload_error,
@@ -197,26 +202,35 @@ class PartnerManager:
 
     # ── Path helpers ──────────────────────────────────────────────
 
-    @property
-    def _partners_dir(self) -> Path:
-        return get_data_dir()
+    @staticmethod
+    def _partners_dir_for_owner(owner_id: str) -> Path:
+        """按 owner_id 返回 partners 根目录。"""
+        from deeptutor.partners.config.paths import _base_dir_for_owner
 
-    def _partner_dir(self, partner_id: str) -> Path:
-        return self._partners_dir / partner_id
+        return _base_dir_for_owner(owner_id)
 
-    def session_store(self, partner_id: str) -> PartnerSessionStore:
+    def _partner_dir(self, partner_id: str, *, owner_id: str | None = None) -> Path:
+        if owner_id is None:
+            owner_id = resolve_owner_for_partner(partner_id)
+        return get_partner_dir(partner_id, owner_id=owner_id)
+
+    def session_store(self, partner_id: str, *, owner_id: str | None = None) -> PartnerSessionStore:
+        if owner_id is None:
+            owner_id = resolve_owner_for_partner(partner_id)
         store = self._stores.get(partner_id)
         if store is None:
-            store = PartnerSessionStore(get_partner_sessions_dir(partner_id))
+            store = PartnerSessionStore(get_partner_sessions_dir(partner_id, owner_id=owner_id))
             self._stores[partner_id] = store
         return store
 
-    def _ensure_partner_dirs(self, partner_id: str) -> None:
-        get_partner_dir(partner_id)
-        ensure_partner_workspace(partner_id)
-        get_partner_sessions_dir(partner_id)
-        if not read_soul(partner_id).strip():
-            write_soul(partner_id, DEFAULT_SOUL)
+    def _ensure_partner_dirs(self, partner_id: str, *, owner_id: str | None = None) -> None:
+        if owner_id is None:
+            owner_id = resolve_owner_for_partner(partner_id)
+        get_partner_dir(partner_id, owner_id=owner_id)
+        ensure_partner_workspace(partner_id, owner_id=owner_id)
+        get_partner_sessions_dir(partner_id, owner_id=owner_id)
+        if not read_soul(partner_id, owner_id=owner_id).strip():
+            write_soul(partner_id, DEFAULT_SOUL, owner_id=owner_id)
 
     # ── Config persistence ────────────────────────────────────────
 
@@ -239,12 +253,25 @@ class PartnerManager:
         "mcp_tools",
     )
 
-    def load_config(self, partner_id: str) -> PartnerConfig | None:
-        path = self._partner_dir(partner_id) / "config.yaml"
+    def load_config(self, partner_id: str, *, owner_id: str | None = None) -> PartnerConfig | None:
+        if owner_id is None:
+            owner_id = resolve_owner_for_partner(partner_id)
+        path = self._partner_dir(partner_id, owner_id=owner_id) / "config.yaml"
         if not path.exists():
             return None
         try:
             data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            # 已有数据迁移：无 owner_id 时自动补充 "local-admin" 并回写
+            loaded_owner_id = str(data.get("owner_id") or "")
+            if "owner_id" not in data:
+                data["owner_id"] = "local-admin"
+                try:
+                    tmp_path = path.with_suffix(path.suffix + ".tmp")
+                    tmp_path.write_text(yaml.dump(data, allow_unicode=True), encoding="utf-8")
+                    tmp_path.replace(path)
+                except Exception:
+                    logger.warning("无法回写 owner_id 迁移到 %s", path, exc_info=True)
+                loaded_owner_id = "local-admin"
             return PartnerConfig(
                 name=data.get("name", partner_id),
                 description=data.get("description", ""),
@@ -259,6 +286,7 @@ class PartnerManager:
                 soul_origin=dict(data.get("soul_origin", {}) or {}),
                 enabled_tools=_optional_str_list(data.get("enabled_tools")),
                 mcp_tools=_optional_str_list(data.get("mcp_tools")),
+                owner_id=loaded_owner_id,
             )
         except Exception:
             logger.exception("Failed to load partner config %s", partner_id)
@@ -273,7 +301,7 @@ class PartnerManager:
         managed separately from config fields (same contract as TutorBot —
         ``None`` preserves the on-disk value; a brand-new partner defaults to
         ``True``)."""
-        partner_dir = self._partner_dir(partner_id)
+        partner_dir = self._partner_dir(partner_id, owner_id=config.owner_id or None)
         path = partner_dir / "config.yaml"
         if auto_start is None:
             auto_start = self._load_auto_start(partner_id, default=False) if path.exists() else True
@@ -288,6 +316,7 @@ class PartnerManager:
             "avatar": config.avatar,
             "soul_origin": config.soul_origin,
             "auto_start": auto_start,
+            "owner_id": config.owner_id,
         }
         if config.llm_selection:
             data["llm_selection"] = config.llm_selection
@@ -303,9 +332,11 @@ class PartnerManager:
         tmp_path = path.with_suffix(path.suffix + ".tmp")
         tmp_path.write_text(yaml.dump(data, allow_unicode=True), encoding="utf-8")
         tmp_path.replace(path)
+        # 更新 owner 缓存
+        invalidate_owner_cache(partner_id)
 
-    def _load_auto_start(self, partner_id: str, *, default: bool = False) -> bool:
-        path = self._partner_dir(partner_id) / "config.yaml"
+    def _load_auto_start(self, partner_id: str, *, default: bool = False, owner_id: str | None = None) -> bool:
+        path = self._partner_dir(partner_id, owner_id=owner_id) / "config.yaml"
         if not path.exists():
             return default
         try:
@@ -335,10 +366,14 @@ class PartnerManager:
         if partner_id in self._partners and self._partners[partner_id].running:
             return self._partners[partner_id]
 
-        self._ensure_partner_dirs(partner_id)
+        owner_id: str | None = None
+        if config is not None:
+            owner_id = config.owner_id or None
+
+        self._ensure_partner_dirs(partner_id, owner_id=owner_id)
 
         if config is None:
-            config = self.load_config(partner_id)
+            config = self.load_config(partner_id, owner_id=owner_id)
         if config is None:
             config = PartnerConfig(name=partner_id)
             self.save_config(partner_id, config)
@@ -346,7 +381,7 @@ class PartnerManager:
         from deeptutor.partners.bus.queue import MessageBus
 
         bus = MessageBus()
-        store = self.session_store(partner_id)
+        store = self.session_store(partner_id, owner_id=config.owner_id or None)
         runner = PartnerRunner(partner_id, config, bus, store, save_config=self.save_config)
 
         try:
@@ -437,8 +472,9 @@ class PartnerManager:
         instance = self._partners.get(partner_id)
         if not instance:
             return False
+        owner_id = instance.config.owner_id or None
         auto_start = (
-            self._load_auto_start(partner_id, default=True) if preserve_auto_start else False
+            self._load_auto_start(partner_id, default=True, owner_id=owner_id) if preserve_auto_start else False
         )
 
         for task in instance.tasks:
@@ -476,6 +512,9 @@ class PartnerManager:
 
         channels_config = ChannelsConfig(**config.channels)
         manager = ChannelManager(channels_config, bus)
+        # 注入 partner_id 到各 channel 实例
+        for ch in manager.channels.values():
+            ch.partner_id = partner_id
         if not manager.channels:
             logger.info("No channels matched config for partner '%s'", partner_id)
             return None
@@ -555,29 +594,61 @@ class PartnerManager:
 
     # ── Listing & discovery ───────────────────────────────────────
 
-    def _discover_partner_ids(self) -> set[str]:
+    def _discover_all_partner_ids(self) -> dict[str, str]:
+        """扫描所有用户目录，返回 partner_id → owner_id 映射。"""
         self._migrate_legacy_tutorbot()
-        ids: set[str] = set()
-        if not self._partners_dir.exists():
-            return ids
-        for entry in self._partners_dir.iterdir():
-            if entry.name in _RESERVED_NAMES or entry.name.startswith((".", "_")):
-                continue
-            if entry.is_dir() and (entry / "config.yaml").exists():
-                ids.add(entry.name)
-        return ids
+        result: dict[str, str] = {}
+
+        # 扫描 admin 目录
+        admin_dir = self._partners_dir_for_owner("")
+        if admin_dir.exists():
+            for entry in admin_dir.iterdir():
+                if entry.name in _RESERVED_NAMES or entry.name.startswith((".", "_")):
+                    continue
+                if entry.is_dir() and (entry / "config.yaml").exists():
+                    result[entry.name] = ""
+
+        # 扫描各用户目录
+        from deeptutor.multi_user.paths import USERS_ROOT
+
+        if USERS_ROOT.exists():
+            for user_dir in USERS_ROOT.iterdir():
+                if not user_dir.is_dir():
+                    continue
+                user_partners = user_dir / "partners"
+                if not user_partners.is_dir():
+                    continue
+                for entry in user_partners.iterdir():
+                    if entry.name in _RESERVED_NAMES or entry.name.startswith((".", "_")):
+                        continue
+                    if entry.is_dir() and (entry / "config.yaml").exists():
+                        result[entry.name] = user_dir.name
+
+        return result
 
     def list_partners(self) -> list[dict[str, Any]]:
-        """All known partners (running + configured on disk); channels keys-only."""
+        """All known partners (running + configured on disk); channels keys-only.
+
+        Admin 返回全部，普通用户只返回自己的（按当前用户过滤）。
+        """
+        from deeptutor.multi_user.context import get_current_user
+
+        current = get_current_user()
         result: dict[str, dict[str, Any]] = {}
 
         for inst in self._partners.values():
+            # 普通用户只能看到自己的 partner
+            if not current.is_admin and inst.config.owner_id != current.id:
+                continue
             result[inst.partner_id] = inst.to_dict()
 
-        for pid in self._discover_partner_ids():
+        for pid, oid in self._discover_all_partner_ids().items():
             if pid in result:
                 continue
-            cfg = self.load_config(pid)
+            # 普通用户只能看到自己的 partner
+            if not current.is_admin and oid != current.id:
+                continue
+            cfg = self.load_config(pid, owner_id=oid or None)
             result[pid] = {
                 "partner_id": pid,
                 "name": cfg.name if cfg else pid,
@@ -593,6 +664,7 @@ class PartnerManager:
                 "soul_origin": cfg.soul_origin if cfg else {},
                 "enabled_tools": cfg.enabled_tools if cfg else None,
                 "mcp_tools": cfg.mcp_tools if cfg else None,
+                "owner_id": cfg.owner_id if cfg else oid,
                 "running": False,
                 "started_at": None,
             }
@@ -602,8 +674,8 @@ class PartnerManager:
     def get_partner(self, partner_id: str) -> PartnerInstance | None:
         return self._partners.get(partner_id)
 
-    def partner_exists(self, partner_id: str) -> bool:
-        return (self._partner_dir(partner_id) / "config.yaml").exists()
+    def partner_exists(self, partner_id: str, *, owner_id: str | None = None) -> bool:
+        return (self._partner_dir(partner_id, owner_id=owner_id) / "config.yaml").exists()
 
     @staticmethod
     def web_session_key(
@@ -627,8 +699,8 @@ class PartnerManager:
 
     def get_recent_active_partners(self, limit: int = 3) -> list[dict[str, Any]]:
         activity: list[tuple[str, dict[str, Any]]] = []
-        for pid in self._discover_partner_ids():
-            sessions = self.session_store(pid).list_sessions()
+        for pid, oid in self._discover_all_partner_ids().items():
+            sessions = self.session_store(pid, owner_id=oid or None).list_sessions()
             if not sessions:
                 continue
             newest = sessions[0]
@@ -681,13 +753,13 @@ class PartnerManager:
     # ── Boot / shutdown ───────────────────────────────────────────
 
     async def auto_start_partners(self) -> None:
-        for pid in self._discover_partner_ids():
+        for pid, oid in self._discover_all_partner_ids().items():
             if pid in self._partners and self._partners[pid].running:
                 continue
             try:
-                if not self._load_auto_start(pid, default=False):
+                if not self._load_auto_start(pid, default=False, owner_id=oid or None):
                     continue
-                config = self.load_config(pid)
+                config = self.load_config(pid, owner_id=oid or None)
                 if config is None:
                     continue
                 await self.start_partner(pid, config)
@@ -700,6 +772,8 @@ class PartnerManager:
             await self.stop_partner(partner_id, preserve_auto_start=preserve_auto_start)
 
     async def destroy_partner(self, partner_id: str) -> bool:
+        instance = self._partners.get(partner_id)
+        owner_id = instance.config.owner_id if instance else None
         await self.stop_partner(partner_id, preserve_auto_start=False)
         self._stores.pop(partner_id, None)
         try:
@@ -708,10 +782,11 @@ class PartnerManager:
             get_cron_service().remove_owner_jobs(f"partner:{partner_id}")
         except Exception:
             logger.warning("Failed to clear cron jobs for '%s'", partner_id, exc_info=True)
-        partner_dir = self._partner_dir(partner_id)
+        partner_dir = self._partner_dir(partner_id, owner_id=owner_id or None)
         if not partner_dir.exists():
             return False
         shutil.rmtree(partner_dir)
+        invalidate_owner_cache(partner_id)
         logger.info("Partner '%s' destroyed (data deleted)", partner_id)
         return True
 
@@ -728,7 +803,8 @@ class PartnerManager:
             return
         self._migrated_legacy = True
 
-        legacy_root = self._partners_dir.parent / "tutorbot"
+        admin_dir = self._partners_dir_for_owner("")
+        legacy_root = admin_dir.parent / "tutorbot"
         if not legacy_root.is_dir():
             return
 
@@ -736,7 +812,7 @@ class PartnerManager:
         new_souls = self._souls_file
         if legacy_souls.is_file() and not new_souls.exists():
             try:
-                self._partners_dir.mkdir(parents=True, exist_ok=True)
+                admin_dir.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(legacy_souls, new_souls)
             except OSError:
                 logger.exception("Failed to migrate TutorBot souls library")
@@ -780,7 +856,7 @@ class PartnerManager:
 
     @property
     def _souls_file(self) -> Path:
-        return self._partners_dir / "_souls.yaml"
+        return self._partners_dir_for_owner("") / "_souls.yaml"
 
     def _load_souls(self) -> list[dict[str, str]]:
         path = self._souls_file
@@ -798,7 +874,8 @@ class PartnerManager:
         return souls
 
     def _save_souls(self, souls: list[dict[str, str]]) -> None:
-        self._partners_dir.mkdir(parents=True, exist_ok=True)
+        admin_dir = self._partners_dir_for_owner("")
+        admin_dir.mkdir(parents=True, exist_ok=True)
         self._souls_file.write_text(
             yaml.dump(souls, allow_unicode=True, default_flow_style=False),
             encoding="utf-8",

--- a/deeptutor/services/partners/manager.py
+++ b/deeptutor/services/partners/manager.py
@@ -629,24 +629,33 @@ class PartnerManager:
     def list_partners(self) -> list[dict[str, Any]]:
         """All known partners (running + configured on disk); channels keys-only.
 
-        Admin 返回全部，普通用户只返回自己的（按当前用户过滤）。
+        Admin 只返回 admin 自己的 partner；普通用户只返回自己的。
         """
         from deeptutor.multi_user.context import get_current_user
+        from deeptutor.partners.config.paths import resolve_owner_for_partner
 
         current = get_current_user()
         result: dict[str, dict[str, Any]] = {}
 
         for inst in self._partners.values():
-            # 普通用户只能看到自己的 partner
-            if not current.is_admin and inst.config.owner_id != current.id:
+            # 用磁盘位置（resolve_owner_for_partner）而非 config.owner_id 判断归属，
+            # 避免遗留迁移 partner（config.owner_id = "local-admin"）被错误过滤。
+            inst_oid = resolve_owner_for_partner(inst.partner_id)
+            if current.is_admin:
+                if inst_oid:
+                    continue
+            elif inst_oid != current.id:
                 continue
             result[inst.partner_id] = inst.to_dict()
 
         for pid, oid in self._discover_all_partner_ids().items():
             if pid in result:
                 continue
-            # 普通用户只能看到自己的 partner
-            if not current.is_admin and oid != current.id:
+            # admin 只能看到自己的 partner（owner_id 为空），普通用户只能看到自己的
+            if current.is_admin:
+                if oid:
+                    continue
+            elif oid != current.id:
                 continue
             cfg = self.load_config(pid, owner_id=oid or None)
             result[pid] = {
@@ -698,8 +707,17 @@ class PartnerManager:
         return store.merged_messages(limit=limit)
 
     def get_recent_active_partners(self, limit: int = 3) -> list[dict[str, Any]]:
+        from deeptutor.multi_user.context import get_current_user
+
+        current = get_current_user()
         activity: list[tuple[str, dict[str, Any]]] = []
         for pid, oid in self._discover_all_partner_ids().items():
+            # admin 只能看到自己的 partner（owner_id 为空），普通用户只能看到自己的
+            if current.is_admin:
+                if oid:
+                    continue
+            elif oid != current.id:
+                continue
             sessions = self.session_store(pid, owner_id=oid or None).list_sessions()
             if not sessions:
                 continue

--- a/deeptutor/services/partners/runtime.py
+++ b/deeptutor/services/partners/runtime.py
@@ -79,12 +79,15 @@ class PartnerRunner:
         bus: MessageBus,
         store: PartnerSessionStore,
         save_config: Callable[[str, Any], None] | None = None,
+        *,
+        owner_id: str | None = None,
     ) -> None:
         self.partner_id = partner_id
         self.config = config
         self.bus = bus
         self.store = store
         self.save_config = save_config
+        self.owner_id = owner_id if owner_id is not None else getattr(config, "owner_id", "")
         self._session_locks: dict[str, asyncio.Lock] = {}
         self._tasks: set[asyncio.Task] = set()
 
@@ -178,7 +181,7 @@ class PartnerRunner:
         on_event: EventCallback | None = None,
         delivery_meta: dict[str, Any] | None = None,
     ) -> str:
-        ensure_partner_workspace(self.partner_id)
+        ensure_partner_workspace(self.partner_id, owner_id=self.owner_id)
         primary = getattr(self.config, "llm_selection", None) or None
         backup = getattr(self.config, "backup_llm_selection", None) or None
 
@@ -386,7 +389,7 @@ class PartnerRunner:
             knowledge_bases=kb_names,
             attachments=attachments,
             language=self._language(),
-            persona_context=read_soul(self.partner_id).strip(),
+            persona_context=read_soul(self.partner_id, owner_id=self.owner_id).strip(),
             skills_manifest=skills_manifest,
             source_manifest=source_manifest,
             metadata=metadata,

--- a/deeptutor/services/partners/scope.py
+++ b/deeptutor/services/partners/scope.py
@@ -20,8 +20,8 @@ def partner_user_id(partner_id: str) -> str:
     return f"{PARTNER_USER_PREFIX}{partner_id}"
 
 
-def partner_scope(partner_id: str) -> UserScope:
-    workspace = get_partner_workspace(partner_id)
+def partner_scope(partner_id: str, *, owner_id: str | None = None) -> UserScope:
+    workspace = get_partner_workspace(partner_id, owner_id=owner_id)
     return UserScope(
         kind="user",
         user_id=partner_user_id(partner_id),

--- a/deeptutor/services/partners/workspace.py
+++ b/deeptutor/services/partners/workspace.py
@@ -65,9 +65,9 @@ adapt to the user's level, and value accuracy over speed.
 """
 
 
-def ensure_partner_workspace(partner_id: str) -> Path:
+def ensure_partner_workspace(partner_id: str, *, owner_id: str | None = None) -> Path:
     """Create the full chat-format workspace tree; returns the scope root."""
-    return ensure_scope_workspace(partner_scope(partner_id))
+    return ensure_scope_workspace(partner_scope(partner_id, owner_id=owner_id))
 
 
 def strip_frontmatter(text: str) -> str:
@@ -85,19 +85,19 @@ def strip_frontmatter(text: str) -> str:
     return raw[end + 4 :].lstrip("\n")
 
 
-def _partner_path_service(partner_id: str) -> PathService:
-    return PathService(workspace_root=ensure_partner_workspace(partner_id))
+def _partner_path_service(partner_id: str, *, owner_id: str | None = None) -> PathService:
+    return PathService(workspace_root=ensure_partner_workspace(partner_id, owner_id=owner_id))
 
 
 # ── Soul ──────────────────────────────────────────────────────────
 
 
-def soul_path(partner_id: str) -> Path:
-    return _partner_path_service(partner_id).get_workspace_dir() / SOUL_FILENAME
+def soul_path(partner_id: str, *, owner_id: str | None = None) -> Path:
+    return _partner_path_service(partner_id, owner_id=owner_id).get_workspace_dir() / SOUL_FILENAME
 
 
-def read_soul(partner_id: str) -> str:
-    path = soul_path(partner_id)
+def read_soul(partner_id: str, *, owner_id: str | None = None) -> str:
+    path = soul_path(partner_id, owner_id=owner_id)
     if not path.exists():
         return ""
     try:
@@ -107,8 +107,8 @@ def read_soul(partner_id: str) -> str:
         return ""
 
 
-def write_soul(partner_id: str, content: str) -> None:
-    path = soul_path(partner_id)
+def write_soul(partner_id: str, content: str, *, owner_id: str | None = None) -> None:
+    path = soul_path(partner_id, owner_id=owner_id)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content or "", encoding="utf-8")
 
@@ -119,6 +119,7 @@ def write_soul(partner_id: str, content: str) -> None:
 def provision_assets(
     partner_id: str,
     *,
+    owner_id: str | None = None,
     knowledge_bases: list[str] | None = None,
     skills: list[str] | None = None,
     notebooks: list[str] | None = None,
@@ -128,7 +129,7 @@ def provision_assets(
     Source resolution honours the calling user's permissions. Returns a
     report dict: ``{"copied": {...}, "errors": [{"type","name","error"}]}``.
     """
-    root = ensure_partner_workspace(partner_id)
+    root = ensure_partner_workspace(partner_id, owner_id=owner_id)
     copied: dict[str, list[str]] = {"knowledge_bases": [], "skills": [], "notebooks": []}
     errors: list[dict[str, str]] = []
 
@@ -141,14 +142,14 @@ def provision_assets(
 
     for skill_name in skills or []:
         try:
-            copied["skills"].append(_copy_skill(skill_name, partner_id))
+            copied["skills"].append(_copy_skill(skill_name, partner_id, owner_id=owner_id))
         except Exception as exc:
             logger.exception("Skill provisioning failed for %s", skill_name)
             errors.append({"type": "skill", "name": skill_name, "error": _err(exc)})
 
     for notebook_id in notebooks or []:
         try:
-            copied["notebooks"].append(_copy_notebook(notebook_id, partner_id))
+            copied["notebooks"].append(_copy_notebook(notebook_id, partner_id, owner_id=owner_id))
         except Exception as exc:
             logger.exception("Notebook provisioning failed for %s", notebook_id)
             errors.append({"type": "notebook", "name": notebook_id, "error": _err(exc)})
@@ -205,9 +206,9 @@ def _skill_source_dir(skill_name: str) -> Path:
     raise FileNotFoundError(f"Skill '{skill_name}' not found or not accessible")
 
 
-def _copy_skill(skill_name: str, partner_id: str) -> str:
+def _copy_skill(skill_name: str, partner_id: str, *, owner_id: str | None = None) -> str:
     src = _skill_source_dir(skill_name)
-    dst = _partner_path_service(partner_id).get_workspace_dir() / "skills" / skill_name
+    dst = _partner_path_service(partner_id, owner_id=owner_id).get_workspace_dir() / "skills" / skill_name
     if dst.exists():
         return skill_name
     dst.parent.mkdir(parents=True, exist_ok=True)
@@ -215,13 +216,13 @@ def _copy_skill(skill_name: str, partner_id: str) -> str:
     return skill_name
 
 
-def _copy_notebook(notebook_id: str, partner_id: str) -> str:
+def _copy_notebook(notebook_id: str, partner_id: str, *, owner_id: str | None = None) -> str:
     src_dir = _requester_path_service().get_notebook_dir()
     src_file = src_dir / f"{notebook_id}.json"
     if not src_file.exists():
         raise FileNotFoundError(f"Notebook '{notebook_id}' not found")
 
-    dst_dir = _partner_path_service(partner_id).get_notebook_dir()
+    dst_dir = _partner_path_service(partner_id, owner_id=owner_id).get_notebook_dir()
     dst_dir.mkdir(parents=True, exist_ok=True)
     dst_file = dst_dir / f"{notebook_id}.json"
     if not dst_file.exists():
@@ -280,9 +281,9 @@ def _merge_index_entry(index_path: Path, entry: dict[str, Any]) -> None:
 # ── Asset inventory / removal (partner-side, no user context needed) ──
 
 
-def list_assets(partner_id: str) -> dict[str, list[dict[str, Any]]]:
-    root = ensure_partner_workspace(partner_id)
-    service = _partner_path_service(partner_id)
+def list_assets(partner_id: str, *, owner_id: str | None = None) -> dict[str, list[dict[str, Any]]]:
+    root = ensure_partner_workspace(partner_id, owner_id=owner_id)
+    service = _partner_path_service(partner_id, owner_id=owner_id)
 
     kbs: list[dict[str, Any]] = []
     kb_root = root / "knowledge_bases"
@@ -318,9 +319,9 @@ def list_assets(partner_id: str) -> dict[str, list[dict[str, Any]]]:
     return {"knowledge_bases": kbs, "skills": skills, "notebooks": notebooks}
 
 
-def remove_asset(partner_id: str, asset_type: str, name: str) -> bool:
-    root = ensure_partner_workspace(partner_id)
-    service = _partner_path_service(partner_id)
+def remove_asset(partner_id: str, asset_type: str, name: str, *, owner_id: str | None = None) -> bool:
+    root = ensure_partner_workspace(partner_id, owner_id=owner_id)
+    service = _partner_path_service(partner_id, owner_id=owner_id)
     if "/" in name or "\\" in name or name.startswith("."):
         raise ValueError("Invalid asset name")
 

--- a/deeptutor/services/partners/workspace.py
+++ b/deeptutor/services/partners/workspace.py
@@ -208,7 +208,11 @@ def _skill_source_dir(skill_name: str) -> Path:
 
 def _copy_skill(skill_name: str, partner_id: str, *, owner_id: str | None = None) -> str:
     src = _skill_source_dir(skill_name)
-    dst = _partner_path_service(partner_id, owner_id=owner_id).get_workspace_dir() / "skills" / skill_name
+    dst = (
+        _partner_path_service(partner_id, owner_id=owner_id).get_workspace_dir()
+        / "skills"
+        / skill_name
+    )
     if dst.exists():
         return skill_name
     dst.parent.mkdir(parents=True, exist_ok=True)
@@ -319,7 +323,9 @@ def list_assets(partner_id: str, *, owner_id: str | None = None) -> dict[str, li
     return {"knowledge_bases": kbs, "skills": skills, "notebooks": notebooks}
 
 
-def remove_asset(partner_id: str, asset_type: str, name: str, *, owner_id: str | None = None) -> bool:
+def remove_asset(
+    partner_id: str, asset_type: str, name: str, *, owner_id: str | None = None
+) -> bool:
     root = ensure_partner_workspace(partner_id, owner_id=owner_id)
     service = _partner_path_service(partner_id, owner_id=owner_id)
     if "/" in name or "\\" in name or name.startswith("."):

--- a/tests/api/test_partners_router.py
+++ b/tests/api/test_partners_router.py
@@ -79,9 +79,14 @@ class TestCreate:
         assert body["soul_origin"] == {"type": "custom", "id": ""}
         assert body["provisioning"]["errors"] == []
 
-    def test_duplicate_id_conflicts(self, client):
-        assert _create(client).status_code == 200
-        assert _create(client).status_code == 409
+    def test_duplicate_id_auto_suffix(self, client):
+        res1 = _create(client)
+        assert res1.status_code == 200
+        assert res1.json()["partner_id"] == "ada"
+        # 同名 partner 自动加后缀，不再返回 409
+        res2 = _create(client)
+        assert res2.status_code == 200
+        assert res2.json()["partner_id"] == "ada-2"
 
     def test_top_level_delivery_flags_rejected(self, client):
         res = _create(client, channels={"send_progress": False})

--- a/tests/services/partners/conftest.py
+++ b/tests/services/partners/conftest.py
@@ -17,6 +17,7 @@ def partners_root(tmp_path, monkeypatch) -> Path:
     patching that module is sufficient to keep tests off the real ``data/``.
     """
     from deeptutor.multi_user import paths
+    from deeptutor.partners.config import paths as partner_paths
 
     project_root = tmp_path
     admin_root = (project_root / "data").resolve()
@@ -25,6 +26,8 @@ def partners_root(tmp_path, monkeypatch) -> Path:
     monkeypatch.setattr(paths, "USERS_ROOT", admin_root / "users")
     monkeypatch.setattr(paths, "SYSTEM_ROOT", admin_root / "system")
     monkeypatch.setattr(paths, "_path_services", {})
+    # 清除 owner 缓存
+    monkeypatch.setattr(partner_paths, "_owner_cache", {})
 
     admin_root.mkdir(parents=True, exist_ok=True)
     return admin_root / "partners"

--- a/tests/services/partners/test_msteams_channel.py
+++ b/tests/services/partners/test_msteams_channel.py
@@ -23,7 +23,7 @@ from deeptutor.partners.channels.msteams import (
 @pytest.fixture
 def state_dir(tmp_path, monkeypatch):
     """Redirect the channel's runtime state dir to a temp directory."""
-    monkeypatch.setattr(msteams_mod, "get_runtime_subdir", lambda name: tmp_path)
+    monkeypatch.setattr(msteams_mod, "get_partner_runtime_subdir", lambda partner_id, name: tmp_path)
     return tmp_path
 
 

--- a/tests/services/partners/test_partner_manager_config.py
+++ b/tests/services/partners/test_partner_manager_config.py
@@ -70,8 +70,11 @@ class TestMergeSemantics:
         assert not hasattr(merged, "bogus")
 
     def test_mergeable_fields_match_partnerconfig_fields(self):
-        """Every config field must be mergeable via the API (anti-drift pin)."""
-        field_names = {f.name for f in dataclasses.fields(PartnerConfig)}
+        """Every config field must be mergeable via the API (anti-drift pin).
+
+        owner_id 除外：它不允许通过 merge 修改，由系统自动管理。
+        """
+        field_names = {f.name for f in dataclasses.fields(PartnerConfig)} - {"owner_id"}
         assert set(PartnerManager._MERGEABLE_FIELDS) == field_names
 
 
@@ -135,7 +138,7 @@ class TestLegacyTutorBotMigration:
         self._seed_legacy_bot(admin_root)
 
         mgr = _mgr()
-        ids = mgr._discover_partner_ids()
+        ids = mgr._discover_all_partner_ids()
         assert "old-bot" in ids
 
         cfg = mgr.load_config("old-bot")
@@ -154,13 +157,13 @@ class TestLegacyTutorBotMigration:
         legacy = self._seed_legacy_bot(admin_root)
 
         mgr = _mgr()
-        mgr._discover_partner_ids()
+        mgr._discover_all_partner_ids()
         # Tweak the migrated partner, then re-discover with a fresh manager.
         from deeptutor.services.partners.workspace import write_soul
 
         write_soul("old-bot", "# Edited after migration")
         mgr2 = _mgr()
-        mgr2._discover_partner_ids()
+        mgr2._discover_all_partner_ids()
         assert read_soul("old-bot") == "# Edited after migration"
         # Legacy tree untouched.
         assert (legacy / "config.yaml").exists()

--- a/tests/services/partners/test_weixin_channel.py
+++ b/tests/services/partners/test_weixin_channel.py
@@ -29,7 +29,7 @@ from deeptutor.partners.channels.weixin import (
 def state_dir(tmp_path, monkeypatch):
     """Redirect default Weixin runtime state to a temp directory."""
 
-    monkeypatch.setattr(weixin_mod, "get_runtime_subdir", lambda name: tmp_path / name)
+    monkeypatch.setattr(weixin_mod, "get_partner_runtime_subdir", lambda partner_id, name: tmp_path / name)
     return tmp_path / "weixin"
 
 

--- a/tests/services/partners/test_zulip_channel.py
+++ b/tests/services/partners/test_zulip_channel.py
@@ -316,7 +316,7 @@ class TestDownloadAttachments:
                 return_value=[("img.png", "/user_uploads/2/ce/abc/img.png")],
             ),
             patch(
-                "deeptutor.partners.channels.zulip.get_media_dir",
+                "deeptutor.partners.channels.zulip.get_partner_media_dir",
                 return_value=tmp_path,
             ),
             patch("deeptutor.partners.channels.zulip.requests.get") as mock_get,
@@ -353,7 +353,7 @@ class TestDownloadAttachments:
                 return_value=[("img.png", "/user_uploads/2/ce/abc/img.png")],
             ),
             patch(
-                "deeptutor.partners.channels.zulip.get_media_dir",
+                "deeptutor.partners.channels.zulip.get_partner_media_dir",
                 return_value=tmp_path,
             ),
         ):
@@ -861,7 +861,7 @@ class TestResolveMediaPath:
         path_id = "/user_uploads/2/ce/abc123/photo.png"
 
         with patch(
-            "deeptutor.partners.channels.zulip.get_media_dir",
+            "deeptutor.partners.channels.zulip.get_partner_media_dir",
             return_value=tmp_path,
         ):
             dest = ZulipChannel._attachment_destination(tmp_path, "photo.png", path_id, 0)
@@ -877,7 +877,7 @@ class TestResolveMediaPath:
 
         with (
             patch(
-                "deeptutor.partners.channels.zulip.get_media_dir",
+                "deeptutor.partners.channels.zulip.get_partner_media_dir",
                 return_value=tmp_path,
             ),
             patch("deeptutor.partners.channels.zulip.requests.get") as mock_get,
@@ -898,7 +898,7 @@ class TestResolveMediaPath:
 
         with (
             patch(
-                "deeptutor.partners.channels.zulip.get_media_dir",
+                "deeptutor.partners.channels.zulip.get_partner_media_dir",
                 return_value=tmp_path,
             ),
             patch("deeptutor.partners.channels.zulip.requests.get") as mock_get,
@@ -917,7 +917,7 @@ class TestResolveMediaPath:
 
         with (
             patch(
-                "deeptutor.partners.channels.zulip.get_media_dir",
+                "deeptutor.partners.channels.zulip.get_partner_media_dir",
                 return_value=tmp_path,
             ),
             patch("deeptutor.partners.channels.zulip.requests.get") as mock_get,


### PR DESCRIPTION
### Description

本 PR 实现 Partner 多用户隔离——按用户 scope 存储 partner 数据。

**问题背景**：DeepTutor 启用多用户认证（multi-user）后，知识库、技能、笔记本等均按用户隔离，但 Partner 层遗漏了这一层隔离，出现两个问题：
1. 普通用户无法创建 partner（`partners` router 硬编码为 `_admin`）
2. Channel 媒体/状态文件全局共享（不同用户的 partner 共用同一路径）

**核心设计**：

| 模块 | 改动概要 |
|------|---------|
| **路径层** [partners/config/paths.py](file://deeptutor/partners/config/paths.py) | 引入 `_base_dir_for_owner(owner_id)` 替代 `_base_dir()`；新增 `get_partner_runtime_subdir`；所有路径函数接受可选 `owner_id` 参数（避免 partner 运行时通过 `get_current_user()` 递归解析路径） |
| **数据模型** [services/partners/manager.py](file://deeptutor/services/partners/manager.py) | `PartnerConfig` 增加 `owner_id` 字段；`save_config` / `load_config` 读写 owner_id；`_discover_all_partner_ids()` 多用户扫描；`list_partners` / `get_recent_active_partners` 按当前用户过滤 |
| **运行时** [services/partners/runtime.py](file://deeptutor/services/partners/runtime.py) | owner_id 从 config 读取，修复空串 fallback 逻辑 |
| **API 注册** [api/main.py](file://deeptutor/api/main.py) | partners router 从 `_admin` 降级为 `_auth`（仅需登录即可访问） |
| **API 校验** [api/routers/partners.py](file://deeptutor/api/routers/partners.py) | 新增 `_check_partner_owner()` 做细粒度 ownership 校验；各 `/{partner_id}` 端点加入校验；同名 partner 自动加后缀；admin 与普通用户完全隔离 |
| **Channel 基类** [partners/channels/base.py](file://deeptutor/partners/channels/base.py) | 增加 `self.partner_id: str = ""` 属性，由 `PartnerManager` 注入 |
| **Channel 实现** [channels/telegram.py](file://deeptutor/partners/channels/telegram.py) / [zulip.py](file://deeptutor/partners/channels/zulip.py) / [weixin.py](file://deeptutor/partners/channels/weixin.py) / [wecom.py](file://deeptutor/partners/channels/wecom.py) / [napcat.py](file://deeptutor/partners/channels/napcat.py) / [matrix.py](file://deeptutor/partners/channels/matrix.py) / [msteams.py](file://deeptutor/partners/channels/msteams.py) / [mochat.py](file://deeptutor/partners/channels/mochat.py) | 媒体/状态路径改为 `get_partner_media_dir` / `get_partner_runtime_subdir` 按 partner 隔离；MSTeams/MoChat 使用 `@property` 延迟初始化（避免 partner_id 注入前访问错误路径） |

**关键决策**：
- Admin 与普通用户的 partner 完全隔离——admin 不能看到或操作普通用户的 partner，反之亦然
- owner_id 为空串表示 admin owner（单机模式下 `get_current_user()` 返回 `local_admin_user()`，所有路径锚定 `data/partners/`，行为完全不变）
- partner_id 在当前用户 scope 内唯一，创建时自动检测冲突并添加后缀；不同用户可创建同名 partner

**向后兼容**：
- 单机模式（`AUTH_ENABLED=false`）：路径仍在 `data/partners/` 下，行为完全不变
- 已有 admin 创建的 partners：`load_config()` 自动补充 `owner_id: ""`（空串 = admin）并回写磁盘，admin 用户可继续操作

**代码变更统计**：22 个文件，**519 行新增，154 行删除**

---

### Related Issues
- 设计文档（含完整设计决策、权限模型、Channel 隔离实现、测试覆盖等）：https://gist.github.com/wedone/393c6e58dc882625937a7002992dcd87

---

### Module(s) Affected
- [x] `api`
- [x] `config`
- [x] `services`
- [x] `tests`
- [ ] Other: `...`

---

### Checklist

- [x] 我已阅读并遵循了 contribution guidelines
- [x] 我的代码遵循了项目的编码标准
- [x] 我已运行 `ruff check --fix` + `ruff format` 并修复了问题（msteams.py/mochat.py 添加 `from pathlib import Path`）
- [x] 我已添加了相关测试或更新了现有测试
- [ ] 如有必要，我已更新了文档
- [x] 我的变更不会引入新的安全漏洞

---

### Additional Notes

（无额外事项）

---

**提交记录**：
- `f5e309ab` feat(partners): Partner 多用户隔离 — 按用户 scope 存储 partner 数据
- `9b5ef4fd` fix(partners): 修复 admin 越权看到普通用户 partner 的问题
- `22368564` chore(partners): 添加 pathlib import + ruff format
- `9795d318` fix(partners): 修复 load_config 迁移分支 owner_id 值错误及测试函数名不同步
