### PR TITLE
fix(llm): enable native tool calls for SiliconFlow

### DIFF
--- a/deeptutor/services/llm/capabilities.py
+++ b/deeptutor/services/llm/capabilities.py
@@ -94,6 +94,18 @@ PROVIDER_CAPABILITIES: dict[str, dict[str, object]] = {
         "system_in_messages": True,
         "has_thinking_tags": True,  # DeepSeek reasoner has thinking tags
     },
+    # SiliconFlow exposes OpenAI-compatible chat completions for hosted models
+    # such as DeepSeek and Qwen; model-specific overrides below still govern
+    # response_format, thinking tags, and vision.
+    "siliconflow": {
+        "supports_response_format": True,
+        "supports_streaming": True,
+        "supports_tools": True,
+        "supports_vision": False,
+        "vision_url_supported": True,
+        "system_in_messages": True,
+        "has_thinking_tags": False,
+    },
     # VolcEngine Ark (Doubao) and BytePlus — OpenAI-compatible gateways that
     # host natively multimodal models (Doubao-Vision). ``supports_vision`` is
     # the Stage-2 fallback hint (see ``multimodal.py``), not a pre-flight gate:

--- a/tests/core/test_agentic_client_provider_kwargs.py
+++ b/tests/core/test_agentic_client_provider_kwargs.py
@@ -175,6 +175,16 @@ def test_custom_qwen_can_use_native_tool_calling() -> None:
     assert can_use_native_tool_calling(binding="dashscope", model="qwen-plus") is True
 
 
+def test_siliconflow_deepseek_can_use_native_tool_calling() -> None:
+    assert (
+        can_use_native_tool_calling(
+            binding="siliconflow",
+            model="deepseek-ai/DeepSeek-V4-Pro",
+        )
+        is True
+    )
+
+
 @pytest.mark.asyncio
 async def test_anthropic_adapter_streams_openai_style_chunks() -> None:
     captured = {}

--- a/tests/services/llm/test_capabilities.py
+++ b/tests/services/llm/test_capabilities.py
@@ -65,6 +65,12 @@ def test_minimax_openai_compat_supports_tools_without_response_format() -> None:
     assert supports_response_format("minimax", "MiniMax-M2.7-highspeed") is False
 
 
+def test_siliconflow_openai_compat_supports_tools_for_deepseek() -> None:
+    assert supports_tools("siliconflow", "deepseek-ai/DeepSeek-V4-Pro") is True
+    assert supports_response_format("siliconflow", "deepseek-ai/DeepSeek-V4-Pro") is False
+    assert has_thinking_tags("siliconflow", "deepseek-ai/DeepSeek-V4-Pro") is True
+
+
 def test_custom_and_dashscope_openai_compat_support_native_tools_for_qwen() -> None:
     assert supports_tools("custom", "qwen3.6-plus") is True
     assert supports_tools("dashscope", "qwen-plus") is True


### PR DESCRIPTION
## Summary
- Add SiliconFlow to provider capabilities as an OpenAI-compatible endpoint with native tool-call support.
- Preserve model-level overrides for DeepSeek response_format and thinking-tag behavior.
- Add regression coverage for SiliconFlow DeepSeek native tool calling.

## Test Plan
- `./.venv/Scripts/python.exe -m pytest tests/services/llm/test_capabilities.py`
- `./.venv/Scripts/python.exe -m pytest tests/core/test_agentic_client_provider_kwargs.py`

## Context
SiliconFlow's OpenAI-compatible chat completions endpoint can return standard `tool_calls` for hosted DeepSeek models. Without a provider capability entry, DeepTutor treated `siliconflow` as an unknown provider and disabled native tool schemas, which could make models emit textual `<tool_calls>` markup instead of executable tool calls in chat/partner flows.