### PR TITLE
fix(web): avoid crashes on malformed Markdown hash links

### DIFF
--- a/web/components/common/RichMarkdownRenderer.tsx
+++ b/web/components/common/RichMarkdownRenderer.tsx
@@ -16,6 +16,7 @@ import {
   escapeUnknownHtmlTagsForDisplay,
   markdownUrlTransform,
   normalizeMarkdownForDisplay,
+  safeDecodeURIComponent,
 } from "@/lib/markdown-display";
 import {
   InlineFileCard,
@@ -584,7 +585,7 @@ export default function RichMarkdownRenderer({
             id && citationAnchorIdFor(id)
               ? citationAnchorIdFor(id)
               : href?.startsWith("#")
-                ? decodeURIComponent(href.slice(1))
+                ? safeDecodeURIComponent(href.slice(1))
                 : "references";
           const target =
             document.getElementById(hashTarget || "") ??
@@ -644,7 +645,7 @@ export default function RichMarkdownRenderer({
             if (!isHashLink || !href) return;
 
             event.preventDefault();
-            const targetId = decodeURIComponent(href.slice(1));
+            const targetId = safeDecodeURIComponent(href.slice(1));
             const target = document.getElementById(targetId);
             if (target) scrollAnchorIntoView(target);
           }}

--- a/web/components/common/SimpleMarkdownRenderer.tsx
+++ b/web/components/common/SimpleMarkdownRenderer.tsx
@@ -7,6 +7,7 @@ import {
   citationAnchorIdFor,
   markdownUrlTransform,
   normalizeMarkdownForDisplay,
+  safeDecodeURIComponent,
 } from "@/lib/markdown-display";
 import {
   InlineFileCard,
@@ -365,7 +366,7 @@ export default function SimpleMarkdownRenderer({
             id && citationAnchorIdFor(id)
               ? citationAnchorIdFor(id)
               : href?.startsWith("#")
-                ? decodeURIComponent(href.slice(1))
+                ? safeDecodeURIComponent(href.slice(1))
                 : "references";
           const target =
             document.getElementById(hashTarget || "") ??
@@ -425,7 +426,7 @@ export default function SimpleMarkdownRenderer({
             if (!isHashLink || !href) return;
 
             event.preventDefault();
-            const targetId = decodeURIComponent(href.slice(1));
+            const targetId = safeDecodeURIComponent(href.slice(1));
             const target = document.getElementById(targetId);
             target?.scrollIntoView({ block: "start", behavior: "smooth" });
           }}

--- a/web/lib/markdown-display.ts
+++ b/web/lib/markdown-display.ts
@@ -213,6 +213,14 @@ export function markdownUrlTransform(
   return "";
 }
 
+export function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 function sanitizeAllowedHtmlTag(tag: string): string {
   return tag
     .replace(HTML_EVENT_ATTR_REGEX, "")

--- a/web/tests/markdown-display.test.ts
+++ b/web/tests/markdown-display.test.ts
@@ -5,6 +5,7 @@ import {
   hasVisibleMarkdownContent,
   markdownUrlTransform,
   normalizeMarkdownForDisplay,
+  safeDecodeURIComponent,
 } from "../lib/markdown-display";
 
 test("normalizeMarkdownForDisplay removes empty details blocks", () => {
@@ -195,6 +196,15 @@ test("markdownUrlTransform only allows data images on img src", () => {
     }),
     "",
   );
+});
+
+test("safeDecodeURIComponent decodes valid hash components", () => {
+  assert.equal(safeDecodeURIComponent("section%201"), "section 1");
+});
+
+test("safeDecodeURIComponent keeps malformed hash components intact", () => {
+  assert.doesNotThrow(() => safeDecodeURIComponent("%E0%A4%A"));
+  assert.equal(safeDecodeURIComponent("%E0%A4%A"), "%E0%A4%A");
 });
 
 test("hasVisibleMarkdownContent rejects empty raw-html placeholders", () => {


### PR DESCRIPTION
﻿<!--
Thank you for contributing to DeepTutor! 🚀
Please ensure your PR is ready for review and follows our contribution guidelines.
For more details, see our [CONTRIBUTING.md](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
-->

### Description
Fixes malformed Markdown hash-link decoding in the frontend renderers.

Previously, hash links were decoded with `decodeURIComponent(...)` directly. If a hash contained malformed percent-encoding, the renderer click/scroll path could throw instead of gracefully falling back. This PR adds `safeDecodeURIComponent(...)`, uses it in both rich and simple Markdown renderers, and covers valid plus malformed hash components with node tests.

Concrete failing payload:

```markdown
[bad](#%E0%A4%A)
```

The affected click path is:

```text
user/model Markdown
  -> SimpleMarkdownRenderer / RichMarkdownRenderer
  -> anchor or citation onClick handler
  -> safeDecodeURIComponent(href.slice(1))
  -> document.getElementById(...)
  -> scroll when a target exists
```

This only changes in-page hash target decoding for Markdown scrolling. It does not change URL sanitization, external links, attachment links, Markdown normalization, citation formatting, or scroll behavior for valid anchors.

### Related Issues
- Related to malformed Markdown/hash anchor handling

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary). Not required for this frontend bug fix.
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
Evidence:

Before this change, malformed hash components could throw while handling an in-page Markdown link click:

```js
decodeURIComponent("%E0%A4%A")
// URIError: malformed URI sequence
```

After this change:

```js
safeDecodeURIComponent("section%201") === "section 1"
safeDecodeURIComponent("%E0%A4%A") === "%E0%A4%A"
```

That keeps valid encoded anchors working while making malformed anchors degrade safely to the raw hash component.

Validation performed locally:

```text
.\node_modules\.bin\tsc.cmd -p tsconfig.node-tests.json
# passed, exit 0

node --test dist\node-tests\tests\markdown-display.test.js
# passed, 33 tests, 0 failed

node --test <all compiled node tests>
# passed, 157 tests, 0 failed

npm run lint
# exit 0, 0 errors; repository currently reports warnings outside this change

git diff --check
# passed
```

Note: `npm run test:node` currently exits with code 1 in this Windows workspace without printing a failing test case. Running the same underlying steps manually (`tsc.cmd` compile followed by `node --test` over the compiled tests) passes successfully.
