### PR TITLE
fix(webui): send edited user message on Enter, keep Shift+Enter as newline

### DIFF
--- a/web/components/chat/home/ChatMessages.tsx
+++ b/web/components/chat/home/ChatMessages.tsx
@@ -51,6 +51,7 @@ import type { StreamEvent } from "@/lib/unified-ws";
 import { hasVisibleMarkdownContent } from "@/lib/markdown-display";
 import type { SelectedBookReference } from "@/lib/book-references";
 import { buildVisiblePath, type SiblingInfo } from "@/lib/message-branches";
+import { shouldSubmitOnEnter } from "@/lib/composer-keyboard";
 import type { SpaceMemoryFile } from "@/lib/space-items";
 import {
   AskUserOptions,
@@ -876,6 +877,7 @@ const UserMessage = memo(function UserMessage({
   const { t } = useTranslation();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(msg.content);
+  const isComposingRef = useRef(false);
   // Connected subagents ride in knowledge_bases (same selection path) but are
   // agents, not KBs — this maps a selected name to its backend kind so the
   // reference chip can badge it with the agent's brand icon.
@@ -1035,7 +1037,20 @@ const UserMessage = memo(function UserMessage({
                 } else if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
                   e.preventDefault();
                   submitEdit();
+                } else if (shouldSubmitOnEnter(e, isComposingRef.current)) {
+                  e.preventDefault();
+                  submitEdit();
                 }
+              }}
+              onCompositionStart={() => {
+                isComposingRef.current = true;
+              }}
+              onCompositionEnd={() => {
+                // Some IMEs fire compositionend before the Enter keydown that confirms
+                // a candidate, so keep the guard through the current event turn.
+                setTimeout(() => {
+                  isComposingRef.current = false;
+                }, 0);
               }}
               rows={Math.min(8, Math.max(2, draft.split("\n").length))}
               className="w-full resize-none border-0 bg-transparent text-[14px] leading-relaxed text-[var(--foreground)] outline-none focus:outline-none"


### PR DESCRIPTION

<!--
Thank you for contributing to DeepTutor! 🚀
Please ensure your PR is ready for review and follows our contribution guidelines.
For more details, see our [CONTRIBUTING.md](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
-->

### Description

When a user clicks the **Edit** button on a sent message, the inline `<textarea>` previously only submitted on `Ctrl/Cmd + Enter`. As a result, both `Enter` and `Shift + Enter` inserted a newline, which is inconsistent with the bottom composer input.

This change makes the edit textarea use the same `shouldSubmitOnEnter()` helper as the composer:

- `Enter` submits the edited message.
- `Shift + Enter` inserts a newline (default textarea behavior).
- `Esc` cancels editing (unchanged).
- `Ctrl/Cmd + Enter` still submits as a fallback.
- `onCompositionStart` / `onCompositionEnd` guards prevent accidental submission while an IME composition (e.g. Chinese/Japanese input) is active.

The affected component is `UserMessage` in `web/components/chat/home/ChatMessages.tsx`.

### Module(s) Affected

- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

- Verified with `npx eslint components/chat/home/ChatMessages.tsx` (no errors) and `npx tsc --noEmit` (no type errors).
- No new tests were added because this is a small keyboard-interaction fix that mirrors existing composer behavior.
- `pre-commit run --all-files` triggered the `prettier` hook, which reformatted a number of existing files (e.g., `web/components/chat/home/ChatMessages.tsx`, `web/components/memory/MemorySection.tsx`, etc.). These formatting changes are auto-fixes applied by `prettier` to legacy code and are **not** caused by the functional changes in this PR.
