### PR TITLE
fix: resolve relative img_path in parsed content lists to absolute paths

### DIFF
--- a/deeptutor/services/parsing/cache.py
+++ b/deeptutor/services/parsing/cache.py
@@ -123,6 +123,24 @@ def find_content_dir(workdir: Path) -> Path:
     return candidate_dirs[0] if candidate_dirs else workdir
 
 
+def _absolutize_img_paths(blocks: list[dict], content_dir: Path) -> list[dict]:
+    """Anchor relative ``img_path`` entries at ``content_dir``.
+
+    Engines (MinerU especially) emit ``img_path`` values like ``images/x.png``
+    relative to the content-list file. Consumers such as RAG-Anything resolve
+    them against their own working directory instead, so the images are never
+    found (issue #624). The cached JSON stays relative — paths are rewritten
+    only on load, keeping the cache dir relocatable.
+    """
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        img_path = block.get("img_path")
+        if img_path and not Path(img_path).is_absolute():
+            block["img_path"] = str(content_dir / img_path)
+    return blocks
+
+
 def load_ir(workdir: Path) -> tuple[str, Optional[list[dict]], Optional[Path]]:
     """Load ``(markdown, blocks, asset_dir)`` from a parsed/cached dir.
 
@@ -143,7 +161,7 @@ def load_ir(workdir: Path) -> tuple[str, Optional[list[dict]], Optional[Path]]:
         try:
             loaded = json.loads(json_files[0].read_text(encoding="utf-8"))
             if isinstance(loaded, list):
-                blocks = loaded
+                blocks = _absolutize_img_paths(loaded, content_dir)
         except Exception as exc:
             logger.warning("Failed to read content_list %s: %s", json_files[0], exc)
 

--- a/tests/services/parsing/test_cache.py
+++ b/tests/services/parsing/test_cache.py
@@ -55,6 +55,33 @@ def test_load_ir_reads_markdown_blocks_images(tmp_path: Path) -> None:
     assert asset_dir == workdir / "images"
 
 
+def test_load_ir_absolutizes_relative_img_paths(tmp_path: Path) -> None:
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    (workdir / "doc.md").write_text("# title", encoding="utf-8")
+    (workdir / "doc_content_list.json").write_text(
+        json.dumps(
+            [
+                {"type": "image", "img_path": "images/fig1.png"},
+                {"type": "table", "img_path": "images/tbl1.png"},
+                {"type": "image", "img_path": "/abs/already.png"},
+                {"type": "image", "img_path": ""},
+                {"type": "text", "text": "t"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (workdir / "images").mkdir()
+
+    _markdown, blocks, _asset_dir = cache.load_ir(workdir)
+    assert blocks is not None
+    assert blocks[0]["img_path"] == str(workdir / "images" / "fig1.png")
+    assert blocks[1]["img_path"] == str(workdir / "images" / "tbl1.png")
+    assert blocks[2]["img_path"] == "/abs/already.png"
+    assert blocks[3]["img_path"] == ""
+    assert blocks[4] == {"type": "text", "text": "t"}
+
+
 def test_load_ir_markdown_only(tmp_path: Path) -> None:
     workdir = tmp_path / "wd"
     workdir.mkdir()


### PR DESCRIPTION
### Description
When indexing documents with MinerU + LightRAG, image description generation fails because content-list `img_path` entries are relative (`images/*.png`). They are relative to the content-list file inside DeepTutor's parse cache, but RAG-Anything resolves them against its own working directory, so the images are never found.

This PR anchors relative `img_path` values at the content dir in `cache.load_ir`, the shared loader all ParseService consumers use. The cached JSON stays relative on disk so cache dirs remain relocatable; absolute paths pass through unchanged.

### Related Issues
- Closes #624

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
Reproduced the failure path in a unit test: `load_ir` returned relative `img_path` values straight from the content-list JSON. Verified with `tests/services/parsing` and `tests/services/rag/test_lightrag_pipeline.py` (59 passed, 2 skipped) plus `ruff check` / `ruff format --check` on the touched files.