### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/assets/releases/past_releases/ver1-4-12.md
+++ b/assets/releases/past_releases/ver1-4-12.md
@@ -24,7 +24,7 @@ A fifth parsing engine joins Text-only, MinerU, Docling, and markitdown. PyMuPDF
 rides on PyMuPDF (already bundled), making it the lightest image-capable option — no
 model downloads, no CUDA, runs on low-end and GPU-less machines — turning PDFs and
 e-books into Markdown and extracting images. Install with
-`pip install deeptutor[parse-pymupdf4llm]`; engines that need packages can now be
+`pip install 'deeptutor[parse-pymupdf4llm]'`; engines that need packages can now be
 installed in the background straight from **Settings → Document Parsing**.
 
 ### FAISS vector retrieval


### PR DESCRIPTION
### Description
Quotes the historical `deeptutor[parse-pymupdf4llm]` install example so shells such as zsh pass the extras expression to pip instead of treating the brackets as a glob. The unquoted command reproduces `no matches found`; the quoted command is preserved correctly.

### Related Issues
- No linked issue; this is a documentation-only copy/paste fix.

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [x] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
- `pre-commit run --files assets/releases/past_releases/ver1-4-12.md --verbose` passes all applicable hooks.
- `git diff --check` and `git show --check` pass.
- No dependencies or runtime behavior change.