### PR TITLE
fix: preserve zero LlamaIndex chunk overlap

### DIFF
--- a/deeptutor/services/rag/pipelines/llamaindex/config.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/config.py
@@ -86,8 +86,10 @@ def chunk_geometry() -> tuple[int, int]:
     """The configured ``(chunk_size, chunk_overlap)`` for indexing."""
     try:
         settings = _load_runtime_settings()
-        return int(settings.get("chunk_size", 512) or 512), int(
-            settings.get("chunk_overlap", 50) or 50
+        chunk_size = settings.get("chunk_size", 512)
+        chunk_overlap = settings.get("chunk_overlap", 50)
+        return int(chunk_size if chunk_size is not None else 512), int(
+            chunk_overlap if chunk_overlap is not None else 50
         )
     except Exception:
         return 512, 50

--- a/tests/services/config/test_llamaindex_settings.py
+++ b/tests/services/config/test_llamaindex_settings.py
@@ -20,12 +20,15 @@ def test_llamaindex_defaults_when_absent(tmp_path: Path) -> None:
 
 def test_llamaindex_roundtrip(tmp_path: Path) -> None:
     svc = RuntimeSettingsService(tmp_path, process_env={})
-    svc.save_llamaindex({"retrieval_profile": "vector", "top_k": 8, "chunk_size": 1024})
+    svc.save_llamaindex(
+        {"retrieval_profile": "vector", "top_k": 8, "chunk_size": 1024, "chunk_overlap": 0}
+    )
 
     loaded = svc.load_llamaindex(include_process_overrides=False)
     assert loaded["retrieval_profile"] == "vector"
     assert loaded["top_k"] == 8
     assert loaded["chunk_size"] == 1024
+    assert loaded["chunk_overlap"] == 0
     # Its own file beside the other per-feature settings.
     assert (tmp_path / "llamaindex.json").exists()
 
@@ -58,3 +61,15 @@ def test_llamaindex_profile_env_override(tmp_path: Path) -> None:
     overridden = RuntimeSettingsService(tmp_path, process_env={"RAG_RETRIEVAL_PROFILE": "hybrid"})
     loaded = overridden.load_llamaindex(include_process_overrides=True)
     assert loaded["retrieval_profile"] == "hybrid"
+
+
+def test_chunk_geometry_preserves_zero_overlap(monkeypatch) -> None:
+    from deeptutor.services.rag.pipelines.llamaindex import config
+
+    monkeypatch.setattr(
+        config,
+        "_load_runtime_settings",
+        lambda: {"chunk_size": 512, "chunk_overlap": 0},
+    )
+
+    assert config.chunk_geometry() == (512, 0)


### PR DESCRIPTION
﻿Fix LlamaIndex chunk geometry so an explicit `chunk_overlap` of `0` is preserved instead of falling back to DeepTutor's default overlap.

### Description
`chunk_geometry()` previously used `settings.get("chunk_overlap", 50) or 50`, which treated a valid configured `0` as missing and silently returned `50`. The runtime settings layer and UI already allow `chunk_overlap=0`, so this made the indexing runtime ignore a user's attempt to disable overlap.

This change distinguishes `None` from other falsy values when applying defaults, preserving explicit zero overlap while keeping the existing `512/50` fallback for missing or unreadable settings.

### Related Issues
- No linked issue. This is a small LlamaIndex runtime configuration bug fix.
- Related but non-overlapping: #525 changes Markdown image preprocessing in the LlamaIndex document loader; #304 discusses future retrieval scalability via HNSW/reranking. This PR only adjusts LlamaIndex chunk size/overlap configuration, so it should compose cleanly with both.

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [x] Other: `services/rag/pipelines/llamaindex`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
Evidence:

Before this change, this runtime settings payload:

```python
{"chunk_size": 512, "chunk_overlap": 0}
```

was interpreted by `chunk_geometry()` as `(512, 50)` because `0 or 50` selected the fallback. After this change, the same payload returns `(512, 0)`.

Possible call chain / impact:

```text
deeptutor/services/rag/pipelines/llamaindex/config.py
  -> chunk_geometry()
  -> deeptutor/services/rag/pipelines/llamaindex/embedding_adapter.py
  -> Settings.chunk_overlap
  -> deeptutor/services/rag/pipelines/llamaindex/ingestion.py
  -> SentenceSplitter(chunk_overlap=Settings.chunk_overlap)
```

This PR is scoped to LlamaIndex chunk geometry configuration. It does not change document loading, parser selection, vector indexing, reranking, or chat retrieval UI behavior.

Validation:

- `mamba run -n prw-deeptutor-py311 pytest -q tests/services/config/test_llamaindex_settings.py` - passed, 5 tests
- `mamba run -n prw-deeptutor-py311 python -m ruff check deeptutor/services/rag/pipelines/llamaindex/config.py tests/services/config/test_llamaindex_settings.py` - passed
- `mamba run -n prw-deeptutor-py311 ruff format --check deeptutor/services/rag/pipelines/llamaindex/config.py tests/services/config/test_llamaindex_settings.py` - passed
- `git diff --check` - passed

Limitation: I did not run the full `pre-commit run --all-files`; validation was focused on the touched Python files and the relevant configuration tests.
