### PR TITLE
feat: user profile page with avatar (account info, icon/image avatar, sign out)

### DIFF
--- a/deeptutor/api/routers/auth.py
+++ b/deeptutor/api/routers/auth.py
@@ -1,18 +1,22 @@
-"""Auth router — login, logout, status, registration, and user-management endpoints."""
+"""Auth router — login, logout, status, registration, profile, and user-management endpoints."""
 
 from contextvars import Token as _CtxToken
 import logging
+import re
 
 from fastapi import (
     APIRouter,
     Cookie,
     Depends,
+    File,
     Header,
     HTTPException,
     Response,
+    UploadFile,
     WebSocket,
     status,
 )
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, field_validator
 
 from deeptutor.services.config import load_auth_settings
@@ -37,9 +41,11 @@ from deeptutor.services.auth import (
     create_token,
     decode_token,
     delete_user,
+    get_user_info,
     is_first_user,
     list_users,
     register_pb,
+    set_avatar,
     set_role,
 )
 
@@ -115,16 +121,43 @@ class AuthStatusResponse(BaseModel):
     username: str | None = None
     role: str | None = None
     is_admin: bool = False
+    avatar: str = ""
 
 
 class UserInfo(BaseModel):
-    """Single user record returned by the GET /users endpoint."""
+    """Single user record returned by the GET /users and /profile endpoints."""
 
     id: str = ""
     username: str
     role: str
     created_at: str
     disabled: bool = False
+    avatar: str = ""
+
+
+# Markers settable through PUT /profile. Image markers ("img:<version>") are
+# managed exclusively by the upload endpoint so users cannot point their
+# avatar at a file that was never validated.
+_ICON_MARKER_RE = re.compile(r"^icon:[a-z0-9-]{1,32}:[a-z0-9-]{1,32}$")
+
+# User ids are generated as "u_<uuid hex>" (plus the "local-admin" /
+# "env-admin" sentinels); reject anything else before it reaches the
+# filesystem layer.
+_USER_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+class UpdateProfileRequest(BaseModel):
+    """Payload for the PUT /profile endpoint."""
+
+    avatar: str
+
+    @field_validator("avatar")
+    @classmethod
+    def avatar_valid(cls, v: str) -> str:
+        v = v.strip()
+        if v and not _ICON_MARKER_RE.match(v):
+            raise ValueError("Avatar must be empty or 'icon:<name>:<color>'")
+        return v
 
 
 # ---------------------------------------------------------------------------
@@ -334,6 +367,11 @@ async def auth_status(
 
     token = _extract_token(authorization, dt_token)
     payload = decode_token(token) if token else None
+    avatar = ""
+    if payload is not None:
+        info = get_user_info(payload.username)
+        if info:
+            avatar = str(info.get("avatar") or "")
     return AuthStatusResponse(
         enabled=True,
         authenticated=payload is not None,
@@ -341,6 +379,7 @@ async def auth_status(
         username=payload.username if payload else None,
         role=payload.role if payload else None,
         is_admin=payload.role == "admin" if payload else False,
+        avatar=avatar,
     )
 
 
@@ -493,6 +532,179 @@ async def check_is_first_user() -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Profile endpoints (any authenticated user, self-service)
+# ---------------------------------------------------------------------------
+
+_AVATAR_MAX_BYTES = 1 * 1024 * 1024
+_AVATAR_MEDIA_TYPES = {"png": "image/png", "jpg": "image/jpeg", "webp": "image/webp"}
+
+
+def _sniff_image(data: bytes) -> str | None:
+    """Detect a supported raster image format from its magic bytes.
+
+    The uploaded filename and Content-Type are attacker-controlled, so the
+    stored extension (and the media type served back) is derived from the
+    bytes alone. SVG is deliberately unsupported — serving user-supplied SVG
+    is a stored-XSS vector.
+    """
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "png"
+    if data[:3] == b"\xff\xd8\xff":
+        return "jpg"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "webp"
+    return None
+
+
+def _require_profile_identity(payload: TokenPayload | None) -> TokenPayload:
+    """Shared guard for the self-service profile endpoints."""
+    if not AUTH_ENABLED or payload is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Auth is disabled — profiles are not available.",
+        )
+    return payload
+
+
+@router.get("/profile", response_model=UserInfo)
+async def get_profile(
+    payload: TokenPayload | None = Depends(require_auth),
+) -> UserInfo:
+    """Return the current user's own account info."""
+    current = _require_profile_identity(payload)
+    info = get_user_info(current.username)
+    if info is None:
+        # PocketBase-backed identities have no local record; fall back to the
+        # token claims so the profile page still renders.
+        return UserInfo(
+            id=current.user_id,
+            username=current.username,
+            role=current.role,
+            created_at="",
+        )
+    return UserInfo(**info)
+
+
+@router.put("/profile")
+async def update_profile(
+    body: UpdateProfileRequest,
+    payload: TokenPayload | None = Depends(require_auth),
+) -> dict:
+    """Update the current user's own avatar marker (icon choice or reset).
+
+    Only the validated ``icon:<name>:<color>`` form (or empty string) is
+    accepted here; ``img:`` markers are owned by the upload endpoint.
+    """
+    current = _require_profile_identity(payload)
+    if not set_avatar(current.username, body.avatar):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    # The marker no longer references an uploaded image, so drop the file.
+    from deeptutor.multi_user.identity import delete_avatar_file
+
+    if current.user_id and _USER_ID_RE.match(current.user_id):
+        delete_avatar_file(current.user_id)
+    return {"ok": True, "avatar": body.avatar}
+
+
+@router.put("/profile/avatar")
+async def upload_avatar(
+    file: UploadFile = File(...),
+    payload: TokenPayload | None = Depends(require_auth),
+) -> dict:
+    """Upload an avatar image for the current user.
+
+    The client is expected to crop/resize before uploading; the server only
+    enforces a size cap and validates the format by magic bytes. Not available
+    in PocketBase mode (those identities have no local user record).
+    """
+    current = _require_profile_identity(payload)
+    if POCKETBASE_ENABLED:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Avatar upload is not available in PocketBase mode.",
+        )
+    if not current.user_id or not _USER_ID_RE.match(current.user_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot store an avatar for this account.",
+        )
+    info = get_user_info(current.username)
+    if info is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    data = await file.read(_AVATAR_MAX_BYTES + 1)
+    if len(data) > _AVATAR_MAX_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="Avatar image is too large (max 1 MB).",
+        )
+    ext = _sniff_image(data)
+    if ext is None:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="Avatar must be a PNG, JPEG or WebP image.",
+        )
+
+    from deeptutor.multi_user.identity import save_avatar_file
+
+    # Bump the version embedded in the marker so clients cache-bust the URL.
+    previous = str(info.get("avatar") or "")
+    version = 1
+    if previous.startswith("img:"):
+        try:
+            version = int(previous.split(":", 1)[1]) + 1
+        except ValueError:
+            version = 1
+    marker = f"img:{version}"
+
+    save_avatar_file(current.user_id, data, ext)
+    if not set_avatar(current.username, marker):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    logger.info(f"User '{current.username}' uploaded a new avatar ({ext}, {len(data)} bytes)")
+    return {"ok": True, "avatar": marker}
+
+
+@router.delete("/profile/avatar")
+async def remove_avatar(
+    payload: TokenPayload | None = Depends(require_auth),
+) -> dict:
+    """Remove the current user's uploaded avatar image and reset the marker."""
+    current = _require_profile_identity(payload)
+    from deeptutor.multi_user.identity import delete_avatar_file
+
+    if current.user_id and _USER_ID_RE.match(current.user_id):
+        delete_avatar_file(current.user_id)
+    set_avatar(current.username, "")
+    return {"ok": True, "avatar": ""}
+
+
+@router.get("/avatar/{user_id}")
+async def get_avatar_image(
+    user_id: str,
+    _: TokenPayload | None = Depends(require_auth),
+) -> FileResponse:
+    """Serve a stored avatar image. Any authenticated user may view avatars
+    (they appear in the admin table and next to the viewer's own profile)."""
+    if not _USER_ID_RE.match(user_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Avatar not found")
+
+    from deeptutor.multi_user.identity import get_avatar_file
+
+    target = get_avatar_file(user_id)
+    if target is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Avatar not found")
+
+    media_type = _AVATAR_MEDIA_TYPES.get(target.suffix.lstrip("."), "application/octet-stream")
+    headers = {
+        # Private user content; the marker version in the URL handles busting.
+        "Cache-Control": "private, max-age=86400",
+        "X-Content-Type-Options": "nosniff",
+        "Content-Disposition": "inline",
+    }
+    return FileResponse(path=str(target), media_type=media_type, headers=headers)
+
+
+# ---------------------------------------------------------------------------
 # Admin-only endpoints
 # ---------------------------------------------------------------------------
 
@@ -579,9 +791,18 @@ async def remove_user(
             detail="You cannot delete your own account",
         )
 
+    # Capture the id before the record disappears so the avatar file can go too.
+    info = get_user_info(username)
+
     removed = delete_user(username)
     if not removed:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    user_id = str(info.get("id") or "") if info else ""
+    if user_id and _USER_ID_RE.match(user_id):
+        from deeptutor.multi_user.identity import delete_avatar_file
+
+        delete_avatar_file(user_id)
 
     logger.info(f"Admin '{current.username if current else 'local'}' deleted user '{username}'")
     return {"ok": True}

--- a/deeptutor/multi_user/identity.py
+++ b/deeptutor/multi_user/identity.py
@@ -51,6 +51,7 @@ def _canonical_record(
             "role": default_role,
             "created_at": utc_now(),
             "disabled": False,
+            "avatar": "",
         }
     if not isinstance(value, dict):
         return None
@@ -66,6 +67,7 @@ def _canonical_record(
         "role": role,
         "created_at": str(value.get("created_at") or utc_now()),
         "disabled": bool(value.get("disabled", False)),
+        "avatar": str(value.get("avatar") or ""),
     }
 
 
@@ -181,6 +183,7 @@ def save_user(username: str, hashed_password: str, role: Role = "user") -> dict[
             "role": effective_role,
             "created_at": str(existing.get("created_at") or utc_now()),
             "disabled": bool(existing.get("disabled", False)),
+            "avatar": str(existing.get("avatar") or ""),
         }
         users[username] = record
         _write_users(users)
@@ -198,6 +201,7 @@ def list_user_info(  # nosec B107 - empty defaults mean "no env fallback supplie
             "role": record.get("role", "user"),
             "created_at": record.get("created_at", ""),
             "disabled": bool(record.get("disabled", False)),
+            "avatar": str(record.get("avatar") or ""),
         }
         for username, record in load_users(env_username, env_password_hash).items()
     ]
