### PR TITLE
feat(docker): make BACKEND_HOST and FRONTEND_HOST env-configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,13 +240,18 @@ RUN cat > /app/start-backend.sh <<'EOF'
 set -e
 
 BACKEND_PORT=${BACKEND_PORT:-8001}
+BACKEND_HOST=${BACKEND_HOST:-0.0.0.0}
 
-echo "[Backend]  🚀 Starting FastAPI backend on port ${BACKEND_PORT}..."
+echo "[Backend]  🚀 Starting FastAPI backend on ${BACKEND_HOST}:${BACKEND_PORT}..."
 
 # Run uvicorn directly - the application's logging system already handles:
 # 1. Console output (visible in docker logs)
 # 2. File logging to data/user/logs/ai_tutor_*.log
-exec python -m uvicorn deeptutor.api.main:app --host 0.0.0.0 --port ${BACKEND_PORT} --no-access-log
+#
+# BACKEND_HOST defaults to 0.0.0.0 (LAN-reachable, matches bridge-mode
+# port publishing). Set BACKEND_HOST=127.0.0.1 when running with
+# network_mode: host to keep the backend on loopback only.
+exec python -m uvicorn deeptutor.api.main:app --host ${BACKEND_HOST} --port ${BACKEND_PORT} --no-access-log
 EOF
 
 RUN sed -i 's/\r$//' /app/start-backend.sh && chmod +x /app/start-backend.sh
@@ -261,10 +266,11 @@ RUN cat > /app/start-frontend.sh <<'EOF'
 set -e
 
 FRONTEND_PORT=${FRONTEND_PORT:-3782}
-echo "[Frontend] 🚀 Starting Next.js frontend on port ${FRONTEND_PORT}..."
+FRONTEND_HOST=${FRONTEND_HOST:-0.0.0.0}
+echo "[Frontend] 🚀 Starting Next.js frontend on ${FRONTEND_HOST}:${FRONTEND_PORT}..."
 
 export PORT=${FRONTEND_PORT}
-export HOSTNAME=0.0.0.0
+export HOSTNAME=${FRONTEND_HOST}
 exec node /app/web/server.js
 EOF
 


### PR DESCRIPTION
## Summary

Two new env vars let deployments pin the backend (uvicorn) and frontend (Next.js) to a specific bind address instead of the image-default `0.0.0.0`. Defaults preserve current behavior, so the change is non-breaking.

| Env var | Maps to | Default |
|---|---|---|
| `BACKEND_HOST` | `uvicorn --host` | `0.0.0.0` |
| `FRONTEND_HOST` | Next.js `HOSTNAME` (consumed by standalone `server.js`) | `0.0.0.0` |

## Why

When `network_mode: host` is used (e.g. for the Ollama-on-host-loopback pattern in podman rootless setups), the container processes bind directly on host interfaces. Today uvicorn binds `0.0.0.0:8001` and Next.js binds `0.0.0.0:3782`, which exposes both ports to the LAN. With this PR, setting `BACKEND_HOST=127.0.0.1` + `FRONTEND_HOST=127.0.0.1` restricts both bindings to loopback while keeping host-mode networking intact.

## Files changed

- `Dockerfile`: two heredoc edits (start-backend.sh, start-frontend.sh). 1 file, +10/-4.

## Usage

```yaml
services:
  deeptutor:
    network_mode: host          # host netns required for the env vars to take effect
    environment:
      - BACKEND_HOST=127.0.0.1
      - FRONTEND_HOST=127.0.0.1
```

## Caveat

Setting `BACKEND_HOST=127.0.0.1` while running in **bridge mode** will silently break the published port forward — uvicorn binds to the container's loopback and the host-side port mapping can't reach it. Only set these env vars together with `network_mode: host` (or when you intentionally want loopback-only access inside the container's own netns).

## Test plan

- [x] `bash -n` on both extracted heredocs (pass)
- [x] Diff reviewed: defaults `0.0.0.0` preserved, no other behavior change
- [ ] Maintainer can validate end-to-end by setting the env vars in a host-mode compose and checking `ss -tln` shows `127.0.0.1:8001` / `127.0.0.1:3782` instead of `0.0.0.0:...`

## Related

- PR #577 (rootless podman hardening — added the non-root user, image-level hardening that this PR complements)
- PR #581 (var-run mode + XDG path — also compose-only, not relevant to this image change but adjacent)