### PR TITLE
fix: run supervisord as root so services start under rootful Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -207,10 +207,12 @@ nodaemon=true
 logfile=/dev/null
 logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
+user=root
 
 [program:backend]
 command=/bin/bash /app/start-backend.sh
 directory=/app
+user=deeptutor
 autostart=true
 autorestart=true
 stdout_logfile=/dev/fd/1
@@ -222,6 +224,7 @@ environment=PYTHONPATH="/app",PYTHONUNBUFFERED="1"
 [program:frontend]
 command=/bin/bash /app/start-frontend.sh
 directory=/app/web
+user=deeptutor
 autostart=true
 autorestart=true
 startsecs=5
@@ -357,10 +360,19 @@ echo "   - data/user/settings/main.yaml"
 echo "   - data/user/settings/agents.yaml"
 echo "============================================"
 
-# Start supervisord as the unprivileged deeptutor user (UID 1000). The
-# supervisord children (backend, frontend) inherit this UID; chown above
-# ensured they can write under /app/data.
-exec gosu deeptutor /usr/bin/supervisord -c /etc/supervisor/conf.d/deeptutor.conf
+# Run supervisord as root so it can open the container's stdout/stderr
+# (/dev/fd/1,2 — root-owned pipes under a rootful daemon like Docker Desktop)
+# and write its pidfile under /var/run. The backend and frontend programs are
+# dropped to the unprivileged deeptutor user (UID 1000) via `user=deeptutor`
+# in the supervisord config, so the app processes stay non-root.
+#
+# Dropping supervisord ITSELF to UID 1000 here (the previous
+# `exec gosu deeptutor ...`) worked under rootless podman — where UID 1000 is
+# the mapped host user that owns those FDs — but under a rootful daemon it
+# could not open /dev/fd/1,2 ("making dispatchers ... EACCES") nor the pidfile,
+# so neither service ever started. Per-program `user=` keeps the children
+# unprivileged in both runtimes without that breakage.
+exec /usr/bin/supervisord -c /etc/supervisor/conf.d/deeptutor.conf
 EOF
 
 RUN sed -i 's/\r$//' /app/entrypoint.sh && chmod +x /app/entrypoint.sh
@@ -403,6 +415,12 @@ COPY --from=frontend-builder /app/web/node_modules ./web/node_modules
 COPY --from=frontend-builder /app/web/package.json ./web/package.json
 COPY --from=frontend-builder /app/web/next.config.js ./web/next.config.js
 
+# `next dev` runs as the unprivileged deeptutor user (via `user=deeptutor` in
+# the supervisord config) and must create/write its build cache under
+# /app/web/.next, so give that user ownership of the web dir and the cache.
+RUN mkdir -p /app/web/.next \
+    && chown deeptutor:deeptutor /app/web /app/web/.next
+
 # Install development tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
     vim \
@@ -423,10 +441,12 @@ nodaemon=true
 logfile=/dev/null
 logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
+user=root
 
 [program:backend]
 command=python -m uvicorn deeptutor.api.main:app --host 0.0.0.0 --port %(ENV_BACKEND_PORT)s --reload --no-access-log
 directory=/app
+user=deeptutor
 autostart=true
 autorestart=true
 stdout_logfile=/dev/fd/1
@@ -438,6 +458,7 @@ environment=PYTHONPATH="/app",PYTHONUNBUFFERED="1"
 [program:frontend]
 command=/bin/bash -c "cd /app/web && node node_modules/next/dist/bin/next dev -H 0.0.0.0 -p ${FRONTEND_PORT:-3782}"
 directory=/app/web
+user=deeptutor
 autostart=true
 autorestart=true
 startsecs=5

--- a/tests/scripts/test_docker_compose.py
+++ b/tests/scripts/test_docker_compose.py
@@ -91,6 +91,35 @@ def test_dockerfile_is_json_driven_without_bundle_sed() -> None:
     assert "export_runtime_settings_to_env" in content
 
 
