### PR TITLE
fix(partners): align WeCom with SDK 1.0.8

### DIFF
--- a/deeptutor/partners/channels/wecom.py
+++ b/deeptutor/partners/channels/wecom.py
@@ -84,13 +84,11 @@ class WecomChannel(BaseChannel):
 
         # Create WebSocket client
         self._client = WSClient(
-            {
-                "bot_id": self.config.bot_id,
-                "secret": self.config.secret,
-                "reconnect_interval": 1000,
-                "max_reconnect_attempts": -1,  # Infinite reconnect
-                "heartbeat_interval": 30000,
-            }
+            self.config.bot_id,
+            self.config.secret,
+            reconnect_interval=1000,
+            max_reconnect_attempts=-1,  # Infinite reconnect
+            heartbeat_interval=30000,
         )
 
         # Register event handlers
@@ -109,7 +107,7 @@ class WecomChannel(BaseChannel):
         logger.info("No public IP required - using WebSocket to receive events")
 
         # Connect
-        await self._client.connect_async()
+        await self._client.connect()
 
         # Keep running until stopped
         while self._running:
@@ -122,11 +120,11 @@ class WecomChannel(BaseChannel):
             await self._client.disconnect()
         logger.info("WeCom bot stopped")
 
-    async def _on_connected(self, frame: Any) -> None:
+    async def _on_connected(self, frame: Any = None) -> None:
         """Handle WebSocket connected event."""
         logger.info("WeCom WebSocket connected")
 
-    async def _on_authenticated(self, frame: Any) -> None:
+    async def _on_authenticated(self, frame: Any = None) -> None:
         """Handle authentication success event."""
         logger.info("WeCom authenticated successfully")
 

--- a/tests/partners/test_wecom_channel.py
+++ b/tests/partners/test_wecom_channel.py
@@ -1,0 +1,86 @@
+"""Regression coverage for the WeCom SDK integration."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import ModuleType
+from typing import Any
+from unittest.mock import Mock
+
+from deeptutor.partners.channels import wecom
+
+
+class CapturingWSClient:
+    """Minimal wecom-aibot-sdk 1.0.8-compatible client used by the channel test."""
+
+    connected = asyncio.Event()
+    instance: CapturingWSClient | None = None
+
+    def __init__(
+        self,
+        bot_id: str,
+        secret: str,
+        *,
+        reconnect_interval: int = 1000,
+        max_reconnect_attempts: int = 10,
+        heartbeat_interval: int = 30000,
+    ) -> None:
+        self.bot_id = bot_id
+        self.secret = secret
+        self.reconnect_interval = reconnect_interval
+        self.max_reconnect_attempts = max_reconnect_attempts
+        self.heartbeat_interval = heartbeat_interval
+        self.handlers: dict[str, Any] = {}
+        self.did_connect = False
+        self.did_disconnect = False
+        type(self).instance = self
+
+    def on(self, event: str, handler: Any) -> None:
+        self.handlers[event] = handler
+
+    async def connect(self) -> None:
+        self.did_connect = True
+        type(self).connected.set()
+
+    async def disconnect(self) -> None:
+        self.did_disconnect = True
+
+
+def test_wecom_channel_uses_the_pinned_sdk_startup_contract(monkeypatch: Any) -> None:
+    """Use the positional constructor, connect(), and zero-argument lifecycle events."""
+    # Regression for https://github.com/HKUDS/DeepTutor/issues/616
+    sdk = ModuleType("wecom_aibot_sdk")
+    sdk.WSClient = CapturingWSClient
+    sdk.generate_req_id = lambda prefix: f"{prefix}-request"
+    monkeypatch.setitem(sys.modules, "wecom_aibot_sdk", sdk)
+    monkeypatch.setattr(wecom, "WECOM_AVAILABLE", True)
+
+    async def exercise_startup() -> None:
+        CapturingWSClient.connected = asyncio.Event()
+        CapturingWSClient.instance = None
+        channel = wecom.WecomChannel(
+            {"bot_id": "bot-id", "secret": "bot-secret"},
+            Mock(),
+        )
+        startup = asyncio.create_task(channel.start())
+        await asyncio.wait_for(CapturingWSClient.connected.wait(), timeout=1)
+
+        client = CapturingWSClient.instance
+        assert client is not None
+        assert (client.bot_id, client.secret) == ("bot-id", "bot-secret")
+        assert client.reconnect_interval == 1000
+        assert client.max_reconnect_attempts == -1
+        assert client.heartbeat_interval == 30000
+        assert client.did_connect
+
+        await client.handlers["connected"]()
+        await client.handlers["authenticated"]()
+
+        startup.cancel()
+        try:
+            await startup
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(exercise_startup())


### PR DESCRIPTION
## Summary

- align the WeCom channel with the pinned `wecom-aibot-sdk` 1.0.8 startup API
- add a focused regression test for client construction, connection, and lifecycle events

## Root cause and impact

The channel passed a configuration dictionary to `WSClient`, called the nonexistent `connect_async()` method, and required a frame for lifecycle callbacks that the SDK invokes without arguments. A normal `deeptutor[partners]` install therefore crashed before the WeCom bot could connect.

## Validation

- installed and inspected the pinned `wecom-aibot-sdk==1.0.8`; verified its positional constructor and `connect()` contract
- `python -m pytest --noconftest tests/partners/test_wecom_channel.py -q` (1 passed)
- `python -m compileall -q deeptutor/partners/channels/wecom.py tests/partners/test_wecom_channel.py`
- `git diff --check`

The targeted test uses an SDK-1.0.8-compatible client that intentionally lacks `connect_async` and emits `connected`/`authenticated` with no arguments; it would fail on the previous implementation.

Fixes #616
