### PR TITLE
fix(memory): parse update facts JSON with raw_decode

### DIFF
--- a/deeptutor/services/memory/consolidator/modes/update.py
+++ b/deeptutor/services/memory/consolidator/modes/update.py
@@ -624,10 +624,13 @@ def _extract_json_object(raw: str) -> str | None:
         if text.rstrip().endswith("```"):
             text = text.rstrip()[:-3]
     start = text.find("{")
-    end = text.rfind("}")
-    if start == -1 or end <= start:
+    if start == -1:
         return None
-    return text[start : end + 1]
+    try:
+        _parsed, end = json.JSONDecoder().raw_decode(text[start:])
+    except json.JSONDecodeError:
+        return None
+    return text[start : start + end]
 
 
 def _append_facts_to_doc(

--- a/tests/services/memory/test_update_facts_json.py
+++ b/tests/services/memory/test_update_facts_json.py
@@ -1,0 +1,16 @@
+"""Regression: memory update fact JSON tolerates trailing brace prose."""
+
+from __future__ import annotations
+
+from deeptutor.services.memory.consolidator.modes import update as update_mode
+
+
+def test_parse_facts_tolerates_trailing_brace_prose() -> None:
+    raw = (
+        '{"facts":[{"text":"hello","section":"Notes","refs":["a:b"]}]}'
+        " trailing {note}"
+    )
+    facts = update_mode._parse_facts(raw)
+    assert len(facts) == 1
+    assert facts[0].text == "hello"
+    assert facts[0].section == "Notes"


### PR DESCRIPTION
_parse_facts is a tolerant LLM JSON parser, but _extract_json_object used a greedy rfind("}") slice. Trailing prose that itself contains braces made the slice invalid, so valid facts were silently dropped. Decode the first JSON object with raw_decode (same approach as line-edit parsing).

Repro: `{"facts":[...]} trailing {note}` previously returned [].