### PR TITLE
refactor: move Back link to its own row in the page header

### DIFF
--- a/web/app/(utility)/profile/page.tsx
+++ b/web/app/(utility)/profile/page.tsx
@@ -209,15 +209,15 @@ export default function ProfilePage() {
     <div className="h-screen overflow-y-auto bg-[var(--background)] px-4 py-10 [scrollbar-gutter:stable]">
       <div className="mx-auto max-w-2xl">
         {/* Header */}
-        <div className="mb-8 flex items-center gap-4">
+        <div className="mb-8">
           <Link
             href="/"
-            className="flex items-center gap-1.5 text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+            className="mb-4 inline-flex items-center gap-1.5 text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
           >
-            <ArrowLeft size={15} />
+            <ArrowLeft size={16} />
             {t("Back")}
           </Link>
-          <div className="flex-1">
+          <div>
             <h1 className="text-xl font-semibold text-[var(--foreground)]">
               {t("My profile")}
             </h1>


### PR DESCRIPTION
### Description

Fixes the misaligned header on the profile page (`/profile`). The Back link
sat on the same row as the title, vertically centered against the two-line
title block — so the small arrow floated awkwardly next to the larger heading.

Moves the Back link to its own row above the title, matching the standard
page-header pattern (same layout used on the admin Users page). Also bumps
the arrow from 15 px to 16 px for consistency.

Single-file, layout-only change — no behavior or logic touched.

### Related Issues
- Related to #553 (profile page shipped in #573; this is a follow-up header polish)

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

Layout-only fix — no test surface (pure CSS class change on a React component).

**Screenshots:**

| Light | Dark |
|---|---|
| <img width="1240" height="980" alt="01-profile" src="https://github.com/user-attachments/assets/72205b63-03e7-4578-80d9-cac068101b99" /> | <img width="1240" height="980" alt="02-profile-dark" src="https://github.com/user-attachments/assets/96cef2e8-7959-42e4-be84-88151e4e1e9b" /> |

---

> Open to any feedback — if this doesn't fit the project's direction, no worries at all, happy to discuss and rework as needed.