@@ -223,6 +227,64 @@ def delete_user(username: str) -> bool:
     users.pop(username, None)
     _write_users(users)
     return True
+
+
+def set_avatar(username: str, avatar: str) -> bool:
+    """Update the avatar marker for an existing user. Returns True on success."""
+    if not USERS_FILE.exists():
+        return False
+    with _USERS_WRITE_LOCK:
+        users = load_users()
+        if username not in users:
+            return False
+        users[username]["avatar"] = avatar
+        _write_users(users)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Avatar image files — stored next to the user store, keyed by user id
+# ---------------------------------------------------------------------------
+
+# Extensions are derived from server-side content sniffing, never from the
+# uploaded filename, so this list is also the full set of files we may serve.
+AVATAR_EXTENSIONS = ("png", "jpg", "webp")
+
+
+def _avatar_dir() -> Path:
+    # Resolved lazily so tests that monkeypatch AUTH_DIR keep avatars isolated.
+    return AUTH_DIR / "avatars"
+
+
+def get_avatar_file(user_id: str) -> Path | None:
+    """Return the stored avatar image for ``user_id``, or None."""
+    for ext in AVATAR_EXTENSIONS:
+        candidate = _avatar_dir() / f"{user_id}.{ext}"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def save_avatar_file(user_id: str, data: bytes, ext: str) -> Path:
+    """Atomically persist an avatar image, replacing any previous one."""
+    if ext not in AVATAR_EXTENSIONS:
+        raise ValueError(f"Unsupported avatar extension: {ext!r}")
+    directory = _avatar_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    target = directory / f"{user_id}.{ext}"
+    tmp = directory / f"{user_id}.{ext}.tmp"
+    tmp.write_bytes(data)
+    tmp.replace(target)
+    # A re-upload may change the extension; drop stale siblings.
+    for other in AVATAR_EXTENSIONS:
+        if other != ext:
+            (directory / f"{user_id}.{other}").unlink(missing_ok=True)
+    return target
+
+
+def delete_avatar_file(user_id: str) -> None:
+    for ext in AVATAR_EXTENSIONS:
+        (_avatar_dir() / f"{user_id}.{ext}").unlink(missing_ok=True)
 
 
 def set_role(username: str, role: Role) -> bool:

--- a/deeptutor/multi_user/models.py
+++ b/deeptutor/multi_user/models.py
@@ -17,6 +17,10 @@ class UserRecord:
     role: Role = "user"
     created_at: str = ""
     disabled: bool = False
+    # Avatar marker: "" (deterministic fallback), "icon:<name>:<color>" for a
+    # picked icon, or "img:<version>" when the user uploaded an image (the
+    # version is bumped on every upload so clients can cache-bust).
+    avatar: str = ""
 
     def public_dict(self) -> dict[str, Any]:
         return {
@@ -25,6 +29,7 @@ class UserRecord:
             "role": self.role,
             "created_at": self.created_at,
             "disabled": self.disabled,
+            "avatar": self.avatar,
         }
 
 

--- a/deeptutor/services/auth.py
+++ b/deeptutor/services/auth.py
@@ -111,6 +111,7 @@ def _make_user_record(hashed: str, role: str = "user", created_at: str = "") -> 
         "role": role,
         "created_at": created_at or datetime.now(timezone.utc).isoformat(),
         "disabled": False,
+        "avatar": "",
     }
 
 
@@ -186,6 +187,29 @@ def set_role(username: str, role: str) -> bool:
         return False
     logger.info(f"User '{username}' role updated to {role!r}")
     return True
+
+
+def set_avatar(username: str, avatar: str) -> bool:
+    """
+    Update the avatar marker for an existing user. Returns True on success.
+
+    The marker is either '' (deterministic fallback), 'icon:<name>:<color>',
+    or 'img:<version>' (managed by the avatar upload endpoint).
+    """
+    from deeptutor.multi_user.identity import set_avatar as _set_avatar
+
+    if not _set_avatar(username, avatar):
+        return False
+    logger.info("User '%s' avatar updated", username)
+    return True
+
+
+def get_user_info(username: str) -> dict | None:
+    """Return the public info dict for a single user, or None if unknown."""
+    for item in list_users():
+        if item.get("username") == username:
+            return item
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/multi_user/test_profile_avatar.py
+++ b/tests/multi_user/test_profile_avatar.py
@@ -1,0 +1,100 @@
+"""Profile avatar — marker persistence, image file storage, upload validation."""
+
+from __future__ import annotations
+
+import pytest
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+JPG_BYTES = b"\xff\xd8\xff\xe0" + b"\x00" * 16
+WEBP_BYTES = b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 16
+
+
+def test_set_avatar_persists_through_normalisation(mu_isolated_root, seed_user):
+    from deeptutor.multi_user.identity import list_user_info, load_users, set_avatar
+
+    seed_user("alice")
+    assert set_avatar("alice", "icon:sparkles:violet")
+
+    # load_users() rewrites records through _canonical_record; the avatar
+    # field must survive that round-trip.
+    assert load_users()["alice"]["avatar"] == "icon:sparkles:violet"
+    users = {u["username"]: u for u in list_user_info()}
+    assert users["alice"]["avatar"] == "icon:sparkles:violet"
+
+
+def test_save_user_preserves_existing_avatar(mu_isolated_root, seed_user):
+    from deeptutor.multi_user.identity import load_users, save_user, set_avatar
+
+    seed_user("alice")
+    set_avatar("alice", "img:3")
+
+    # Password change (save_user on an existing name) must not drop the avatar.
+    save_user("alice", "$2b$12$newhash", role="admin")
+    assert load_users()["alice"]["avatar"] == "img:3"
+
+
+def test_set_avatar_unknown_user_returns_false(mu_isolated_root, seed_user):
+    from deeptutor.multi_user.identity import set_avatar
+
+    seed_user("alice")
+    assert not set_avatar("nobody", "icon:leaf:teal")
+
+
+def test_records_without_avatar_default_to_empty(mu_isolated_root, seed_user):
+    from deeptutor.multi_user.identity import list_user_info
+
+    seed_user("alice")
+    users = {u["username"]: u for u in list_user_info()}
+    assert users["alice"]["avatar"] == ""
+
+
+def test_avatar_file_roundtrip_and_extension_replacement(mu_isolated_root):
+    from deeptutor.multi_user.identity import (
+        delete_avatar_file,
+        get_avatar_file,
+        save_avatar_file,
+    )
+
+    assert get_avatar_file("u_abc") is None
+
+    saved = save_avatar_file("u_abc", PNG_BYTES, "png")
+    assert saved.read_bytes() == PNG_BYTES
+    assert get_avatar_file("u_abc") == saved
+
+    # Re-upload with a different format must drop the stale sibling.
+    replaced = save_avatar_file("u_abc", WEBP_BYTES, "webp")
+    assert get_avatar_file("u_abc") == replaced
+    assert not saved.exists()
+
+    delete_avatar_file("u_abc")
+    assert get_avatar_file("u_abc") is None
+
+
+def test_save_avatar_file_rejects_unknown_extension(mu_isolated_root):
+    from deeptutor.multi_user.identity import save_avatar_file
+
+    with pytest.raises(ValueError):
+        save_avatar_file("u_abc", b"<svg/>", "svg")
+
+
+def test_sniff_image_detects_supported_formats_only():
+    from deeptutor.api.routers.auth import _sniff_image
+
+    assert _sniff_image(PNG_BYTES) == "png"
+    assert _sniff_image(JPG_BYTES) == "jpg"
+    assert _sniff_image(WEBP_BYTES) == "webp"
+    # SVG (stored-XSS vector) and arbitrary bytes must be rejected.
+    assert _sniff_image(b"<svg xmlns='http://www.w3.org/2000/svg'/>") is None
+    assert _sniff_image(b"GIF89a" + b"\x00" * 16) is None
+    assert _sniff_image(b"") is None
+
+
+def test_update_profile_request_validates_marker():
+    from deeptutor.api.routers.auth import UpdateProfileRequest
+
+    assert UpdateProfileRequest(avatar="").avatar == ""
+    assert UpdateProfileRequest(avatar="icon:sparkles:violet").avatar == "icon:sparkles:violet"
+
+    for bad in ("img:1", "icon:Sparkles:violet", "icon:a:b:c", "../etc/passwd", "icon::"):
+        with pytest.raises(ValueError):
+            UpdateProfileRequest(avatar=bad)

