### PR TITLE
fix: render LaTeX in quiz options

### DIFF
--- a/web/components/quiz/QuizViewer.tsx
+++ b/web/components/quiz/QuizViewer.tsx
@@ -1038,7 +1038,13 @@ export default function QuizViewer({
                       key
                     )}
                   </span>
-                  <span className="leading-relaxed">{text}</span>
+                  <span className="min-w-0 leading-relaxed">
+                    <MarkdownRenderer
+                      content={text}
+                      variant="compact"
+                      enableMath
+                    />
+                  </span>
                 </button>
               );
             })}

--- a/web/tests/quiz-option-latex.test.ts
+++ b/web/tests/quiz-option-latex.test.ts
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+test("QuizViewer renders multiple-choice options through MarkdownRenderer", () => {
+  const source = readFileSync(
+    path.join(process.cwd(), "components/quiz/QuizViewer.tsx"),
+    "utf8",
+  );
+  const optionsStart = source.indexOf(
+    "{Object.entries(q.options!).map(([key, text]) => {",
+  );
+  assert.notEqual(optionsStart, -1, "choice option renderer not found");
+
+  const optionsEnd = source.indexOf(") : isConcept ?", optionsStart);
+  assert.notEqual(optionsEnd, -1, "choice option branch end not found");
+
+  const optionsBranch = source.slice(optionsStart, optionsEnd);
+  assert.match(
+    optionsBranch,
+    /<MarkdownRenderer[\s\S]*content=\{text\}[\s\S]*variant="compact"[\s\S]*enableMath/,
+  );
+  assert.doesNotMatch(
+    optionsBranch,
+    /<span className="leading-relaxed">\{text\}<\/span>/,
+  );
+});


### PR DESCRIPTION
## Summary

- render multiple-choice option labels with the existing MarkdownRenderer math pipeline
- add a regression test that prevents option labels from falling back to raw text rendering

Fixes #587

## Checks

- npm run test:node
- pre-commit run --all-files