### PR TITLE
fix: set Secure attribute when clearing dt_token on logout

### DIFF
--- a/deeptutor/api/routers/auth.py
+++ b/deeptutor/api/routers/auth.py
@@ -446,8 +446,18 @@ async def login(body: LoginRequest, response: Response) -> dict:
 
 @router.post("/logout")
 async def logout(response: Response) -> dict:
-    """Clear the JWT cookie."""
-    response.delete_cookie(key=_COOKIE_NAME, samesite=_SAMESITE)
+    """Clear the JWT cookie.
+
+    Attributes must mirror ``login``'s ``set_cookie`` call — ``delete_cookie``
+    defaults ``secure=False``, which browsers reject when paired with
+    ``SameSite=None`` and silently keep the old cookie. See #623.
+    """
+    response.delete_cookie(
+        key=_COOKIE_NAME,
+        httponly=True,
+        samesite=_SAMESITE,
+        secure=_SECURE,
+    )
     return {"ok": True}
 
 

--- a/tests/api/test_auth_logout_cookie.py
+++ b/tests/api/test_auth_logout_cookie.py
@@ -1,0 +1,57 @@
+"""Regression test for #623.
+
+``Response.delete_cookie()`` defaults ``secure=False``. The logout endpoint
+passed only ``samesite=_SAMESITE`` (no ``secure``), so when
+``cookie_secure=true`` (``_SAMESITE="none"``) the expiry header became
+``SameSite=None`` without ``Secure`` — an invalid combination browsers
+reject outright, leaving the original ``dt_token`` cookie in place and the
+user still signed in after clicking "Sign out".
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_logout_sets_secure_when_cookie_secure_enabled(monkeypatch) -> None:
+    from deeptutor.api.routers import auth as auth_router
+
+    monkeypatch.setattr(auth_router, "_SECURE", True)
+    monkeypatch.setattr(auth_router, "_SAMESITE", "none")
+
+    app = FastAPI()
+    app.add_api_route("/logout", auth_router.logout, methods=["POST"])
+
+    with TestClient(app) as client:
+        resp = client.post("/logout")
+
+    assert resp.status_code == 200
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "Max-Age=0" in set_cookie
+    assert "samesite=none" in set_cookie.lower()
+    assert "secure" in set_cookie.lower(), (
+        "logout must set Secure on the deletion cookie when cookie_secure=true, "
+        "otherwise browsers reject the invalid SameSite=None (no Secure) "
+        "combination and never clear dt_token — see #623."
+    )
+
+
+def test_logout_omits_secure_when_cookie_secure_disabled(monkeypatch) -> None:
+    """Local dev (cookie_secure=false → SameSite=Lax) must not gain a stray
+    Secure attribute — browsers drop Secure cookies over plain HTTP."""
+    from deeptutor.api.routers import auth as auth_router
+
+    monkeypatch.setattr(auth_router, "_SECURE", False)
+    monkeypatch.setattr(auth_router, "_SAMESITE", "lax")
+
+    app = FastAPI()
+    app.add_api_route("/logout", auth_router.logout, methods=["POST"])
+
+    with TestClient(app) as client:
+        resp = client.post("/logout")
+
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "Max-Age=0" in set_cookie
+    assert "samesite=lax" in set_cookie.lower()
+    assert "secure" not in set_cookie.lower()


### PR DESCRIPTION
### Description
`logout()` cleared the JWT cookie with `response.delete_cookie(key=_COOKIE_NAME, samesite=_SAMESITE)`, omitting `secure`. FastAPI/Starlette's `delete_cookie()` defaults `secure=False`, so when `cookie_secure=true` (which forces `SameSite=None`), the expiry header became the invalid combination `SameSite=None` without `Secure`. Browsers reject that combination outright and never clear the cookie, so the user stays signed in after clicking "Sign out". Fixed by mirroring `login`'s `set_cookie` attributes (`secure=_SECURE`, `httponly=True`) on the delete call.

### Related Issues
- Closes #623

### Module(s) Affected
- [x] `api`
- [x] `tests`

### Checklist
- [x] I have read and followed the contribution guidelines.
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues. *(ran `ruff check` / `ruff format --check` on changed files)*
- [x] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary). *(no user-facing docs affected)*
- [x] My changes do not introduce any new security vulnerabilities. *(this fix removes one)*

### Additional Notes
Reproduced locally end-to-end: enabled auth + `cookie_secure=true`, logged in, confirmed `dt_token` had `Secure`/`SameSite=None`, then logged out and confirmed the browser flagged the `Set-Cookie` response header as invalid (missing `Secure`) and left the old cookie in place — matching the issue's repro steps exactly. After the fix, the deletion header includes `Secure` and the browser clears the cookie.