--- a/tests/multi_user/test_profile_router.py
+++ b/tests/multi_user/test_profile_router.py
@@ -1,0 +1,269 @@
+"""Router-level tests for the self-service profile/avatar endpoints.
+
+These mount the real auth router on a throwaway FastAPI app with
+``AUTH_ENABLED`` forced on and ``decode_token`` stubbed, so the full
+dependency chain (``require_auth`` → contextvar install → handler) runs
+against the isolated user store from ``mu_isolated_root``.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+WEBP_BYTES = b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 64
+GIF_BYTES = b"GIF89a" + b"\x00" * 64
+SVG_BYTES = b"<svg xmlns='http://www.w3.org/2000/svg'></svg>"
+
+
+def _auth(token: str | None) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+@pytest.fixture
+def profile_client(mu_isolated_root, monkeypatch):
+    """TestClient over the auth router with two seeded users and stub tokens.
+
+    Returns ``(client, users)`` where ``users`` maps username → stored record.
+    Valid bearer tokens: ``admin-token`` (alice), ``user-token`` (bob), and
+    ``ghost-token`` (a valid JWT whose user is absent from the local store,
+    mirroring PocketBase-backed identities).
+    """
+    import deeptutor.api.routers.auth as auth_router
+    from deeptutor.multi_user.identity import save_user
+    from deeptutor.services.auth import TokenPayload
+
+    alice = save_user("alice", "$2b$12$placeholder", role="admin")
+    bob = save_user("bob", "$2b$12$placeholder", role="user")
+
+    tokens = {
+        "admin-token": TokenPayload(username="alice", role="admin", user_id=alice["id"]),
+        "user-token": TokenPayload(username="bob", role="user", user_id=bob["id"]),
+        "ghost-token": TokenPayload(username="ghost", role="user", user_id="u_ghost"),
+    }
+    monkeypatch.setattr(auth_router, "AUTH_ENABLED", True)
+    monkeypatch.setattr(auth_router, "decode_token", lambda token: tokens.get(token))
+
+    app = FastAPI()
+    app.include_router(auth_router.router, prefix="/api/v1/auth")
+    return TestClient(app), {"alice": alice, "bob": bob}
+
+
+def test_profile_endpoints_require_auth(profile_client):
+    client, users = profile_client
+    requests = [
+        ("get", "/api/v1/auth/profile", {}),
+        ("put", "/api/v1/auth/profile", {"json": {"avatar": ""}}),
+        ("put", "/api/v1/auth/profile/avatar", {"files": {"file": ("a.png", PNG_BYTES)}}),
+        ("delete", "/api/v1/auth/profile/avatar", {}),
+        ("get", f"/api/v1/auth/avatar/{users['bob']['id']}", {}),
+    ]
+    for method, url, kwargs in requests:
+        response = getattr(client, method)(url, **kwargs)
+        assert response.status_code == 401, f"{method.upper()} {url}"
+
+
+def test_get_profile_returns_own_record(profile_client):
+    client, users = profile_client
+    body = client.get("/api/v1/auth/profile", headers=_auth("user-token")).json()
+    assert body["username"] == "bob"
+    assert body["role"] == "user"
+    assert body["id"] == users["bob"]["id"]
+    assert body["avatar"] == ""
+
+
+def test_get_profile_falls_back_to_token_claims(profile_client):
+    """Identities without a local record (PocketBase mode) still render."""
+    client, _ = profile_client
+    response = client.get("/api/v1/auth/profile", headers=_auth("ghost-token"))
+    assert response.status_code == 200
+    body = response.json()
+    assert body["username"] == "ghost"
+    assert body["id"] == "u_ghost"
+
+
+def test_put_profile_sets_marker_on_own_record_only(profile_client):
+    from deeptutor.multi_user.identity import load_users
+
+    client, _ = profile_client
+    response = client.put(
+        "/api/v1/auth/profile",
+        headers=_auth("user-token"),
+        json={"avatar": "icon:leaf:teal"},
+    )
+    assert response.status_code == 200
+    users = load_users()
+    assert users["bob"]["avatar"] == "icon:leaf:teal"
+    assert users["alice"]["avatar"] == ""
+
+
+def test_put_profile_rejects_img_and_malformed_markers(profile_client):
+    client, _ = profile_client
+    for bad in ("img:1", "icon:Leaf:teal", "icon:a:b:c", "../etc/passwd"):
+        response = client.put(
+            "/api/v1/auth/profile",
+            headers=_auth("user-token"),
+            json={"avatar": bad},
+        )
+        assert response.status_code == 422, bad
+
+
+def test_upload_avatar_stores_file_and_bumps_version(profile_client):
+    from deeptutor.multi_user.identity import get_avatar_file, load_users
+
+    client, users = profile_client
+    bob_id = users["bob"]["id"]
+
+    first = client.put(
+        "/api/v1/auth/profile/avatar",
+        headers=_auth("user-token"),
+        files={"file": ("photo.png", PNG_BYTES, "image/png")},
+    )
+    assert first.status_code == 200
+    assert first.json()["avatar"] == "img:1"
+    stored = get_avatar_file(bob_id)
+    assert stored is not None and stored.suffix == ".png"
+
+    # Re-upload in another format: version bumps, stale extension is removed.
+    second = client.put(
+        "/api/v1/auth/profile/avatar",
+        headers=_auth("user-token"),
+        files={"file": ("photo.webp", WEBP_BYTES, "image/webp")},
+    )
+    assert second.status_code == 200
+    assert second.json()["avatar"] == "img:2"
+    stored = get_avatar_file(bob_id)
+    assert stored is not None and stored.suffix == ".webp"
+    assert load_users()["bob"]["avatar"] == "img:2"
+
+
+def test_upload_avatar_validates_by_magic_bytes_not_filename(profile_client):
+    client, _ = profile_client
+    # Claimed PNG name/content-type, but GIF and SVG bytes must be rejected.
+    for payload in (GIF_BYTES, SVG_BYTES):
+        response = client.put(
+            "/api/v1/auth/profile/avatar",
+            headers=_auth("user-token"),
+            files={"file": ("totally-a.png", payload, "image/png")},
+        )
+        assert response.status_code == 415
+
+
+def test_upload_avatar_enforces_size_cap(profile_client):
+    client, _ = profile_client
+    oversized = PNG_BYTES + b"\x00" * (1024 * 1024)
+    response = client.put(
+        "/api/v1/auth/profile/avatar",
+        headers=_auth("user-token"),
+        files={"file": ("big.png", oversized, "image/png")},
+    )
+    assert response.status_code == 413
+
+
+def test_upload_avatar_disabled_in_pocketbase_mode(profile_client, monkeypatch):
+    import deeptutor.api.routers.auth as auth_router
+
+    client, _ = profile_client
+    monkeypatch.setattr(auth_router, "POCKETBASE_ENABLED", True)
+    response = client.put(
+        "/api/v1/auth/profile/avatar",
+        headers=_auth("user-token"),
+        files={"file": ("photo.png", PNG_BYTES, "image/png")},
+    )
+    assert response.status_code == 400
+
+
+def test_delete_avatar_removes_file_and_resets_marker(profile_client):
+    from deeptutor.multi_user.identity import get_avatar_file, load_users
+
+    client, users = profile_client
+    client.put(
+        "/api/v1/auth/profile/avatar",
+        headers=_auth("user-token"),
+        files={"file": ("photo.png", PNG_BYTES, "image/png")},
+    )
+
+    response = client.delete("/api/v1/auth/profile/avatar", headers=_auth("user-token"))
+    assert response.status_code == 200
+    assert get_avatar_file(users["bob"]["id"]) is None
+    assert load_users()["bob"]["avatar"] == ""
+
+
+def test_picking_icon_after_upload_drops_the_image_file(profile_client):
+    from deeptutor.multi_user.identity import get_avatar_file
+
+    client, users = profile_client
+    client.put(
+        "/api/v1/auth/profile/avatar",
+        headers=_auth("user-token"),
+        files={"file": ("photo.png", PNG_BYTES, "image/png")},
+    )
+    client.put(
+        "/api/v1/auth/profile",
+        headers=_auth("user-token"),
+        json={"avatar": "icon:leaf:teal"},
+    )
+    assert get_avatar_file(users["bob"]["id"]) is None
+
+
+def test_avatar_serving_headers_and_visibility(profile_client):
+    client, users = profile_client
+    client.put(
+        "/api/v1/auth/profile/avatar",
+        headers=_auth("user-token"),
+        files={"file": ("photo.png", PNG_BYTES, "image/png")},
+    )
+
+    # Any authenticated user may view (admin table shows all avatars).
+    response = client.get(f"/api/v1/auth/avatar/{users['bob']['id']}", headers=_auth("admin-token"))
+    assert response.status_code == 200
+    assert response.content == PNG_BYTES
+    assert response.headers["content-type"] == "image/png"
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert "private" in response.headers["cache-control"]
+
+
+def test_admin_user_deletion_removes_avatar_file(profile_client):
+    """Deleting an account must not leave its avatar image orphaned on disk."""
+    from deeptutor.multi_user.identity import get_avatar_file
+
+    client, users = profile_client
+    client.put(
+        "/api/v1/auth/profile/avatar",
+        headers=_auth("user-token"),
+        files={"file": ("photo.png", PNG_BYTES, "image/png")},
+    )
+    assert get_avatar_file(users["bob"]["id"]) is not None
+
+    response = client.delete("/api/v1/auth/users/bob", headers=_auth("admin-token"))
+    assert response.status_code == 200
+    assert get_avatar_file(users["bob"]["id"]) is None
+
+
+def test_avatar_serving_rejects_missing_and_malformed_ids(profile_client):
+    client, users = profile_client
+    # No avatar stored for alice yet.
+    missing = client.get(f"/api/v1/auth/avatar/{users['alice']['id']}", headers=_auth("user-token"))
+    assert missing.status_code == 404
+    # Traversal-shaped ids never reach the filesystem layer.
+    for bad in ("..%2F..%2Fauth_secret", ".."):
+        response = client.get(f"/api/v1/auth/avatar/{bad}", headers=_auth("user-token"))
+        assert response.status_code == 404, bad
+
+
+def test_auth_status_exposes_avatar_marker(profile_client):
+    client, _ = profile_client
+    client.put(
+        "/api/v1/auth/profile",
+        headers=_auth("user-token"),
+        json={"avatar": "icon:star:rose"},
+    )
+    body = client.get("/api/v1/auth/status", headers=_auth("user-token")).json()
+    assert body["authenticated"] is True
+    assert body["avatar"] == "icon:star:rose"
+
+    anonymous = client.get("/api/v1/auth/status").json()
+    assert anonymous["authenticated"] is False
+    assert anonymous["avatar"] == ""

--- a/web/app/(utility)/profile/page.tsx
+++ b/web/app/(utility)/profile/page.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { createElement } from "react";
+import { ArrowLeft, ImageUp, LogOut, ShieldCheck, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { AUTH_ENABLED, fetchAuthStatus, logout } from "@/lib/auth";
+import {
+  getProfile,
+  removeAvatarImage,
+  setAvatarMarker,
+  uploadAvatarImage,
+  type ProfileInfo,
+} from "@/lib/profile-api";
+import {
+  AVATAR_COLOR_NAMES,
+  AVATAR_COLORS,
+  AVATAR_ICON_NAMES,
+  AVATAR_ICONS,
+  fallbackAvatarFor,
+  UserAvatar,
+} from "@/components/UserAvatar";
+import { parseAvatarMarker } from "@/lib/avatar";
+import { formatDate, type Language } from "@/lib/datetime";
+
+const AVATAR_OUTPUT_SIZE = 256;
+// Decoding a huge photo just to throw away most pixels wastes memory; the
+// server enforces its own 1 MB cap on the (much smaller) cropped result.
+const MAX_SOURCE_BYTES = 20 * 1024 * 1024;
+
+/** Center-crop to a square and downscale; canvas re-encode also strips EXIF. */
+async function cropToSquareBlob(file: File): Promise<Blob> {
+  let source: CanvasImageSource;
+  let width: number;
+  let height: number;
+  try {
+    const bitmap = await createImageBitmap(file);
+    source = bitmap;
+    width = bitmap.width;
+    height = bitmap.height;
+  } catch {
+    // Older Safari: fall back to decoding via an <img> element.
+    const url = URL.createObjectURL(file);
+    try {
+      const image = await new Promise<HTMLImageElement>((resolve, reject) => {
+        const el = new Image();
+        el.onload = () => resolve(el);
+        el.onerror = () => reject(new Error("Could not decode image"));
+        el.src = url;
+      });
+      source = image;
+      width = image.naturalWidth;
+      height = image.naturalHeight;
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }
+  if (!width || !height) throw new Error("Could not decode image");
+
+  const side = Math.min(width, height);
+  const canvas = document.createElement("canvas");
+  canvas.width = AVATAR_OUTPUT_SIZE;
+  canvas.height = AVATAR_OUTPUT_SIZE;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Could not decode image");
+  ctx.drawImage(
+    source,
+    (width - side) / 2,
+    (height - side) / 2,
+    side,
+    side,
+    0,
+    0,
+    AVATAR_OUTPUT_SIZE,
+    AVATAR_OUTPUT_SIZE,
+  );
+  // Release the decoder/GPU memory now instead of waiting for GC.
+  if (typeof ImageBitmap !== "undefined" && source instanceof ImageBitmap) {
+    source.close();
+  }
+
+  const toBlob = (type: string, quality?: number) =>
+    new Promise<Blob | null>((resolve) =>
+      canvas.toBlob(resolve, type, quality),
+    );
+  // WebP keeps avatars tiny; browsers without a WebP encoder return null.
+  const blob =
+    (await toBlob("image/webp", 0.85)) ?? (await toBlob("image/png"));
+  if (!blob) throw new Error("Could not encode image");
+  return blob;
+}
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const { t, i18n } = useTranslation();
+  const [profile, setProfile] = useState<ProfileInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!AUTH_ENABLED) {
+      router.replace("/");
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const status = await fetchAuthStatus();
+      if (cancelled) return;
+      if (!status?.authenticated) {
+        router.replace("/login");
+        return;
+      }
+      try {
+        const info = await getProfile();
+        if (!cancelled) setProfile(info);
+      } catch {
+        if (!cancelled) setError(t("Failed to load profile"));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [router, t]);
+
+  const applyMarker = useCallback(async (marker: string) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const saved = await setAvatarMarker(marker);
+      setProfile((prev) => (prev ? { ...prev, avatar: saved } : prev));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const handleUpload = useCallback(
+    async (file: File) => {
+      setBusy(true);
+      setError(null);
+      try {
+        if (file.size > MAX_SOURCE_BYTES) {
+          throw new Error(t("Image is too large"));
+        }
+        const blob = await cropToSquareBlob(file);
+        const marker = await uploadAvatarImage(blob);
+        setProfile((prev) => (prev ? { ...prev, avatar: marker } : prev));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setBusy(false);
+        if (fileInputRef.current) fileInputRef.current.value = "";
+      }
+    },
+    [t],
+  );
+
+  const handleRemoveImage = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await removeAvatarImage();
+      setProfile((prev) => (prev ? { ...prev, avatar: "" } : prev));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const handleSignOut = useCallback(async () => {
+    await logout();
+    router.replace("/login");
+  }, [router]);
+
+  if (!AUTH_ENABLED) return null;
+
+  const descriptor = parseAvatarMarker(profile?.avatar);
+  const hasImage = descriptor.kind === "image";
+  const fallback = fallbackAvatarFor(profile?.username ?? "");
+  const selectedIcon =
+    descriptor.kind === "icon"
+      ? descriptor.icon
+      : hasImage
+        ? null
+        : fallback.icon;
+  const selectedColor =
+    descriptor.kind === "icon"
+      ? descriptor.color
+      : hasImage
+        ? null
+        : fallback.color;
+  const isAdmin = profile?.role === "admin";
+  const lang: Language = i18n.language?.startsWith("zh") ? "zh" : "en";
+  const joinedDate = profile?.created_at ? new Date(profile.created_at) : null;
+  const joined =
+    joinedDate && !Number.isNaN(joinedDate.getTime())
+      ? formatDate(joinedDate, lang)
+      : null;
+
+  return (
+    <div className="h-screen overflow-y-auto bg-[var(--background)] px-4 py-10 [scrollbar-gutter:stable]">
+      <div className="mx-auto max-w-2xl">
+        {/* Header */}
+        <div className="mb-8 flex items-center gap-4">
+          <Link
+            href="/"
+            className="flex items-center gap-1.5 text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+          >
+            <ArrowLeft size={15} />
+            {t("Back")}
+          </Link>
+          <div className="flex-1">
+            <h1 className="text-xl font-semibold text-[var(--foreground)]">
+              {t("My profile")}
+            </h1>
+            <p className="mt-0.5 text-sm text-[var(--muted-foreground)]">
+              {t("View your account and personalize your avatar")}
+            </p>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-600 dark:text-red-400">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center justify-center rounded-2xl border border-[var(--border)] bg-[var(--card)] py-16 text-sm text-[var(--muted-foreground)] shadow-sm">
+            {t("Loading…")}
+          </div>
+        ) : !profile ? null : (
+          <>
+            {/* Account card */}
+            <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+              <div className="flex items-center gap-5">
+                <UserAvatar
+                  username={profile.username}
+                  userId={profile.id}
+                  avatar={profile.avatar}
+                  role={profile.role}
+                  size={72}
+                />
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2.5">
+                    <span className="truncate text-lg font-semibold text-[var(--foreground)]">
+                      {profile.username}
+                    </span>
+                    <span
+                      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ${
+                        isAdmin
+                          ? "bg-amber-500/15 text-amber-600 dark:text-amber-400"
+                          : "bg-[var(--muted)]/70 text-[var(--muted-foreground)]"
+                      }`}
+                    >
+                      {isAdmin && <ShieldCheck size={11} strokeWidth={2} />}
+                      {isAdmin ? t("Administrator") : t("User")}
+                    </span>
+                  </div>
+                  {joined && (
+                    <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+                      {t("Joined")}: {joined}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Avatar card */}
+            <div className="mt-4 rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+              <h2 className="text-sm font-semibold text-[var(--foreground)]">
+                {t("Avatar")}
+              </h2>
+              <p className="mt-0.5 text-sm text-[var(--muted-foreground)]">
+                {t("Upload a picture or pick an icon")}
+              </p>
+
+              <div className="mt-4 flex flex-wrap items-center gap-2.5">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp"
+                  className="hidden"
+                  onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    if (file) void handleUpload(file);
+                  }}
+                />
+                <button
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={busy}
+                  className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm
+                             border border-[var(--border)] text-[var(--foreground)]
+                             hover:bg-[var(--background)]/60 disabled:opacity-50 transition-colors"
+                >
+                  <ImageUp size={14} />
+                  {t("Upload image")}
+                </button>
+                {hasImage && (
+                  <button
+                    onClick={() => void handleRemoveImage()}
+                    disabled={busy}
+                    className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm
+                               border border-[var(--border)] text-[var(--muted-foreground)]
+                               hover:text-red-500 disabled:opacity-50 transition-colors"
+                  >
+                    <Trash2 size={14} />
+                    {t("Remove photo")}
+                  </button>
+                )}
+              </div>
+
+              {/* Icon grid */}
+              <div className="mt-5">
+                <p className="mb-2 text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
+                  {t("Or pick an icon")}
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {AVATAR_ICON_NAMES.map((name) => {
+                    const active = !hasImage && name === selectedIcon;
+                    const color = selectedColor ?? fallback.color;
+                    return (
+                      <button
+                        key={name}
+                        onClick={() =>
+                          void applyMarker(`icon:${name}:${color}`)
+                        }
+                        disabled={busy}
+                        aria-label={name}
+                        aria-pressed={active}
+                        className={`flex h-10 w-10 items-center justify-center rounded-full text-white transition-all disabled:opacity-50 ${
+                          active
+                            ? "ring-2 ring-[var(--foreground)] ring-offset-2 ring-offset-[var(--card)]"
+                            : "opacity-75 hover:opacity-100"
+                        }`}
+                        style={{ backgroundColor: AVATAR_COLORS[color] }}
+                      >
+                        {createElement(AVATAR_ICONS[name], {
+                          size: 18,
+                          strokeWidth: 1.8,
+                        })}
+                      </button>
+                    );
+                  })}
+                </div>
+                <p className="mb-2 mt-4 text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
+                  {t("Color")}
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {AVATAR_COLOR_NAMES.map((name) => {
+                    const active = !hasImage && name === selectedColor;
+                    const icon = selectedIcon ?? fallback.icon;
+                    return (
+                      <button
+                        key={name}
+                        onClick={() => void applyMarker(`icon:${icon}:${name}`)}
+                        disabled={busy}
+                        aria-label={name}
+                        aria-pressed={active}
+                        className={`h-7 w-7 rounded-full transition-all disabled:opacity-50 ${
+                          active
+                            ? "ring-2 ring-[var(--foreground)] ring-offset-2 ring-offset-[var(--card)]"
+                            : "opacity-75 hover:opacity-100"
+                        }`}
+                        style={{ backgroundColor: AVATAR_COLORS[name] }}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+
+            {/* Sign out card */}
+            <div className="mt-4 flex items-center justify-between rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+              <div>
+                <h2 className="text-sm font-semibold text-[var(--foreground)]">
+                  {t("Sign out")}
+                </h2>
+                <p className="mt-0.5 text-sm text-[var(--muted-foreground)]">
+                  {t("End your session on this device")}
+                </p>
+              </div>
+              <button
+                onClick={() => void handleSignOut()}
+                className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm
+                           border border-red-500/40 text-red-600 dark:text-red-400
+                           hover:bg-red-500/10 transition-colors"
+              >
+                <LogOut size={14} />
+                {t("Sign out")}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/components/UserAvatar.tsx
+++ b/web/components/UserAvatar.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { createElement, useState } from "react";
+import {
+  Cherry,
+  Cloud,
+  Compass,
+  Cookie,
+  Droplet,
+  Feather,
+  Flame,
+  Heart,
+  Leaf,
+  Lightbulb,
+  Moon,
+  Music,
+  Shield,
+  Sparkles,
+  Sprout,
+  Star,
+  Sun,
+  type LucideIcon,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  AVATAR_COLOR_NAMES,
+  AVATAR_COLORS,
+  AVATAR_ICON_NAMES,
+  fallbackAvatarFor,
+  parseAvatarMarker,
+} from "@/lib/avatar";
+import { avatarImageUrl } from "@/lib/profile-api";
+
+/**
+ * User avatars. Marker parsing and the deterministic fallback live in
+ * lib/avatar.ts (pure, unit-tested); this component maps icon names to
+ * lucide components and renders the marker.
+ *
+ * Admins get an amber ring at every size plus a small shield badge once the
+ * avatar is large enough for it to stay legible (>= 40px).
+ */
+
+// Must cover every name in AVATAR_ICON_NAMES (lib/avatar.ts).
+export const AVATAR_ICONS: Record<string, LucideIcon> = {
+  sparkles: Sparkles,
+  sprout: Sprout,
+  leaf: Leaf,
+  feather: Feather,
+  cloud: Cloud,
+  droplet: Droplet,
+  sun: Sun,
+  moon: Moon,
+  flame: Flame,
+  star: Star,
+  heart: Heart,
+  lightbulb: Lightbulb,
+  compass: Compass,
+  cherry: Cherry,
+  cookie: Cookie,
+  music: Music,
+};
+
+// Re-exported so picker UIs only need one import site.
+export {
+  AVATAR_COLOR_NAMES,
+  AVATAR_COLORS,
+  AVATAR_ICON_NAMES,
+  fallbackAvatarFor,
+};
+
+const ADMIN_RING_COLOR = "#e0a83c";
+
+interface UserAvatarProps {
+  username: string;
+  /** Needed to resolve "img:" markers to an image URL. */
+  userId?: string;
+  /** Avatar marker; empty/undefined renders the deterministic fallback. */
+  avatar?: string;
+  /** Admins get the amber ring (and a shield badge at size >= 40). */
+  role?: string;
+  size?: number;
+  className?: string;
+}
+
+export function UserAvatar({
+  username,
+  userId,
+  avatar = "",
+  role,
+  size = 28,
+  className,
+}: UserAvatarProps) {
+  const { t } = useTranslation();
+  const [imageBroken, setImageBroken] = useState(false);
+  // A re-upload changes the marker version; give the new URL a fresh chance.
+  // Render-time reset (instead of an effect) per react.dev's "adjusting
+  // state when a prop changes" guidance.
+  const imageKey = `${userId ?? ""}:${avatar}`;
+  const [lastImageKey, setLastImageKey] = useState(imageKey);
+  if (imageKey !== lastImageKey) {
+    setLastImageKey(imageKey);
+    setImageBroken(false);
+  }
+
+  const isAdmin = role === "admin";
+  const showBadge = isAdmin && size >= 40;
+  const descriptor = parseAvatarMarker(avatar);
+  const isImage =
+    descriptor.kind === "image" && Boolean(userId) && !imageBroken;
+
+  let iconName: string;
+  let colorName: string;
+  if (descriptor.kind === "icon") {
+    iconName = descriptor.icon;
+    colorName = descriptor.color;
+  } else {
+    const fallback = fallbackAvatarFor(username);
+    iconName = fallback.icon;
+    colorName = fallback.color;
+  }
+
+  const ringStyle = isAdmin
+    ? {
+        outline: `${Math.max(1.5, size / 18)}px solid ${ADMIN_RING_COLOR}`,
+        outlineOffset: `${Math.max(1, size / 28)}px`,
+      }
+    : undefined;
+  const adminLabel = t("Administrator");
+
+  return (
+    <span
+      className={`relative inline-flex shrink-0 ${className ?? ""}`}
+      style={{ width: size, height: size }}
+      title={isAdmin ? `${username} — ${adminLabel}` : username}
+      aria-label={isAdmin ? `${username} (${adminLabel})` : username}
+    >
+      {isImage ? (
+        /* Dynamic backend URL with cookie auth; next/image cannot optimize it. */
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={avatarImageUrl(userId as string, avatar)}
+          alt=""
+          width={size}
+          height={size}
+          onError={() => setImageBroken(true)}
+          className="h-full w-full rounded-full object-cover"
+          style={ringStyle}
+        />
+      ) : (
+        <span
+          className="flex h-full w-full items-center justify-center rounded-full text-white"
+          style={{ backgroundColor: AVATAR_COLORS[colorName], ...ringStyle }}
+        >
+          {createElement(AVATAR_ICONS[iconName] ?? Sparkles, {
+            size: Math.round(size * 0.55),
+            strokeWidth: 1.8,
+          })}
+        </span>
+      )}
+      {showBadge && (
+        <span
+          className="absolute flex items-center justify-center rounded-full"
+          style={{
+            right: -size / 14,
+            bottom: -size / 14,
+            width: Math.round(size * 0.38),
+            height: Math.round(size * 0.38),
+            backgroundColor: "#f7ecd4",
+            border: "2px solid var(--background)",
+            color: "#8a5d0b",
+          }}
+          aria-hidden
+        >
+          <Shield size={Math.round(size * 0.2)} strokeWidth={2.2} />
+        </span>
+      )}
+    </span>
+  );
+}

--- a/web/components/auth/ProfileLink.tsx
+++ b/web/components/auth/ProfileLink.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useTranslation } from "react-i18next";
+import { fetchAuthStatus, AUTH_ENABLED, type AuthStatus } from "@/lib/auth";
+import { UserAvatar } from "@/components/UserAvatar";
+
+interface ProfileLinkProps {
+  collapsed?: boolean;
+}
+
+export function ProfileLink({ collapsed = false }: ProfileLinkProps) {
+  const pathname = usePathname();
+  const { t } = useTranslation();
+  const [status, setStatus] = useState<AuthStatus | null>(null);
+
+  useEffect(() => {
+    if (!AUTH_ENABLED) return;
+    fetchAuthStatus().then((next) => {
+      if (next?.authenticated) setStatus(next);
+    });
+  }, []);
+
+  if (!AUTH_ENABLED || !status?.username) return null;
+
+  const active = pathname.startsWith("/profile");
+  const avatar = (
+    <UserAvatar
+      username={status.username}
+      userId={status.user_id}
+      avatar={status.avatar}
+      size={collapsed ? 18 : 16}
+    />
+  );
+
+  if (collapsed) {
+    return (
+      <Link
+        href="/profile"
+        className={`rounded-lg p-2 transition-colors
+          ${
+            active
+              ? "bg-[var(--primary)]/10 text-[var(--primary)]"
+              : "text-[var(--muted-foreground)] hover:bg-[var(--background)]/50 hover:text-[var(--foreground)]"
+          }`}
+        aria-label={t("My profile")}
+        title={`${t("My profile")} — ${status.username}`}
+      >
+        {avatar}
+      </Link>
+    );
+  }
+
+  return (
+    <Link
+      href="/profile"
+      className={`flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-[13.5px] transition-colors
+        ${
+          active
+            ? "bg-[var(--primary)]/10 text-[var(--primary)]"
+            : "text-[var(--muted-foreground)] hover:bg-[var(--background)]/50 hover:text-[var(--foreground)]"
+        }`}
+      title={t("My profile")}
+    >
+      {avatar}
+      <span className="truncate">{status.username}</span>
+    </Link>
+  );
+}

--- a/web/components/sidebar/UtilitySidebar.tsx
+++ b/web/components/sidebar/UtilitySidebar.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { SidebarShell } from "@/components/sidebar/SidebarShell";
 import { LogoutButton } from "@/components/auth/LogoutButton";
 import { AdminLink } from "@/components/auth/AdminLink";
+import { ProfileLink } from "@/components/auth/ProfileLink";
 import { useAppShell } from "@/context/AppShellContext";
 import {
   deleteSession,
@@ -92,6 +93,7 @@ export default function UtilitySidebar() {
       onDeleteSession={handleDeleteSession}
       footerSlot={(collapsed) => (
         <>
+          <ProfileLink collapsed={collapsed} />
           <AdminLink collapsed={collapsed} />
           <LogoutButton collapsed={collapsed} />
         </>

--- a/web/components/sidebar/WorkspaceSidebar.tsx
+++ b/web/components/sidebar/WorkspaceSidebar.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { SidebarShell } from "@/components/sidebar/SidebarShell";
 import { LogoutButton } from "@/components/auth/LogoutButton";
 import { AdminLink } from "@/components/auth/AdminLink";
+import { ProfileLink } from "@/components/auth/ProfileLink";
 import { useUnifiedChat } from "@/context/UnifiedChatContext";
 import {
   deleteSession,
@@ -134,6 +135,7 @@ export default function WorkspaceSidebar() {
       onDeleteSession={handleDeleteSession}
       footerSlot={(collapsed) => (
         <>
+          <ProfileLink collapsed={collapsed} />
           <AdminLink collapsed={collapsed} />
           <LogoutButton collapsed={collapsed} />
         </>

--- a/web/lib/admin-api.ts
+++ b/web/lib/admin-api.ts
@@ -6,6 +6,8 @@ export interface UserRecord {
   role: "admin" | "user";
   created_at: string;
   disabled?: boolean;
+  /** Avatar marker: "", "icon:<name>:<color>", or "img:<version>". */
+  avatar?: string;
 }
 
 export async function listUsers(): Promise<UserRecord[]> {

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -17,6 +17,8 @@ export interface AuthStatus {
   username?: string;
   role?: string;
   is_admin?: boolean;
+  /** Avatar marker: "", "icon:<name>:<color>", or "img:<version>". */
+  avatar?: string;
 }
 
 /**

--- a/web/lib/avatar.ts
+++ b/web/lib/avatar.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure avatar logic — marker parsing and the deterministic fallback.
+ *
+ * The marker format (persisted in the user record) is:
+ *   ""                    — deterministic icon+color derived from the username
+ *   "icon:<name>:<color>" — an explicitly picked icon and color (keys below)
+ *   "img:<version>"       — an uploaded image served from /api/v1/auth/avatar
+ *
+ * Kept free of React/lucide imports so node unit tests can pin the behavior;
+ * the UserAvatar component maps icon names to lucide components on top.
+ */
+
+// Same curated icon set as SessionAvatar, so the app keeps one visual voice.
+// Order matters: the fallback hash indexes into this list, so reordering or
+// removing entries silently reassigns every user's fallback avatar.
+export const AVATAR_ICON_NAMES: readonly string[] = [
+  "sparkles",
+  "sprout",
+  "leaf",
+  "feather",
+  "cloud",
+  "droplet",
+  "sun",
+  "moon",
+  "flame",
+  "star",
+  "heart",
+  "lightbulb",
+  "compass",
+  "cherry",
+  "cookie",
+  "music",
+];
+
+// Fixed hexes (not theme variables) so a user's chosen color reads the same
+// across Light/Dark/Snow/Glass themes; all carry white icons at 4.5:1+.
+export const AVATAR_COLORS: Record<string, string> = {
+  violet: "#7c5fd3",
+  blue: "#3f7cc8",
+  teal: "#2a9d8f",
+  green: "#4f9d4f",
+  amber: "#c98a2d",
+  rose: "#d05c7c",
+  slate: "#6b7a8c",
+  pink: "#bb5fb2",
+};
+
+export const AVATAR_COLOR_NAMES = Object.keys(AVATAR_COLORS);
+
+// Cheap, stable FNV-1a hash (same as SessionAvatar) so a username always maps
+// to the same fallback icon/color without anything persisted.
+function hashString(input: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+export function fallbackAvatarFor(username: string): {
+  icon: string;
+  color: string;
+} {
+  const hash = hashString(username || "user");
+  return {
+    icon: AVATAR_ICON_NAMES[hash % AVATAR_ICON_NAMES.length],
+    // ">>>" not ">>": a signed shift of a hash >= 2^31 yields a negative
+    // index, which would silently drop the background color entirely.
+    color: AVATAR_COLOR_NAMES[(hash >>> 4) % AVATAR_COLOR_NAMES.length],
+  };
+}
+
+export type AvatarDescriptor =
+  | { kind: "image"; version: string }
+  | { kind: "icon"; icon: string; color: string }
+  | { kind: "fallback" };
+
+const ICON_MARKER_RE = /^icon:([a-z0-9-]+):([a-z0-9-]+)$/;
+
+/**
+ * Classify an avatar marker. Unknown icon/color names (e.g. from a stale or
+ * hand-edited user record) degrade to the deterministic fallback instead of
+ * rendering a broken avatar.
+ */
+export function parseAvatarMarker(
+  marker: string | null | undefined,
+): AvatarDescriptor {
+  const value = (marker ?? "").trim();
+  if (value.startsWith("img:")) {
+    return { kind: "image", version: value.slice(4) };
+  }
+  const match = ICON_MARKER_RE.exec(value);
+  if (
+    match &&
+    AVATAR_ICON_NAMES.includes(match[1]) &&
+    AVATAR_COLORS[match[2]]
+  ) {
+    return { kind: "icon", icon: match[1], color: match[2] };
+  }
+  return { kind: "fallback" };
+}

--- a/web/lib/profile-api.ts
+++ b/web/lib/profile-api.ts
@@ -1,0 +1,80 @@
+import { apiFetch, apiUrl } from "@/lib/api";
+
+export interface ProfileInfo {
+  id: string;
+  username: string;
+  role: "admin" | "user";
+  created_at: string;
+  disabled?: boolean;
+  /** Avatar marker: "", "icon:<name>:<color>", or "img:<version>". */
+  avatar?: string;
+}
+
+function extractDetail(data: unknown, fallback: string): string {
+  if (typeof data === "object" && data !== null && "detail" in data) {
+    const detail = (data as { detail: unknown }).detail;
+    if (typeof detail === "string") return detail;
+  }
+  return fallback;
+}
+
+/** Fetch the signed-in user's own profile. */
+export async function getProfile(): Promise<ProfileInfo> {
+  const res = await apiFetch(apiUrl("/api/v1/auth/profile"));
+  if (!res.ok) throw new Error("Failed to fetch profile");
+  return res.json();
+}
+
+/**
+ * Persist an icon-based avatar choice ("icon:<name>:<color>") or reset to the
+ * deterministic fallback (""). Uploaded-image markers are managed by
+ * `uploadAvatarImage`.
+ */
+export async function setAvatarMarker(avatar: string): Promise<string> {
+  const res = await apiFetch(apiUrl("/api/v1/auth/profile"), {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ avatar }),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(extractDetail(data, "Failed to update avatar"));
+  }
+  const data = await res.json();
+  return String(data.avatar ?? avatar);
+}
+
+/** Upload an avatar image (already cropped/resized client-side). */
+export async function uploadAvatarImage(blob: Blob): Promise<string> {
+  const form = new FormData();
+  form.append("file", blob, "avatar");
+  const res = await apiFetch(apiUrl("/api/v1/auth/profile/avatar"), {
+    method: "PUT",
+    body: form,
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(extractDetail(data, "Failed to upload avatar"));
+  }
+  const data = await res.json();
+  return String(data.avatar ?? "");
+}
+
+/** Remove the uploaded avatar image and reset the marker. */
+export async function removeAvatarImage(): Promise<void> {
+  const res = await apiFetch(apiUrl("/api/v1/auth/profile/avatar"), {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(extractDetail(data, "Failed to remove avatar"));
+  }
+}
+
+/** Build the image URL for an "img:<version>" marker (version cache-busts). */
+export function avatarImageUrl(userId: string, marker: string): string {
+  const version = marker.startsWith("img:") ? marker.slice(4) : "0";
+  return apiUrl(
+    `/api/v1/auth/avatar/${encodeURIComponent(userId)}?v=${encodeURIComponent(version)}`,
+  );
+}

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -2358,5 +2358,18 @@
   "Partner": "Partner",
   "Edited — your version becomes this partner's soul. The original template is untouched.": "Edited — your version becomes this partner's soul. The original template is untouched.",
   "Mastery-based tutoring with a hard gate": "Mastery-based tutoring with a hard gate",
-  "Mastery Path tooltip": "Mastery-based learning with a hard gate"
+  "Mastery Path tooltip": "Mastery-based learning with a hard gate",
+  "My profile": "My profile",
+  "View your account and personalize your avatar": "View your account and personalize your avatar",
+  "Administrator": "Administrator",
+  "Joined": "Joined",
+  "Avatar": "Avatar",
+  "Upload a picture or pick an icon": "Upload a picture or pick an icon",
+  "Upload image": "Upload image",
+  "Remove photo": "Remove photo",
+  "Or pick an icon": "Or pick an icon",
+  "Sign out": "Sign out",
+  "End your session on this device": "End your session on this device",
+  "Failed to load profile": "Failed to load profile",
+  "Image is too large": "Image is too large"
 }

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -2358,5 +2358,18 @@
   "Partner": "伙伴",
   "Edited — your version becomes this partner's soul. The original template is untouched.": "已编辑——你的版本将成为这个伙伴的 soul，原模板保持不变。",
   "Mastery-based tutoring with a hard gate": "掌握式辅导：硬门槛 + 间隔复习",
-  "Mastery Path tooltip": "掌握式学习：硬门槛与间隔复习"
+  "Mastery Path tooltip": "掌握式学习：硬门槛与间隔复习",
+  "My profile": "个人资料",
+  "View your account and personalize your avatar": "查看账户信息并个性化你的头像",
+  "Administrator": "管理员",
+  "Joined": "注册时间",
+  "Avatar": "头像",
+  "Upload a picture or pick an icon": "上传图片或选择一个图标",
+  "Upload image": "上传图片",
+  "Remove photo": "移除照片",
+  "Or pick an icon": "或选择一个图标",
+  "Sign out": "退出登录",
+  "End your session on this device": "结束此设备上的会话",
+  "Failed to load profile": "加载个人资料失败",
+  "Image is too large": "图片过大"
 }

--- a/web/tests/avatar.test.ts
+++ b/web/tests/avatar.test.ts
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  AVATAR_COLOR_NAMES,
+  AVATAR_COLORS,
+  AVATAR_ICON_NAMES,
+  fallbackAvatarFor,
+  parseAvatarMarker,
+} from "../lib/avatar";
+
+test("icon and color tables are well-formed", () => {
+  assert.equal(AVATAR_ICON_NAMES.length, 16);
+  assert.equal(AVATAR_COLOR_NAMES.length, 8);
+  assert.equal(new Set(AVATAR_ICON_NAMES).size, AVATAR_ICON_NAMES.length);
+  for (const name of AVATAR_ICON_NAMES) {
+    assert.match(name, /^[a-z0-9-]+$/);
+  }
+  for (const hex of Object.values(AVATAR_COLORS)) {
+    assert.match(hex, /^#[0-9a-f]{6}$/);
+  }
+});
+
+test("fallbackAvatarFor is deterministic and always valid", () => {
+  for (const username of ["alice", "bob", "局长", "", "a".repeat(200)]) {
+    const first = fallbackAvatarFor(username);
+    assert.deepEqual(first, fallbackAvatarFor(username));
+    assert.ok(AVATAR_ICON_NAMES.includes(first.icon), `icon for ${username}`);
+    assert.ok(
+      AVATAR_COLOR_NAMES.includes(first.color),
+      `color for ${username}`,
+    );
+  }
+});
+
+test("fallback assignment is pinned — a hash change would shuffle every user's avatar", () => {
+  // These values are part of the visual contract: users recognise each other
+  // by the fallback avatar, so a refactor must not silently reassign them.
+  assert.deepEqual(fallbackAvatarFor("alice"), {
+    icon: "moon",
+    color: "slate",
+  });
+  assert.deepEqual(fallbackAvatarFor("bob"), { icon: "cloud", color: "rose" });
+  assert.deepEqual(fallbackAvatarFor("局长"), {
+    icon: "sparkles",
+    color: "slate",
+  });
+  // Empty usernames hash the literal "user" placeholder.
+  assert.deepEqual(fallbackAvatarFor(""), { icon: "leaf", color: "pink" });
+  assert.deepEqual(fallbackAvatarFor("user"), { icon: "leaf", color: "pink" });
+});
+
+test("fallback color index uses an unsigned shift (regression)", () => {
+  // "alice" hashes above 2^31; with a signed ">> 4" the color index went
+  // negative and the avatar lost its background fill entirely.
+  const { color } = fallbackAvatarFor("alice");
+  assert.notEqual(AVATAR_COLORS[color], undefined);
+});
+
+test("parseAvatarMarker classifies image markers", () => {
+  assert.deepEqual(parseAvatarMarker("img:1"), { kind: "image", version: "1" });
+  assert.deepEqual(parseAvatarMarker("img:42"), {
+    kind: "image",
+    version: "42",
+  });
+});
+
+test("parseAvatarMarker classifies known icon markers", () => {
+  assert.deepEqual(parseAvatarMarker("icon:leaf:teal"), {
+    kind: "icon",
+    icon: "leaf",
+    color: "teal",
+  });
+  assert.deepEqual(parseAvatarMarker(" icon:moon:slate "), {
+    kind: "icon",
+    icon: "moon",
+    color: "slate",
+  });
+});
+
+test("parseAvatarMarker degrades everything else to the fallback", () => {
+  const fallbackInputs = [
+    "",
+    "   ",
+    undefined,
+    null,
+    "icon:not-a-real-icon:teal",
+    "icon:leaf:not-a-color",
+    "ICON:Leaf:Teal",
+    "icon:leaf",
+    "icon:leaf:teal:extra",
+    "../etc/passwd",
+    "javascript:alert(1)",
+  ];
+  for (const input of fallbackInputs) {
+    assert.deepEqual(
+      parseAvatarMarker(input),
+      { kind: "fallback" },
+      `input: ${String(input)}`,
+    );
+  }
+});


### PR DESCRIPTION
### Description

Implements the **Profile** half of #553: a self-service account page for any
signed-in user. Today a regular user can only see their identity in the
Admin → User Management table, and only if they're an admin — this gives every
user one place to see who they're logged in as, pick an avatar, and sign out.

The Admin → User Management redesign (the other half of #553) will follow as a
separate, independent PR.

**Frontend** — a new `/profile` route (under the existing `(utility)` group):
- Account info: username, role badge, join date.
- Avatar: upload your own picture **or** pick from a predefined icon set
  (16 icons × 8 colors). Uploads are cropped to a square and resized to 256px
  client-side via `<canvas>` (which also strips EXIF), keeping the stored file
  small.
- Sign out.
- A shared `UserAvatar` component (image → picked icon → deterministic fallback
  by username hash). Admins get an amber ring + shield badge, always paired with
  an `aria-label`/role badge so the cue is never color-only.

**Backend** — no new dependencies:
- `UserRecord` gains an optional, backward-compatible `avatar` marker
  (`""`, `"icon:<name>:<color>"`, or `"img:<version>"`); surfaced on
  `/auth/status` and `/auth/users`.
- New endpoints: `GET/PUT /api/v1/auth/profile`,
  `PUT/DELETE /api/v1/auth/profile/avatar`, `GET /api/v1/auth/avatar/{user_id}`.
- Uploaded images are validated by **magic bytes** (PNG/JPEG/WebP only; SVG
  rejected as a stored-XSS vector), capped at 1 MB, stored on disk under
  `multi-user/_system/auth/avatars/<user_id>.<ext>` with an atomic
  write-then-replace, and served with `nosniff` + private caching. Deleting a
  user also removes their avatar file.

### Related Issues
- Related to #553

### Module(s) Affected
- [ ] `agents`
- [x] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [x] Other: `multi_user` (identity store / user model)

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

Rebased onto the latest `dev` and verified end-to-end in the Docker build (auth
enabled): login → Profile link in the sidebar → upload an image, pick an
icon/color, remove photo, and sign out all work. Screenshots below.

**Design decisions** (answering the open questions in #553):
- Route, not popover — fits the existing `(utility)` group.
- Hybrid avatars (upload *and* an icon set that also serves as the fallback);
  stored in the user record, with image bytes on disk rather than in the user
  JSON.
- Profile endpoints require auth but **not** admin; a user can only edit their
  own record, and `img:` markers can only be set via the validated upload
  endpoint.

**Intentional tradeoffs (happy to change):**
- `/auth/status` now reads the user store to include the avatar marker so the
  sidebar avatar needs no extra request — could be cached for very large user
  stores.
- `set_avatar` takes the existing users-file write lock; the sibling
  `delete_user`/`set_role` helpers predate it and don't — I left that asymmetry
  alone to keep the diff scoped, happy to align them.
- With `AUTH_ENABLED=false` (default localhost mode) the Profile link is hidden
  and the page redirects, matching the existing admin-area behavior.

This is a proposal, not a fixed design. If you disagree with any of it, or want
something added, reworked, split up differently, renamed, or dropped — no problem
at all, I'm happy to discuss and iterate on whatever direction you prefer.

**Screenshots**

| Profile — uploaded image (admin) | Profile — picked icon (admin) | Profile — regular user |
| --- | --- | --- |
| <img width="730" height="715" alt="image" src="https://github.com/user-attachments/assets/3c84db26-b156-4d75-9ac3-8c6f69fbf415" /> | <img width="2120" height="1800" alt="02-profile-admin-icon" src="https://github.com/user-attachments/assets/418233d3-fba0-4632-9fc9-253ab4e0ee0f" /> | <img width="2120" height="1800" alt="01-profile-user" src="https://github.com/user-attachments/assets/c6f81f8e-8c5c-41ab-806b-677ba6cb93cd" /> |

| Sidebar — expanded | Sidebar — collapsed |
| --- | --- |
| <img width="440" height="1800" alt="03-sidebar-expanded" src="https://github.com/user-attachments/assets/6961669e-610f-4672-b986-ab50bcb6e017" /> | <img width="120" height="1800" alt="04-sidebar-collapsed" src="https://github.com/user-attachments/assets/f60a1aad-9f5a-4136-b3de-d82c8e9d033b" /> |