### PR TITLE
feat(cowriter): export markdown drafts as PDF

### DIFF
--- a/web/app/(workspace)/co-writer/[docId]/page.tsx
+++ b/web/app/(workspace)/co-writer/[docId]/page.tsx
@@ -15,6 +15,7 @@ import {
   Code2,
   Download,
   Eraser,
+  FileDown,
   FileText,
   Heading1,
   Heading2,
@@ -48,6 +49,7 @@ import {
   updateCoWriterDocument,
 } from "@/lib/co-writer-api";
 import { notifyCoWriterChanged } from "@/lib/co-writer-events";
+import { downloadElementAsPdf } from "@/lib/pdf-export";
 import SaveToNotebookModal, {
   type NotebookSavePayload,
 } from "@/components/notebook/SaveToNotebookModal";
@@ -171,6 +173,7 @@ export default function CoWriterPage() {
   const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const previewScrollRef = useRef<HTMLDivElement>(null);
+  const previewContentRef = useRef<HTMLDivElement>(null);
   const splitContainerRef = useRef<HTMLDivElement>(null);
   const scrollSyncSourceRef = useRef<"editor" | "preview" | null>(null);
   const scrollSyncResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -807,6 +810,35 @@ export default function CoWriterPage() {
     anchor.download = `${safeTitle || "co-writer"}.md`;
     anchor.click();
     URL.revokeObjectURL(url);
+  };
+
+  const handleDownloadPdf = async () => {
+    const source = previewContentRef.current;
+    if (!source) {
+      setError(t("Open the preview before exporting PDF."));
+      return;
+    }
+    if (!markdown.trim()) {
+      setError(t("Add some content before exporting PDF."));
+      return;
+    }
+    const safeTitle = (docTitle || "co-writer")
+      .trim()
+      .replace(/[\\/:*?"<>|]/g, "-")
+      .slice(0, 80);
+    try {
+      setStatus(t("Preparing PDF..."));
+      setError("");
+      await downloadElementAsPdf(source, {
+        filename: `${safeTitle || "co-writer"}.pdf`,
+        title: docTitle || t("Untitled draft"),
+      });
+      setStatus(t("PDF exported."));
+    } catch (err) {
+      console.error("Failed to export PDF", err);
+      setError(t("PDF export failed."));
+      setStatus("");
+    }
   };
 
   const handleOpenSaveToNotebook = useCallback(() => {
@@ -1781,6 +1813,12 @@ export default function CoWriterPage() {
             <Download size={17} strokeWidth={1.7} />
           </ToolbarIconBtn>
           <ToolbarIconBtn
+            title={t("Export PDF")}
+            onClick={() => void handleDownloadPdf()}
+          >
+            <FileDown size={17} strokeWidth={1.7} />
+          </ToolbarIconBtn>
+          <ToolbarIconBtn
             title={t("Save to Notebook")}
             onClick={handleOpenSaveToNotebook}
           >
@@ -1997,11 +2035,13 @@ export default function CoWriterPage() {
               onScroll={handlePreviewScrollSync}
               className="min-h-0 flex-1 overflow-y-auto p-5"
             >
-              <MarkdownRenderer
-                content={markdown || `_${t("Nothing to preview yet.")}_`}
-                variant="prose"
-                trackSourceLines
-              />
+              <div ref={previewContentRef}>
+                <MarkdownRenderer
+                  content={markdown || `_${t("Nothing to preview yet.")}_`}
+                  variant="prose"
+                  trackSourceLines
+                />
+              </div>
             </div>
           </div>
         )}

--- a/web/lib/pdf-export.ts
+++ b/web/lib/pdf-export.ts
@@ -1,0 +1,129 @@
+export interface DownloadElementPdfOptions {
+  filename: string;
+  title?: string;
+}
+
+function normalizeFilename(filename: string): string {
+  const cleaned = filename
+    .trim()
+    .replace(/[\\/:*?"<>|\n\r\t]/g, "-")
+    .replace(/\s+/g, "-")
+    .slice(0, 80);
+  return cleaned.endsWith(".pdf")
+    ? cleaned
+    : `${cleaned || "deeptutor-export"}.pdf`;
+}
+
+function prepareExportNode(source: HTMLElement, title?: string): HTMLElement {
+  const container = document.createElement("div");
+  container.style.position = "fixed";
+  container.style.left = "-10000px";
+  container.style.top = "0";
+  container.style.width = "794px";
+  container.style.minHeight = "1123px";
+  container.style.boxSizing = "border-box";
+  container.style.padding = "56px";
+  container.style.background = "#ffffff";
+  container.style.color = "#111827";
+  container.style.fontFamily =
+    'ui-serif, Georgia, Cambria, "Times New Roman", Times, serif';
+  container.style.fontSize = "16px";
+  container.style.lineHeight = "1.65";
+  container.style.setProperty("--background", "#ffffff");
+  container.style.setProperty("--foreground", "#111827");
+  container.style.setProperty("--muted", "#f3f4f6");
+  container.style.setProperty("--muted-foreground", "#4b5563");
+  container.style.setProperty("--border", "#d1d5db");
+  container.style.setProperty("--card", "#ffffff");
+  container.style.setProperty("--popover", "#ffffff");
+  container.style.setProperty("--primary", "#111827");
+  container.style.setProperty("--primary-foreground", "#ffffff");
+
+  if (title?.trim()) {
+    const heading = document.createElement("h1");
+    heading.textContent = title.trim();
+    heading.style.margin = "0 0 24px";
+    heading.style.fontSize = "28px";
+    heading.style.lineHeight = "1.25";
+    heading.style.fontWeight = "700";
+    container.appendChild(heading);
+  }
+
+  const clone = source.cloneNode(true) as HTMLElement;
+  clone.style.maxHeight = "none";
+  clone.style.overflow = "visible";
+  clone.style.width = "100%";
+  container.appendChild(clone);
+  document.body.appendChild(container);
+  return container;
+}
+
+function canvasSlice(
+  source: HTMLCanvasElement,
+  y: number,
+  height: number,
+): HTMLCanvasElement {
+  const slice = document.createElement("canvas");
+  slice.width = source.width;
+  slice.height = height;
+  const ctx = slice.getContext("2d");
+  if (!ctx) throw new Error("Unable to create PDF canvas context.");
+  ctx.drawImage(
+    source,
+    0,
+    y,
+    source.width,
+    height,
+    0,
+    0,
+    source.width,
+    height,
+  );
+  return slice;
+}
+
+export async function downloadElementAsPdf(
+  source: HTMLElement,
+  options: DownloadElementPdfOptions,
+): Promise<void> {
+  const [{ default: html2canvas }, { jsPDF }] = await Promise.all([
+    import("html2canvas"),
+    import("jspdf"),
+  ]);
+
+  const exportNode = prepareExportNode(source, options.title);
+  try {
+    if (document.fonts?.ready) {
+      await document.fonts.ready;
+    }
+    const canvas = await html2canvas(exportNode, {
+      backgroundColor: "#ffffff",
+      scale: Math.min(window.devicePixelRatio || 1, 2),
+      useCORS: true,
+      logging: false,
+      windowWidth: exportNode.scrollWidth,
+      windowHeight: exportNode.scrollHeight,
+    });
+
+    const pdf = new jsPDF({ unit: "pt", format: "a4", orientation: "portrait" });
+    const pageWidth = pdf.internal.pageSize.getWidth();
+    const pageHeight = pdf.internal.pageSize.getHeight();
+    const margin = 36;
+    const contentWidth = pageWidth - margin * 2;
+    const contentHeight = pageHeight - margin * 2;
+    const ratio = contentWidth / canvas.width;
+    const sliceHeight = Math.max(1, Math.floor(contentHeight / ratio));
+
+    for (let y = 0, page = 0; y < canvas.height; y += sliceHeight, page += 1) {
+      if (page > 0) pdf.addPage();
+      const height = Math.min(sliceHeight, canvas.height - y);
+      const slice = canvasSlice(canvas, y, height);
+      const image = slice.toDataURL("image/png");
+      pdf.addImage(image, "PNG", margin, margin, contentWidth, height * ratio);
+    }
+
+    pdf.save(normalizeFilename(options.filename));
+  } finally {
+    exportNode.remove();
+  }
+}


### PR DESCRIPTION
## Summary
- Add a reusable client-side PDF export helper backed by the existing html2canvas + jspdf dependencies.
- Add an Export PDF toolbar action to Co-Writer next to the existing Markdown export.
- Render exports with a light, e-ink-friendly A4 layout and preserve the rendered Markdown preview, including KaTeX/math and diagram output when present in the preview.

## Notes
- This initial implementation intentionally avoids a server-side Pandoc dependency, so it works in the existing web app without installing external binaries.
- The generated PDF is rendered from the preview DOM, which favors visual fidelity for formulas/diagrams over selectable text.

## Validation
- npm run lint -- "app/(workspace)/co-writer/[docId]/page.tsx" "lib/pdf-export.ts" (passes with existing repo warnings)
- npx tsc --noEmit --pretty false
- git diff --check
- Browser smoke test: created a temporary Co-Writer draft with Markdown, math, and Mermaid content; confirmed Export PDF button renders and completes with PDF exported and no console errors.