### PR TITLE
fix(knowledge): make KB configuration updates atomic and race-safe

### DIFF
--- a/deeptutor/api/routers/knowledge.py
+++ b/deeptutor/api/routers/knowledge.py
@@ -2132,12 +2132,15 @@ async def create_knowledge_base(
                 "task_id": task_id,
             },
         )
-        # Also store rag_provider in config (reload and update)
-        manager.config = manager._load_config()
-        if name in manager.config.get("knowledge_bases", {}):
-            manager.config["knowledge_bases"][name]["rag_provider"] = rag_provider
-            manager.config["knowledge_bases"][name]["needs_reindex"] = False
-            manager._save_config()
+
+        # Also store rag_provider in config (transactional update)
+        def _set_provider(config: dict) -> None:
+            entry = config.get("knowledge_bases", {}).get(name)
+            if entry is not None:
+                entry["rag_provider"] = rag_provider
+                entry["needs_reindex"] = False
+
+        manager._mutate_config(_set_provider)
 
         progress_tracker = ProgressTracker(name, kb_base_dir)
 
@@ -2293,18 +2296,18 @@ async def run_reindex_task(kb_name: str, base_dir: str, task_id: str, signature_
                     "index_action": "reindex",
                 },
             )
+
             # Clear the legacy mismatch / needs_reindex flags now that an
             # index version matching the active config exists on disk.
-            kb_entry = manager.config.get("knowledge_bases", {}).get(kb_name) or {}
-            mutated = False
-            if kb_entry.get("needs_reindex"):
-                kb_entry["needs_reindex"] = False
-                mutated = True
-            if kb_entry.get("embedding_mismatch"):
+            def _clear_flags(config: dict) -> None:
+                kb_entry = config.get("knowledge_bases", {}).get(kb_name)
+                if not kb_entry:
+                    return
                 kb_entry.pop("embedding_mismatch", None)
-                mutated = True
-            if mutated:
-                manager._save_config()
+                if kb_entry.get("needs_reindex"):
+                    kb_entry["needs_reindex"] = False
+
+            manager._mutate_config(_clear_flags)
 
             _task_log(task_id, f"Re-index of '{kb_name}' complete", level="success")
             task_manager.update_task_status(task_id, "completed")

--- a/deeptutor/api/routers/knowledge.py
+++ b/deeptutor/api/routers/knowledge.py
@@ -7,7 +7,6 @@ Handles knowledge base CRUD operations, file uploads, and initialization.
 
 import asyncio
 from datetime import datetime
-import json
 import logging
 import mimetypes
 import os
@@ -37,6 +36,7 @@ from deeptutor.knowledge.add_documents import DocumentAdder, remove_raw_document
 from deeptutor.knowledge.initializer import KnowledgeBaseInitializer
 from deeptutor.knowledge.kb_types import is_connected_kb
 from deeptutor.knowledge.manager import KnowledgeBaseManager
+from deeptutor.knowledge.metadata_store import get_metadata_store
 from deeptutor.knowledge.naming import validate_knowledge_base_name
 from deeptutor.knowledge.progress_tracker import ProgressStage, ProgressTracker
 from deeptutor.multi_user.context import get_current_user
@@ -2131,6 +2131,7 @@ async def create_knowledge_base(
                 "total": len(files),
                 "task_id": task_id,
             },
+            allow_recreate=True,
         )
 
         # Also store rag_provider in config (transactional update)
