### PR TITLE
fix(llm): enable OpenAI Codex native tool calls

### DIFF
--- a/deeptutor/core/agentic/client.py
+++ b/deeptutor/core/agentic/client.py
@@ -332,7 +332,7 @@ def can_use_native_tool_calling(*, binding: str, model: str | None) -> bool:
 
     Resolution order:
 
-    1. Anthropic-backed providers always support tool use (native Messages API).
+    1. Native provider adapters backed by Anthropic or OpenAI Codex support tools.
     2. Local OpenAI-compatible servers (Ollama, vLLM, LM Studio, llama.cpp,
        Lemonade, OVMS, …) and anything in ``_NATIVE_TOOL_BLOCKED_BINDINGS`` are
        opted out — tool support there depends on the loaded model and is
@@ -348,7 +348,7 @@ def can_use_native_tool_calling(*, binding: str, model: str | None) -> bool:
        ``_NATIVE_TOOL_BLOCKED_BINDINGS``.
     """
     spec = find_by_name(binding)
-    if spec and spec.backend == "anthropic":
+    if spec and spec.backend in {"anthropic", "openai_codex"}:
         return True
     if binding in _NATIVE_TOOL_BLOCKED_BINDINGS or (spec and spec.is_local):
         return False

--- a/tests/core/test_agentic_client_provider_kwargs.py
+++ b/tests/core/test_agentic_client_provider_kwargs.py
@@ -205,9 +205,19 @@ def test_registered_cloud_openai_compat_providers_enable_native_tools() -> None:
         assert can_use_native_tool_calling(binding=binding, model=None) is True, binding
 
 
-def test_local_and_oauth_backends_stay_opted_out_of_native_tools() -> None:
-    # Local OpenAI-compatible servers (model-dependent, unreliable tool support)
-    # and the OAuth CLI backends keep native tool schemas disabled.
+def test_openai_codex_backend_can_use_native_tool_calling() -> None:
+    assert (
+        can_use_native_tool_calling(
+            binding="openai_codex",
+            model="openai-codex/gpt-5.5",
+        )
+        is True
+    )
+
+
+def test_local_and_github_copilot_backends_stay_opted_out_of_native_tools() -> None:
+    # Local OpenAI-compatible servers have model-dependent, unreliable tool support.
+    # GitHub Copilot remains opted out until its native tool path is validated.
     for binding in (
         "ollama",
         "vllm",
@@ -215,7 +225,6 @@ def test_local_and_oauth_backends_stay_opted_out_of_native_tools() -> None:
         "llama_cpp",
         "lemonade",
         "ovms",
-        "openai_codex",
         "github_copilot",
     ):
         assert can_use_native_tool_calling(binding=binding, model=None) is False, binding


### PR DESCRIPTION
### Description

OpenAI Codex already has a native Responses API adapter that serializes function tools, parses function-call SSE events, and sends tool results back on later rounds. However, `can_use_native_tool_calling()` only enabled native adapters backed by Anthropic. Because `openai_codex` is neither an `openai_compat` backend nor explicitly capability-enabled, agentic pipelines silently removed every tool schema before calling Codex.

This prevented tool-driven capabilities such as Mastery Path from persisting or grading progress: the model could generate a grounded path in prose, but `mastery_status` / `mastery_build` were never available.

This PR:

- treats the native `openai_codex` backend as tool-capable;
- adds a regression test for OpenAI Codex native tool availability;
- keeps local providers and the unvalidated GitHub Copilot OAuth backend opted out.

This follows the backend-driven capability policy introduced after #584 rather than hard-coding individual Codex model names.

### Related Issues

- No existing issue found.
- Related precedent: #584.

### Module(s) Affected

- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [x] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Test Plan

- `pytest -q tests deeptutor/learning/tests` → `2624 passed, 6 skipped`
- `pytest -q tests/core/test_agentic_client_provider_kwargs.py tests/services/llm/test_openai_responses_converters.py tests/services/llm/test_codex_disable_ssl_verify.py` → `30 passed`
- `ruff check .` → passed
- `ruff format --check .` → passed
- `pre-commit run --files deeptutor/core/agentic/client.py tests/core/test_agentic_client_provider_kwargs.py` → passed
- Live protocol probe with `OpenAICodexProvider`: Codex returned a structured `echo_probe({"value": "ok"})` call; after receiving the tool result, the second round returned `probe-complete` with no further tool call.

### Checklist

- [x] I have read and followed the contribution guidelines.
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (not necessary for this behavior correction).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

`pre-commit run --all-files` passed all Python, secrets, Bandit, and MyPy hooks, but the Prettier hook rewrote 31 unrelated pre-existing frontend files. Those changes were intentionally reverted to keep this PR surgical; the complete hook set passes on the two touched files.

Design sync is not applicable: this corrects the capability declaration for an existing native provider adapter and does not change architecture, persistence, or API contracts.
