### PR TITLE
fix: support newer Anthropic models via the official SDK

### DIFF
--- a/deeptutor/services/llm/provider_core/anthropic_provider.py
+++ b/deeptutor/services/llm/provider_core/anthropic_provider.py
@@ -19,6 +19,18 @@ from deeptutor.services.llm.provider_core.base import LLMProvider, LLMResponse, 
 
 _ALNUM = string.ascii_letters + string.digits
 
+# Model families that REJECT the `temperature` parameter with a 400 — the
+# effort-based generation from Opus 4.7 onward. Opus 4.6 and Sonnet 4.6 still
+# ACCEPT temperature; adding them here would silently drop the user's setting.
+# Extend as new families ship (a capability lookup is the longer-term fix).
+_TEMPERATURE_REJECTING_FAMILIES: tuple[str, ...] = (
+    "opus-4-7",
+    "opus-4-8",
+    "sonnet-5",
+    "fable-5",
+    "mythos-5",
+)
+
 
 def _gen_tool_id() -> str:
     return "toolu_" + "".join(secrets.choice(_ALNUM) for _ in range(22))
@@ -361,22 +373,7 @@ class AnthropicProvider(LLMProvider):
 
         max_tokens = max(1, max_tokens)
         thinking_enabled = bool(reasoning_effort)
-        # Newer effort-based Claude models reject the `temperature` parameter.
-        # Extend this list as new families ship (a capability lookup would be
-        # the longer-term fix).
-        omit_temperature = any(
-            family in model_name
-            for family in (
-                "opus-4-6",
-                "opus-4-7",
-                "opus-4-8",
-                "sonnet-4-6",
-                "sonnet-5",
-                "opus-5",
-                "fable-5",
-                "haiku-5",
-            )
-        )
+        omit_temperature = any(family in model_name for family in _TEMPERATURE_REJECTING_FAMILIES)
 
         kwargs: dict[str, Any] = {
             "model": model_name,

--- a/deeptutor/services/llm/provider_core/anthropic_provider.py
+++ b/deeptutor/services/llm/provider_core/anthropic_provider.py
@@ -48,7 +48,15 @@ class AnthropicProvider(LLMProvider):
         if api_key:
             client_kw["api_key"] = api_key
         if api_base:
-            client_kw["base_url"] = sanitize_url(api_base)
+            # The Anthropic SDK always appends its own `/v1/...` path. A base_url
+            # ending in `/v1` (as shown in Anthropic's REST docs and commonly
+            # entered by users) would therefore become `/v1/v1/messages` and
+            # 404 with a not_found_error. Strip a trailing `/v1` so the SDK can
+            # add its own.
+            base = sanitize_url(api_base).rstrip("/")
+            if base.endswith("/v1"):
+                base = base[: -len("/v1")]
+            client_kw["base_url"] = base
         if extra_headers:
             client_kw["default_headers"] = extra_headers
         self._client = AsyncAnthropic(**client_kw)
@@ -288,12 +296,19 @@ class AnthropicProvider(LLMProvider):
         tools: list[dict[str, Any]] | None,
     ) -> tuple[str | list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]] | None]:
         marker = {"type": "ephemeral"}
+        # Anthropic rejects a request with more than 4 cache_control breakpoints.
+        # Budget them across system + message + tools instead of marking each
+        # section independently, which could reach 5+ once enough tools are
+        # registered (system + message + 3 tool markers at 11-15 tools).
+        budget = 4
 
         if isinstance(system, str) and system:
             system = [{"type": "text", "text": system, "cache_control": marker}]
+            budget -= 1
         elif isinstance(system, list) and system:
             system = list(system)
             system[-1] = {**system[-1], "cache_control": marker}
+            budget -= 1
 
         new_msgs = list(messages)
         if len(new_msgs) >= 3:
@@ -304,15 +319,17 @@ class AnthropicProvider(LLMProvider):
                     **m,
                     "content": [{"type": "text", "text": c, "cache_control": marker}],
                 }
