### PR TITLE
fix(partners): avoid hang in split_message when max_len <= 0

### DIFF
--- a/deeptutor/partners/helpers.py
+++ b/deeptutor/partners/helpers.py
@@ -50,6 +50,9 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
     """
     if not content:
         return []
+    # Non-positive max_len cannot advance the cut pointer; return unsplit.
+    if max_len <= 0:
+        return [content]
     if len(content) <= max_len:
         return [content]
     chunks: list[str] = []

--- a/tests/services/partners/test_split_message.py
+++ b/tests/services/partners/test_split_message.py
@@ -1,0 +1,17 @@
+"""Regression tests for partners.helpers.split_message."""
+
+from __future__ import annotations
+
+from deeptutor.partners.helpers import split_message
+
+
+def test_split_message_nonpositive_max_len_returns_unsplit() -> None:
+    content = "hello world"
+    assert split_message(content, max_len=0) == [content]
+    assert split_message(content, max_len=-1) == [content]
+
+
+def test_split_message_normal_path() -> None:
+    chunks = split_message("aaa\nbbb\nccc", max_len=5)
+    assert chunks
+    assert all(len(c) <= 5 for c in chunks)


### PR DESCRIPTION
When max_len is 0 or negative, the cut pointer never advances and split_message loops forever. Return the content unsplit so Discord/Telegram/Weixin outbound paths cannot wedge.

Repro: split_message("hello world", max_len=0).