### PR TITLE
fix: show only provider-relevant fields in Search settings

### DIFF
--- a/web/components/settings/ServiceConfigEditor.tsx
+++ b/web/components/settings/ServiceConfigEditor.tsx
@@ -25,6 +25,7 @@ import {
   useSettings,
 } from "./SettingsContext";
 import { DimensionField } from "./DimensionField";
+import { searchProviderFields } from "./search-providers";
 import {
   activeProfileDetail,
   deprecatedSearchProviders,
@@ -749,6 +750,15 @@ function ProfileFields({
   const providerValue =
     service === "search" ? profile.provider || "" : profile.binding || "";
 
+  // Only the search service hides fields by provider. LLM/embedding always
+  // expose Base URL and API Key, so default both to shown for them.
+  const fields =
+    service === "search"
+      ? searchProviderFields(profile.provider)
+      : { apiKey: true, baseUrl: true, baseUrlRequired: false };
+  const searxngMissingBaseUrl =
+    fields.baseUrlRequired && !String(profile.base_url || "").trim();
+
   return (
     <div className="grid gap-4 sm:grid-cols-2">
       <div className="sm:col-span-2">
@@ -822,61 +832,72 @@ function ProfileFields({
           </p>
         )}
       </div>
-      <div className="sm:col-span-2">
-        <div className="mb-1.5 text-[12px] text-[var(--muted-foreground)]">
-          {service === "embedding" ? t("Endpoint URL") : t("Base URL")}
-        </div>
-        <input
-          className={inputClass}
-          value={profile.base_url}
-          onChange={(e) =>
-            updateProfileField(service, "base_url", e.target.value)
-          }
-          placeholder={
-            service === "embedding"
-              ? "https://api.openai.com/v1/embeddings"
-              : "https://api.openai.com/v1"
-          }
-        />
-        {service === "embedding" && (
-          <p className="mt-1.5 text-[11px] text-[var(--muted-foreground)]">
-            {t(
-              "Embedding requests are sent to this URL exactly; DeepTutor does not append /embeddings or /api/embed at request time.",
-            )}
-          </p>
-        )}
-      </div>
-      <div className="sm:col-span-2">
-        <div className="mb-1.5 text-[12px] text-[var(--muted-foreground)]">
-          {t("API Key")}
-        </div>
-        <div className="relative">
+      {fields.baseUrl && (
+        <div className="sm:col-span-2">
+          <div className="mb-1.5 text-[12px] text-[var(--muted-foreground)]">
+            {service === "embedding" ? t("Endpoint URL") : t("Base URL")}
+          </div>
           <input
-            type={showApiKey ? "text" : "password"}
-            autoComplete="new-password"
-            spellCheck={false}
-            className={`${inputClass} pr-10 font-mono`}
-            value={profile.api_key}
+            className={inputClass}
+            value={profile.base_url}
             onChange={(e) =>
-              updateProfileField(service, "api_key", e.target.value)
+              updateProfileField(service, "base_url", e.target.value)
             }
-            placeholder="sk-..."
+            placeholder={
+              service === "embedding"
+                ? "https://api.openai.com/v1/embeddings"
+                : service === "search"
+                  ? "http://localhost:8888"
+                  : "https://api.openai.com/v1"
+            }
           />
-          <button
-            type="button"
-            onClick={() => setShowApiKey((prev) => !prev)}
-            className="absolute right-1 top-1/2 -translate-y-1/2 rounded-md p-1.5 text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-[var(--foreground)]"
-            aria-label={showApiKey ? t("Hide API key") : t("Show API key")}
-            title={showApiKey ? t("Hide API key") : t("Show API key")}
-          >
-            {showApiKey ? (
-              <EyeOff className="h-4 w-4" />
-            ) : (
-              <Eye className="h-4 w-4" />
-            )}
-          </button>
+          {service === "embedding" && (
+            <p className="mt-1.5 text-[11px] text-[var(--muted-foreground)]">
+              {t(
+                "Embedding requests are sent to this URL exactly; DeepTutor does not append /embeddings or /api/embed at request time.",
+              )}
+            </p>
+          )}
+          {searxngMissingBaseUrl && (
+            <p className="mt-1.5 text-[11px] text-amber-600 dark:text-amber-400">
+              {t("Required — without it, search falls back to DuckDuckGo.")}
+            </p>
+          )}
         </div>
-      </div>
+      )}
+      {fields.apiKey && (
+        <div className="sm:col-span-2">
+          <div className="mb-1.5 text-[12px] text-[var(--muted-foreground)]">
+            {t("API Key")}
+          </div>
+          <div className="relative">
+            <input
+              type={showApiKey ? "text" : "password"}
+              autoComplete="new-password"
+              spellCheck={false}
+              className={`${inputClass} pr-10 font-mono`}
+              value={profile.api_key}
+              onChange={(e) =>
+                updateProfileField(service, "api_key", e.target.value)
+              }
+              placeholder="sk-..."
+            />
+            <button
+              type="button"
+              onClick={() => setShowApiKey((prev) => !prev)}
+              className="absolute right-1 top-1/2 -translate-y-1/2 rounded-md p-1.5 text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-[var(--foreground)]"
+              aria-label={showApiKey ? t("Hide API key") : t("Show API key")}
+              title={showApiKey ? t("Hide API key") : t("Show API key")}
+            >
+              {showApiKey ? (
+                <EyeOff className="h-4 w-4" />
+              ) : (
+                <Eye className="h-4 w-4" />
+              )}
+            </button>
+          </div>
+        </div>
+      )}
       <div className="sm:col-span-2 rounded-xl border border-[var(--border)]/60 bg-[var(--muted)]/20">
         <button
           type="button"

--- a/web/components/settings/search-providers.ts
+++ b/web/components/settings/search-providers.ts
@@ -1,0 +1,71 @@
+// Which connection fields a web-search provider actually uses.
+//
+// This mirrors the backend resolver in
+// `deeptutor/services/config/provider_runtime.py`
+// (`resolve_search_runtime_config`): brave/tavily/jina/perplexity/serper
+// authenticate with an API key, searxng is configured by its instance Base
+// URL, and duckduckgo/none need no connection details at all. Every search
+// provider ships an empty `base_url` from the settings API
+// (`_provider_choices` in `deeptutor/api/routers/settings.py`), so the Base
+// URL only ever carries a value for searxng.
+//
+// Keep this table in sync with SUPPORTED_SEARCH_PROVIDERS on the backend.
+
+export type SearchProviderFieldSpec = {
+  /** Provider authenticates with an API key. */
+  apiKey: boolean;
+  /** Provider is configured with a Base URL. */
+  baseUrl: boolean;
+  /** The Base URL is mandatory — the provider cannot work without it. */
+  baseUrlRequired: boolean;
+};
+
+const KEY_ONLY: SearchProviderFieldSpec = {
+  apiKey: true,
+  baseUrl: false,
+  baseUrlRequired: false,
+};
+
+const NO_CREDENTIALS: SearchProviderFieldSpec = {
+  apiKey: false,
+  baseUrl: false,
+  baseUrlRequired: false,
+};
+
+const BASE_URL_ONLY: SearchProviderFieldSpec = {
+  apiKey: false,
+  baseUrl: true,
+  baseUrlRequired: true,
+};
+
+// Providers we don't model (a custom/unknown value, the deprecated
+// exa/baidu/openrouter set, or an empty selection): show every field so we
+// never hide a control the provider might actually need.
+const UNKNOWN: SearchProviderFieldSpec = {
+  apiKey: true,
+  baseUrl: true,
+  baseUrlRequired: false,
+};
+
+const SEARCH_PROVIDER_FIELDS: Record<string, SearchProviderFieldSpec> = {
+  none: NO_CREDENTIALS,
+  duckduckgo: NO_CREDENTIALS,
+  searxng: BASE_URL_ONLY,
+  brave: KEY_ONLY,
+  tavily: KEY_ONLY,
+  jina: KEY_ONLY,
+  perplexity: KEY_ONLY,
+  serper: KEY_ONLY,
+};
+
+/**
+ * Resolve which connection fields to show for a search provider. Unknown,
+ * custom, or empty provider names fall back to showing every field.
+ */
+export function searchProviderFields(
+  provider: string | null | undefined,
+): SearchProviderFieldSpec {
+  const key = (provider ?? "").trim().toLowerCase();
+  if (!key) return UNKNOWN;
+  return SEARCH_PROVIDER_FIELDS[key] ?? UNKNOWN;
+}

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -720,6 +720,7 @@
   "Select provider...": "Select provider...",
   "Perplexity requires API key. It will fail hard without credentials.": "Perplexity requires API key. It will fail hard without credentials.",
   "Supported provider.": "Supported provider.",
+  "Required — without it, search falls back to DuckDuckGo.": "Required — without it, search falls back to DuckDuckGo.",
   "Deprecated provider. Switch to brave/tavily/jina/searxng/duckduckgo/perplexity.": "Deprecated provider. Switch to brave/tavily/jina/searxng/duckduckgo/perplexity.",
   "Unsupported provider. Use brave/tavily/jina/searxng/duckduckgo/perplexity.": "Unsupported provider. Use brave/tavily/jina/searxng/duckduckgo/perplexity.",
   "API Version": "API Version",

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -724,6 +724,7 @@
   "Select provider...": "选择提供商...",
   "Perplexity requires API key. It will fail hard without credentials.": "Perplexity 需要 API 密钥，缺少凭证将无法使用。",
   "Supported provider.": "受支持的提供商。",
+  "Required — without it, search falls back to DuckDuckGo.": "必填——缺少它，搜索将回退到 DuckDuckGo。",
   "Deprecated provider. Switch to brave/tavily/jina/searxng/duckduckgo/perplexity.": "已弃用的提供商。请切换到 brave/tavily/jina/searxng/duckduckgo/perplexity。",
   "Unsupported provider. Use brave/tavily/jina/searxng/duckduckgo/perplexity.": "不受支持的提供商。请使用 brave/tavily/jina/searxng/duckduckgo/perplexity。",
   "API Version": "API 版本",

--- a/web/tests/search-providers.test.ts
+++ b/web/tests/search-providers.test.ts
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { searchProviderFields } from "../components/settings/search-providers";
+
+test("key-based providers show only the API key field", () => {
+  for (const provider of ["brave", "tavily", "jina", "perplexity", "serper"]) {
+    assert.deepEqual(
+      searchProviderFields(provider),
+      { apiKey: true, baseUrl: false, baseUrlRequired: false },
+      `expected ${provider} to require only an API key`,
+    );
+  }
+});
+
+test("searxng shows only a required Base URL", () => {
+  assert.deepEqual(searchProviderFields("searxng"), {
+    apiKey: false,
+    baseUrl: true,
+    baseUrlRequired: true,
+  });
+});
+
+test("zero-config providers show no connection fields", () => {
+  for (const provider of ["duckduckgo", "none"]) {
+    assert.deepEqual(
+      searchProviderFields(provider),
+      { apiKey: false, baseUrl: false, baseUrlRequired: false },
+      `expected ${provider} to need no credentials`,
+    );
+  }
+});
+
+test("unknown, deprecated, and empty providers fall back to showing every field", () => {
+  // Deprecated (exa/baidu/openrouter), a custom value, and no selection must
+  // never hide a control we can't reason about.
+  for (const provider of [
+    "exa",
+    "baidu",
+    "openrouter",
+    "custom-thing",
+    "",
+    null,
+    undefined,
+  ]) {
+    assert.deepEqual(
+      searchProviderFields(provider),
+      { apiKey: true, baseUrl: true, baseUrlRequired: false },
+      `expected ${String(provider)} to show all fields`,
+    );
+  }
+});
+
+test("provider name is matched case-insensitively and trimmed", () => {
+  assert.deepEqual(searchProviderFields("  Brave "), {
+    apiKey: true,
+    baseUrl: false,
+    baseUrlRequired: false,
+  });
+  assert.deepEqual(searchProviderFields("SearXNG"), {
+    apiKey: false,
+    baseUrl: true,
+    baseUrlRequired: true,
+  });
+});
+
+// The 8 providers the backend offers in the Search dropdown
+// (deeptutor/api/routers/settings.py:_provider_choices) plus a few
+// off-list values. Keep in sync if the backend adds a provider.
+const ALL_PROVIDERS = [
+  "none",
+  "brave",
+  "tavily",
+  "jina",
+  "searxng",
+  "duckduckgo",
+  "perplexity",
+  "serper",
+  "exa",
+  "baidu",
+  "openrouter",
+  "custom",
+  "",
+];
+
+test("a required Base URL is never hidden (baseUrlRequired implies baseUrl)", () => {
+  // A field that is mandatory but not rendered would be an unfixable
+  // configuration — guard the whole matrix against that state.
+  for (const provider of ALL_PROVIDERS) {
+    const fields = searchProviderFields(provider);
+    if (fields.baseUrlRequired) {
+      assert.ok(
+        fields.baseUrl,
+        `${provider}: baseUrlRequired must imply baseUrl is shown`,
+      );
+    }
+  }
+});
+
+test("searxng is the only provider that requires a Base URL", () => {
+  const requiring = ALL_PROVIDERS.filter(
+    (p) => searchProviderFields(p).baseUrlRequired,
+  );
+  assert.deepEqual(requiring, ["searxng"]);
+});


### PR DESCRIPTION
### Description

The Search settings editor (`/settings/search`) rendered **both** the API Key and Base URL inputs for every web-search provider, regardless of whether the selected provider uses them. This is misleading:

- **DuckDuckGo** (zero-config) showed an **API Key** box that does nothing.
- **SearXNG** (which is configured by its instance URL) gave no indication that **Base URL** is mandatory — leave it blank and search silently falls back to DuckDuckGo.

This PR renders the two connection fields conditionally, per provider, mirroring the backend resolver `resolve_search_runtime_config` in `deeptutor/services/config/provider_runtime.py`:

| Provider | API Key | Base URL |
|---|---|---|
| brave / tavily / jina / perplexity / serper | shown | hidden |
| searxng | hidden | shown, with an amber **required** hint when empty |
| duckduckgo / none | hidden | hidden |
| unknown / deprecated / unselected | shown | shown *(never hide a field we can't model)* |

A small pure helper (`web/components/settings/search-providers.ts`) holds the capability table so it can be unit-tested and kept in sync with the backend. LLM and embedding editors are unchanged. One new i18n string was added (en + zh).

### 💬 Open to discussion

These visibility rules are a **proposal, not dogma**. If anything doesn't match your intent, let's discuss before merging — happy to adjust. A few choices I'd especially welcome feedback on:

- Hiding **Base URL** for key-based providers (every search provider ships an empty `base_url` from the API, so it's only ever set for SearXNG — but say the word if you'd rather keep it visible as an advanced override).
- Showing the **API Key** field for the deprecated `serper` (the backend still treats it as supported and key-requiring, so I kept it shown).
- The amber **"required"** hint wording for SearXNG's Base URL.

### Related Issues

_No existing issue — searched open/closed issues and PRs; none cover this. Happy to open one if preferred._

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run` on the changed files — all hooks pass.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Screenshots

A couple of representative examples (not exhaustive — the full behavior is in the table above):

**Key-based provider (e.g. Jina)** — only the **API Key** field is shown; Base URL is hidden:

<img width="1040" height="434" alt="image" src="https://github.com/user-attachments/assets/81cd9cf5-b400-4eb7-aaa0-af5235605217" />


**Zero-config provider (DuckDuckGo)** — no API Key or Base URL fields at all; the form goes straight to the optional Extra section:

<img width="1035" height="510" alt="image" src="https://github.com/user-attachments/assets/a250aad4-f79b-4454-9974-494b8f7b3f08" />


> Other providers follow the same rule set: SearXNG shows only a required Base URL, and key-based providers (Brave/Tavily/Perplexity/Serper) behave like Jina.

### Additional Notes

**Verification**
- `tsc --noEmit` (full project) — clean
- `node --test` — `tests/search-providers.test.ts` (7 cases: key-only, searxng-required, zero-config, unknown→show-all, case-insensitive, plus two invariant guards) passes; full web suite green
- `eslint` — 0 errors (no new warnings)
- `i18n:parity` — OK (new key present in `en` + `zh`)
- Rebuilt the Docker image and confirmed the change is bundled and the app boots healthy.

**Scope (intentionally left out)**
- The collapsed **Extra (optional)** section still shows an **API Version** field for search, which the search resolver ignores. Left as-is to keep this PR focused; candidate for a small follow-up.
- Pre-existing FE/BE mismatch on `serper` (frontend marks it *deprecated* in the warning text; backend treats it as supported and key-requiring). This PR shows the API Key field for `serper` per the backend (it needs one) and does not otherwise touch that mismatch.