@@ -2260,18 +2261,14 @@ async def run_reindex_task(kb_name: str, base_dir: str, task_id: str, signature_
             completed_at = datetime.now().isoformat()
             metadata_file = kb_dir / "metadata.json"
             try:
-                metadata = {}
-                if metadata_file.exists():
-                    with open(metadata_file, encoding="utf-8") as handle:
-                        loaded_metadata = json.load(handle)
-                    if isinstance(loaded_metadata, dict):
-                        metadata = loaded_metadata
-                metadata["last_updated"] = completed_at
-                metadata["last_indexed_at"] = completed_at
-                metadata["last_indexed_count"] = len(file_paths)
-                metadata["last_indexed_action"] = "reindex"
-                with open(metadata_file, "w", encoding="utf-8") as handle:
-                    json.dump(metadata, handle, indent=2, ensure_ascii=False)
+
+                def mutate(metadata: dict) -> None:
+                    metadata["last_updated"] = completed_at
+                    metadata["last_indexed_at"] = completed_at
+                    metadata["last_indexed_count"] = len(file_paths)
+                    metadata["last_indexed_action"] = "reindex"
+
+                get_metadata_store(metadata_file).transaction(mutate)
             except Exception as meta_err:
                 logger.warning(
                     "Failed to update re-index metadata for '%s': %s",

--- a/deeptutor/knowledge/add_documents.py
+++ b/deeptutor/knowledge/add_documents.py
@@ -8,12 +8,12 @@ import asyncio
 from dataclasses import dataclass
 from datetime import datetime
 import hashlib
-import json
 import logging
 from pathlib import Path
 import shutil
 from typing import List, Optional
 
+from deeptutor.knowledge.metadata_store import get_metadata_store
 from deeptutor.services.config import resolve_llm_runtime_config
 from deeptutor.services.rag.factory import (
     DEFAULT_PROVIDER,
@@ -78,24 +78,6 @@ class RawDocumentRemoval:
     was_indexed: bool
 
 
-def _read_metadata(metadata_file: Path) -> dict:
-    """Load a KB's metadata.json, returning {} when absent or unreadable."""
-    if not metadata_file.exists():
-        return {}
-    try:
-        with open(metadata_file, "r", encoding="utf-8") as f:
-            data = json.load(f)
-    except Exception:
-        return {}
-    return data if isinstance(data, dict) else {}
-
-
-def _write_metadata(metadata_file: Path, metadata: dict) -> None:
-    """Persist a KB's metadata.json (pretty-printed, non-ASCII preserved)."""
-    with open(metadata_file, "w", encoding="utf-8") as f:
-        json.dump(metadata, f, indent=2, ensure_ascii=False)
-
-
 def _raw_hash_key(file_path: Path, raw_dir: Path) -> str:
     """Stable ``file_hashes`` key for a staged file.
 
@@ -126,17 +108,23 @@ def remove_raw_document(kb_dir: Path, file_path: Path) -> RawDocumentRemoval:
     raw_dir = kb_dir / "raw"
     hash_key = _raw_hash_key(file_path, raw_dir)
 
-    target = file_path.resolve()
-    if target.exists():
-        target.unlink()
-
     metadata_file = kb_dir / "metadata.json"
-    metadata = _read_metadata(metadata_file)
-    hashes = metadata.get("file_hashes")
-    was_indexed = isinstance(hashes, dict) and hash_key in hashes
-    if was_indexed:
-        del hashes[hash_key]
-        _write_metadata(metadata_file, metadata)
+
+    def mutate(metadata: dict) -> bool:
+        hashes = metadata.get("file_hashes")
+        was_indexed = isinstance(hashes, dict) and hash_key in hashes
+        # Keep file removal and hash removal in the same metadata transaction.
+        # This validates metadata before the irreversible unlink and prevents a
+        # concurrent successful-index update from recording a stale hash after
+        # the document has been deleted.
+        target = file_path.resolve()
+        if target.exists():
+            target.unlink()
+        if was_indexed:
+            del hashes[hash_key]
+        return was_indexed
+
+    _, was_indexed = get_metadata_store(metadata_file).transaction(mutate)
 
     return RawDocumentRemoval(rel_path=hash_key, was_indexed=was_indexed)
 
@@ -204,14 +192,10 @@ class DocumentAdder:
         return sha256_hash.hexdigest()
 
     def get_ingested_hashes(self) -> dict[str, str]:
-        if self.metadata_file.exists():
-            try:
-                with open(self.metadata_file, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-                return data.get("file_hashes", {})
-            except Exception:
-                return {}
-        return {}
+        if not self.metadata_file.exists():
+            return {}
+        hashes = get_metadata_store(self.metadata_file).read().get("file_hashes", {})
+        return hashes if isinstance(hashes, dict) else {}
 
     def add_documents(self, source_files: List[str], allow_duplicates: bool = False) -> List[Path]:
         """Validate and stage files into raw/ before indexing."""
@@ -294,43 +278,49 @@ class DocumentAdder:
 
     def _record_successful_hash(self, file_path: Path) -> None:
         file_hash = self._get_file_hash(file_path)
-        metadata = _read_metadata(self.metadata_file)
         hash_key = _raw_hash_key(file_path, self.raw_dir)
-        metadata.setdefault("file_hashes", {})[hash_key] = file_hash
-        _write_metadata(self.metadata_file, metadata)
+
+        def mutate(metadata: dict) -> None:
+            # A concurrent raw-document deletion holds this same transaction
+            # while unlinking. If it won first, do not resurrect a hash for a
+            # document that is no longer staged.
+            if not file_path.exists():
+                return
+            hashes = metadata.setdefault("file_hashes", {})
+            if not isinstance(hashes, dict):
+                raise ValueError(f"Invalid file_hashes metadata for knowledge base: {self.kb_name}")
+            hashes[hash_key] = file_hash
+
+        get_metadata_store(self.metadata_file).transaction(mutate)
 
     def update_metadata(self, added_count: int) -> None:
         """Update metadata after incremental add."""
-        metadata: dict = {}
-        if self.metadata_file.exists():
-            try:
-                with open(self.metadata_file, "r", encoding="utf-8") as f:
-                    metadata = json.load(f)
-            except Exception:
-                metadata = {}
-
-        metadata["rag_provider"] = self.rag_provider
-        metadata["needs_reindex"] = False
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        metadata["last_updated"] = timestamp
-        if added_count > 0:
-            metadata["last_indexed_at"] = timestamp
-            metadata["last_indexed_count"] = added_count
-            metadata["last_indexed_action"] = "upload"
 
-        history = metadata.get("update_history", [])
-        history.append(
-            {
-                "timestamp": metadata["last_updated"],
-                "action": "incremental_add",
-                "count": added_count,
-                "provider": self.rag_provider,
-            }
-        )
-        metadata["update_history"] = history
+        def mutate(metadata: dict) -> None:
+            metadata["rag_provider"] = self.rag_provider
+            metadata["needs_reindex"] = False
+            metadata["last_updated"] = timestamp
+            if added_count > 0:
+                metadata["last_indexed_at"] = timestamp
+                metadata["last_indexed_count"] = added_count
+                metadata["last_indexed_action"] = "upload"
 
-        with open(self.metadata_file, "w", encoding="utf-8") as f:
-            json.dump(metadata, f, indent=2, ensure_ascii=False)
+            history = metadata.setdefault("update_history", [])
+            if not isinstance(history, list):
+                raise ValueError(
+                    f"Invalid update_history metadata for knowledge base: {self.kb_name}"
+                )
+            history.append(
+                {
+                    "timestamp": timestamp,
+                    "action": "incremental_add",
+                    "count": added_count,
+                    "provider": self.rag_provider,
+                }
+            )
+
+        get_metadata_store(self.metadata_file).transaction(mutate)
 
 
 async def add_documents(

--- a/deeptutor/knowledge/config_store.py
+++ b/deeptutor/knowledge/config_store.py
@@ -1,0 +1,201 @@
+"""Atomic, lock-guarded store for the shared ``kb_config.json`` file.
+
+Both ``KnowledgeBaseManager`` and ``KnowledgeBaseConfigService`` mutate the
+same JSON file. Historically each did its own read-modify-write with no lock
+spanning the cycle (and truncated the file before locking it), so concurrent
+writers lost updates and readers could observe an empty file. This module is
+the single write path that fixes both:
+
+* Every mutation runs inside :meth:`KBConfigStore.transaction`: an exclusive
+  lock on a stable sidecar file is held across read → mutate → write, so no
+  writer can base its write on a stale snapshot.
+* Writes go through a unique same-directory temp file + ``fsync`` +
+  ``os.replace``, so any reader — locked or not — only ever sees the previous
+  or the new file, never a truncated or partial one.
+* A file that exists but does not parse raises :class:`KBConfigCorruptionError`
+  instead of silently becoming an empty default that a later write would
+  persist over the damaged (but possibly recoverable) original.
+
+The lock lives in a sidecar (``.kb_config.json.lock``) rather than on the data
+file because ``os.replace`` swaps the data file's inode on every commit — a
+lock taken on the old inode would not exclude writers that open the new one.
+The sidecar is created once and never deleted, so its identity is stable.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import json
+import logging
+import os
+from pathlib import Path
+import sys
+import tempfile
+import time
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LOCK_TIMEOUT = 10.0
+_LOCK_POLL_INTERVAL = 0.01
+
+
+class KBConfigCorruptionError(RuntimeError):
+    """The KB config file exists but cannot be parsed.
+
+    Raised instead of falling back to a default payload: a fallback would let
+    the next mutation overwrite the damaged file with a near-empty config,
+    destroying whatever the original still holds.
+    """
+
+
+def write_json_atomic(path: Path, payload: dict) -> None:
+    """Write JSON via a same-directory temp file and ``os.replace`` so
+    readers only ever see the previous or the new file, never a partial
+    write, and a crash mid-write cannot leave ``path`` truncated.
+    """
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fp:
+            json.dump(payload, fp, indent=2, ensure_ascii=False)
+            fp.flush()
+            os.fsync(fp.fileno())
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _try_lock_exclusive(fd: int) -> bool:
+    """One non-blocking exclusive-lock attempt; ``False`` when held elsewhere."""
+    if sys.platform == "win32":
+        import msvcrt
+
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            # msvcrt has no blocking primitive that waits indefinitely;
+            # contention surfaces as OSError and the caller retries.
+            return False
+    else:
+        import fcntl
+
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except OSError:
+            return False
+
+
+def _unlock(fd: int) -> None:
+    if sys.platform == "win32":
+        import msvcrt
+
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+class KBConfigStore:
+    """Serialized read-modify-write access to one JSON config file.
+
+    Instances are cheap and stateless besides their paths; any number of
+    instances (across threads or processes) pointing at the same file
+    coordinate through the same sidecar lock.
+    """
+
+    def __init__(
+        self,
+        config_path: Path | str,
+        *,
+        default_factory: Callable[[], dict] | None = None,
+        lock_timeout: float = DEFAULT_LOCK_TIMEOUT,
+    ):
+        self.config_path = Path(config_path)
+        self.lock_path = self.config_path.with_name(f".{self.config_path.name}.lock")
+        self._default_factory = default_factory or (lambda: {"knowledge_bases": {}})
+        self._lock_timeout = lock_timeout
+
+    @contextmanager
+    def _locked(self):
+        """Hold the sidecar's exclusive lock; bounded wait on contention.
+
+        Both platforms poll a non-blocking attempt against a deadline: msvcrt
+        offers nothing that blocks indefinitely, and a shared bounded loop
+        also turns a would-be deadlock into a ``TimeoutError``.
+        """
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(str(self.lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+        try:
+            deadline = time.monotonic() + self._lock_timeout
+            while not _try_lock_exclusive(fd):
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"Timed out after {self._lock_timeout}s waiting for "
+                        f"exclusive lock on {self.lock_path}"
+                    )
+                time.sleep(_LOCK_POLL_INTERVAL)
+            try:
+                yield
+            finally:
+                _unlock(fd)
+        finally:
+            os.close(fd)
+
+    def _read_current(self) -> dict:
+        try:
+            raw = self.config_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return self._default_factory()
+        if not raw.strip():
+            # A zero-byte file is a truncate-crash artifact from the legacy
+            # write path. It carries no data, so recovering as the default
+            # loses nothing — unlike invalid JSON below, which does.
+            logger.warning("%s is empty; treating it as an unwritten config.", self.config_path)
+            return self._default_factory()
+        try:
+            config = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise KBConfigCorruptionError(
+                f"{self.config_path} is not valid JSON ({exc}). Refusing to fall back "
+                f"to an empty config; repair or remove the file manually."
+            ) from exc
+        if not isinstance(config, dict):
+            raise KBConfigCorruptionError(
+                f"{self.config_path} does not contain a JSON object (got {type(config).__name__})."
+            )
+        return config
+
+    def read(self) -> dict:
+        """Lock-free snapshot of the current config.
+
+        Safe without the lock because every writer commits via atomic
+        replace: this returns the previous or the new config in full, never
+        a torn intermediate state.
+        """
+        return self._read_current()
+
+    def transaction(self, mutate: Callable[[dict], Any]) -> tuple[dict, Any]:
+        """Run one locked read-modify-write cycle.
+
+        ``mutate`` receives the latest on-disk state and edits it in place;
+        its return value is passed through. If it raises, nothing is written
+        and the exception propagates. Returns ``(committed_state, result)``.
+
+        ``mutate`` must not invoke another transaction on the same file (the
+        lock is not reentrant) and should not perform slow I/O — prepare
+        expensive inputs before entering the transaction.
+        """
+        with self._locked():
+            config = self._read_current()
+            result = mutate(config)
+            write_json_atomic(self.config_path, config)
+        return config, result

--- a/deeptutor/knowledge/config_store.py
+++ b/deeptutor/knowledge/config_store.py
@@ -12,9 +12,11 @@ the single write path that fixes both:
 * Writes go through a unique same-directory temp file + ``fsync`` +
   ``os.replace``, so any reader — locked or not — only ever sees the previous
   or the new file, never a truncated or partial one.
-* A file that exists but does not parse raises :class:`KBConfigCorruptionError`
-  instead of silently becoming an empty default that a later write would
-  persist over the damaged (but possibly recoverable) original.
+* A file that exists but does not parse — including a zero-byte file left
+  behind by an interrupted legacy truncate-then-write — raises
+  :class:`KBConfigCorruptionError` instead of silently becoming an empty
+  default that a later write would persist over the damaged (but possibly
+  recoverable) original. Only a missing file bootstraps the default payload.
 
 The lock lives in a sidecar (``.kb_config.json.lock``) rather than on the data
 file because ``os.replace`` swaps the data file's inode on every commit — a
@@ -156,11 +158,14 @@ class KBConfigStore:
         except FileNotFoundError:
             return self._default_factory()
         if not raw.strip():
-            # A zero-byte file is a truncate-crash artifact from the legacy
-            # write path. It carries no data, so recovering as the default
-            # loses nothing — unlike invalid JSON below, which does.
-            logger.warning("%s is empty; treating it as an unwritten config.", self.config_path)
-            return self._default_factory()
+            # A zero-byte file is the signature of the legacy truncate-then-
+            # crash write path: the pre-truncate content is already gone, and
+            # silently rebuilding a default here would hide that damage.
+            raise KBConfigCorruptionError(
+                f"{self.config_path} exists but is empty — likely an interrupted "
+                f"write truncated it. Refusing to rebuild it silently; remove the "
+                f"file to start fresh or restore it from a backup."
+            )
         try:
             config = json.loads(raw)
         except json.JSONDecodeError as exc:

--- a/deeptutor/knowledge/config_store.py
+++ b/deeptutor/knowledge/config_store.py
@@ -1,4 +1,4 @@
-"""Atomic, lock-guarded store for the shared ``kb_config.json`` file.
+"""Atomic, lock-guarded store for shared JSON state files.
 
 Both ``KnowledgeBaseManager`` and ``KnowledgeBaseConfigService`` mutate the
 same JSON file. Historically each did its own read-modify-write with no lock
@@ -120,11 +120,15 @@ class KBConfigStore:
         *,
         default_factory: Callable[[], dict] | None = None,
         lock_timeout: float = DEFAULT_LOCK_TIMEOUT,
+        validate_kb_schema: bool = True,
+        create_parent: bool = True,
     ):
         self.config_path = Path(config_path)
         self.lock_path = self.config_path.with_name(f".{self.config_path.name}.lock")
         self._default_factory = default_factory or (lambda: {"knowledge_bases": {}})
         self._lock_timeout = lock_timeout
+        self._validate_kb_schema = validate_kb_schema
+        self._create_parent = create_parent
 
     @contextmanager
     def _locked(self):
@@ -134,7 +138,12 @@ class KBConfigStore:
         offers nothing that blocks indefinitely, and a shared bounded loop
         also turns a would-be deadlock into a ``TimeoutError``.
         """
-        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        if self._create_parent:
+            self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        elif not self.lock_path.parent.is_dir():
+            raise FileNotFoundError(
+                f"Cannot lock {self.config_path}: parent directory {self.lock_path.parent} is missing."
+            )
         fd = os.open(str(self.lock_path), os.O_RDWR | os.O_CREAT, 0o644)
         try:
             deadline = time.monotonic() + self._lock_timeout
@@ -151,6 +160,17 @@ class KBConfigStore:
                 _unlock(fd)
         finally:
             os.close(fd)
+
+    @contextmanager
+    def exclusive_lock(self):
+        """Hold this store's stable sidecar lock without reading or writing.
+
+        Used for per-resource lifecycle transitions whose filesystem work must
+        serialize with each other, but must not hold the global JSON-config
+        transaction lock for the duration of slow I/O.
+        """
+        with self._locked():
+            yield
 
     def _read_current(self) -> dict:
         try:
@@ -177,6 +197,13 @@ class KBConfigStore:
             raise KBConfigCorruptionError(
                 f"{self.config_path} does not contain a JSON object (got {type(config).__name__})."
             )
+        if self._validate_kb_schema:
+            for key in ("knowledge_bases", "defaults", "_deleted_knowledge_bases"):
+                if key in config and not isinstance(config[key], dict):
+                    raise KBConfigCorruptionError(
+                        f"{self.config_path}.{key} must be a JSON object "
+                        f"(got {type(config[key]).__name__})."
+                    )
         return config
 
     def read(self) -> dict:

--- a/deeptutor/knowledge/initializer.py
+++ b/deeptutor/knowledge/initializer.py
@@ -67,11 +67,13 @@ class KnowledgeBaseInitializer:
                     "total": 0,
                 },
             )
-            manager.config = manager._load_config()
-            manager.config.setdefault("knowledge_bases", {}).setdefault(self.kb_name, {})[
-                "rag_provider"
-            ] = self.rag_provider
-            manager._save_config()
+
+            def set_provider(config: dict) -> None:
+                config.setdefault("knowledge_bases", {}).setdefault(self.kb_name, {})[
+                    "rag_provider"
+                ] = self.rag_provider
+
+            manager._mutate_config(set_provider)
         except Exception as e:
             logger.warning(f"Failed to register KB to config: {e}")
 

--- a/deeptutor/knowledge/initializer.py
+++ b/deeptutor/knowledge/initializer.py
@@ -6,12 +6,13 @@ from __future__ import annotations
 import argparse
 import asyncio
 from datetime import datetime
-import json
 import logging
 from pathlib import Path
 import shutil
 from typing import Optional
+from uuid import uuid4
 
+from deeptutor.knowledge.metadata_store import get_metadata_store
 from deeptutor.knowledge.naming import validate_knowledge_base_name
 from deeptutor.knowledge.progress_tracker import ProgressStage, ProgressTracker
 from deeptutor.services.config import resolve_llm_runtime_config
@@ -45,6 +46,40 @@ class KnowledgeBaseInitializer:
         self.base_url = base_url
         self.progress_tracker = progress_tracker or ProgressTracker(self.kb_name, self.base_dir)
         self.rag_provider = normalize_provider_name(rag_provider)
+        self._creation_generation: str | None = None
+        try:
+            from deeptutor.knowledge.manager import KnowledgeBaseManager
+
+            entry = (
+                KnowledgeBaseManager(base_dir=str(self.base_dir))
+                .config.get("knowledge_bases", {})
+                .get(self.kb_name, {})
+            )
+            generation = entry.get("_creation_generation") if isinstance(entry, dict) else None
+            if isinstance(generation, str):
+                self._creation_generation = generation
+                self.progress_tracker.set_creation_generation(generation)
+        except Exception:
+            pass
+
+    def _assert_current_generation(self) -> None:
+        """Reject delayed initializer work from an older KB generation."""
+        from deeptutor.knowledge.manager import KnowledgeBaseManager
+
+        manager = KnowledgeBaseManager(base_dir=str(self.base_dir))
+        deleted = manager.config.get("_deleted_knowledge_bases", {})
+        if isinstance(deleted, dict) and self.kb_name in deleted:
+            raise ValueError(f"Knowledge base '{self.kb_name}' was deleted.")
+        if self._creation_generation is None:
+            return
+        entry = manager.config.get("knowledge_bases", {}).get(self.kb_name)
+        if (
+            not isinstance(entry, dict)
+            or entry.get("_creation_generation") != self._creation_generation
+        ):
+            raise ValueError(
+                f"Knowledge base '{self.kb_name}' was recreated; refusing stale initializer work."
+            )
 
     def _register_to_config(self) -> None:
         """Register KB in kb_config.json with initializing state."""
@@ -69,35 +104,28 @@ class KnowledgeBaseInitializer:
             )
 
             def set_provider(config: dict) -> None:
-                config.setdefault("knowledge_bases", {}).setdefault(self.kb_name, {})[
-                    "rag_provider"
-                ] = self.rag_provider
+                entry = config.get("knowledge_bases", {}).get(self.kb_name)
+                if entry is not None:
+                    entry["rag_provider"] = self.rag_provider
 
             manager._mutate_config(set_provider)
         except Exception as e:
             logger.warning(f"Failed to register KB to config: {e}")
 
     def _update_metadata_with_provider(self, provider: str) -> None:
+        self._assert_current_generation()
         metadata_file = self.kb_dir / "metadata.json"
-        metadata: dict = {}
-        if metadata_file.exists():
-            try:
-                with open(metadata_file, "r", encoding="utf-8") as f:
-                    metadata = json.load(f)
-            except Exception:
-                metadata = {}
-
-        metadata["rag_provider"] = provider
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        metadata["last_updated"] = timestamp
-        metadata["last_indexed_at"] = timestamp
-        metadata["last_indexed_count"] = len(
-            FileTypeRouter.collect_supported_files(self.raw_dir, recursive=True)
-        )
-        metadata["last_indexed_action"] = "create"
+        file_count = len(FileTypeRouter.collect_supported_files(self.raw_dir, recursive=True))
 
-        with open(metadata_file, "w", encoding="utf-8") as f:
-            json.dump(metadata, f, indent=2, ensure_ascii=False)
+        def mutate(metadata: dict) -> None:
+            metadata["rag_provider"] = provider
+            metadata["last_updated"] = timestamp
+            metadata["last_indexed_at"] = timestamp
+            metadata["last_indexed_count"] = file_count
+            metadata["last_indexed_action"] = "create"
+
+        get_metadata_store(metadata_file).transaction(mutate)
 
         try:
             from deeptutor.services.config import get_kb_config_service
@@ -112,11 +140,13 @@ class KnowledgeBaseInitializer:
         """Create KB directory structure."""
         logger.info(f"Creating directory structure for knowledge base: {self.kb_name}")
 
-        for dir_path in [
-            self.raw_dir,
-        ]:
-            dir_path.mkdir(parents=True, exist_ok=True)
+        # A delete leaves a durable tombstone so delayed background work cannot
+        # recreate a directory after the user has removed the KB. Explicit
+        # recreation first registers a fresh ``initializing`` entry through
+        # the manager/API, which clears this marker.
+        from deeptutor.knowledge.manager import KnowledgeBaseManager
 
+        manager = KnowledgeBaseManager(base_dir=str(self.base_dir))
         metadata = {
             "name": self.kb_name,
             "created_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
@@ -126,13 +156,62 @@ class KnowledgeBaseInitializer:
             "needs_reindex": False,
         }
 
-        with open(self.kb_dir / "metadata.json", "w", encoding="utf-8") as f:
-            json.dump(metadata, indent=2, ensure_ascii=False, fp=f)
+        with manager._kb_lifecycle_lock(self.kb_name):
+            state = manager._store.read()
+            deleted = state.get("_deleted_knowledge_bases", {})
+            if isinstance(deleted, dict) and self.kb_name in deleted:
+                raise ValueError(
+                    f"Knowledge base '{self.kb_name}' was deleted; register a new creation before "
+                    "initializing it."
+                )
+            if self._creation_generation is not None:
+                entry = state.get("knowledge_bases", {}).get(self.kb_name)
+                if not isinstance(entry, dict) or (
+                    entry.get("_creation_generation") != self._creation_generation
+                ):
+                    raise ValueError(
+                        f"Knowledge base '{self.kb_name}' was recreated; refusing stale initializer work."
+                    )
+            if self._creation_generation is None and self.kb_name not in state.get(
+                "knowledge_bases", {}
+            ):
+                self._creation_generation = uuid4().hex
+                self.progress_tracker.set_creation_generation(self._creation_generation)
 
-        self._register_to_config()
+            self.raw_dir.mkdir(parents=True, exist_ok=True)
+
+            metadata_file = self.kb_dir / "metadata.json"
+
+            def initialize_metadata(existing: dict) -> None:
+                if not existing:
+                    existing.update(metadata)
+
+            get_metadata_store(metadata_file).transaction(initialize_metadata)
+
+            def register(config: dict) -> None:
+                deleted = config.get("_deleted_knowledge_bases", {})
+                if isinstance(deleted, dict) and self.kb_name in deleted:
+                    raise ValueError(
+                        f"Knowledge base '{self.kb_name}' was deleted while it was initializing."
+                    )
+                # Legacy direct users may initialize a previously unseen name;
+                # API-created KBs already have this entry.
+                config.setdefault("knowledge_bases", {}).setdefault(
+                    self.kb_name,
+                    {
+                        "path": self.kb_name,
+                        "description": f"Knowledge base: {self.kb_name}",
+                        "status": "initializing",
+                        "updated_at": datetime.now().isoformat(),
+                        "_creation_generation": self._creation_generation,
+                    },
+                )
+
+            manager._mutate_config(register)
 
     def copy_documents(self, source_files: list[str]) -> list[str]:
         """Copy source documents into raw directory."""
+        self._assert_current_generation()
         copied_files: list[str] = []
         for source in source_files:
             source_path = Path(source)
@@ -148,6 +227,7 @@ class KnowledgeBaseInitializer:
         self,
     ) -> bool:
         """Process documents with the KB's bound provider."""
+        self._assert_current_generation()
         provider = self.rag_provider
 
         self.progress_tracker.update(
@@ -257,6 +337,10 @@ async def initialize_knowledge_base(
     from deeptutor.knowledge.manager import KnowledgeBaseManager
 
     manager = KnowledgeBaseManager(base_dir=base_dir)
+    # This public command is an explicit user-requested creation, unlike a
+    # delayed initializer callback. It is therefore allowed to recreate a
+    # previously deleted name before constructing the initializer.
+    manager.update_kb_status(kb_name, "initializing", allow_recreate=True)
     initializer = KnowledgeBaseInitializer(
         kb_name=kb_name,
         base_dir=base_dir,
@@ -331,6 +415,13 @@ async def main() -> None:
         docs_dir = Path(args.docs_dir)
         if docs_dir.exists() and docs_dir.is_dir():
             doc_files.extend(str(f) for f in FileTypeRouter.collect_supported_files(docs_dir))
+
+    # The module CLI is also an explicit create request, so clear a prior
+    # deletion tombstone before the initializer performs filesystem work.
+    from deeptutor.knowledge.manager import KnowledgeBaseManager
+
+    manager = KnowledgeBaseManager(base_dir=args.base_dir)
+    manager.update_kb_status(args.name, "initializing", allow_recreate=True)
 
     initializer = KnowledgeBaseInitializer(
         kb_name=args.name,

--- a/deeptutor/knowledge/manager.py
+++ b/deeptutor/knowledge/manager.py
@@ -5,6 +5,7 @@ Knowledge Base Manager
 Manages multiple knowledge bases and provides utilities for accessing them.
 """
 
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 import hashlib
 import json
@@ -14,10 +15,10 @@ from pathlib import Path
 import shutil
 import stat
 from typing import Any
+from uuid import uuid4
 
 from deeptutor.knowledge.config_store import (
     KBConfigStore,
-    write_json_atomic,
 )
 from deeptutor.knowledge.kb_types import (
     LIGHTRAG_SERVER_KB_TYPE,
@@ -27,6 +28,7 @@ from deeptutor.knowledge.kb_types import (
     external_root_of,
     is_connected_kb,
 )
+from deeptutor.knowledge.metadata_store import get_metadata_store
 from deeptutor.services.rag.factory import (
     DEFAULT_PROVIDER,
     KNOWN_PROVIDERS,
@@ -227,6 +229,11 @@ class KnowledgeBaseManager:
         self.config_file = self.base_dir / "kb_config.json"
         self._store = KBConfigStore(self.config_file)
         self.config = self._load_config()
+        self._observed_generations = {
+            name: entry["_creation_generation"]
+            for name, entry in self.config.get("knowledge_bases", {}).items()
+            if isinstance(entry, dict) and isinstance(entry.get("_creation_generation"), str)
+        }
 
         # PocketBase sync — enabled when integrations.pocketbase_url is set.
         # The local JSON file stays the source of truth; PocketBase gets a
@@ -269,7 +276,10 @@ class KnowledgeBaseManager:
         # the removal is committed — otherwise every later transaction reads
         # the raw file and faithfully writes the stale field back.
         if "default" in config:
-            del config["default"]
+            legacy_default = config.pop("default")
+            defaults = config.setdefault("defaults", {})
+            if isinstance(defaults, dict) and defaults.get("default_kb") is None:
+                defaults["default_kb"] = legacy_default
             config_changed = True
 
         # Migration: normalize unknown/removed providers to the default
@@ -333,6 +343,13 @@ class KnowledgeBaseManager:
         self.config = config
         return result
 
+    @contextmanager
+    def _kb_lifecycle_lock(self, name: str):
+        """Serialize create/delete filesystem transitions for one KB only."""
+        lifecycle_store = KBConfigStore(self.base_dir / f".{name}.lifecycle")
+        with lifecycle_store.exclusive_lock():
+            yield
+
     def _register_entry(self, name: str, entry: dict) -> None:
         """Insert a new KB entry, failing on a name clash.
 
@@ -345,6 +362,9 @@ class KnowledgeBaseManager:
             knowledge_bases = config.setdefault("knowledge_bases", {})
             if name in knowledge_bases:
                 raise ValueError(f"A knowledge base named '{name}' already exists.")
+            deleted = config.get("_deleted_knowledge_bases")
+            if isinstance(deleted, dict):
+                deleted.pop(name, None)
             knowledge_bases[name] = entry
 
         self._mutate_config(mutate)
@@ -383,6 +403,9 @@ class KnowledgeBaseManager:
         name: str,
         status: str,
         progress: dict | None = None,
+        *,
+        allow_recreate: bool = False,
+        expected_generation: str | None = None,
     ):
         """
         Update knowledge base status and progress in kb_config.json.
@@ -405,6 +428,13 @@ class KnowledgeBaseManager:
         index_changed = False
         indexed_count: int | None = None
         index_action: str | None = None
+        if allow_recreate:
+            # An explicit create request intentionally starts a new generation
+            # after deletion, even when this cached manager observed the old
+            # one earlier in its lifetime.
+            expected_generation = None
+        elif expected_generation is None:
+            expected_generation = self._observed_generations.get(name)
         if isinstance(progress, dict):
             raw_indexed_count = progress.get("indexed_count")
             if isinstance(raw_indexed_count, bool):
@@ -450,14 +480,30 @@ class KnowledgeBaseManager:
             except Exception:  # pragma: no cover - best-effort metadata
                 pass
 
-        def mutate(config: dict) -> dict:
+        def mutate(config: dict) -> dict | None:
             knowledge_bases = config.setdefault("knowledge_bases", {})
+            existing = knowledge_bases.get(name)
+            if expected_generation is not None and (
+                not isinstance(existing, dict)
+                or existing.get("_creation_generation") != expected_generation
+            ):
+                return None
             if name not in knowledge_bases:
-                # Auto-register if not exists
+                # Background workers can report a stale status after delete.
+                # Only the explicit create path may clear this durable marker
+                # and create a fresh entry with the same name.
+                deleted = config.get("_deleted_knowledge_bases")
+                if isinstance(deleted, dict) and name in deleted:
+                    if not allow_recreate:
+                        return None
+                    deleted.pop(name, None)
+                # Auto-register if not exists.
                 knowledge_bases[name] = {
                     "path": name,
                     "description": f"Knowledge base: {name}",
                 }
+                if allow_recreate:
+                    knowledge_bases[name]["_creation_generation"] = uuid4().hex
 
             kb_config = knowledge_bases[name]
             kb_config["status"] = status
@@ -493,7 +539,17 @@ class KnowledgeBaseManager:
             return kb_config
 
         kb_config = self._mutate_config(mutate)
+        if kb_config is None:
+            logger.info(
+                "Ignoring late status update for deleted knowledge base '%s'.",
+                name,
+            )
+            return False
         self._sync_kb_to_pb(name, kb_config)
+        generation = kb_config.get("_creation_generation")
+        if isinstance(generation, str):
+            self._observed_generations[name] = generation
+        return True
 
     def get_kb_status(self, name: str) -> dict | None:
         """Get status and progress for a knowledge base."""
@@ -521,6 +577,8 @@ class KnowledgeBaseManager:
         self.config = self._load_config()
 
         config_kbs = self.config.get("knowledge_bases", {})
+        deleted_kbs = self.config.get("_deleted_knowledge_bases", {})
+        deleted_names = set(deleted_kbs) if isinstance(deleted_kbs, dict) else set()
         kb_list: set[str] = set()
         prune_candidates: list[str] = []
 
@@ -563,6 +621,13 @@ class KnowledgeBaseManager:
         if base_exists:
             for item in self.base_dir.iterdir():
                 if not item.is_dir() or item.name.startswith(("__", ".")):
+                    continue
+                # A delete may have had to leave orphan files behind (for
+                # example a Windows handle blocked rmtree). Do not turn that
+                # orphan back into a live KB merely because it still looks
+                # indexable; explicit registration/recreation clears the
+                # tombstone first.
+                if item.name in deleted_names:
                     continue
 
                 # Skip if already in config
@@ -608,6 +673,9 @@ class KnowledgeBaseManager:
                     )
                     del knowledge_bases[kb_name]
                 for kb_name, kb_entry in discovered.items():
+                    deleted = config.get("_deleted_knowledge_bases")
+                    if isinstance(deleted, dict) and kb_name in deleted:
+                        continue
                     knowledge_bases.setdefault(kb_name, kb_entry)
 
             self._mutate_config(mutate)
@@ -884,7 +952,7 @@ class KnowledgeBaseManager:
         """
         self.config = self._load_config()
         if name is None:
-            name = self.config.get("default")
+            name = self.get_default()
             if name is None:
                 raise ValueError("No default knowledge base set")
 
@@ -934,37 +1002,26 @@ class KnowledgeBaseManager:
         return kb_dir / "raw"
 
     def set_default(self, name: str):
-        """Set default knowledge base using centralized config service."""
+        """Set the default in this manager's own config store."""
         if name not in self.list_knowledge_bases():
             raise ValueError(f"Knowledge base not found: {name}")
 
-        # Persist default KB selection via the canonical KB config service.
-        try:
-            from deeptutor.services.config import get_kb_config_service
-
-            kb_config_service = get_kb_config_service()
-            kb_config_service.set_default_kb(name)
-        except Exception as e:
-            logger.warning(f"Failed to save default to centralized config: {e}")
+        self._mutate_config(
+            lambda config: config.setdefault("defaults", {}).update({"default_kb": name})
+        )
 
     def get_default(self) -> str | None:
         """
         Get default knowledge base name.
 
         Priority:
-        1. Canonical KB config service (`data/knowledge_bases/kb_config.json`)
+        1. Canonical ``defaults.default_kb`` in this manager's config file
         2. First knowledge base in the list (auto-fallback)
         """
-        # Try centralized config first
-        try:
-            from deeptutor.services.config import get_kb_config_service
-
-            kb_config_service = get_kb_config_service()
-            default_kb = kb_config_service.get_default_kb()
-            if default_kb and default_kb in self.list_knowledge_bases():
-                return default_kb
-        except Exception:
-            pass
+        self.config = self._load_config()
+        default_kb = self.config.get("defaults", {}).get("default_kb")
+        if default_kb and default_kb in self.list_knowledge_bases():
+            return default_kb
 
         # Fallback to first knowledge base in sorted list
         kb_list = self.list_knowledge_bases()
@@ -1261,19 +1318,7 @@ class KnowledgeBaseManager:
         if name not in config_kbs and not (self.base_dir / name).exists():
             raise ValueError(f"Knowledge base not found: {name}")
 
-        # Resolve the directory directly to stay idempotent: if the on-disk
-        # folder was already removed (e.g. manually rm-rf'd) we still want to
-        # purge the orphaned entry from kb_config.json instead of failing.
         kb_dir = self.base_dir / name
-        dir_exists = kb_dir.exists()
-
-        # Connected KBs (Obsidian vaults, linked indexes, subagent pointers)
-        # reference the user's own external resource — or, for subagents, no
-        # folder at all. Deleting one must only drop our pointer entry; never
-        # touch what it references, and don't warn about the "missing" folder.
-        connected = is_connected_kb(config_kbs.get(name, {}))
-        if connected:
-            dir_exists = False
 
         if not confirm:
             # Ask for confirmation in CLI
@@ -1284,47 +1329,47 @@ class KnowledgeBaseManager:
                 print("Deletion cancelled.")
                 return False
 
-        if dir_exists:
+        def _on_rmtree_error(func, path, exc_info):
+            exc = exc_info[1]
+            if isinstance(exc, FileNotFoundError):
+                return
+            try:
+                os.chmod(path, stat.S_IWRITE)
+                func(path)
+            except Exception as retry_exc:
+                logger.warning(
+                    f"Could not remove '{path}' while deleting KB '{name}': "
+                    f"{retry_exc}. Continuing; orphan files may remain on disk."
+                )
 
-            def _on_rmtree_error(func, path, exc_info):
-                exc = exc_info[1]
-                if isinstance(exc, FileNotFoundError):
-                    # Race: something else removed the entry between walk and unlink.
-                    return
-                # On Windows (and some bind-mounted filesystems) a read-only bit
-                # or a stale handle from a failed RAG init can block removal.
-                # Clear the read-only bit and retry once; if it still fails, log
-                # and continue so the config entry gets cleaned up regardless —
-                # leaving the KB stuck in the list is worse than orphan files on
-                # disk (issue #370).
-                try:
-                    os.chmod(path, stat.S_IWRITE)
-                    func(path)
-                except Exception as retry_exc:
-                    logger.warning(
-                        f"Could not remove '{path}' while deleting KB '{name}': "
-                        f"{retry_exc}. Continuing; orphan files may remain on disk."
-                    )
+        with self._kb_lifecycle_lock(name):
+            current = self._store.read().get("knowledge_bases", {}).get(name, {})
+            connected = is_connected_kb(current)
+            if not connected and kb_dir.exists():
+                shutil.rmtree(kb_dir, onerror=_on_rmtree_error)
+            elif not connected:
+                logger.warning(
+                    "KB directory '%s' missing on disk; cleaning up orphaned config entry.",
+                    kb_dir,
+                )
 
-            shutil.rmtree(kb_dir, onerror=_on_rmtree_error)
-        elif not connected:
-            logger.warning(
-                f"KB directory '{kb_dir}' missing on disk; cleaning up orphaned config entry."
-            )
+            def mutate(config: dict) -> None:
+                knowledge_bases = config.setdefault("knowledge_bases", {})
+                knowledge_bases.pop(name, None)
+                deleted = config.setdefault("_deleted_knowledge_bases", {})
+                deleted[name] = datetime.now().isoformat()
 
-        # Remove from config. The directory work above stays outside the
-        # transaction — only the entry removal runs under the store lock.
-        def mutate(config: dict) -> None:
-            knowledge_bases = config.setdefault("knowledge_bases", {})
-            knowledge_bases.pop(name, None)
+                # Keep the canonical default valid after deletion.  The legacy
+                # top-level field is migrated during load, but retain this branch
+                # for an interrupted migration or a manually edited old file.
+                remaining = sorted(knowledge_bases)
+                defaults = config.get("defaults")
+                if isinstance(defaults, dict) and defaults.get("default_kb") == name:
+                    defaults["default_kb"] = remaining[0] if remaining else None
+                if config.get("default") == name:
+                    config["default"] = remaining[0] if remaining else None
 
-            # Update default if this was the default (legacy field; the
-            # canonical default lives in the config service's ``defaults``)
-            if config.get("default") == name:
-                remaining = [n for n in knowledge_bases.keys() if n != name]
-                config["default"] = sorted(remaining)[0] if remaining else None
-
-        self._mutate_config(mutate)
+            self._mutate_config(mutate)
         return True
 
     def clean_rag_storage(self, name: str | None = None, backup: bool = True) -> bool:
@@ -1419,44 +1464,27 @@ class KnowledgeBaseManager:
             str(folder).encode(), usedforsecurity=False
         ).hexdigest()[:8]
 
-        # Load existing linked folders from metadata
         kb_dir = self.base_dir / kb_name
         metadata_file = kb_dir / "metadata.json"
-        metadata: dict = {}
-
-        if metadata_file.exists():
-            try:
-                with open(metadata_file, encoding="utf-8") as fp:
-                    metadata = json.load(fp)
-            except Exception:
-                metadata = {}
-
-        if "linked_folders" not in metadata:
-            metadata["linked_folders"] = []
-
-        # Check if already linked
-        existing_ids = [item["id"] for item in metadata.get("linked_folders", [])]
-        if folder_id in existing_ids:
-            # If already linked, treat as success (idempotent)
-            # Find and return existing info
-            for item in metadata.get("linked_folders", []):
-                if item["id"] == folder_id:
-                    return item
-
-        # Add folder info
         folder_info = {
             "id": folder_id,
             "path": str(folder),
             "added_at": datetime.now().isoformat(),
             "file_count": len(files),
         }
-        metadata["linked_folders"].append(folder_info)
 
-        # Save metadata
-        with open(metadata_file, "w", encoding="utf-8") as fp:
-            json.dump(metadata, fp, indent=2, ensure_ascii=False)
+        def mutate(metadata: dict) -> dict:
+            linked = metadata.setdefault("linked_folders", [])
+            if not isinstance(linked, list):
+                raise ValueError(f"Invalid linked_folders metadata for knowledge base: {kb_name}")
+            for item in linked:
+                if isinstance(item, dict) and item.get("id") == folder_id:
+                    return item
+            linked.append(folder_info)
+            return folder_info
 
-        return folder_info
+        _, linked_folder = get_metadata_store(metadata_file).transaction(mutate)
+        return linked_folder
 
     def get_linked_folders(self, kb_name: str) -> list[dict]:
         """
@@ -1476,13 +1504,9 @@ class KnowledgeBaseManager:
 
         if not metadata_file.exists():
             return []
-
-        try:
-            with open(metadata_file, encoding="utf-8") as f:
-                metadata = json.load(f)
-                return metadata.get("linked_folders", [])
-        except Exception:
-            return []
+        metadata = get_metadata_store(metadata_file).read()
+        linked = metadata.get("linked_folders", [])
+        return linked if isinstance(linked, list) else []
 
     def unlink_folder(self, kb_name: str, folder_id: str) -> bool:
         """
@@ -1504,24 +1528,20 @@ class KnowledgeBaseManager:
         if not metadata_file.exists():
             return False
 
-        try:
-            with open(metadata_file, encoding="utf-8") as f:
-                metadata = json.load(f)
-        except Exception:
-            return False
+        def mutate(metadata: dict) -> bool:
+            linked = metadata.get("linked_folders", [])
+            if not isinstance(linked, list):
+                return False
+            new_linked = [
+                item for item in linked if not isinstance(item, dict) or item.get("id") != folder_id
+            ]
+            if len(new_linked) == len(linked):
+                return False
+            metadata["linked_folders"] = new_linked
+            return True
 
-        linked = metadata.get("linked_folders", [])
-        new_linked = [f for f in linked if f["id"] != folder_id]
-
-        if len(new_linked) == len(linked):
-            return False  # Not found
-
-        metadata["linked_folders"] = new_linked
-
-        with open(metadata_file, "w", encoding="utf-8") as f:
-            json.dump(metadata, f, indent=2, ensure_ascii=False)
-
-        return True
+        _, removed = get_metadata_store(metadata_file).transaction(mutate)
+        return removed
 
     def scan_linked_folder(self, folder_path: str, provider: str = DEFAULT_PROVIDER) -> list[str]:
         """
@@ -1631,21 +1651,20 @@ class KnowledgeBaseManager:
         if not metadata_file.exists():
             return
 
-        try:
-            with open(metadata_file, encoding="utf-8") as f:
-                metadata = json.load(f)
-        except Exception:
-            return
-
-        linked = metadata.get("linked_folders", [])
-
-        for folder in linked:
-            if folder["id"] == folder_id:
+        def mutate(metadata: dict) -> None:
+            linked = metadata.get("linked_folders", [])
+            if not isinstance(linked, list):
+                return
+            for folder in linked:
+                if not isinstance(folder, dict) or folder.get("id") != folder_id:
+                    continue
                 # Record sync timestamp
                 folder["last_sync"] = datetime.now().isoformat()
 
                 # Record file modification times
                 file_states = folder.get("synced_files", {})
+                if not isinstance(file_states, dict):
+                    file_states = {}
                 for file_path in synced_files:
                     try:
                         p = Path(file_path)
@@ -1657,8 +1676,9 @@ class KnowledgeBaseManager:
 
                 folder["synced_files"] = file_states
                 folder["file_count"] = len(file_states)
-                write_json_atomic(metadata_file, metadata)
-                break
+                return
+
+        get_metadata_store(metadata_file).transaction(mutate)
 
 
 def main():

--- a/deeptutor/knowledge/manager.py
+++ b/deeptutor/knowledge/manager.py
@@ -5,7 +5,6 @@ Knowledge Base Manager
 Manages multiple knowledge bases and provides utilities for accessing them.
 """
 
-from contextlib import contextmanager
 from datetime import datetime, timedelta
 import hashlib
 import json
@@ -14,10 +13,12 @@ import os
 from pathlib import Path
 import shutil
 import stat
-import sys
-import tempfile
 from typing import Any
 
+from deeptutor.knowledge.config_store import (
+    KBConfigStore,
+    write_json_atomic,
+)
 from deeptutor.knowledge.kb_types import (
     LIGHTRAG_SERVER_KB_TYPE,
     LINKED_KB_TYPE,
@@ -84,51 +85,6 @@ def _detect_provider_from_versions(versions: list[dict[str, Any]]) -> str:
         if provider != DEFAULT_PROVIDER:
             return provider
     return DEFAULT_PROVIDER
-
-
-# Cross-platform file locking
-@contextmanager
-def file_lock_shared(file_handle):
-    """Acquire a shared (read) lock on a file - cross-platform."""
-    if sys.platform == "win32":
-        import msvcrt
-
-        msvcrt.locking(file_handle.fileno(), msvcrt.LK_NBLCK, 1)
-        try:
-            yield
-        finally:
-            file_handle.seek(0)
-            msvcrt.locking(file_handle.fileno(), msvcrt.LK_UNLCK, 1)
-    else:
-        import fcntl
-
-        fcntl.flock(file_handle.fileno(), fcntl.LOCK_SH)
-        try:
-            yield
-        finally:
-            fcntl.flock(file_handle.fileno(), fcntl.LOCK_UN)
-
-
-@contextmanager
-def file_lock_exclusive(file_handle):
-    """Acquire an exclusive (write) lock on a file - cross-platform."""
-    if sys.platform == "win32":
-        import msvcrt
-
-        msvcrt.locking(file_handle.fileno(), msvcrt.LK_NBLCK, 1)
-        try:
-            yield
-        finally:
-            file_handle.seek(0)
-            msvcrt.locking(file_handle.fileno(), msvcrt.LK_UNLCK, 1)
-    else:
-        import fcntl
-
-        fcntl.flock(file_handle.fileno(), fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(file_handle.fileno(), fcntl.LOCK_UN)
 
 
 def _get_embedding_fingerprint() -> tuple[str, int] | None:
@@ -258,26 +214,6 @@ def _reconcile_embedding_flags(knowledge_bases: dict, base_dir: Path | None = No
     return changed
 
 
-def _write_json_atomic(path: Path, payload: dict) -> None:
-    """Write JSON via a same-directory temp file and ``os.replace`` so
-    readers only ever see the previous or the new file, never a partial
-    write, and a crash mid-write cannot leave ``path`` truncated.
-    """
-    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fp:
-            json.dump(payload, fp, indent=2, ensure_ascii=False)
-            fp.flush()
-            os.fsync(fp.fileno())
-        os.replace(tmp_name, path)
-    except BaseException:
-        try:
-            os.unlink(tmp_name)
-        except OSError:
-            pass
-        raise
-
-
 class KnowledgeBaseManager:
     """Manager for knowledge bases"""
 
@@ -285,8 +221,11 @@ class KnowledgeBaseManager:
         self.base_dir = Path(base_dir)
         self.base_dir.mkdir(parents=True, exist_ok=True)
 
-        # Config file to track knowledge bases
+        # Config file to track knowledge bases. All reads go through the
+        # store's atomic snapshot; all writes go through its locked
+        # transactions so concurrent managers/services never lose updates.
         self.config_file = self.base_dir / "kb_config.json"
+        self._store = KBConfigStore(self.config_file)
         self.config = self._load_config()
 
         # PocketBase sync — enabled when integrations.pocketbase_url is set.
@@ -297,98 +236,114 @@ class KnowledgeBaseManager:
         self._pb_enabled = is_pocketbase_enabled()
 
     def _load_config(self) -> dict:
-        """Load knowledge base configuration from the canonical kb_config.json file."""
-        if self.config_file.exists():
+        """Load knowledge base configuration from the canonical kb_config.json file.
+
+        Raises ``KBConfigCorruptionError`` when the file exists but does not
+        parse — falling back to an empty config here would let the next write
+        silently destroy whatever the damaged file still holds.
+        """
+        config = self._store.read()
+        if self._normalize_config(config):
+            # Persist migrations through a transaction so the write is based
+            # on the latest on-disk state, not this (possibly stale) read.
             try:
-                with open(self.config_file, encoding="utf-8") as f:
-                    with file_lock_shared(f):
-                        content = f.read()
-                        if not content.strip():
-                            # Empty file, return default
-                            return {"knowledge_bases": {}}
-                        config = json.loads(content)
+                config, _ = self._store.transaction(self._normalize_config)
+            except Exception as save_err:
+                logger.warning(f"Failed to persist normalized KB config: {save_err}")
+        return config
 
-                # Ensure knowledge_bases key exists
-                if "knowledge_bases" not in config:
-                    config["knowledge_bases"] = {}
+    def _normalize_config(self, config: dict) -> bool:
+        """Migrate/normalize a config payload in place; True when it changed.
 
-                # Migration: remove old "default" field if present
-                if "default" in config:
-                    del config["default"]
-                    # Note: Don't save during load to avoid recursion issues
-                    # The next _save_config() call will persist this change
+        Also runs inside a store transaction when changes must be persisted,
+        so it must stay cheap: per-KB local index probes only.
+        """
+        # Ensure knowledge_bases key exists
+        if "knowledge_bases" not in config:
+            config["knowledge_bases"] = {}
 
-                # Migration: normalize unknown/removed providers to the default
-                # and mark them for rebuild. Known non-default providers are
-                # first-class engines and must be preserved.
-                knowledge_bases = config.get("knowledge_bases", {})
-                config_changed = False
-                for kb_name, kb_entry in knowledge_bases.items():
-                    if not isinstance(kb_entry, dict):
-                        continue
+        # Migration: remove old "default" field if present (superseded by the
+        # config service's ``defaults.default_kb``). Dropped in memory; the
+        # next persisted write picks it up.
+        config.pop("default", None)
 
-                    # Connected KBs (Obsidian vaults, linked indexes) are
-                    # pointers with no index pipeline — none of the
-                    # provider/embedding normalization below applies. Leave
-                    # their type/external pointer untouched.
-                    if is_connected_kb(kb_entry):
-                        continue
+        # Migration: normalize unknown/removed providers to the default
+        # and mark them for rebuild. Known non-default providers are
+        # first-class engines and must be preserved.
+        knowledge_bases = config.get("knowledge_bases", {})
+        config_changed = False
+        for kb_name, kb_entry in knowledge_bases.items():
+            if not isinstance(kb_entry, dict):
+                continue
 
-                    raw_provider = kb_entry.get("rag_provider")
-                    provider = normalize_provider_name(raw_provider)
-                    if kb_entry.get("rag_provider") != provider:
-                        kb_entry["rag_provider"] = provider
-                        config_changed = True
+            # Connected KBs (Obsidian vaults, linked indexes) are
+            # pointers with no index pipeline — none of the
+            # provider/embedding normalization below applies. Leave
+            # their type/external pointer untouched.
+            if is_connected_kb(kb_entry):
+                continue
 
-                    raw_provider_text = str(raw_provider or "").strip().lower()
-                    if raw_provider_text and raw_provider_text not in KNOWN_PROVIDERS:
-                        if not kb_entry.get("needs_reindex", False):
-                            kb_entry["needs_reindex"] = True
-                            config_changed = True
+            raw_provider = kb_entry.get("rag_provider")
+            provider = normalize_provider_name(raw_provider)
+            if kb_entry.get("rag_provider") != provider:
+                kb_entry["rag_provider"] = provider
+                config_changed = True
 
-                    kb_dir = self.base_dir / kb_name
-                    legacy_storage = kb_dir / "rag_storage"
-                    has_llamaindex_index = has_ready_provider_index(kb_dir, DEFAULT_PROVIDER)
-                    if (
-                        provider == DEFAULT_PROVIDER
-                        and legacy_storage.exists()
-                        and legacy_storage.is_dir()
-                        and not has_llamaindex_index
-                    ):
-                        if not kb_entry.get("needs_reindex", False):
-                            kb_entry["needs_reindex"] = True
-                            config_changed = True
-                        if kb_entry.get("status") == "ready":
-                            kb_entry["status"] = "needs_reindex"
-                            config_changed = True
-
-                if _reconcile_embedding_flags(knowledge_bases, self.base_dir):
+            raw_provider_text = str(raw_provider or "").strip().lower()
+            if raw_provider_text and raw_provider_text not in KNOWN_PROVIDERS:
+                if not kb_entry.get("needs_reindex", False):
+                    kb_entry["needs_reindex"] = True
                     config_changed = True
 
-                if config_changed:
-                    try:
-                        with open(self.config_file, "w", encoding="utf-8") as f:
-                            with file_lock_exclusive(f):
-                                json.dump(config, f, indent=2, ensure_ascii=False)
-                                f.flush()
-                                os.fsync(f.fileno())
-                    except Exception as save_err:
-                        logger.warning(f"Failed to persist normalized KB config: {save_err}")
+            kb_dir = self.base_dir / kb_name
+            legacy_storage = kb_dir / "rag_storage"
+            has_llamaindex_index = has_ready_provider_index(kb_dir, DEFAULT_PROVIDER)
+            if (
+                provider == DEFAULT_PROVIDER
+                and legacy_storage.exists()
+                and legacy_storage.is_dir()
+                and not has_llamaindex_index
+            ):
+                if not kb_entry.get("needs_reindex", False):
+                    kb_entry["needs_reindex"] = True
+                    config_changed = True
+                if kb_entry.get("status") == "ready":
+                    kb_entry["status"] = "needs_reindex"
+                    config_changed = True
 
-                return config
-            except (json.JSONDecodeError, Exception) as e:
-                logger.warning(f"Error loading config: {e}")
-                return {"knowledge_bases": {}}
-        return {"knowledge_bases": {}}
+        if _reconcile_embedding_flags(knowledge_bases, self.base_dir):
+            config_changed = True
 
-    def _save_config(self):
-        """Save knowledge base configuration (thread-safe with file locking)"""
-        # Use exclusive lock for writing
-        with open(self.config_file, "w", encoding="utf-8") as f:
-            with file_lock_exclusive(f):
-                json.dump(self.config, f, indent=2, ensure_ascii=False)
-                f.flush()
-                os.fsync(f.fileno())  # Ensure data is written to disk
+        return config_changed
+
+    def _mutate_config(self, mutate):
+        """Run one locked read-modify-write mutation on kb_config.json.
+
+        The mutator receives the latest on-disk state (not ``self.config``,
+        which may be stale) and edits it in place; the committed snapshot
+        replaces ``self.config``. Returns the mutator's result. Mutators must
+        not start another transaction and must not do slow I/O — prepare
+        expensive inputs before calling this.
+        """
+        config, result = self._store.transaction(mutate)
+        self.config = config
+        return result
+
+    def _register_entry(self, name: str, entry: dict) -> None:
+        """Insert a new KB entry, failing on a name clash.
+
+        The clash check runs inside the transaction against the latest
+        on-disk state, so two concurrent registrations of the same name
+        cannot both succeed.
+        """
+
+        def mutate(config: dict) -> None:
+            knowledge_bases = config.setdefault("knowledge_bases", {})
+            if name in knowledge_bases:
+                raise ValueError(f"A knowledge base named '{name}' already exists.")
+            knowledge_bases[name] = entry
+
+        self._mutate_config(mutate)
 
     def _sync_kb_to_pb(self, name: str, kb_entry: dict) -> None:
         """
@@ -443,22 +398,6 @@ class KnowledgeBaseManager:
                 - file_name: Current file being processed
                 - error: Error message (if status is "error")
         """
-        # Reload config to get latest state
-        self.config = self._load_config()
-
-        if "knowledge_bases" not in self.config:
-            self.config["knowledge_bases"] = {}
-
-        if name not in self.config["knowledge_bases"]:
-            # Auto-register if not exists
-            self.config["knowledge_bases"][name] = {
-                "path": name,
-                "description": f"Knowledge base: {name}",
-            }
-
-        kb_config = self.config["knowledge_bases"][name]
-        kb_config["status"] = status
-        kb_config["updated_at"] = datetime.now().isoformat()
         index_changed = False
         indexed_count: int | None = None
         index_action: str | None = None
@@ -481,34 +420,14 @@ class KnowledgeBaseManager:
             if isinstance(raw_index_action, str) and raw_index_action.strip():
                 index_action = raw_index_action.strip()
 
-        if status == "ready":
-            # Ready KBs should look like stable resources in the UI instead of
-            # permanently carrying a "completed" progress banner.
-            kb_config.pop("progress", None)
-            kb_config.pop("last_error", None)
-            kb_config.pop("last_error_at", None)
-            if progress is not None:
-                kb_config["last_completed_at"] = (
-                    progress.get("timestamp") or datetime.now().isoformat()
-                )
-                if index_changed:
-                    kb_config["last_indexed_at"] = kb_config["last_completed_at"]
-                    if indexed_count is not None:
-                        kb_config["last_indexed_count"] = max(indexed_count, 0)
-                    if index_action:
-                        kb_config["last_indexed_action"] = index_action
-        elif status == "error":
-            if progress is not None:
-                kb_config["progress"] = progress
-                kb_config["last_error"] = progress.get("error") or progress.get("message")
-                kb_config["last_error_at"] = progress.get("timestamp") or datetime.now().isoformat()
-        elif progress is not None:
-            kb_config["progress"] = progress
-
+        # Collect "ready" metadata before entering the config transaction:
+        # embedding fingerprinting and index-version probing are comparatively
+        # slow and must not run while the store lock is held.
+        ready_meta: dict[str, Any] = {}
         if status == "ready":
             fp = _get_embedding_fingerprint()
             if fp:
-                kb_config["embedding_model"], kb_config["embedding_dim"] = fp
+                ready_meta["embedding_model"], ready_meta["embedding_dim"] = fp
             # Record the active signature + the on-disk version registry so
             # the UI can render version chips without recomputing.
             try:
@@ -518,15 +437,58 @@ class KnowledgeBaseManager:
 
                 sig = signature_from_embedding_config()
                 if sig is not None:
-                    kb_config["embedding_signature"] = sig.hash()
+                    ready_meta["embedding_signature"] = sig.hash()
                 kb_dir = self.base_dir / name
                 if kb_dir.is_dir():
-                    provider = normalize_provider_name(kb_config.get("rag_provider"))
-                    kb_config["index_versions"] = inspect_kb_versions(kb_dir, provider)
+                    current = self._store.read().get("knowledge_bases", {}).get(name) or {}
+                    provider = normalize_provider_name(current.get("rag_provider"))
+                    ready_meta["index_versions"] = inspect_kb_versions(kb_dir, provider)
             except Exception:  # pragma: no cover - best-effort metadata
                 pass
 
-        self._save_config()
+        def mutate(config: dict) -> dict:
+            knowledge_bases = config.setdefault("knowledge_bases", {})
+            if name not in knowledge_bases:
+                # Auto-register if not exists
+                knowledge_bases[name] = {
+                    "path": name,
+                    "description": f"Knowledge base: {name}",
+                }
+
+            kb_config = knowledge_bases[name]
+            kb_config["status"] = status
+            kb_config["updated_at"] = datetime.now().isoformat()
+
+            if status == "ready":
+                # Ready KBs should look like stable resources in the UI instead of
+                # permanently carrying a "completed" progress banner.
+                kb_config.pop("progress", None)
+                kb_config.pop("last_error", None)
+                kb_config.pop("last_error_at", None)
+                if progress is not None:
+                    kb_config["last_completed_at"] = (
+                        progress.get("timestamp") or datetime.now().isoformat()
+                    )
+                    if index_changed:
+                        kb_config["last_indexed_at"] = kb_config["last_completed_at"]
+                        if indexed_count is not None:
+                            kb_config["last_indexed_count"] = max(indexed_count, 0)
+                        if index_action:
+                            kb_config["last_indexed_action"] = index_action
+                kb_config.update(ready_meta)
+            elif status == "error":
+                if progress is not None:
+                    kb_config["progress"] = progress
+                    kb_config["last_error"] = progress.get("error") or progress.get("message")
+                    kb_config["last_error_at"] = (
+                        progress.get("timestamp") or datetime.now().isoformat()
+                    )
+            elif progress is not None:
+                kb_config["progress"] = progress
+
+            return kb_config
+
+        kb_config = self._mutate_config(mutate)
         self._sync_kb_to_pb(name, kb_config)
 
     def get_kb_status(self, name: str) -> dict | None:
@@ -556,7 +518,7 @@ class KnowledgeBaseManager:
 
         config_kbs = self.config.get("knowledge_bases", {})
         kb_list: set[str] = set()
-        config_changed = False
+        prune_candidates: list[str] = []
 
         # Filter out orphan entries whose KB directory is gone. The on-disk
         # folder is the source of truth for existence — without it the KB
@@ -571,7 +533,7 @@ class KnowledgeBaseManager:
         # be wiring things up.
         base_exists = self.base_dir.exists()
         grace_cutoff = datetime.now() - timedelta(seconds=_ORPHAN_PRUNE_GRACE_SECONDS)
-        for kb_name, kb_entry in list(config_kbs.items()):
+        for kb_name, kb_entry in config_kbs.items():
             # Connected KBs (Obsidian vaults, linked indexes) live outside
             # ``base_dir`` — they have no on-disk KB folder by design, so the
             # orphan prune below would wrongly delete them. Keep them
@@ -585,18 +547,15 @@ class KnowledgeBaseManager:
                 if _entry_updated_after(kb_entry, grace_cutoff):
                     kb_list.add(kb_name)
                     continue
-                logger.warning(
-                    "Pruning orphaned KB entry '%s': directory %s no longer exists.",
-                    kb_name,
-                    kb_dir,
-                )
-                del config_kbs[kb_name]
-                config_changed = True
+                prune_candidates.append(kb_name)
                 continue
             kb_list.add(kb_name)
 
         # Also scan directory for KBs that may not be registered yet
-        # This ensures backward compatibility and auto-discovery
+        # This ensures backward compatibility and auto-discovery. The scan
+        # (and the metadata probing behind each discovered entry) runs before
+        # the config transaction so no directory I/O happens under the lock.
+        discovered: dict[str, dict] = {}
         if base_exists:
             for item in self.base_dir.iterdir():
                 if not item.is_dir() or item.name.startswith(("__", ".")):
@@ -619,19 +578,47 @@ class KnowledgeBaseManager:
                 if is_valid_kb:
                     # Auto-register this KB to kb_config.json
                     kb_list.add(item.name)
-                    self._auto_register_kb(item.name)
-                    config_changed = True
+                    discovered[item.name] = self._build_auto_register_entry(item.name)
 
-        # Save config if we pruned orphans or registered new KBs
-        if config_changed:
-            self._save_config()
+        # Commit prunes/discoveries in one transaction against the latest
+        # on-disk state, so a racing writer's changes are never overwritten.
+        if prune_candidates or discovered:
+
+            def mutate(config: dict) -> None:
+                knowledge_bases = config.setdefault("knowledge_bases", {})
+                cutoff = datetime.now() - timedelta(seconds=_ORPHAN_PRUNE_GRACE_SECONDS)
+                for kb_name in prune_candidates:
+                    kb_entry = knowledge_bases.get(kb_name)
+                    # Re-check under the lock: the entry may have been
+                    # re-created, converted, or freshly touched since the
+                    # unlocked pass above.
+                    if kb_entry is None or is_connected_kb(kb_entry):
+                        continue
+                    kb_dir = self.base_dir / (kb_entry or {}).get("path", kb_name)
+                    if kb_dir.exists() or _entry_updated_after(kb_entry, cutoff):
+                        continue
+                    logger.warning(
+                        "Pruning orphaned KB entry '%s': directory %s no longer exists.",
+                        kb_name,
+                        kb_dir,
+                    )
+                    del knowledge_bases[kb_name]
+                for kb_name, kb_entry in discovered.items():
+                    knowledge_bases.setdefault(kb_name, kb_entry)
+
+            self._mutate_config(mutate)
+            # Racing writers may have added or removed entries while we
+            # scanned; report only names present in the committed snapshot.
+            kb_list &= set(self.config.get("knowledge_bases", {}))
 
         return sorted(kb_list)
 
-    def _auto_register_kb(self, name: str):
-        """Auto-register an existing KB to kb_config.json.
+    def _build_auto_register_entry(self, name: str) -> dict[str, Any]:
+        """Build the config entry to auto-register an existing KB directory.
 
         Reads info from metadata.json (if exists) for backward compatibility.
+        Pure probe/build — insertion into kb_config.json happens inside the
+        caller's transaction.
         """
         kb_dir = self.base_dir / name
         from deeptutor.services.rag.index_versioning import list_kb_versions
@@ -693,12 +680,8 @@ class KnowledgeBaseManager:
         else:
             kb_entry["status"] = "unknown"
 
-        # Add to config
-        if "knowledge_bases" not in self.config:
-            self.config["knowledge_bases"] = {}
-        self.config["knowledge_bases"][name] = kb_entry
-
-        logger.info(f"Auto-registered KB '{name}' to kb_config.json")
+        logger.info(f"Auto-registering KB '{name}' to kb_config.json")
+        return kb_entry
 
     def register_knowledge_base(self, name: str, description: str = "", set_default: bool = False):
         """Register a knowledge base"""
@@ -706,16 +689,19 @@ class KnowledgeBaseManager:
         if not kb_dir.exists():
             raise ValueError(f"Knowledge base directory does not exist: {kb_dir}")
 
-        if "knowledge_bases" not in self.config:
-            self.config["knowledge_bases"] = {}
+        def mutate(config: dict) -> None:
+            config.setdefault("knowledge_bases", {})[name] = {
+                "path": name,
+                "description": description,
+            }
 
-        self.config["knowledge_bases"][name] = {"path": name, "description": description}
+        self._mutate_config(mutate)
 
-        # Only set default if explicitly requested
+        # Only set default if explicitly requested. Runs after the entry is
+        # committed (the config service takes the same lock) so the
+        # validation inside ``set_default`` can see the new KB.
         if set_default:
             self.set_default(name)
-
-        self._save_config()
 
     def register_obsidian_vault(self, name: str, vault_path: str, description: str = "") -> dict:
         """Register a connected Obsidian vault as a pointer-type KB.
@@ -732,11 +718,6 @@ class KnowledgeBaseManager:
         if not vault.is_dir():
             raise ValueError(f"Vault path is not a directory: {vault_path}")
 
-        self.config = self._load_config()
-        knowledge_bases = self.config.setdefault("knowledge_bases", {})
-        if name in knowledge_bases:
-            raise ValueError(f"A knowledge base named '{name}' already exists.")
-
         now = datetime.now().isoformat()
         entry = {
             "path": name,
@@ -747,8 +728,7 @@ class KnowledgeBaseManager:
             "created_at": now,
             "updated_at": now,
         }
-        knowledge_bases[name] = entry
-        self._save_config()
+        self._register_entry(name, entry)
         return entry
 
     def register_linked_kb(
@@ -778,11 +758,6 @@ class KnowledgeBaseManager:
         if not folder.is_dir():
             raise ValueError(f"Folder path is not a directory: {external_path}")
 
-        self.config = self._load_config()
-        knowledge_bases = self.config.setdefault("knowledge_bases", {})
-        if name in knowledge_bases:
-            raise ValueError(f"A knowledge base named '{name}' already exists.")
-
         now = datetime.now().isoformat()
         entry: dict[str, Any] = {
             "path": name,
@@ -801,8 +776,7 @@ class KnowledgeBaseManager:
         if stats and stats.get("doc_count") is not None:
             entry["last_indexed_count"] = stats["doc_count"]
             entry["last_indexed_action"] = "link"
-        knowledge_bases[name] = entry
-        self._save_config()
+        self._register_entry(name, entry)
         return entry
 
     def register_subagent_connection(
@@ -837,11 +811,6 @@ class KnowledgeBaseManager:
                 raise ValueError(f"Working directory is not a directory: {cwd}")
             resolved_cwd = str(folder.resolve())
 
-        self.config = self._load_config()
-        knowledge_bases = self.config.setdefault("knowledge_bases", {})
-        if name in knowledge_bases:
-            raise ValueError(f"A knowledge base named '{name}' already exists.")
-
         now = datetime.now().isoformat()
         entry = {
             "path": name,
@@ -854,8 +823,7 @@ class KnowledgeBaseManager:
             "created_at": now,
             "updated_at": now,
         }
-        knowledge_bases[name] = entry
-        self._save_config()
+        self._register_entry(name, entry)
         return entry
 
     def register_lightrag_server_kb(
@@ -884,11 +852,6 @@ class KnowledgeBaseManager:
         if not server_url:
             raise ValueError("LightRAG server URL is required.")
 
-        self.config = self._load_config()
-        knowledge_bases = self.config.setdefault("knowledge_bases", {})
-        if name in knowledge_bases:
-            raise ValueError(f"A knowledge base named '{name}' already exists.")
-
         now = datetime.now().isoformat()
         entry: dict[str, Any] = {
             "path": name,
@@ -905,8 +868,7 @@ class KnowledgeBaseManager:
         search_mode = (search_mode or "").strip().lower()
         if search_mode:
             entry["search_mode"] = search_mode
-        knowledge_bases[name] = entry
-        self._save_config()
+        self._register_entry(name, entry)
         return entry
 
     def get_knowledge_base_path(self, name: str | None = None) -> Path:
@@ -1346,16 +1308,19 @@ class KnowledgeBaseManager:
                 f"KB directory '{kb_dir}' missing on disk; cleaning up orphaned config entry."
             )
 
-        # Remove from config
-        if name in self.config.get("knowledge_bases", {}):
-            del self.config["knowledge_bases"][name]
+        # Remove from config. The directory work above stays outside the
+        # transaction — only the entry removal runs under the store lock.
+        def mutate(config: dict) -> None:
+            knowledge_bases = config.setdefault("knowledge_bases", {})
+            knowledge_bases.pop(name, None)
 
-        # Update default if this was the default
-        if self.config.get("default") == name:
-            remaining = [n for n in self.config.get("knowledge_bases", {}).keys() if n != name]
-            self.config["default"] = sorted(remaining)[0] if remaining else None
+            # Update default if this was the default (legacy field; the
+            # canonical default lives in the config service's ``defaults``)
+            if config.get("default") == name:
+                remaining = [n for n in knowledge_bases.keys() if n != name]
+                config["default"] = sorted(remaining)[0] if remaining else None
 
-        self._save_config()
+        self._mutate_config(mutate)
         return True
 
     def clean_rag_storage(self, name: str | None = None, backup: bool = True) -> bool:
@@ -1688,7 +1653,7 @@ class KnowledgeBaseManager:
 
                 folder["synced_files"] = file_states
                 folder["file_count"] = len(file_states)
-                _write_json_atomic(metadata_file, metadata)
+                write_json_atomic(metadata_file, metadata)
                 break
 
 

--- a/deeptutor/knowledge/manager.py
+++ b/deeptutor/knowledge/manager.py
@@ -258,20 +258,24 @@ class KnowledgeBaseManager:
         Also runs inside a store transaction when changes must be persisted,
         so it must stay cheap: per-KB local index probes only.
         """
+        config_changed = False
+
         # Ensure knowledge_bases key exists
         if "knowledge_bases" not in config:
             config["knowledge_bases"] = {}
 
         # Migration: remove old "default" field if present (superseded by the
-        # config service's ``defaults.default_kb``). Dropped in memory; the
-        # next persisted write picks it up.
-        config.pop("default", None)
+        # config service's ``defaults.default_kb``). Must count as a change so
+        # the removal is committed — otherwise every later transaction reads
+        # the raw file and faithfully writes the stale field back.
+        if "default" in config:
+            del config["default"]
+            config_changed = True
 
         # Migration: normalize unknown/removed providers to the default
         # and mark them for rebuild. Known non-default providers are
         # first-class engines and must be preserved.
         knowledge_bases = config.get("knowledge_bases", {})
-        config_changed = False
         for kb_name, kb_entry in knowledge_bases.items():
             if not isinstance(kb_entry, dict):
                 continue

--- a/deeptutor/knowledge/metadata_store.py
+++ b/deeptutor/knowledge/metadata_store.py
@@ -1,0 +1,17 @@
+"""Atomic, lock-guarded access to a knowledge base's ``metadata.json``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from deeptutor.knowledge.config_store import KBConfigStore
+
+
+def get_metadata_store(metadata_file: Path | str) -> KBConfigStore:
+    """Return the shared store for metadata without KB-config-specific validation."""
+    return KBConfigStore(
+        metadata_file,
+        default_factory=dict,
+        validate_kb_schema=False,
+        create_parent=False,
+    )

--- a/deeptutor/knowledge/progress_tracker.py
+++ b/deeptutor/knowledge/progress_tracker.py
@@ -34,16 +34,34 @@ class ProgressTracker:
 
     def __init__(self, kb_name: str, base_dir: Path):
         self.kb_name = kb_name
-        self.base_dir = base_dir
-        self.kb_dir = base_dir / kb_name
+        self.base_dir = Path(base_dir)
+        self.kb_dir = self.base_dir / kb_name
         self.progress_file = self.kb_dir / ".progress.json"
         self._callbacks: list = []  # Support multiple callbacks
         self.task_id: str | None = None  # Task ID (for log identification)
+        self._creation_generation: str | None = None
+        try:
+            from deeptutor.knowledge.manager import KnowledgeBaseManager
+
+            entry = (
+                KnowledgeBaseManager(base_dir=str(self.base_dir))
+                .config.get("knowledge_bases", {})
+                .get(self.kb_name, {})
+            )
+            generation = entry.get("_creation_generation") if isinstance(entry, dict) else None
+            if isinstance(generation, str):
+                self._creation_generation = generation
+        except Exception:
+            pass
 
     def set_callback(self, callback: Callable[[dict], None]):
         """Set progress callback function (can be called multiple times to add multiple callbacks)"""
         if callback not in self._callbacks:
             self._callbacks.append(callback)
+
+    def set_creation_generation(self, generation: str | None) -> None:
+        """Bind this tracker to the KB creation generation that owns it."""
+        self._creation_generation = generation
 
     def remove_callback(self, callback: Callable[[dict], None]):
         """Remove progress callback function"""
@@ -98,7 +116,7 @@ class ProgressTracker:
                 status = "initializing"
 
             # Update kb_config.json with status and progress
-            manager.update_kb_status(
+            persisted = manager.update_kb_status(
                 name=self.kb_name,
                 status=status,
                 progress={
@@ -115,9 +133,13 @@ class ProgressTracker:
                     "index_changed": progress.get("index_changed"),
                     "index_action": progress.get("index_action"),
                 },
+                expected_generation=self._creation_generation,
             )
+            if persisted is False:
+                return
         except Exception as e:
             _logger_instance().warning("Failed to save progress to kb_config.json: %s", e)
+            return
 
         # Persist the last seen progress snapshot so websocket subscribers and
         # page reloads can recover the live state without relying on in-memory callbacks.

--- a/deeptutor/services/config/knowledge_base_config.py
+++ b/deeptutor/services/config/knowledge_base_config.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
+from deeptutor.knowledge.config_store import KBConfigStore
 from deeptutor.services.path_service import get_path_service
 from deeptutor.services.rag.factory import (
     DEFAULT_PROVIDER,
@@ -41,6 +42,10 @@ class KnowledgeBaseConfigService:
 
     def __init__(self, config_path: Path | None = None):
         self.config_path = config_path or DEFAULT_CONFIG_PATH
+        # Shares the sidecar lock + atomic-replace write path with
+        # ``KnowledgeBaseManager``: both mutate the same file, so both must
+        # go through the same locked read-modify-write transactions.
+        self._store = KBConfigStore(self.config_path, default_factory=_default_payload)
         self._config = self._load_config()
 
     @classmethod
@@ -54,19 +59,30 @@ class KnowledgeBaseConfigService:
         return cls._instances[key]
 
     def _load_config(self) -> dict[str, Any]:
-        payload = _default_payload()
-        if self.config_path.exists():
-            try:
-                with open(self.config_path, "r", encoding="utf-8") as handle:
-                    loaded = json.load(handle) or {}
-                payload.update({k: v for k, v in loaded.items() if k != "defaults"})
-                payload["defaults"].update(loaded.get("defaults", {}))
-            except Exception as exc:
-                logger.warning(f"Failed to load KB config: {exc}")
-        payload.setdefault("knowledge_bases", {})
-        payload.setdefault("defaults", _default_payload()["defaults"])
-        payload = self._normalize_payload(payload)
-        return payload
+        """Read the latest on-disk config, coerced and normalized.
+
+        Raises ``KBConfigCorruptionError`` when the file exists but does not
+        parse — the legacy fallback to a default payload let the next write
+        overwrite the damaged file with a near-empty config.
+        """
+        state = self._store.read()
+        self._coerce_payload(state)
+        return self._normalize_payload(state)
+
+    def _coerce_payload(self, state: dict[str, Any]) -> dict[str, Any]:
+        """Shape a raw payload in place: full defaults section + KB map.
+
+        The file is shared with ``KnowledgeBaseManager``, which knows nothing
+        about the ``defaults`` section — merge the stored values over the
+        stock defaults so partially-written sections stay complete.
+        """
+        defaults = _default_payload()["defaults"]
+        stored_defaults = state.get("defaults")
+        if isinstance(stored_defaults, dict):
+            defaults.update(stored_defaults)
+        state["defaults"] = defaults
+        state.setdefault("knowledge_bases", {})
+        return state
 
     def _normalize_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
         defaults = payload.setdefault("defaults", _default_payload()["defaults"])
@@ -105,24 +121,36 @@ class KnowledgeBaseConfigService:
 
         return payload
 
-    def _save(self) -> None:
-        self._config = self._normalize_payload(self._config)
-        self.config_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(self.config_path, "w", encoding="utf-8") as handle:
-            json.dump(self._config, handle, indent=2, ensure_ascii=False)
+    def _mutate(self, mutate: Callable[[dict[str, Any]], Any]) -> Any:
+        """Run one locked read-modify-write transaction on kb_config.json.
+
+        The mutator sees the latest coerced on-disk state — never the cached
+        ``self._config``, which may be stale — and edits it in place; the
+        committed, normalized snapshot becomes the new cache. Returns the
+        mutator's result.
+        """
+
+        def wrapped(state: dict[str, Any]) -> Any:
+            self._coerce_payload(state)
+            result = mutate(state)
+            self._normalize_payload(state)
+            return result
+
+        state, result = self._store.transaction(wrapped)
+        self._config = state
+        return result
 
     def _refresh(self) -> None:
         """Re-read kb_config.json so this singleton sees changes made by
         ``KnowledgeBaseManager`` (orphan pruning, new KB registrations).
-
-        Without this, every mutating call would rewrite the file from the
-        in-memory snapshot taken at process start and undo any external
-        cleanup. Read-modify-write keeps the two writers consistent.
+        Read-only paths call this; mutations always start from the latest
+        on-disk state inside ``_mutate`` regardless.
         """
         self._config = self._load_config()
 
-    def _ensure_kb(self, kb_name: str) -> dict[str, Any]:
-        knowledge_bases = self._config.setdefault("knowledge_bases", {})
+    @staticmethod
+    def _ensure_kb(state: dict[str, Any], kb_name: str) -> dict[str, Any]:
+        knowledge_bases = state.setdefault("knowledge_bases", {})
         if kb_name not in knowledge_bases:
             knowledge_bases[kb_name] = {
                 "path": kb_name,
@@ -145,10 +173,10 @@ class KnowledgeBaseConfigService:
         return merged
 
     def set_kb_config(self, kb_name: str, config: dict[str, Any]) -> None:
-        self._refresh()
-        entry = self._ensure_kb(kb_name)
-        entry.update(config)
-        self._save()
+        def mutate(state: dict[str, Any]) -> None:
+            self._ensure_kb(state, kb_name).update(config)
+
+        self._mutate(mutate)
 
     def get_rag_provider(self, kb_name: str) -> str:
         return normalize_provider_name(self.get_kb_config(kb_name).get("rag_provider"))
@@ -169,33 +197,32 @@ class KnowledgeBaseConfigService:
         return str(modes.get(provider, "")) if isinstance(modes, dict) else ""
 
     def set_provider_mode(self, provider: str, mode: str) -> None:
-        self._refresh()
-        defaults = self._config.setdefault("defaults", _default_payload()["defaults"])
-        modes = defaults.setdefault("provider_modes", {})
-        modes[provider] = mode
-        self._save()
+        def mutate(state: dict[str, Any]) -> None:
+            state["defaults"].setdefault("provider_modes", {})[provider] = mode
+
+        self._mutate(mutate)
 
     def delete_kb_config(self, kb_name: str) -> None:
-        self._refresh()
-        knowledge_bases = self._config.get("knowledge_bases", {})
-        if kb_name in knowledge_bases:
-            del knowledge_bases[kb_name]
-            self._save()
+        def mutate(state: dict[str, Any]) -> None:
+            state.get("knowledge_bases", {}).pop(kb_name, None)
+
+        self._mutate(mutate)
 
     def get_all_configs(self) -> dict[str, Any]:
         self._refresh()
         return self._config
 
     def set_global_defaults(self, defaults: dict[str, Any]) -> None:
-        self._refresh()
-        current = self._config.setdefault("defaults", _default_payload()["defaults"])
-        current.update(defaults)
-        self._save()
+        def mutate(state: dict[str, Any]) -> None:
+            state["defaults"].update(defaults)
+
+        self._mutate(mutate)
 
     def set_default_kb(self, kb_name: str | None) -> None:
-        self._refresh()
-        self._config.setdefault("defaults", _default_payload()["defaults"])["default_kb"] = kb_name
-        self._save()
+        def mutate(state: dict[str, Any]) -> None:
+            state["defaults"]["default_kb"] = kb_name
+
+        self._mutate(mutate)
 
     def get_default_kb(self) -> str | None:
         self._refresh()

--- a/deeptutor/services/config/knowledge_base_config.py
+++ b/deeptutor/services/config/knowledge_base_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 import json
 import logging
 from pathlib import Path
@@ -149,9 +150,12 @@ class KnowledgeBaseConfigService:
         self._config = self._load_config()
 
     @staticmethod
-    def _ensure_kb(state: dict[str, Any], kb_name: str) -> dict[str, Any]:
+    def _ensure_kb(state: dict[str, Any], kb_name: str) -> dict[str, Any] | None:
         knowledge_bases = state.setdefault("knowledge_bases", {})
         if kb_name not in knowledge_bases:
+            deleted = state.get("_deleted_knowledge_bases")
+            if isinstance(deleted, dict) and kb_name in deleted:
+                return None
             knowledge_bases[kb_name] = {
                 "path": kb_name,
                 "description": f"Knowledge base: {kb_name}",
@@ -174,7 +178,9 @@ class KnowledgeBaseConfigService:
 
     def set_kb_config(self, kb_name: str, config: dict[str, Any]) -> None:
         def mutate(state: dict[str, Any]) -> None:
-            self._ensure_kb(state, kb_name).update(config)
+            kb_config = self._ensure_kb(state, kb_name)
+            if kb_config is not None:
+                kb_config.update(config)
 
         self._mutate(mutate)
 
@@ -205,6 +211,12 @@ class KnowledgeBaseConfigService:
     def delete_kb_config(self, kb_name: str) -> None:
         def mutate(state: dict[str, Any]) -> None:
             state.get("knowledge_bases", {}).pop(kb_name, None)
+            deleted = state.setdefault("_deleted_knowledge_bases", {})
+            deleted[kb_name] = datetime.now().isoformat()
+            defaults = state.get("defaults")
+            if isinstance(defaults, dict) and defaults.get("default_kb") == kb_name:
+                remaining = sorted(state.get("knowledge_bases", {}))
+                defaults["default_kb"] = remaining[0] if remaining else None
 
         self._mutate(mutate)
 

--- a/deeptutor/services/memory/snapshot/adapters.py
+++ b/deeptutor/services/memory/snapshot/adapters.py
@@ -19,6 +19,7 @@ import json
 import logging
 import sqlite3
 
+from deeptutor.knowledge.config_store import KBConfigStore
 from deeptutor.services.memory.paths import Surface
 from deeptutor.services.memory.snapshot.entity import Entity
 from deeptutor.services.path_service import get_path_service
@@ -339,13 +340,7 @@ def read_kb_entities() -> list[Entity]:
     consolidator combines both signals.
     """
     kb_root = get_path_service().get_knowledge_bases_root()
-    cfg_file = kb_root / "kb_config.json"
-    if not cfg_file.exists():
-        return []
-    try:
-        cfg = json.loads(cfg_file.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return []
+    cfg = KBConfigStore(kb_root / "kb_config.json").read()
     kbs = cfg.get("knowledge_bases") or {}
     if not isinstance(kbs, dict):
         return []

--- a/deeptutor/services/partners/workspace.py
+++ b/deeptutor/services/partners/workspace.py
@@ -32,6 +32,10 @@ from pathlib import Path
 import shutil
 from typing import Any
 
+from deeptutor.knowledge.config_store import (
+    KBConfigCorruptionError,
+    KBConfigStore,
+)
 from deeptutor.multi_user.paths import (
     ensure_scope_workspace,
     get_admin_path_service,
@@ -331,14 +335,14 @@ def remove_asset(partner_id: str, asset_type: str, name: str) -> bool:
         shutil.rmtree(target)
         config_file = root / "knowledge_bases" / "kb_config.json"
         if config_file.exists():
+            # The partner-side KnowledgeBaseManager reads/writes this same
+            # file, so the prune must go through the shared store — a raw
+            # read-modify-write here can lose a concurrent writer's update.
             try:
-                config = json.loads(config_file.read_text(encoding="utf-8"))
-                if name in config.get("knowledge_bases", {}):
-                    config["knowledge_bases"].pop(name, None)
-                    config_file.write_text(
-                        json.dumps(config, ensure_ascii=False, indent=2), encoding="utf-8"
-                    )
-            except (OSError, json.JSONDecodeError):
+                KBConfigStore(config_file).transaction(
+                    lambda config: config.get("knowledge_bases", {}).pop(name, None)
+                )
+            except (OSError, KBConfigCorruptionError):
                 logger.warning("Could not prune kb_config entry for %s", name, exc_info=True)
         return True
 

--- a/deeptutor/services/rag/kb_paths.py
+++ b/deeptutor/services/rag/kb_paths.py
@@ -13,9 +13,9 @@ results.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
+from deeptutor.knowledge.config_store import KBConfigStore
 from deeptutor.knowledge.kb_types import external_root_of
 
 KB_CONFIG_FILENAME = "kb_config.json"
@@ -35,16 +35,19 @@ def resolve_kb_dir(kb_base_dir: str | Path, kb_name: str) -> Path:
 
 
 def _external_path(base: Path, kb_name: str) -> str | None:
-    """Read a KB entry's external pointer from ``kb_config.json``, if any."""
-    cfg = base / KB_CONFIG_FILENAME
-    if not cfg.exists():
+    """Read a KB entry's external pointer from ``kb_config.json``, if any.
+
+    A missing config file reads as pointer-less; a corrupt one raises
+    ``KBConfigCorruptionError`` — treating damage as "no pointer" would
+    resolve a linked KB to a non-existent local folder and silently return
+    empty results.
+    """
+    config = KBConfigStore(base / KB_CONFIG_FILENAME).read()
+    knowledge_bases = config.get("knowledge_bases")
+    if not isinstance(knowledge_bases, dict):
         return None
-    try:
-        with open(cfg, encoding="utf-8") as handle:
-            entry = json.load(handle).get("knowledge_bases", {}).get(kb_name, {})
-    except Exception:
-        return None
-    return external_root_of(entry)
+    entry = knowledge_bases.get(kb_name, {})
+    return external_root_of(entry if isinstance(entry, dict) else {})
 
 
 __all__ = ["resolve_kb_dir"]

--- a/deeptutor/services/rag/pipelines/llamaindex/pipeline.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/pipeline.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from pathlib import Path
 import traceback
 from typing import Any, Callable, Dict, List, Optional
 
+from deeptutor.knowledge.config_store import KBConfigCorruptionError, KBConfigStore
 from deeptutor.runtime.home import get_runtime_data_root
 from deeptutor.services.embedding import get_embedding_config
 from deeptutor.services.rag.embedding_signature import signature_from_embedding_config
@@ -178,11 +178,8 @@ class LlamaIndexPipeline:
 
     def _embedding_mismatch_warning(self, kb_name: str) -> str:
         try:
-            cfg_path = Path(self.kb_base_dir) / "kb_config.json"
-            if not cfg_path.exists():
-                return ""
-            with open(cfg_path, encoding="utf-8") as handle:
-                kb_entry = json.load(handle).get("knowledge_bases", {}).get(kb_name, {})
+            config = KBConfigStore(Path(self.kb_base_dir) / "kb_config.json").read()
+            kb_entry = config.get("knowledge_bases", {}).get(kb_name, {})
             if not kb_entry.get("embedding_mismatch"):
                 return ""
             stored = kb_entry.get("embedding_model", "unknown")
@@ -193,6 +190,11 @@ class LlamaIndexPipeline:
             )
             self.logger.warning(warning)
             return warning
+        except KBConfigCorruptionError as exc:
+            # Cosmetic path — never fail a search over the mismatch banner —
+            # but surface the damaged config instead of staying silent.
+            self.logger.warning(f"Cannot check embedding mismatch: {exc}")
+            return ""
         except Exception:
             return ""
 

--- a/deeptutor/services/rag/pipelines/modes.py
+++ b/deeptutor/services/rag/pipelines/modes.py
@@ -11,9 +11,10 @@ Resolution order, first valid wins:
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any, Optional, Sequence
+
+from deeptutor.knowledge.config_store import KBConfigStore
 
 
 def resolve_kb_mode(
@@ -25,17 +26,24 @@ def resolve_kb_mode(
     supported: Sequence[str],
     default: str,
 ) -> str:
+    """Resolve the retrieval mode; see the module docstring for the order.
+
+    A missing ``kb_config.json`` contributes no candidates; a corrupt one
+    raises ``KBConfigCorruptionError`` instead of silently dropping the
+    user's configured mode.
+    """
     candidates: list[Any] = [explicit]
-    try:
-        cfg_path = Path(kb_base_dir) / "kb_config.json"
-        if cfg_path.exists():
-            data = json.loads(cfg_path.read_text(encoding="utf-8"))
-            if kb_name:
-                entry = data.get("knowledge_bases", {}).get(kb_name, {})
-                candidates.append(entry.get("search_mode"))
-            candidates.append(data.get("defaults", {}).get("provider_modes", {}).get(provider))
-    except Exception:  # pragma: no cover - defensive
-        pass
+    data = KBConfigStore(Path(kb_base_dir) / "kb_config.json").read()
+    knowledge_bases = data.get("knowledge_bases")
+    if kb_name and isinstance(knowledge_bases, dict):
+        entry = knowledge_bases.get(kb_name)
+        if isinstance(entry, dict):
+            candidates.append(entry.get("search_mode"))
+    defaults = data.get("defaults")
+    if isinstance(defaults, dict):
+        provider_modes = defaults.get("provider_modes")
+        if isinstance(provider_modes, dict):
+            candidates.append(provider_modes.get(provider))
 
     supported_set = {m.lower() for m in supported}
     for candidate in candidates:

--- a/deeptutor/services/rag/provider_binding.py
+++ b/deeptutor/services/rag/provider_binding.py
@@ -13,20 +13,23 @@ import json
 from pathlib import Path
 from typing import Any
 
+from deeptutor.knowledge.config_store import KBConfigStore
 from deeptutor.services.rag.factory import DEFAULT_PROVIDER, normalize_provider_name
 
 
 def load_kb_config_entry(kb_base_dir: str | Path, kb_name: str) -> dict[str, Any]:
-    """Return the raw ``kb_config.json`` entry for ``kb_name``, if present."""
-    config_path = Path(kb_base_dir) / "kb_config.json"
-    if not config_path.exists():
+    """Return the raw ``kb_config.json`` entry for ``kb_name``, if present.
+
+    A missing config file reads as empty. A file that exists but does not
+    parse raises ``KBConfigCorruptionError`` — silently returning ``{}``
+    here would rebind the KB to the default provider and mask the damage.
+    """
+    config = KBConfigStore(Path(kb_base_dir) / "kb_config.json").read()
+    knowledge_bases = config.get("knowledge_bases")
+    if not isinstance(knowledge_bases, dict):
         return {}
-    try:
-        with open(config_path, encoding="utf-8") as handle:
-            entry = json.load(handle).get("knowledge_bases", {}).get(kb_name, {})
-        return entry if isinstance(entry, dict) else {}
-    except Exception:
-        return {}
+    entry = knowledge_bases.get(kb_name, {})
+    return entry if isinstance(entry, dict) else {}
 
 
 def load_metadata_provider(kb_base_dir: str | Path, kb_name: str) -> str | None:
@@ -49,6 +52,10 @@ def resolve_bound_provider(kb_base_dir: str | Path, kb_name: str | None) -> str:
     1. ``kb_config.json``: authoritative runtime state.
     2. ``metadata.json``: legacy/import fallback.
     3. default provider.
+
+    A corrupt ``kb_config.json`` raises ``KBConfigCorruptionError`` instead
+    of falling through — resolving a damaged binding to the default provider
+    would silently query the wrong engine.
     """
     if kb_name:
         entry = load_kb_config_entry(kb_base_dir, kb_name)

--- a/tests/api/test_knowledge_router.py
+++ b/tests/api/test_knowledge_router.py
@@ -44,8 +44,8 @@ class _FakeKBManager:
     def _load_config(self) -> dict:
         return self.config
 
-    def _save_config(self) -> None:
-        pass
+    def _mutate_config(self, mutate):
+        return mutate(self.config)
 
     def list_knowledge_bases(self) -> list[str]:
         return sorted(self.config.get("knowledge_bases", {}).keys())

--- a/tests/api/test_knowledge_router.py
+++ b/tests/api/test_knowledge_router.py
@@ -50,10 +50,19 @@ class _FakeKBManager:
     def list_knowledge_bases(self) -> list[str]:
         return sorted(self.config.get("knowledge_bases", {}).keys())
 
-    def update_kb_status(self, name: str, status: str, progress: dict | None = None) -> None:
+    def update_kb_status(
+        self,
+        name: str,
+        status: str,
+        progress: dict | None = None,
+        *,
+        allow_recreate: bool = False,
+        expected_generation: str | None = None,
+    ) -> bool:
         entry = self.config.setdefault("knowledge_bases", {}).setdefault(name, {"path": name})
         entry["status"] = status
         entry["progress"] = progress or {}
+        return True
 
     def get_default(self) -> str | None:
         names = self.list_knowledge_bases()

--- a/tests/knowledge/test_document_adder_provider.py
+++ b/tests/knowledge/test_document_adder_provider.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+import threading
+
+import pytest
 
 from deeptutor.knowledge.add_documents import (
     DocumentAdder,
     RawDocumentRemoval,
     remove_raw_document,
 )
+from deeptutor.knowledge.config_store import KBConfigCorruptionError
 
 
 def _write_provider_version(kb_dir: Path, provider: str) -> None:
@@ -159,3 +163,57 @@ def test_remove_raw_document_uses_relative_key_for_nested_file(
     assert removal.rel_path == "papers/2024/a.pdf"
     remaining = json.loads((kb_dir / "metadata.json").read_text(encoding="utf-8"))
     assert remaining["file_hashes"] == {"other.pdf": "keep"}
+
+
+def test_remove_raw_document_does_not_unlink_when_metadata_is_corrupt(tmp_path: Path) -> None:
+    kb_dir = tmp_path / "kb"
+    raw_dir = kb_dir / "raw"
+    raw_dir.mkdir(parents=True)
+    doc = raw_dir / "a.txt"
+    doc.write_text("keep me", encoding="utf-8")
+    metadata_file = kb_dir / "metadata.json"
+    damaged = "{broken"
+    metadata_file.write_text(damaged, encoding="utf-8")
+
+    with pytest.raises(KBConfigCorruptionError):
+        remove_raw_document(kb_dir, doc)
+
+    assert doc.exists()
+    assert metadata_file.read_text(encoding="utf-8") == damaged
+
+
+def test_delete_racing_hash_record_does_not_leave_stale_hash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    kb_dir = tmp_path / "kb"
+    raw_dir = kb_dir / "raw"
+    raw_dir.mkdir(parents=True)
+    _write_provider_version(kb_dir, "llamaindex")
+    doc = raw_dir / "a.txt"
+    doc.write_text("hello", encoding="utf-8")
+    adder = DocumentAdder(kb_name="kb", base_dir=str(tmp_path))
+
+    hash_computed = threading.Event()
+    release_hash_writer = threading.Event()
+    original_hash = adder._get_file_hash
+
+    def pause_after_hash(path: Path) -> str:
+        value = original_hash(path)
+        hash_computed.set()
+        assert release_hash_writer.wait(10)
+        return value
+
+    monkeypatch.setattr(adder, "_get_file_hash", pause_after_hash)
+    writer = threading.Thread(target=adder._record_successful_hash, args=(doc,))
+    writer.start()
+    assert hash_computed.wait(10)
+
+    removal = remove_raw_document(kb_dir, doc)
+    release_hash_writer.set()
+    writer.join(10)
+
+    assert not writer.is_alive()
+    assert removal.was_indexed is False
+    assert not doc.exists()
+    metadata = json.loads((kb_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata.get("file_hashes", {}) == {}

--- a/tests/knowledge/test_kb_config_store.py
+++ b/tests/knowledge/test_kb_config_store.py
@@ -1,0 +1,375 @@
+"""KBConfigStore: atomic, lock-guarded kb_config.json persistence.
+
+Pins the three failure modes the store exists to prevent:
+
+* lost updates — two writers doing read-modify-write with no lock spanning
+  the cycle, so the slower one commits a stale snapshot over the faster one;
+* torn reads — the legacy writer truncated the file (``open(..., "w")``)
+  before locking, so readers observed an empty/partial file and fell back to
+  an empty default that a later write persisted;
+* silent corruption recovery — a file that exists but does not parse must
+  raise, never become a mutable default payload.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+from deeptutor.knowledge import config_store as config_store_module
+from deeptutor.knowledge.config_store import (
+    KBConfigCorruptionError,
+    KBConfigStore,
+)
+from deeptutor.knowledge.manager import KnowledgeBaseManager
+from deeptutor.services.config.knowledge_base_config import KnowledgeBaseConfigService
+
+
+class TestStoreBasics:
+    def test_missing_file_reads_as_default(self, tmp_path: Path) -> None:
+        store = KBConfigStore(tmp_path / "kb_config.json")
+        assert store.read() == {"knowledge_bases": {}}
+
+    def test_zero_byte_file_reads_as_default(self, tmp_path: Path) -> None:
+        path = tmp_path / "kb_config.json"
+        path.write_text("", encoding="utf-8")
+        store = KBConfigStore(path)
+        assert store.read() == {"knowledge_bases": {}}
+
+    def test_invalid_json_raises_and_preserves_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "kb_config.json"
+        damaged = '{"knowledge_bases": {"kb": {"path": "kb"'
+        path.write_text(damaged, encoding="utf-8")
+        store = KBConfigStore(path)
+
+        with pytest.raises(KBConfigCorruptionError):
+            store.read()
+        with pytest.raises(KBConfigCorruptionError):
+            store.transaction(lambda config: None)
+
+        # The damaged file must survive both attempts byte-for-byte.
+        assert path.read_text(encoding="utf-8") == damaged
+
+    def test_non_object_json_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "kb_config.json"
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+        with pytest.raises(KBConfigCorruptionError):
+            KBConfigStore(path).read()
+
+    def test_transaction_commits_and_returns_result(self, tmp_path: Path) -> None:
+        path = tmp_path / "kb_config.json"
+        store = KBConfigStore(path)
+
+        def mutate(config: dict) -> str:
+            config["knowledge_bases"]["kb"] = {"path": "kb"}
+            return "done"
+
+        state, result = store.transaction(mutate)
+        assert result == "done"
+        assert state["knowledge_bases"]["kb"] == {"path": "kb"}
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        assert on_disk == state
+
+    def test_mutator_exception_writes_nothing_and_releases_lock(self, tmp_path: Path) -> None:
+        path = tmp_path / "kb_config.json"
+        store = KBConfigStore(path)
+        store.transaction(lambda config: config.update(marker=1))
+
+        with pytest.raises(RuntimeError, match="boom"):
+            store.transaction(lambda config: (_ for _ in ()).throw(RuntimeError("boom")))
+
+        assert json.loads(path.read_text(encoding="utf-8"))["marker"] == 1
+        # Lock must be free again for the next writer.
+        store.transaction(lambda config: config.update(marker=2))
+        assert json.loads(path.read_text(encoding="utf-8"))["marker"] == 2
+
+    def test_unserializable_payload_preserves_file_and_cleans_temp(self, tmp_path: Path) -> None:
+        path = tmp_path / "kb_config.json"
+        store = KBConfigStore(path)
+        store.transaction(lambda config: config.update(ok=True))
+        before = path.read_bytes()
+
+        with pytest.raises(TypeError):
+            store.transaction(lambda config: config.update(bad=object()))
+
+        assert path.read_bytes() == before
+        leftovers = {p.name for p in tmp_path.iterdir()}
+        assert leftovers == {"kb_config.json", ".kb_config.json.lock"}
+
+    def test_replace_failure_preserves_file_and_cleans_temp(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = tmp_path / "kb_config.json"
+        store = KBConfigStore(path)
+        store.transaction(lambda config: config.update(ok=True))
+        before = path.read_bytes()
+
+        def failing_replace(src: str, dst: str) -> None:
+            raise OSError("simulated cross-process interference")
+
+        monkeypatch.setattr(config_store_module.os, "replace", failing_replace)
+        with pytest.raises(OSError, match="simulated"):
+            store.transaction(lambda config: config.update(ok=False))
+        monkeypatch.undo()
+
+        assert path.read_bytes() == before
+        leftovers = {p.name for p in tmp_path.iterdir()}
+        assert leftovers == {"kb_config.json", ".kb_config.json.lock"}
+
+    def test_lock_contention_retries_until_acquired(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Contention surfaces as a failed non-blocking attempt (this is how
+        Windows' ``msvcrt.locking(LK_NBLCK)`` behaves); the store must retry
+        within its deadline instead of failing on the first attempt."""
+        attempts = {"count": 0}
+        real_try = config_store_module._try_lock_exclusive
+
+        def flaky(fd: int) -> bool:
+            attempts["count"] += 1
+            if attempts["count"] <= 2:
+                return False
+            return real_try(fd)
+
+        monkeypatch.setattr(config_store_module, "_try_lock_exclusive", flaky)
+        store = KBConfigStore(tmp_path / "kb_config.json")
+        store.transaction(lambda config: None)
+        assert attempts["count"] == 3
+
+    def test_lock_timeout_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "kb_config.json"
+        holder = KBConfigStore(path)
+        waiter = KBConfigStore(path, lock_timeout=0.2)
+        entered = threading.Event()
+        release = threading.Event()
+
+        def hold(config: dict) -> None:
+            entered.set()
+            assert release.wait(10)
+
+        thread = threading.Thread(target=holder.transaction, args=(hold,))
+        thread.start()
+        try:
+            assert entered.wait(10)
+            with pytest.raises(TimeoutError):
+                waiter.transaction(lambda config: None)
+        finally:
+            release.set()
+            thread.join(10)
+
+
+class TestStoreConcurrency:
+    def test_second_writer_blocks_and_neither_update_is_lost(self, tmp_path: Path) -> None:
+        """The historic lost-update: writer B commits while writer A holds a
+        pre-B snapshot, then A commits and erases B. With the lock spanning
+        read-modify-write, B cannot even read until A commits."""
+        path = tmp_path / "kb_config.json"
+        first = KBConfigStore(path)
+        second = KBConfigStore(path)
+        entered = threading.Event()
+        release = threading.Event()
+
+        def slow_mutate(config: dict) -> None:
+            config["knowledge_bases"]["first"] = {"path": "first"}
+            entered.set()
+            assert release.wait(10)
+
+        t1 = threading.Thread(target=first.transaction, args=(slow_mutate,))
+        t1.start()
+        assert entered.wait(10)
+
+        t2 = threading.Thread(
+            target=second.transaction,
+            args=(lambda config: config["knowledge_bases"].update(second={"path": "second"}),),
+        )
+        t2.start()
+        time.sleep(0.05)  # give t2 the chance to (wrongly) slip past the lock
+        release.set()
+        t1.join(10)
+        t2.join(10)
+
+        kbs = json.loads(path.read_text(encoding="utf-8"))["knowledge_bases"]
+        assert kbs["first"] == {"path": "first"}
+        assert kbs["second"] == {"path": "second"}
+
+    def test_reader_sees_only_complete_snapshots_mid_transaction(self, tmp_path: Path) -> None:
+        """The legacy writer truncated the file before locking; a mid-write
+        reader saw an empty file. Now the file must stay the complete old
+        snapshot until the commit lands."""
+        path = tmp_path / "kb_config.json"
+        store = KBConfigStore(path)
+        store.transaction(lambda config: config.update(marker="old"))
+        entered = threading.Event()
+        release = threading.Event()
+
+        def mutate(config: dict) -> None:
+            config["marker"] = "new"
+            entered.set()
+            assert release.wait(10)
+
+        thread = threading.Thread(target=store.transaction, args=(mutate,))
+        thread.start()
+        try:
+            assert entered.wait(10)
+            assert json.loads(path.read_text(encoding="utf-8"))["marker"] == "old"
+            assert KBConfigStore(path).read()["marker"] == "old"
+        finally:
+            release.set()
+            thread.join(10)
+        assert json.loads(path.read_text(encoding="utf-8"))["marker"] == "new"
+
+    def test_multiprocess_writers_lose_no_updates(self, tmp_path: Path) -> None:
+        """The lock must exclude other processes, not just other threads."""
+        path = tmp_path / "kb_config.json"
+        workers = [
+            subprocess.Popen(
+                [sys.executable, "-c", _MP_WORKER_CODE, str(path), str(worker_id), str(_MP_ROUNDS)]
+            )
+            for worker_id in range(2)
+        ]
+        for proc in workers:
+            assert proc.wait(timeout=120) == 0
+
+        kbs = json.loads(path.read_text(encoding="utf-8"))["knowledge_bases"]
+        expected = {f"w{w}-{i}" for w in range(2) for i in range(_MP_ROUNDS)}
+        assert set(kbs) == expected
+
+
+_MP_ROUNDS = 10
+
+# Runs in a separate interpreter: hammer the shared config with distinct keys.
+_MP_WORKER_CODE = """
+import sys
+
+from deeptutor.knowledge.config_store import KBConfigStore
+
+config_path, worker_id, rounds = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+store = KBConfigStore(config_path)
+for i in range(rounds):
+    key = f"w{worker_id}-{i}"
+
+    def mutate(config, key=key):
+        config.setdefault("knowledge_bases", {})[key] = {"path": key}
+
+    store.transaction(mutate)
+"""
+
+
+def _stall_transactions(manager: KnowledgeBaseManager) -> tuple[threading.Event, threading.Event]:
+    """Make the manager's next transaction park inside the lock until released."""
+    entered = threading.Event()
+    release = threading.Event()
+    original = manager._store.transaction
+
+    def stalled(mutate):
+        def wrapped(config: dict):
+            entered.set()
+            assert release.wait(10)
+            return mutate(config)
+
+        return original(wrapped)
+
+    manager._store.transaction = stalled  # type: ignore[method-assign]
+    return entered, release
+
+
+class TestManagerAndServiceRaces:
+    def test_two_managers_concurrent_status_updates_both_persist(self, tmp_path: Path) -> None:
+        """The audit reproduction: manager A pauses mid-update while manager B
+        commits; A's commit used to erase B's entirely."""
+        base = tmp_path / "kbs"
+        first = KnowledgeBaseManager(base_dir=str(base))
+        second = KnowledgeBaseManager(base_dir=str(base))
+        entered, release = _stall_transactions(first)
+
+        t1 = threading.Thread(target=first.update_kb_status, args=("kb", "ready"))
+        t1.start()
+        assert entered.wait(10)
+
+        t2 = threading.Thread(
+            target=second.update_kb_status,
+            args=("other", "error", {"message": "second writer"}),
+        )
+        t2.start()
+        time.sleep(0.05)
+        release.set()
+        t1.join(10)
+        t2.join(10)
+
+        kbs = json.loads((base / "kb_config.json").read_text(encoding="utf-8"))["knowledge_bases"]
+        assert kbs["kb"]["status"] == "ready"
+        assert kbs["other"]["status"] == "error"
+
+    def test_manager_and_config_service_concurrent_writes_both_persist(
+        self, tmp_path: Path
+    ) -> None:
+        base = tmp_path / "kbs"
+        manager = KnowledgeBaseManager(base_dir=str(base))
+        service = KnowledgeBaseConfigService(config_path=base / "kb_config.json")
+        entered, release = _stall_transactions(manager)
+
+        t1 = threading.Thread(target=manager.update_kb_status, args=("kb", "ready"))
+        t1.start()
+        assert entered.wait(10)
+
+        t2 = threading.Thread(target=service.set_provider_mode, args=("lightrag", "mix"))
+        t2.start()
+        time.sleep(0.05)
+        release.set()
+        t1.join(10)
+        t2.join(10)
+
+        on_disk = json.loads((base / "kb_config.json").read_text(encoding="utf-8"))
+        assert on_disk["knowledge_bases"]["kb"]["status"] == "ready"
+        assert on_disk["defaults"]["provider_modes"]["lightrag"] == "mix"
+
+    def test_concurrent_registration_of_same_name_fails_second_writer(self, tmp_path: Path) -> None:
+        base = tmp_path / "kbs"
+        first = KnowledgeBaseManager(base_dir=str(base))
+        second = KnowledgeBaseManager(base_dir=str(base))
+        vault = tmp_path / "vault"
+        vault.mkdir()
+
+        first.register_obsidian_vault("Vault", str(vault))
+        with pytest.raises(ValueError, match="already exists"):
+            second.register_obsidian_vault("Vault", str(vault))
+
+    def test_manager_init_raises_on_corrupt_config(self, tmp_path: Path) -> None:
+        base = tmp_path / "kbs"
+        base.mkdir()
+        damaged = '{"knowledge_bases": {"kb": '
+        (base / "kb_config.json").write_text(damaged, encoding="utf-8")
+
+        with pytest.raises(KBConfigCorruptionError):
+            KnowledgeBaseManager(base_dir=str(base))
+
+        assert (base / "kb_config.json").read_text(encoding="utf-8") == damaged
+
+    def test_service_init_raises_on_corrupt_config(self, tmp_path: Path) -> None:
+        path = tmp_path / "kb_config.json"
+        path.write_text('{"defaults": ', encoding="utf-8")
+
+        with pytest.raises(KBConfigCorruptionError):
+            KnowledgeBaseConfigService(config_path=path)
+
+    def test_service_cache_updates_from_committed_snapshot(self, tmp_path: Path) -> None:
+        """A mutation must fold in changes other writers committed since the
+        service last read the file — the cache is the transaction's output,
+        not its input."""
+        path = tmp_path / "kb_config.json"
+        service = KnowledgeBaseConfigService(config_path=path)
+        manager = KnowledgeBaseManager(base_dir=str(tmp_path))
+        manager.update_kb_status("external", "ready")
+
+        service.set_provider_mode("lightrag", "mix")
+
+        assert "external" in service._config["knowledge_bases"]
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        assert "external" in on_disk["knowledge_bases"]
+        assert on_disk["defaults"]["provider_modes"]["lightrag"] == "mix"

--- a/tests/knowledge/test_kb_config_store.py
+++ b/tests/knowledge/test_kb_config_store.py
@@ -36,11 +36,19 @@ class TestStoreBasics:
         store = KBConfigStore(tmp_path / "kb_config.json")
         assert store.read() == {"knowledge_bases": {}}
 
-    def test_zero_byte_file_reads_as_default(self, tmp_path: Path) -> None:
+    def test_zero_byte_file_raises_and_is_preserved(self, tmp_path: Path) -> None:
+        """An empty file is the legacy truncate-crash artifact, not a fresh
+        install — rebuilding a default over it would hide the damage."""
         path = tmp_path / "kb_config.json"
         path.write_text("", encoding="utf-8")
         store = KBConfigStore(path)
-        assert store.read() == {"knowledge_bases": {}}
+
+        with pytest.raises(KBConfigCorruptionError, match="empty"):
+            store.read()
+        with pytest.raises(KBConfigCorruptionError, match="empty"):
+            store.transaction(lambda config: config.update(marker=1))
+
+        assert path.read_text(encoding="utf-8") == ""
 
     def test_invalid_json_raises_and_preserves_file(self, tmp_path: Path) -> None:
         path = tmp_path / "kb_config.json"
@@ -357,6 +365,30 @@ class TestManagerAndServiceRaces:
 
         with pytest.raises(KBConfigCorruptionError):
             KnowledgeBaseConfigService(config_path=path)
+
+    def test_legacy_default_field_removal_is_committed(self, tmp_path: Path) -> None:
+        """Migrating away the legacy top-level ``default`` field must be
+        persisted — an in-memory-only pop meant every later transaction read
+        the raw file and faithfully wrote the stale field back."""
+        base = tmp_path / "kbs"
+        base.mkdir()
+        (base / "kb").mkdir()
+        seed = {
+            "default": "legacy-kb",
+            "knowledge_bases": {
+                "kb": {"path": "kb", "description": "", "rag_provider": "llamaindex"}
+            },
+        }
+        (base / "kb_config.json").write_text(json.dumps(seed), encoding="utf-8")
+
+        manager = KnowledgeBaseManager(base_dir=str(base))
+        on_disk = json.loads((base / "kb_config.json").read_text(encoding="utf-8"))
+        assert "default" not in on_disk
+
+        manager.update_kb_status("kb", "processing")
+        on_disk = json.loads((base / "kb_config.json").read_text(encoding="utf-8"))
+        assert "default" not in on_disk
+        assert on_disk["knowledge_bases"]["kb"]["status"] == "processing"
 
     def test_service_cache_updates_from_committed_snapshot(self, tmp_path: Path) -> None:
         """A mutation must fold in changes other writers committed since the

--- a/tests/knowledge/test_kb_config_store.py
+++ b/tests/knowledge/test_kb_config_store.py
@@ -18,7 +18,6 @@ from pathlib import Path
 import subprocess
 import sys
 import threading
-import time
 
 import pytest
 
@@ -70,6 +69,23 @@ class TestStoreBasics:
         with pytest.raises(KBConfigCorruptionError):
             KBConfigStore(path).read()
 
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"knowledge_bases": []},
+            {"defaults": []},
+            {"knowledge_bases": None},
+            {"_deleted_knowledge_bases": []},
+        ],
+    )
+    def test_invalid_top_level_sections_raise(self, tmp_path: Path, payload: dict) -> None:
+        path = tmp_path / "kb_config.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(KBConfigCorruptionError):
+            KBConfigStore(path).read()
+        assert json.loads(path.read_text(encoding="utf-8")) == payload
+
     def test_transaction_commits_and_returns_result(self, tmp_path: Path) -> None:
         path = tmp_path / "kb_config.json"
         store = KBConfigStore(path)
@@ -83,6 +99,21 @@ class TestStoreBasics:
         assert state["knowledge_bases"]["kb"] == {"path": "kb"}
         on_disk = json.loads(path.read_text(encoding="utf-8"))
         assert on_disk == state
+
+    def test_legacy_default_is_migrated_without_losing_its_value(self, tmp_path: Path) -> None:
+        path = tmp_path / "kb_config.json"
+        path.write_text(
+            json.dumps({"knowledge_bases": {"legacy": {"path": "legacy"}}, "default": "legacy"}),
+            encoding="utf-8",
+        )
+        (tmp_path / "legacy").mkdir()
+
+        manager = KnowledgeBaseManager(base_dir=str(tmp_path))
+
+        assert manager.get_default() == "legacy"
+        persisted = json.loads(path.read_text(encoding="utf-8"))
+        assert "default" not in persisted
+        assert persisted["defaults"]["default_kb"] == "legacy"
 
     def test_mutator_exception_writes_nothing_and_releases_lock(self, tmp_path: Path) -> None:
         path = tmp_path / "kb_config.json"
@@ -173,7 +204,9 @@ class TestStoreBasics:
 
 
 class TestStoreConcurrency:
-    def test_second_writer_blocks_and_neither_update_is_lost(self, tmp_path: Path) -> None:
+    def test_second_writer_blocks_and_neither_update_is_lost(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """The historic lost-update: writer B commits while writer A holds a
         pre-B snapshot, then A commits and erases B. With the lock spanning
         read-modify-write, B cannot even read until A commits."""
@@ -192,12 +225,27 @@ class TestStoreConcurrency:
         t1.start()
         assert entered.wait(10)
 
-        t2 = threading.Thread(
-            target=second.transaction,
-            args=(lambda config: config["knowledge_bases"].update(second={"path": "second"}),),
-        )
+        second_started = threading.Event()
+        second_attempted_lock = threading.Event()
+        original_try_lock = config_store_module._try_lock_exclusive
+
+        def observe_second_lock_attempt(fd: int) -> bool:
+            if second_started.is_set():
+                second_attempted_lock.set()
+            return original_try_lock(fd)
+
+        monkeypatch.setattr(config_store_module, "_try_lock_exclusive", observe_second_lock_attempt)
+
+        def second_transaction() -> None:
+            second_started.set()
+            second.transaction(
+                lambda config: config["knowledge_bases"].update(second={"path": "second"})
+            )
+
+        t2 = threading.Thread(target=second_transaction)
         t2.start()
-        time.sleep(0.05)  # give t2 the chance to (wrongly) slip past the lock
+        assert second_started.wait(10)
+        assert second_attempted_lock.wait(10)
         release.set()
         t1.join(10)
         t2.join(10)
@@ -288,7 +336,9 @@ def _stall_transactions(manager: KnowledgeBaseManager) -> tuple[threading.Event,
 
 
 class TestManagerAndServiceRaces:
-    def test_two_managers_concurrent_status_updates_both_persist(self, tmp_path: Path) -> None:
+    def test_two_managers_concurrent_status_updates_both_persist(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """The audit reproduction: manager A pauses mid-update while manager B
         commits; A's commit used to erase B's entirely."""
         base = tmp_path / "kbs"
@@ -300,12 +350,25 @@ class TestManagerAndServiceRaces:
         t1.start()
         assert entered.wait(10)
 
-        t2 = threading.Thread(
-            target=second.update_kb_status,
-            args=("other", "error", {"message": "second writer"}),
-        )
+        second_started = threading.Event()
+        second_attempted_lock = threading.Event()
+        original_try_lock = config_store_module._try_lock_exclusive
+
+        def observe_second_lock_attempt(fd: int) -> bool:
+            if second_started.is_set():
+                second_attempted_lock.set()
+            return original_try_lock(fd)
+
+        monkeypatch.setattr(config_store_module, "_try_lock_exclusive", observe_second_lock_attempt)
+
+        def second_update() -> None:
+            second_started.set()
+            second.update_kb_status("other", "error", {"message": "second writer"})
+
+        t2 = threading.Thread(target=second_update)
         t2.start()
-        time.sleep(0.05)
+        assert second_started.wait(10)
+        assert second_attempted_lock.wait(10)
         release.set()
         t1.join(10)
         t2.join(10)
@@ -315,7 +378,7 @@ class TestManagerAndServiceRaces:
         assert kbs["other"]["status"] == "error"
 
     def test_manager_and_config_service_concurrent_writes_both_persist(
-        self, tmp_path: Path
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         base = tmp_path / "kbs"
         manager = KnowledgeBaseManager(base_dir=str(base))
@@ -326,9 +389,27 @@ class TestManagerAndServiceRaces:
         t1.start()
         assert entered.wait(10)
 
-        t2 = threading.Thread(target=service.set_provider_mode, args=("lightrag", "mix"))
+        service_started = threading.Event()
+        service_attempted_lock = threading.Event()
+        original_try_lock = config_store_module._try_lock_exclusive
+
+        def observe_service_lock_attempt(fd: int) -> bool:
+            if service_started.is_set():
+                service_attempted_lock.set()
+            return original_try_lock(fd)
+
+        monkeypatch.setattr(
+            config_store_module, "_try_lock_exclusive", observe_service_lock_attempt
+        )
+
+        def service_update() -> None:
+            service_started.set()
+            service.set_provider_mode("lightrag", "mix")
+
+        t2 = threading.Thread(target=service_update)
         t2.start()
-        time.sleep(0.05)
+        assert service_started.wait(10)
+        assert service_attempted_lock.wait(10)
         release.set()
         t1.join(10)
         t2.join(10)
@@ -384,10 +465,12 @@ class TestManagerAndServiceRaces:
         manager = KnowledgeBaseManager(base_dir=str(base))
         on_disk = json.loads((base / "kb_config.json").read_text(encoding="utf-8"))
         assert "default" not in on_disk
+        assert on_disk["defaults"]["default_kb"] == "legacy-kb"
 
         manager.update_kb_status("kb", "processing")
         on_disk = json.loads((base / "kb_config.json").read_text(encoding="utf-8"))
         assert "default" not in on_disk
+        assert on_disk["defaults"]["default_kb"] == "legacy-kb"
         assert on_disk["knowledge_bases"]["kb"]["status"] == "processing"
 
     def test_service_cache_updates_from_committed_snapshot(self, tmp_path: Path) -> None:

--- a/tests/knowledge/test_linked_folder_sync.py
+++ b/tests/knowledge/test_linked_folder_sync.py
@@ -13,7 +13,8 @@ from pathlib import Path
 
 import pytest
 
-from deeptutor.knowledge.manager import KnowledgeBaseManager, _write_json_atomic
+from deeptutor.knowledge.config_store import write_json_atomic
+from deeptutor.knowledge.manager import KnowledgeBaseManager
 
 
 def _manager_with_linked_folder(tmp_path: Path) -> tuple[KnowledgeBaseManager, Path, str, Path]:
@@ -65,7 +66,7 @@ def test_write_json_atomic_preserves_original_on_failure(tmp_path: Path) -> None
     target.write_text('{"ok": true}', encoding="utf-8")
 
     with pytest.raises(TypeError):
-        _write_json_atomic(target, {"bad": object()})
+        write_json_atomic(target, {"bad": object()})
 
     assert json.loads(target.read_text(encoding="utf-8")) == {"ok": True}
     # The failed write must not litter temp files next to the target.

--- a/tests/knowledge/test_linked_folder_sync.py
+++ b/tests/knowledge/test_linked_folder_sync.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import threading
 
 import pytest
 
-from deeptutor.knowledge.config_store import write_json_atomic
+from deeptutor.knowledge.config_store import KBConfigStore, write_json_atomic
 from deeptutor.knowledge.manager import KnowledgeBaseManager
+from deeptutor.knowledge.metadata_store import get_metadata_store
 
 
 def _manager_with_linked_folder(tmp_path: Path) -> tuple[KnowledgeBaseManager, Path, str, Path]:
@@ -59,6 +61,102 @@ def test_update_folder_sync_state_unknown_folder_writes_nothing(tmp_path: Path) 
     manager.update_folder_sync_state("kb", "no-such-id", [str(doc)])
 
     assert metadata_file.read_bytes() == before
+
+
+def test_concurrent_folder_links_keep_both_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manager, metadata_file, _folder_id, _doc = _manager_with_linked_folder(tmp_path)
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "first.md").write_text("one", encoding="utf-8")
+    (second / "second.md").write_text("two", encoding="utf-8")
+
+    entered = threading.Event()
+    release = threading.Event()
+    original = KBConfigStore.transaction
+
+    def stall_first_metadata_transaction(self, mutate):
+        if self.config_path == metadata_file and not entered.is_set():
+
+            def stalled(metadata):
+                entered.set()
+                assert release.wait(10)
+                return mutate(metadata)
+
+            return original(self, stalled)
+        return original(self, mutate)
+
+    monkeypatch.setattr(KBConfigStore, "transaction", stall_first_metadata_transaction)
+    failures: list[BaseException] = []
+
+    def link(path: Path) -> None:
+        try:
+            manager.link_folder("kb", str(path))
+        except BaseException as exc:  # pragma: no cover - assertion diagnostic
+            failures.append(exc)
+
+    one = threading.Thread(target=link, args=(first,))
+    two = threading.Thread(target=link, args=(second,))
+    one.start()
+    assert entered.wait(10)
+    two.start()
+    release.set()
+    one.join(10)
+    two.join(10)
+
+    assert not failures
+    assert not one.is_alive() and not two.is_alive()
+    on_disk = json.loads(metadata_file.read_text(encoding="utf-8"))
+    assert {item["path"] for item in on_disk["linked_folders"]} == {
+        str((tmp_path / "notes").resolve()),
+        str(first.resolve()),
+        str(second.resolve()),
+    }
+
+
+def test_metadata_store_preserves_unrelated_metadata_updates(tmp_path: Path) -> None:
+    """Metadata writers share one serialized read-modify-write primitive."""
+    metadata_file = tmp_path / "metadata.json"
+    first = get_metadata_store(metadata_file)
+    second = get_metadata_store(metadata_file)
+    entered = threading.Event()
+    release = threading.Event()
+
+    def slow_mutate(metadata: dict) -> None:
+        metadata["linked_folders"] = [{"id": "folder"}]
+        entered.set()
+        assert release.wait(10)
+
+    thread = threading.Thread(target=first.transaction, args=(slow_mutate,))
+    thread.start()
+    assert entered.wait(10)
+
+    second_thread = threading.Thread(
+        target=second.transaction,
+        args=(lambda metadata: metadata.setdefault("file_hashes", {}).update({"note.md": "hash"}),),
+    )
+    second_thread.start()
+    release.set()
+    thread.join(10)
+    second_thread.join(10)
+
+    assert not thread.is_alive() and not second_thread.is_alive()
+    assert json.loads(metadata_file.read_text(encoding="utf-8")) == {
+        "linked_folders": [{"id": "folder"}],
+        "file_hashes": {"note.md": "hash"},
+    }
+
+
+def test_metadata_store_never_recreates_a_deleted_kb_directory(tmp_path: Path) -> None:
+    metadata_file = tmp_path / "deleted-kb" / "metadata.json"
+
+    with pytest.raises(FileNotFoundError):
+        get_metadata_store(metadata_file).transaction(lambda metadata: metadata.update(ok=True))
+
+    assert not metadata_file.parent.exists()
 
 
 def test_write_json_atomic_preserves_original_on_failure(tmp_path: Path) -> None:

--- a/tests/knowledge/test_manager_delete.py
+++ b/tests/knowledge/test_manager_delete.py
@@ -13,11 +13,13 @@ def _create_kb(manager: KnowledgeBaseManager, name: str) -> Path:
     (kb_dir / "raw").mkdir(parents=True, exist_ok=True)
     (kb_dir / "version-1").mkdir(parents=True, exist_ok=True)
     (kb_dir / "version-1" / "docstore.json").write_text("{}", encoding="utf-8")
-    manager.config.setdefault("knowledge_bases", {})[name] = {
+    entry = {
         "path": name,
         "description": "",
     }
-    manager._save_config()
+    manager._mutate_config(
+        lambda config: config.setdefault("knowledge_bases", {}).update({name: entry})
+    )
     return kb_dir
 
 

--- a/tests/knowledge/test_manager_delete.py
+++ b/tests/knowledge/test_manager_delete.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import threading
 
 import pytest
 
+from deeptutor.knowledge.initializer import KnowledgeBaseInitializer
 from deeptutor.knowledge.manager import KnowledgeBaseManager
 
 
@@ -37,6 +39,115 @@ def test_delete_knowledge_base_removes_config_and_directory(tmp_path: Path) -> N
     assert "demo" not in _read_config(manager.config_file).get("knowledge_bases", {})
 
 
+def test_delete_knowledge_base_replaces_canonical_default(tmp_path: Path) -> None:
+    manager = KnowledgeBaseManager(base_dir=str(tmp_path))
+    _create_kb(manager, "first")
+    _create_kb(manager, "second")
+    manager._mutate_config(
+        lambda config: config.setdefault("defaults", {}).update({"default_kb": "first"})
+    )
+
+    assert manager.delete_knowledge_base("first", confirm=True) is True
+
+    persisted = _read_config(manager.config_file)
+    assert persisted["defaults"]["default_kb"] == "second"
+
+
+def test_custom_base_dir_uses_its_own_canonical_default(tmp_path: Path) -> None:
+    manager = KnowledgeBaseManager(base_dir=str(tmp_path / "isolated-kbs"))
+    _create_kb(manager, "alpha")
+    _create_kb(manager, "zeta")
+
+    manager.set_default("zeta")
+
+    assert manager.get_default() == "zeta"
+    assert manager.get_knowledge_base_path() == manager.base_dir / "zeta"
+
+
+def test_late_status_update_does_not_resurrect_deleted_kb(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = tmp_path / "kbs"
+    deleter = KnowledgeBaseManager(base_dir=str(base))
+    updater = KnowledgeBaseManager(base_dir=str(base))
+    _create_kb(deleter, "demo")
+
+    removed_from_config = threading.Event()
+    release_delete = threading.Event()
+    original_mutate = deleter._mutate_config
+
+    def pause_after_delete_commit(mutate):
+        result = original_mutate(mutate)
+        removed_from_config.set()
+        assert release_delete.wait(10)
+        return result
+
+    monkeypatch.setattr(deleter, "_mutate_config", pause_after_delete_commit)
+    delete_thread = threading.Thread(
+        target=deleter.delete_knowledge_base,
+        args=("demo",),
+        kwargs={"confirm": True},
+    )
+    delete_thread.start()
+    assert removed_from_config.wait(10)
+
+    updater.update_kb_status("demo", "initializing", {"stage": "initializing"})
+    release_delete.set()
+    delete_thread.join(10)
+
+    assert not delete_thread.is_alive()
+    persisted = _read_config(deleter.config_file)
+    assert "demo" not in persisted.get("knowledge_bases", {})
+    assert "demo" in persisted["_deleted_knowledge_bases"]
+
+
+def test_explicit_recreate_clears_delete_tombstone(tmp_path: Path) -> None:
+    manager = KnowledgeBaseManager(base_dir=str(tmp_path))
+    _create_kb(manager, "demo")
+    assert manager.delete_knowledge_base("demo", confirm=True) is True
+
+    manager.update_kb_status("demo", "initializing", allow_recreate=True)
+
+    persisted = _read_config(manager.config_file)
+    assert "demo" in persisted["knowledge_bases"]
+    assert "demo" not in persisted["_deleted_knowledge_bases"]
+
+
+def test_stale_initializer_cannot_clear_delete_tombstone(tmp_path: Path) -> None:
+    manager = KnowledgeBaseManager(base_dir=str(tmp_path))
+    _create_kb(manager, "demo")
+    assert manager.delete_knowledge_base("demo", confirm=True) is True
+
+    # Models an initializer queued before deletion and only reaching its
+    # directory/registration step afterward.
+    with pytest.raises(ValueError, match="was deleted"):
+        KnowledgeBaseInitializer(
+            kb_name="demo", base_dir=str(tmp_path)
+        ).create_directory_structure()
+
+    persisted = _read_config(manager.config_file)
+    assert "demo" not in persisted["knowledge_bases"]
+    assert "demo" in persisted["_deleted_knowledge_bases"]
+    assert not (tmp_path / "demo").exists()
+
+
+def test_old_initializer_generation_cannot_write_new_same_name_kb(tmp_path: Path) -> None:
+    manager = KnowledgeBaseManager(base_dir=str(tmp_path))
+    manager.update_kb_status("demo", "initializing", allow_recreate=True)
+    old = KnowledgeBaseInitializer(kb_name="demo", base_dir=str(tmp_path), rag_provider="graphrag")
+    old.create_directory_structure()
+
+    assert manager.delete_knowledge_base("demo", confirm=True) is True
+    manager.update_kb_status("demo", "initializing", allow_recreate=True)
+    new = KnowledgeBaseInitializer(
+        kb_name="demo", base_dir=str(tmp_path), rag_provider="llamaindex"
+    )
+    new.create_directory_structure()
+
+    with pytest.raises(ValueError, match="recreated"):
+        old._update_metadata_with_provider("graphrag")
+
+
 def test_delete_knowledge_base_clears_config_when_rmtree_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -66,6 +177,9 @@ def test_delete_knowledge_base_clears_config_when_rmtree_fails(
 
     assert manager.delete_knowledge_base("broken", confirm=True) is True
     assert "broken" not in _read_config(manager.config_file).get("knowledge_bases", {})
+    # The intentionally orphaned directory may still look indexable; it must
+    # not be auto-discovered again after the delete committed its tombstone.
+    assert "broken" not in manager.list_knowledge_bases()
 
 
 def test_delete_knowledge_base_removes_orphan_config_when_directory_missing(

--- a/tests/knowledge/test_manager_embedding_flags.py
+++ b/tests/knowledge/test_manager_embedding_flags.py
@@ -79,11 +79,13 @@ def test_ready_version_without_active_signature_marks_reindex(
     )
 
     manager = KnowledgeBaseManager(base_dir=str(tmp_path))
-    manager.config.setdefault("knowledge_bases", {})["old-kb"] = {
+    entry = {
         "path": "old-kb",
         "rag_provider": "llamaindex",
     }
-    manager._save_config()
+    manager._mutate_config(
+        lambda config: config.setdefault("knowledge_bases", {}).update({"old-kb": entry})
+    )
 
     reloaded = KnowledgeBaseManager(base_dir=str(tmp_path))
     entry = reloaded.config["knowledge_bases"]["old-kb"]

--- a/tests/knowledge/test_manager_get_info_status.py
+++ b/tests/knowledge/test_manager_get_info_status.py
@@ -229,12 +229,14 @@ def test_ready_lightrag_with_failed_doc_status_reports_error(
         encoding="utf-8",
     )
     manager = KnowledgeBaseManager(base_dir=str(tmp_path))
-    manager.config.setdefault("knowledge_bases", {})["kb-lightrag"] = {
+    entry = {
         "path": "kb-lightrag",
         "rag_provider": "lightrag",
         "status": "ready",
     }
-    manager._save_config()
+    manager._mutate_config(
+        lambda config: config.setdefault("knowledge_bases", {}).update({"kb-lightrag": entry})
+    )
 
     info = KnowledgeBaseManager(base_dir=str(tmp_path)).get_info("kb-lightrag")
     assert info["status"] == "error"

--- a/tests/knowledge/test_manager_list.py
+++ b/tests/knowledge/test_manager_list.py
@@ -21,12 +21,14 @@ def _seed_kb(manager: KnowledgeBaseManager, name: str) -> Path:
     (kb_dir / "raw").mkdir(parents=True, exist_ok=True)
     (kb_dir / "version-1").mkdir(parents=True, exist_ok=True)
     (kb_dir / "version-1" / "docstore.json").write_text("{}", encoding="utf-8")
-    manager.config.setdefault("knowledge_bases", {})[name] = {
+    entry = {
         "path": name,
         "description": "",
         "status": "ready",
     }
-    manager._save_config()
+    manager._mutate_config(
+        lambda config: config.setdefault("knowledge_bases", {}).update({name: entry})
+    )
     return kb_dir
 
 
@@ -62,12 +64,14 @@ def test_list_keeps_recent_entry_with_missing_dir(tmp_path: Path) -> None:
     a recent ``updated_at`` keeps it in the list.
     """
     manager = KnowledgeBaseManager(base_dir=str(tmp_path))
-    manager.config.setdefault("knowledge_bases", {})["in-flight"] = {
+    entry = {
         "path": "in-flight",
         "status": "initializing",
         "updated_at": datetime.now().isoformat(),
     }
-    manager._save_config()
+    manager._mutate_config(
+        lambda config: config.setdefault("knowledge_bases", {}).update({"in-flight": entry})
+    )
 
     assert manager.list_knowledge_bases() == ["in-flight"]
     assert "in-flight" in _read_config(manager.config_file).get("knowledge_bases", {})

--- a/tests/knowledge/test_obsidian_kb.py
+++ b/tests/knowledge/test_obsidian_kb.py
@@ -15,7 +15,7 @@ from deeptutor.knowledge.manager import KnowledgeBaseManager
 
 
 def _seed_obsidian(manager: KnowledgeBaseManager, name: str, vault_path: str) -> None:
-    manager.config.setdefault("knowledge_bases", {})[name] = {
+    entry = {
         "type": "obsidian",
         "vault_path": vault_path,
         "description": "Connected vault",
@@ -23,7 +23,9 @@ def _seed_obsidian(manager: KnowledgeBaseManager, name: str, vault_path: str) ->
         # rewrite + flag for reindex — must be left alone for obsidian entries.
         "rag_provider": "pageindex",
     }
-    manager._save_config()
+    manager._mutate_config(
+        lambda config: config.setdefault("knowledge_bases", {}).update({name: entry})
+    )
 
 
 def test_obsidian_entry_survives_orphan_prune(tmp_path: Path) -> None:
@@ -70,8 +72,11 @@ def test_ordinary_kb_metadata_has_no_vault_fields(tmp_path: Path) -> None:
     kb_dir = manager.base_dir / "plain"
     (kb_dir / "version-1").mkdir(parents=True)
     (kb_dir / "version-1" / "docstore.json").write_text("{}", encoding="utf-8")
-    manager.config.setdefault("knowledge_bases", {})["plain"] = {"path": "plain", "status": "ready"}
-    manager._save_config()
+    manager._mutate_config(
+        lambda config: config.setdefault("knowledge_bases", {}).update(
+            {"plain": {"path": "plain", "status": "ready"}}
+        )
+    )
 
     meta = manager.get_metadata("plain")
     assert "type" not in meta and "vault_path" not in meta

--- a/tests/services/config/test_knowledge_base_config.py
+++ b/tests/services/config/test_knowledge_base_config.py
@@ -228,3 +228,20 @@ class TestPersistence:
         assert fresh_service.get_default_kb() == "primary"
         fresh_service.set_default_kb(None)
         assert fresh_service.get_default_kb() is None
+
+    def test_delete_kb_config_replaces_default(self, fresh_service) -> None:
+        fresh_service.set_kb_config("first", {"path": "first"})
+        fresh_service.set_kb_config("second", {"path": "second"})
+        fresh_service.set_default_kb("first")
+
+        fresh_service.delete_kb_config("first")
+
+        assert fresh_service.get_default_kb() == "second"
+
+    def test_late_service_update_does_not_resurrect_deleted_kb(self, fresh_service) -> None:
+        fresh_service.set_kb_config("demo", {"path": "demo"})
+        fresh_service.delete_kb_config("demo")
+
+        fresh_service.set_kb_config("demo", {"rag_provider": "graphrag"})
+
+        assert "demo" not in fresh_service.get_all_configs()["knowledge_bases"]

--- a/tests/services/partners/test_partner_workspace.py
+++ b/tests/services/partners/test_partner_workspace.py
@@ -175,6 +175,44 @@ class TestInventoryAndRemoval:
         with pytest.raises(ValueError):
             remove_asset("ada", "skill", "../escape")
 
+    def test_remove_kb_prunes_only_its_config_entry(self, partners_root):
+        """The prune goes through KBConfigStore now — unrelated entries must
+        survive and the file must never pass through a truncated state."""
+        admin_root = partners_root.parent
+        _seed_admin_kb(admin_root)
+        provision_assets("ada", knowledge_bases=["physics"])
+        config_file = partners_root / "ada" / "workspace" / "knowledge_bases" / "kb_config.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "knowledge_bases": {
+                        "physics": {"path": "physics"},
+                        "chemistry": {"path": "chemistry"},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert remove_asset("ada", "knowledge_base", "physics") is True
+
+        config = json.loads(config_file.read_text(encoding="utf-8"))
+        assert "physics" not in config["knowledge_bases"]
+        assert "chemistry" in config["knowledge_bases"]
+
+    def test_remove_kb_leaves_corrupt_config_untouched(self, partners_root):
+        admin_root = partners_root.parent
+        _seed_admin_kb(admin_root)
+        provision_assets("ada", knowledge_bases=["physics"])
+        config_file = partners_root / "ada" / "workspace" / "knowledge_bases" / "kb_config.json"
+        damaged = '{"knowledge_bases": {"physics": '
+        config_file.write_text(damaged, encoding="utf-8")
+
+        # Directory removal still succeeds; the damaged config is preserved
+        # instead of being replaced by a rebuilt default.
+        assert remove_asset("ada", "knowledge_base", "physics") is True
+        assert config_file.read_text(encoding="utf-8") == damaged
+
 
 class TestStripFrontmatter:
     def test_strips_yaml_block(self):

--- a/tests/services/rag/test_kb_config_readers.py
+++ b/tests/services/rag/test_kb_config_readers.py
@@ -1,0 +1,93 @@
+"""Corrupt ``kb_config.json`` must surface through the RAG readers.
+
+These resolvers used to swallow every parse/I/O error and fall back to their
+defaults, so a damaged config silently rebound a KB to the default provider,
+dropped its configured retrieval mode, or resolved a linked KB to a
+non-existent local folder. Only a *missing* file may fall back.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from deeptutor.knowledge.config_store import KBConfigCorruptionError
+from deeptutor.services.rag.kb_paths import resolve_kb_dir
+from deeptutor.services.rag.pipelines.modes import resolve_kb_mode
+from deeptutor.services.rag.provider_binding import (
+    load_kb_config_entry,
+    resolve_bound_provider,
+)
+
+
+@pytest.fixture
+def corrupt_base(tmp_path: Path) -> Path:
+    (tmp_path / "kb_config.json").write_text('{"knowledge_bases": {"kb": ', encoding="utf-8")
+    return tmp_path
+
+
+class TestCorruptConfigRaises:
+    def test_load_kb_config_entry(self, corrupt_base: Path) -> None:
+        with pytest.raises(KBConfigCorruptionError):
+            load_kb_config_entry(corrupt_base, "kb")
+
+    def test_resolve_bound_provider(self, corrupt_base: Path) -> None:
+        with pytest.raises(KBConfigCorruptionError):
+            resolve_bound_provider(corrupt_base, "kb")
+
+    def test_resolve_kb_dir(self, corrupt_base: Path) -> None:
+        with pytest.raises(KBConfigCorruptionError):
+            resolve_kb_dir(corrupt_base, "kb")
+
+    def test_resolve_kb_mode(self, corrupt_base: Path) -> None:
+        with pytest.raises(KBConfigCorruptionError):
+            resolve_kb_mode(
+                corrupt_base, "kb", "lightrag", supported=["hybrid", "mix"], default="hybrid"
+            )
+
+    def test_zero_byte_config_raises_too(self, tmp_path: Path) -> None:
+        (tmp_path / "kb_config.json").write_text("", encoding="utf-8")
+        with pytest.raises(KBConfigCorruptionError):
+            resolve_bound_provider(tmp_path, "kb")
+
+
+class TestMissingConfigStillFallsBack:
+    def test_provider_defaults(self, tmp_path: Path) -> None:
+        assert resolve_bound_provider(tmp_path, "kb") == "llamaindex"
+        assert load_kb_config_entry(tmp_path, "kb") == {}
+
+    def test_kb_dir_uses_conventional_layout(self, tmp_path: Path) -> None:
+        assert resolve_kb_dir(tmp_path, "kb") == tmp_path / "kb"
+
+    def test_mode_uses_engine_default(self, tmp_path: Path) -> None:
+        mode = resolve_kb_mode(
+            tmp_path, "kb", "lightrag", supported=["hybrid", "mix"], default="hybrid"
+        )
+        assert mode == "hybrid"
+
+
+class TestValidConfigStillResolves:
+    def test_provider_mode_and_linked_path(self, tmp_path: Path) -> None:
+        external = tmp_path / "external"
+        external.mkdir()
+        (tmp_path / "kb_config.json").write_text(
+            json.dumps(
+                {
+                    "defaults": {"provider_modes": {"lightrag": "mix"}},
+                    "knowledge_bases": {
+                        "kb": {"path": "kb", "rag_provider": "graphrag"},
+                        "linked": {"type": "linked", "external_path": str(external)},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert resolve_bound_provider(tmp_path, "kb") == "graphrag"
+        assert resolve_kb_dir(tmp_path, "linked") == external
+        mode = resolve_kb_mode(
+            tmp_path, "kb", "lightrag", supported=["hybrid", "mix"], default="hybrid"
+        )
+        assert mode == "mix"

--- a/tests/services/rag/test_kb_config_readers.py
+++ b/tests/services/rag/test_kb_config_readers.py
@@ -52,6 +52,13 @@ class TestCorruptConfigRaises:
         with pytest.raises(KBConfigCorruptionError):
             resolve_bound_provider(tmp_path, "kb")
 
+    def test_schema_corrupt_config_raises_too(self, tmp_path: Path) -> None:
+        (tmp_path / "kb_config.json").write_text(
+            json.dumps({"knowledge_bases": []}), encoding="utf-8"
+        )
+        with pytest.raises(KBConfigCorruptionError):
+            resolve_bound_provider(tmp_path, "kb")
+
 
 class TestMissingConfigStillFallsBack:
     def test_provider_defaults(self, tmp_path: Path) -> None:


### PR DESCRIPTION
### Description
`kb_config.json` is mutated by two independent writers — `KnowledgeBaseManager` and `KnowledgeBaseConfigService` — and neither held a lock across its full read-modify-write cycle. Concretely:

- **Lost updates.** Each writer loaded the file, mutated its in-memory snapshot, and dumped the whole snapshot back. If writer B committed while writer A was between its read and its write, A's commit erased B's change entirely. This affects status updates, registrations, provider/default changes, orphan pruning, and deletions.
- **Torn reads / truncate-before-lock.** `_save_config()` opened the file with `"w"` (truncating it) *before* acquiring its lock, and the service's `_save()` had no lock at all. A reader entering that window saw an empty file, `_load_config()` silently fell back to `{"knowledge_bases": {}}`, and the next mutation persisted that empty fallback over the previously valid config. A crash between truncate and write left the same empty file behind permanently.
- **Silent corruption recovery.** Any parse error was swallowed into a mutable default payload, so a damaged-but-recoverable file could be overwritten by the next write.

This PR routes every mutation of `kb_config.json` through a single new `KBConfigStore` (`deeptutor/knowledge/config_store.py`, stdlib-only):

- One exclusive lock on a **stable sidecar** (`.kb_config.json.lock`) held across read → mutate → write. A sidecar is required because `os.replace` swaps the data file's inode on every commit, so a lock on the data file itself would not exclude writers that open the new inode. Acquisition polls a non-blocking attempt against a bounded deadline (`TimeoutError` on expiry), which also maps cleanly onto Windows' non-blocking `msvcrt.locking(LK_NBLCK)` semantics.
- Commits write a **unique same-directory temp file + `fsync` + `os.replace`**. Readers — locked or not — only ever observe the previous or the new snapshot, never a truncated or partial file, and a crash mid-write cannot damage the current config.
- A file that exists but does not parse raises a dedicated `KBConfigCorruptionError` and is left untouched. This includes a zero-byte file — the artifact the legacy truncate-crash leaves behind — since rebuilding a default over it would hide the damage. Only a missing file bootstraps the default payload.

Both writer classes were refactored onto the store: all `KnowledgeBaseManager` mutators (status updates, all five registration paths, orphan pruning + auto-discovery in `list_knowledge_bases`, deletion, load-time migration) and all `KnowledgeBaseConfigService` mutators (`set_kb_config`, `set_provider_mode`, `set_global_defaults`, `set_default_kb`, `delete_kb_config`) now run their read-modify-write inside one transaction, and their caches are updated from the committed snapshot rather than written from a possibly-stale one. The remaining direct writers found outside those classes — `initializer.py`, two spots in the knowledge router, and the partner-workspace KB prune in `remove_asset` (which shares its `kb_config.json` with the partner-side manager) — were moved onto transactions as well; no direct writer to any `kb_config.json` remains. The legacy top-level `"default"` field migration is now actually committed, so later transactions can no longer write the stale field back.

Slow work is kept **outside** the lock by construction: directory scans and metadata probing for auto-discovery, embedding fingerprint/index-version probes for "ready" status, `shutil.rmtree` in deletion, and the best-effort PocketBase mirror all run before or after the transaction, never inside it.

Adversarial review of the store surfaced a second family of lifecycle races, fixed here as well. Per-KB `metadata.json` writers (folder link/unlink, sync state, document hashes, initializer/reindex stamps) now share the same sidecar-lock transaction + atomic-replace primitive, so concurrent metadata writers no longer lose each other's updates or tear the file. Deleting a KB repoints the canonical `defaults.default_kb` (the legacy top-level `default` migration also preserves its value now instead of dropping it), and leaves a durable tombstone plus per-KB creation generations: a late status/progress/initializer write queued before the delete can no longer resurrect the KB or write into a same-name successor, and auto-discovery skips tombstoned orphan directories. Explicit recreation clears the marker. Create/delete filesystem transitions serialize on a per-KB lifecycle lock, so a slow `rmtree` cannot interleave with recreation without blocking unrelated config transactions.

The query-time readers were brought under the same corruption contract. `resolve_bound_provider` (provider binding), `resolve_kb_mode` (retrieval mode), and `resolve_kb_dir` (linked-KB external pointer) used to swallow every parse error, so a corrupt config silently rebound the KB to the default provider, dropped its configured mode, or resolved a linked KB to a non-existent local folder with empty results. They now read through `KBConfigStore.read()`: a missing file falls back exactly as before; a file that exists but does not parse raises `KBConfigCorruptionError`. The llamaindex embedding-mismatch banner keeps its never-fail-the-search contract but logs the corruption instead of hiding it.

### Related Issues
- None (follow-up to #619, which this branch is based on — that commit is included here and should merge first)

### Module(s) Affected
- [ ] `agents`
- [x] `api`
- [ ] `config`
- [ ] `core`
- [x] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
`tests/knowledge/test_kb_config_store.py` pins the store contract: lost-update prevention across two threads and across two OS processes, mid-transaction readers seeing only complete snapshots, corruption (invalid JSON, zero-byte, and wrong-shaped sections alike) raising while preserving the damaged file byte-for-byte, the legacy `"default"` migration keeping its value, failed serialization / failed `os.replace` leaving the original intact with no temp-file litter, bounded lock retry under contention, lock timeout, and manager+service cross-class races. `tests/services/rag/test_kb_config_readers.py` covers the readers: corrupt and zero-byte configs raise through provider/mode/path resolution, a missing file still falls back, and valid configs still resolve providers, modes, and linked external paths. `tests/knowledge/test_manager_delete.py` and `test_linked_folder_sync.py` add the lifecycle regressions: delete repoints the canonical default, late status updates and stale initializers cannot resurrect or clear a tombstone, an old generation cannot write into a same-name successor, concurrent folder links keep both entries, and concurrent metadata writers preserve each other's keys. `tests/services/partners/test_partner_workspace.py` gains two regressions for the `remove_asset` prune. Existing manager/service/router tests that seeded state through the removed private `_save_config()` were ported to the transactional API. Full suite: 2421 passed; the 10 failures on this machine (partners/msteams/cron) reproduce identically on `dev` and stem from missing optional deps, not this change.

Notes for reviewers: `_deleted_knowledge_bases` entries persist until the same name is explicitly recreated — deliberate, since the tombstone is what keeps late background writers and orphaned-but-indexable directories from resurrecting a deleted KB; the map only accumulates names deleted and never reused. Intentionally out of scope: no retry was added around transient `os.replace` failures on Windows (small follow-up candidate).
