### PR TITLE
fix(docker): make supervisord config portable across rootful + rootless keep-id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -200,7 +200,6 @@ nodaemon=true
 logfile=/dev/null
 logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
-user=root
 
 [program:backend]
 command=/bin/bash /app/start-backend.sh
@@ -359,18 +358,24 @@ echo "   - data/user/settings/main.yaml"
 echo "   - data/user/settings/agents.yaml"
 echo "============================================"
 
-# Run supervisord as root so it can open the container's stdout/stderr
-# (/dev/fd/1,2 — root-owned pipes under a rootful daemon like Docker Desktop)
-# and write its pidfile under /var/run. The backend and frontend programs are
-# dropped to the unprivileged deeptutor user (UID 1000) via `user=deeptutor`
-# in the supervisord config, so the app processes stay non-root.
+# Run supervisord with PID 1's UID — deliberately omitting `user=` from the
+# [supervisord] section so supervisord inherits whatever UID the container
+# started with (root under rootful Docker/Podman; UID 1000 under rootless
+# podman + userns_mode: keep-id, where PID 1 is the host user).
 #
-# Dropping supervisord ITSELF to UID 1000 here (the previous
-# `exec gosu deeptutor ...`) worked under rootless podman — where UID 1000 is
-# the mapped host user that owns those FDs — but under a rootful daemon it
-# could not open /dev/fd/1,2 ("making dispatchers ... EACCES") nor the pidfile,
-# so neither service ever started. Per-program `user=` keeps the children
-# unprivileged in both runtimes without that breakage.
+# Why no `user=root`: under rootless + keep-id, PID 1 is UID 1000 and has no
+# CAP_SETUID, so forcing `user=root` would make supervisord fail at startup
+# with "Error: Can't drop privilege as nonroot user" (see supervisord
+# options.py — it refuses to drop privileges when not running as root). The
+# previous design with `user=root` worked under rootful but broke rootless.
+#
+# The backend and frontend programs are still dropped to the unprivileged
+# deeptutor user (UID 1000) via per-program `user=deeptutor` in the
+# supervisord config — that setuid works because either (a) PID 1 is root
+# (rootful) and has CAP_SETUID, or (b) PID 1 is already UID 1000 (rootless
+# keep-id) and the setuid is a no-op. /dev/fd/1,2 ownership matches PID 1's
+# UID in both runtimes, so supervisord can write to them without an explicit
+# setuid dance.
 exec /usr/bin/supervisord -c /etc/supervisor/conf.d/deeptutor.conf
 EOF
 
@@ -440,7 +445,6 @@ nodaemon=true
 logfile=/dev/null
 logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
-user=root
 
 [program:backend]
 command=python -m uvicorn deeptutor.api.main:app --host 0.0.0.0 --port %(ENV_BACKEND_PORT)s --reload --no-access-log


### PR DESCRIPTION
## Summary

Removes `user=root` from the `[supervisord]` section in both production and development supervisord configs. Supervisord now inherits PID 1's UID (root under rootful daemons; UID 1000 under rootless podman + `userns_mode: keep-id`) instead of forcing a privilege drop.

## Bug

Under rootless podman + `userns_mode: keep-id`, container PID 1 is the host user (UID 1000). The previous `user=root` line in the `[supervisord]` section makes supervisord exit at startup with:

```
Error: Can't drop privilege as nonroot user
For help, use /usr/bin/supervisord -h
```

Source: supervisord's `options.py` refuses to drop privileges when not running as root (`if self.user and not os.geteuid() == 0: self.usage(...)`). Rootful daemons worked because PID 1 is root with `CAP_SETUID`; rootless + keep-id has neither.

## Fix

Omit `user=` from `[supervisord]`. Supervisord runs as PID 1's UID. Children still drop to UID 1000 via the existing per-program `user=deeptutor`:

- **Rootful**: PID 1 = root → supervisord = root; setuid(1000) for children works.
- **Rootless keep-id**: PID 1 = UID 1000 → supervisord = UID 1000; setuid(1000) for children is a no-op.

`/dev/fd/1,2` ownership matches PID 1's UID in both runtimes, so the supervisord stdout/stderr writes work without an explicit setuid dance.

## Diff

```diff
-    user=root
```
(removed from both production and development `[supervisord]` blocks, plus an entrypoint comment rewrite explaining the new design)

```
1 file changed, 17 insertions(+), 13 deletions(-)
```

## Test plan

- [x] Heredoc body has consistent no-indent format
- [x] Both `[supervisord]` sections confirmed without `user=root`
- [x] Entrypoint comment explains the new design rationale
- [ ] `podman build -t deeptutor:pr-test -f Dockerfile --target production .` succeeds
- [ ] `podman compose -f compose.yaml up -d` brings both services up healthy
- [ ] End-to-end test of rootless + keep-id + host-mode (the bug-triggering combo) — supervisord starts, backend + frontend reach RUNNING, no CRIT
- [ ] End-to-end test of rootful Docker (regression check) — same behavior as before this PR

## Related

- #577 — initial rootless podman hardening (baked the `deeptutor` user; this PR fixes the supervisord config the original PR set up)
- #586 — `BACKEND_HOST`/`FRONTEND_HOST` env-configurable bindings (orthogonal; combined with this PR, rootless keep-id + host-mode works end-to-end)

## Discovered while

Trying to run the user's host-mode + `BACKEND_HOST=127.0.0.1` + `FRONTEND_HOST=127.0.0.1` setup against `ghcr.io/hkuds/deeptutor:latest`. The image started, the entrypoint env-setup lines printed (📌 API Base URL, 📌 Auth enabled, …), then died at the supervisord gate with the message above. Diagnosed by reading the supervisord config heredoc, the entrypoint heredoc, and the supervisord `options.py` source.