### PR TITLE
fix: chat page not full width, scrollbar only works in middle area

### DIFF
--- a/web/app/(workspace)/home/[[...sessionId]]/page.tsx
+++ b/web/app/(workspace)/home/[[...sessionId]]/page.tsx
@@ -1852,12 +1852,16 @@ export default function ChatPage() {
               />
             </div>
           </div>
-          <div className="mx-auto flex w-full max-w-[960px] flex-1 min-h-0 flex-col overflow-hidden px-6">
+          <div className="flex w-full flex-1 min-h-0 flex-col">
             {sessionLoading ? (
-              <SessionLoadingView onCancel={cancelSessionLoad} />
+              <div className="flex w-full flex-1 min-h-0 items-center justify-center px-6">
+                <div className="w-full max-w-[960px]">
+                  <SessionLoadingView onCancel={cancelSessionLoad} />
+                </div>
+              </div>
             ) : !hasMessages ? (
-              <div className="flex flex-1 min-h-0 flex-col items-center justify-end pb-14 animate-fade-in">
-                <div className="flex items-center justify-center gap-4">
+              <div className="flex w-full flex-1 min-h-0 items-end justify-center pb-14 animate-fade-in px-6">
+                <div className="w-full max-w-[960px] flex items-center justify-center gap-4">
                   <img
                     src="/logo_black.png"
                     alt="DeepTutor"
@@ -1877,7 +1881,7 @@ export default function ChatPage() {
                 data-chat-scroll-root="true"
                 onScroll={handleMessagesScroll}
                 onClick={handleMessagesClick}
-                className={`mx-auto w-full flex-1 min-h-0 space-y-9 overflow-y-auto pr-4 [scrollbar-gutter:stable] ${hasMessages ? "pt-6" : "pt-2 pb-6"}`}
+                className={`w-full flex-1 min-h-0 overflow-y-auto [scrollbar-gutter:stable] ${hasMessages ? "pt-6" : "pt-2 pb-6"}`}
                 style={
                   hasMessages
                     ? (() => {
@@ -1899,22 +1903,24 @@ export default function ChatPage() {
                     : undefined
                 }
               >
-                <ChatMessageList
-                  messages={state.messages}
-                  isStreaming={state.isStreaming}
-                  sessionId={state.sessionId}
-                  language={state.language}
-                  onCopyAssistantMessage={copyAssistantMessage}
-                  onRegenerateMessage={handleRegenerateMessage}
-                  onConfirmOutline={handleConfirmOutline}
-                  onPreviewAttachment={handlePreviewMessageAttachment}
-                  onDeleteTurn={deleteTurn}
-                  selectedBranches={state.selectedBranches}
-                  onEditMessage={editMessage}
-                  onSwitchBranch={switchBranch}
-                  onSubmitUserReply={submitUserReply}
-                />
-                <div ref={messagesEndRef} className="h-px w-full shrink-0" />
+                <div className="mx-auto w-full max-w-[960px] space-y-9 px-6">
+                  <ChatMessageList
+                    messages={state.messages}
+                    isStreaming={state.isStreaming}
+                    sessionId={state.sessionId}
+                    language={state.language}
+                    onCopyAssistantMessage={copyAssistantMessage}
+                    onRegenerateMessage={handleRegenerateMessage}
+                    onConfirmOutline={handleConfirmOutline}
+                    onPreviewAttachment={handlePreviewMessageAttachment}
+                    onDeleteTurn={deleteTurn}
+                    selectedBranches={state.selectedBranches}
+                    onEditMessage={editMessage}
+                    onSwitchBranch={switchBranch}
+                    onSubmitUserReply={submitUserReply}
+                  />
+                  <div ref={messagesEndRef} className="h-px w-full shrink-0" />
+                </div>
               </div>
             )}
 


### PR DESCRIPTION
### Description
    Fix chat page layout issue: the chat content was constrained to max-width 960px centered, causing the scrollbar to appear in the middle of the page and scroll wheel only working in the middle area, with
  meaningless blank space on both sides. This change moves the scroll container to full width while keeping message content and input box at the original 960px centered width, so scrollbar appears at the far
  right and works across the entire page area without changing any visual appearance.

    ### Module(s) Affected
    - [x] `web` (Frontend)

    ### Checklist
    - [x] I have read and followed the contribution guidelines.
    - [x] My code follows the project's coding standards.
    - [ ] I have run `pre-commit run --all-files` and fixed any issues. (Pure CSS/HTML class change, no logic modified, no formatting issues)
    - [ ] I have added relevant tests for my changes. (UI layout bugfix, no functional changes, no tests needed)
    - [ ] I have updated the documentation (if necessary). (UI bugfix, no docs update needed)
    - [x] My changes do not introduce any new security vulnerabilities.

    ### Additional Notes
    The fix keeps all original UI appearance unchanged (message width, centered alignment, input box style all remain exactly the same), only moves the scrollbar to the far right edge of the page and allows
  scrolling anywhere in the chat area.