### PR TITLE
feat: discoverable profile rename and auto-name by provider

### DIFF
--- a/web/components/settings/ServiceConfigEditor.tsx
+++ b/web/components/settings/ServiceConfigEditor.tsx
@@ -8,6 +8,7 @@ import {
   EyeOff,
   Info,
   Loader2,
+  Pencil,
   Plus,
   Terminal,
   Trash2,
@@ -25,6 +26,7 @@ import {
   useSettings,
 } from "./SettingsContext";
 import { DimensionField } from "./DimensionField";
+import { nextProfileName } from "./profile-naming";
 import {
   activeProfileDetail,
   deprecatedSearchProviders,
@@ -265,12 +267,24 @@ export function ServiceConfigEditor({ service }: { service: ServiceName }) {
                           size={13}
                         />
                         <div
-                          className={`min-w-0 truncate text-[13px] leading-tight ${
+                          className={`min-w-0 flex-1 truncate text-[13px] leading-tight ${
                             isActive ? "font-semibold" : "font-medium"
                           }`}
                         >
                           {profile.name}
                         </div>
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            startProfileRename(profile);
+                          }}
+                          className="-mr-1 shrink-0 rounded-md p-1 text-[var(--muted-foreground)]/60 transition-colors hover:bg-[var(--muted)] hover:text-[var(--foreground)]"
+                          aria-label={t("Rename profile")}
+                          title={t("Rename profile")}
+                        >
+                          <Pencil className="h-3 w-3" />
+                        </button>
                       </div>
                     )}
                     <div className="mt-0.5 truncate text-[11px] leading-tight text-[var(--muted-foreground)]/70">
@@ -769,10 +783,20 @@ function ProfileFields({
             onChange={(e) => {
               const val = e.target.value;
               const field = service === "search" ? "provider" : "binding";
+              const options = providers[service] || [];
+              const previousLabel =
+                options.find((p) => p.value === providerValue)?.label ?? "";
+              const match = options.find((p) => p.value === val);
               updateProfileField(service, field, val);
-              const match = (providers[service] || []).find(
-                (p) => p.value === val,
+              // Keep an un-customized profile name tracking its provider.
+              const renamed = nextProfileName(
+                profile.name,
+                previousLabel,
+                match?.label ?? "",
               );
+              if (renamed !== profile.name) {
+                updateProfileField(service, "name", renamed);
+              }
               if (match?.base_url) {
                 updateProfileField(service, "base_url", match.base_url);
               }

--- a/web/components/settings/profile-naming.ts
+++ b/web/components/settings/profile-naming.ts
@@ -1,0 +1,25 @@
+// Auto-naming for connection profiles.
+//
+// A new profile is created already named after its provider (see `addProfile`
+// in SettingsContext). As long as the user hasn't typed a custom name, we want
+// the name to keep tracking the provider when they switch it — so a profile
+// created as "Brave" becomes "Jina" when the provider changes to Jina, but a
+// profile the user renamed to "My search" is left untouched.
+//
+// The heuristic is deliberately stateless (no extra persisted field): the name
+// is considered "auto" when it is empty or still equals the previous provider's
+// label. Once it diverges, it is treated as user-owned and never overwritten.
+
+export function nextProfileName(
+  currentName: string,
+  previousProviderLabel: string,
+  nextProviderLabel: string,
+): string {
+  // Never overwrite with an empty label (e.g. "Select provider…").
+  if (!nextProviderLabel) return currentName;
+  const trimmed = (currentName ?? "").trim();
+  if (trimmed === "" || trimmed === (previousProviderLabel ?? "").trim()) {
+    return nextProviderLabel;
+  }
+  return currentName;
+}

--- a/web/tests/profile-naming.test.ts
+++ b/web/tests/profile-naming.test.ts
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { nextProfileName } from "../components/settings/profile-naming";
+
+test("an auto name (matching the previous provider) tracks the new provider", () => {
+  assert.equal(nextProfileName("Brave", "Brave", "Jina"), "Jina");
+});
+
+test("an empty name is filled from the new provider", () => {
+  assert.equal(nextProfileName("", "Brave", "Jina"), "Jina");
+  assert.equal(nextProfileName("   ", "Brave", "Jina"), "Jina");
+});
+
+test("a user-customized name is never overwritten", () => {
+  assert.equal(nextProfileName("My search", "Brave", "Jina"), "My search");
+});
+
+test("never overwrites with an empty provider label (e.g. deselected)", () => {
+  assert.equal(nextProfileName("Brave", "Brave", ""), "Brave");
+  assert.equal(nextProfileName("My search", "Brave", ""), "My search");
+});
+
+test("matching against the previous label ignores surrounding whitespace", () => {
+  assert.equal(nextProfileName("  Brave  ", "Brave", "Jina"), "Jina");
+  assert.equal(nextProfileName("Brave", "  Brave  ", "Jina"), "Jina");
+});
+
+test("a name equal to the new provider is effectively unchanged", () => {
+  // Re-selecting the same provider must not corrupt the name.
+  assert.equal(nextProfileName("Jina", "Jina", "Jina"), "Jina");
+});


### PR DESCRIPTION
### Description

Two related papercuts in the Settings **profile sidebar** (shared by LLM / Embedding / Search):

1. **Renaming a profile was undiscoverable.** The only way to rename was a double-click on the row — with no visible affordance, users couldn't find it.
2. **The profile name didn't follow its provider.** A profile is created already named after its provider (e.g. "Brave"), but switching the provider afterwards left the old name — so a profile showing **"Brave"** could actually be pointing at **DuckDuckGo**, which is confusing.

This PR:

1. Adds an always-visible **pencil button** in each profile row, styled like the existing icon buttons (muted, brightening on hover; keyboard-reachable). It opens the same inline rename, reusing the existing `Rename profile` label. **Double-click still works.**
2. Keeps an **un-customized** name in sync with the provider: when the provider changes, a name that is empty or still equal to the previous provider's label is updated to the new provider; a name the user typed by hand is **never** overwritten. The check is stateless — no new persisted field (`nextProfileName` in `web/components/settings/profile-naming.ts`).

No new i18n strings (reuses the existing `Rename profile` key). LLM / Embedding / Search all benefit, since they share the sidebar and the provider→name logic.

> ⚠️ **Depends on #570** — please merge that one first. Both PRs edit `web/components/settings/ServiceConfigEditor.tsx`; this branch is cut from `dev` and builds on its own, but it's intended to land **after** #570 to avoid a merge conflict (see *Note on stacking* below).

### 💬 Open to discussion

Happy to adjust before merging if you see it differently — e.g.:

- **Pencil always-visible vs. hover-only** — I went always-visible (dimmed) for discoverability and touch; can switch to reveal-on-hover if you prefer a cleaner row.
- **Auto-name heuristic** — it's intentionally stateless (name follows provider until you type a custom name). If you'd rather have an explicit "name locked" flag persisted in the catalog, I can do that instead.

### Related Issues

- Depends on #570 (Search field visibility) — merge after it.

_No existing issue for this change — searched open/closed issues and PRs; none cover it. Happy to open one if preferred._

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run` on the changed files — all hooks pass.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Screenshots

**Rename affordance** — a pencil button is now visible in each profile row. The name also tracks the provider until customized (here it reads `DuckDuckGo` because the profile hasn't been renamed):

<img width="1005" height="199" alt="image" src="https://github.com/user-attachments/assets/aacb80c8-4f4f-4b52-8ff4-825cd7be7af6" />

**Inline rename** — clicking the pencil (or double-click) opens the rename field in place:

<img width="212" height="157" alt="image" src="https://github.com/user-attachments/assets/597cc3c5-704e-442b-a8cf-66eccd20d6db" />

> A profile you've manually renamed keeps its name when you change providers — only auto-named profiles follow.

### Additional Notes

**Note on stacking (#570)**
This touches `web/components/settings/ServiceConfigEditor.tsx`, same as #570 (Search field visibility). The changes are in different regions (sidebar/rename vs. provider field rendering), so the only collision is an adjacent import line. To keep history clean I'd merge **#570 first**, then rebase this branch onto `dev` (trivial) before merging.

**Verification**
- `tsc --noEmit` (full project) — clean
- `node --test` — full web suite green (137 tests), incl. new `tests/profile-naming.test.ts` (6 cases: auto name tracks provider, empty name filled, custom name preserved, empty new label no-op, whitespace-insensitive, same-provider no-op)
- `eslint` — 0 errors
- Rebuilt the Docker image and confirmed the change is bundled and the app boots healthy.