### PR TITLE
fix: restore recency weighting in compute_mastery (#618)

### DIFF
--- a/deeptutor/learning/mastery.py
+++ b/deeptutor/learning/mastery.py
@@ -31,7 +31,7 @@ def compute_mastery(correctness: list[bool]) -> float:
         return 0.0
     recent = correctness[-len(_RECENCY_WEIGHTS) :]
     weights = _RECENCY_WEIGHTS[-len(recent) :]
-    score = sum(w * (1.0 if c else 0.0) for w, c in zip(recent, weights, strict=True)) / sum(
+    score = sum(w * (1.0 if c else 0.0) for c, w in zip(recent, weights, strict=True)) / sum(
         weights
     )
     return min(score, _CONFIDENCE_CAP.get(len(recent), 1.0))

--- a/deeptutor/learning/tests/test_guided_mastery_updates.py
+++ b/deeptutor/learning/tests/test_guided_mastery_updates.py
@@ -69,6 +69,18 @@ def test_compute_mastery_partial_correctness_scales():
     assert one_of_five < two_of_five < three_of_five
 
 
+def test_compute_mastery_weighs_recent_attempts_more_heavily():
+    """Regression test for #618: recency weighting must actually distinguish
+    a recovering history from a declining one, even with the same correct
+    count. A miss-then-two-hits history should score higher than a
+    two-hits-then-miss history."""
+    recovering = compute_mastery([False, True, True])
+    declining = compute_mastery([True, True, False])
+    assert recovering > declining
+    assert recovering == pytest.approx(0.696, abs=1e-3)
+    assert declining == pytest.approx(0.643, abs=1e-3)
+
+
 # ── grade_and_record: the unified post-answer pipeline ─────────────────────
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to DeepTutor! 🚀
Please ensure your PR is ready for review and follows our contribution guidelines.
For more details, see our [CONTRIBUTING.md](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
-->

### Description
`compute_mastery` is documented as recency-weighted accuracy (newer attempts should count more), but the scoring line bound the `zip(recent, weights)` loop variables in the wrong order (`for w, c in zip(...)`), so `w` was bound to the correctness bool and `c` to the (always-truthy) weight. This made `1.0 if c else 0.0` always evaluate to `1.0`, collapsing the numerator to a plain correct-count — mastery became order-independent, so a recovering history (`[False, True, True]`) scored identically to a declining one (`[True, True, False]`), both `0.714...`.

Fix: swap the unpack order to `for c, w in zip(recent, weights, strict=True)` so `c` binds to correctness and `w` binds to the recency weight, matching what `zip` actually emits.

After the fix:
- `compute_mastery([False, True, True])` = `0.696` (recovering, now scores higher)
- `compute_mastery([True, True, False])` = `0.643` (declining, now scores lower)

Added a regression test (`test_compute_mastery_weighs_recent_attempts_more_heavily`) in `test_guided_mastery_updates.py` that pins both values and asserts the ordering, so this exact bug can't silently regress. `_CONFIDENCE_CAP` behavior and all other `compute_mastery` tests are unaffected.

### Related Issues
- Closes #618

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [x] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
One-line fix in `deeptutor/learning/mastery.py`. Verified locally: full `deeptutor/learning/tests/` suite (219 tests) passes, `ruff check`/`ruff format --check` clean on both changed files.