+def test_supervisord_runs_as_root_with_unprivileged_children() -> None:
+    """supervisord itself must run as root so it can open the container's
+    stdout/stderr (``/dev/fd/1,2`` — root-owned pipes under a rootful daemon
+    such as Docker Desktop) and write its pidfile under ``/var/run``. Dropping
+    supervisord to the unprivileged ``deeptutor`` user via ``gosu`` made child
+    spawning fail with ``EACCES`` ("making dispatchers ... EACCES"), so neither
+    the backend nor the frontend started under rootful Docker (it only worked
+    under rootless podman). The app processes stay non-root via the per-program
+    ``user=deeptutor`` directive instead, which keeps them unprivileged in both
+    runtimes. This guards against reintroducing the ``gosu`` privilege drop.
+    """
+    root = Path(__file__).resolve().parents[2]
+    content = (root / "Dockerfile").read_text(encoding="utf-8")
+    # supervisord is launched directly (as root), not behind a gosu priv-drop.
+    assert "exec /usr/bin/supervisord" in content
+    assert "gosu deeptutor /usr/bin/supervisord" not in content
+    # Every supervisord program drops to the unprivileged deeptutor user, so the
+    # backend/frontend processes never run as root. Each config heredoc closes
+    # with ``EOF``; slice to it so a program's section is bounded correctly.
+    program_blocks = content.split("[program:")[1:]
+    assert program_blocks, "expected supervisord [program:*] sections in the Dockerfile"
+    for block in program_blocks:
+        name = block.splitlines()[0].rstrip("]")
+        section = block.split("EOF")[0]
+        assert "user=deeptutor" in section, (
+            f"supervisord program '{name}' must run as deeptutor (user=deeptutor)"
+        )
+
+
 def test_frontend_api_is_url_agnostic_passthrough() -> None:
     """web/lib/api.ts no longer carries a build-time API base or a placeholder
     token; apiUrl/wsUrl are pass-throughs and the Next.js middleware


### PR DESCRIPTION
### Description

The published image does not boot under a **rootful Docker daemon** (Docker
Desktop on Windows/macOS, or plain Docker on Linux): supervisord fails to spawn
its children and **neither the backend nor the frontend starts**. The container
stays "up" but `:8001` and `:3782` never respond.

#### Root cause

The entrypoint dropped **supervisord itself** to the unprivileged `deeptutor`
user (UID 1000) via `exec gosu deeptutor /usr/bin/supervisord`. Supervisord
logs its programs to `/dev/fd/1,2` (the container's stdout/stderr pipes).
Under a **rootful daemon** those pipes are owned by root, so after the `gosu`
drop UID 1000 cannot open them:
```bash
CRIT could not write pidfile /var/run/supervisord.pid
INFO spawnerr: unknown error making dispatchers for 'backend': EACCES
INFO spawnerr: unknown error making dispatchers for 'frontend': EACCES
INFO gave up: backend entered FATAL state, too many start retries
INFO gave up: frontend entered FATAL state, too many start retries
```

The `gosu` approach only worked under **rootless podman** (`userns_mode:
keep-id`), where UID 1000 is mapped to the host user that owns those FDs.

#### Relation to #580 / #581

Issue #580 and PR #581 address a **different, cosmetic** symptom of the same
`gosu` hardening (PR #577): under rootless podman the pidfile `CRIT` appears
in the log, but children still spawn and the stack is fully functional. Their
fix (`/var/run` tmpfs `mode=1777`) is correct for that case.

This PR addresses the **fatal** case: under a rootful daemon the children
**never spawn at all** because `/dev/fd/1,2` — not the pidfile — are
inaccessible to UID 1000. Changing the tmpfs mode does not help here; the
file descriptors are inherited from the container runtime, not a tmpfs path.

| | PR #581 | This PR |
|---|---|---|
| Runtime | rootless podman + keep-id | rootful Docker Desktop / Engine |
| Symptom | `CRIT` pidfile in logs (cosmetic) | `EACCES` on fd/1,2 — app never starts (fatal) |
| Fix | `compose.yaml` tmpfs mode | `Dockerfile` supervisord config |
| Files changed | `compose.yaml` | `Dockerfile`, test |

#### Fix

Run **supervisord as root** and drop only the app processes to `deeptutor`
via supervisord's own `user=` directive — applied to both the production and
development supervisord configs:

- entrypoint: `exec /usr/bin/supervisord …` (no `gosu` prefix)
- `[supervisord]` section: `user=root`
- `[program:backend]` and `[program:frontend]`: `user=deeptutor`

Root opens the log FDs and pidfile, then supervisord `setuid`s each child —
so the **backend and frontend processes stay non-root in both runtimes**,
preserving the security goal of PR #577.

The dev stage also `chown`s `/app/web/.next` so `next dev` can write its
build cache as the unprivileged user.

### Related Issues
- Related to #580 (same root: `gosu`-based priv-drop from PR #577; different
  symptom and runtime)
- Related to #581 (complementary fix for rootless podman; this PR fixes
  rootful Docker)

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [x] Other: `Docker (Dockerfile / container runtime)`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

**Reproduction (released image, no overrides needed):**

```bash
docker run ghcr.io/hkuds/deeptutor:latest
# CRIT could not write pidfile /var/run/supervisord.pid
# INFO spawnerr: unknown error making dispatchers for 'backend': EACCES
# INFO spawnerr: unknown error making dispatchers for 'frontend': EACCES
# INFO gave up: backend entered FATAL state, too many start retries
```

**Verification (rebuilt `--target production`, plain `docker run`, no overrides):**
```bash
INFO supervisord started with pid 1
INFO spawned: 'backend' with pid 18
INFO spawned: 'frontend' with pid 19
INFO success: backend entered RUNNING state
▲ Next.js 16.2.3  ✓ Ready
```

`GET /api/v1/auth/status` → `200`, `GET /` → `200`. App processes confirmed
running as `deeptutor` (UID 1000) via the `user=` directive.

**Tests:** added `test_supervisord_runs_as_root_with_unprivileged_children` in
`tests/scripts/test_docker_compose.py`. Parses the Dockerfile and asserts: (1)
no `gosu deeptutor` before `supervisord`, (2) every `[program:*]` declares
`user=deeptutor`. Runs without a Docker build. `pytest -q
tests/scripts/test_docker_compose.py` → 6 passed.

---

> Open to any feedback — if this doesn't fit the project's direction, no worries at all, happy to discuss and rework as needed.