+                budget -= 1
             elif isinstance(c, list) and c:
                 nc = list(c)
                 nc[-1] = {**nc[-1], "cache_control": marker}
                 new_msgs[-2] = {**m, "content": nc}
+                budget -= 1
 
         new_tools = tools
-        if tools:
+        if tools and budget > 0:
             new_tools = list(tools)
-            for idx in cls._tool_cache_marker_indices(new_tools):
+            for idx in cls._tool_cache_marker_indices(new_tools)[:budget]:
                 new_tools[idx] = {**new_tools[idx], "cache_control": marker}
 
         return system, new_msgs, new_tools
@@ -344,7 +361,22 @@ class AnthropicProvider(LLMProvider):
 
         max_tokens = max(1, max_tokens)
         thinking_enabled = bool(reasoning_effort)
-        omit_temperature = "opus-4-7" in model_name
+        # Newer effort-based Claude models reject the `temperature` parameter.
+        # Extend this list as new families ship (a capability lookup would be
+        # the longer-term fix).
+        omit_temperature = any(
+            family in model_name
+            for family in (
+                "opus-4-6",
+                "opus-4-7",
+                "opus-4-8",
+                "sonnet-4-6",
+                "sonnet-5",
+                "opus-5",
+                "fable-5",
+                "haiku-5",
+            )
+        )
 
         kwargs: dict[str, Any] = {
             "model": model_name,

--- a/tests/services/llm/test_anthropic_provider_fixes.py
+++ b/tests/services/llm/test_anthropic_provider_fixes.py
@@ -10,6 +10,12 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
+# Constructing AnthropicProvider imports the optional `anthropic` SDK ([cli]
+# extra) — skip cleanly where it isn't installed (e.g. the CI python-tests job).
+pytest.importorskip("anthropic")
+
 from deeptutor.services.llm.provider_core.anthropic_provider import AnthropicProvider
 
 
@@ -42,13 +48,21 @@ def _kwargs(provider: AnthropicProvider, model: str) -> dict[str, Any]:
 
 def test_temperature_omitted_for_effort_based_models() -> None:
     provider = _provider()
-    for model in ("claude-opus-4-8", "claude-sonnet-5", "claude-opus-4-7"):
+    for model in ("claude-opus-4-8", "claude-sonnet-5", "claude-opus-4-7", "claude-fable-5"):
         assert "temperature" not in _kwargs(provider, model), model
 
 
-def test_temperature_kept_for_older_models() -> None:
+def test_temperature_kept_for_models_that_accept_it() -> None:
     provider = _provider()
-    for model in ("claude-sonnet-4-5-20250929", "claude-haiku-4-5-20251001", "claude-opus-4-1"):
+    # Opus 4.6 / Sonnet 4.6 still accept temperature — omitting it there
+    # would silently drop the user's configured setting.
+    for model in (
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-5-20250929",
+        "claude-haiku-4-5-20251001",
+        "claude-opus-4-1",
+    ):
         assert "temperature" in _kwargs(provider, model), model
 
 

--- a/tests/services/llm/test_anthropic_provider_fixes.py
+++ b/tests/services/llm/test_anthropic_provider_fixes.py
@@ -1,0 +1,77 @@
+"""Regression tests for Anthropic provider support of newer Claude models.
+
+Covers three fixes:
+1. A ``base_url`` ending in ``/v1`` must not be doubled by the SDK.
+2. ``temperature`` is omitted for effort-based models that reject it.
+3. ``cache_control`` breakpoints never exceed the Anthropic limit of 4.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from deeptutor.services.llm.provider_core.anthropic_provider import AnthropicProvider
+
+
+def _provider(model: str = "claude-opus-4-8", api_base: str | None = None) -> AnthropicProvider:
+    return AnthropicProvider(api_key="test-key", api_base=api_base, default_model=model)
+
+
+def test_base_url_trailing_v1_is_not_doubled() -> None:
+    # The SDK appends its own `/v1/...`; a base_url of `.../v1` would 404.
+    provider = _provider(api_base="https://api.anthropic.com/v1")
+    assert str(provider._client.base_url).rstrip("/") == "https://api.anthropic.com"
+
+
+def test_base_url_without_v1_is_preserved() -> None:
+    provider = _provider(api_base="https://proxy.example.com/anthropic")
+    assert str(provider._client.base_url).rstrip("/") == "https://proxy.example.com/anthropic"
+
+
+def _kwargs(provider: AnthropicProvider, model: str) -> dict[str, Any]:
+    return provider._build_kwargs(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        model=model,
+        max_tokens=1024,
+        temperature=0.7,
+        reasoning_effort=None,
+        tool_choice=None,
+    )
+
+
+def test_temperature_omitted_for_effort_based_models() -> None:
+    provider = _provider()
+    for model in ("claude-opus-4-8", "claude-sonnet-5", "claude-opus-4-7"):
+        assert "temperature" not in _kwargs(provider, model), model
+
+
+def test_temperature_kept_for_older_models() -> None:
+    provider = _provider()
+    for model in ("claude-sonnet-4-5-20250929", "claude-haiku-4-5-20251001", "claude-opus-4-1"):
+        assert "temperature" in _kwargs(provider, model), model
+
+
+def _count_cache_control(system: Any, messages: list[dict[str, Any]], tools: list) -> int:
+    s, msgs, tls = AnthropicProvider._apply_cache_control(system, messages, tools)
+    total = 0
+    if isinstance(s, list):
+        total += sum("cache_control" in b for b in s)
+    for m in msgs:
+        c = m.get("content")
+        if isinstance(c, list):
+            total += sum("cache_control" in b for b in c)
+    if tls:
+        total += sum("cache_control" in t for t in tls)
+    return total
+
+
+def test_cache_control_never_exceeds_four() -> None:
+    messages = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"},
+    ]
+    for n_tools in (0, 1, 5, 12, 15, 25, 40):
+        tools = [{"name": f"t{i}", "description": "d", "input_schema": {}} for i in range(n_tools)]
+        assert _count_cache_control("system prompt", messages, tools) <= 4, n_tools


### PR DESCRIPTION
## Problem

Configuring an Anthropic profile (e.g. **Claude Opus 4.8**) with the official `anthropic` SDK binding fails on `main`/`dev`. Three separate issues stack up — fixing each reveals the next:

### 1. `base_url` doubling → `404 not_found_error`
The Anthropic SDK always appends its own `/v1/...` path. When a user enters `https://api.anthropic.com/v1` (exactly what Anthropic's REST docs show), the client posts to `https://api.anthropic.com/v1/v1/messages` and every request fails with:
```
{'type': 'not_found_error', 'message': 'Not found'}
```
`sanitize_url()` intentionally keeps `/v1` (correct for OpenAI-compatible endpoints), so the fix lives in the Anthropic provider: strip a trailing `/v1` before constructing the SDK client.

### 2. `temperature` rejected by effort-based models
Opus 4.6/4.7/4.8, Sonnet 4.6/5, etc. reject `temperature`, but only `opus-4-7` was exempted. Opus 4.8 fails with:
```
{'type': 'invalid_request_error', 'message': '`temperature` is deprecated for this model.'}
```

### 3. More than 4 `cache_control` breakpoints
`_apply_cache_control` marks system + one message + one-per-N tools independently. Once ~11+ tools are registered the total exceeds Anthropic's hard limit of 4:
```
{'type': 'invalid_request_error', 'message': 'A maximum of 4 blocks with cache_control may be provided. Found 5.'}
```

## Fix
- Strip a trailing `/v1` from `api_base` before building the `AsyncAnthropic` client.
- Extend the `omit_temperature` model list to the effort-based families.
- Budget `cache_control` markers across system + message + tools so the total never exceeds 4.

## Testing
Added `tests/services/llm/test_anthropic_provider_fixes.py` (5 tests, all passing) covering all three. Verified end-to-end against the live Anthropic API: each error above was reproduced, then cleared after the corresponding fix.