### PR TITLE
fix(embedding): don't send encoding_format by default for OpenAI-compatible providers

### DIFF
--- a/deeptutor/services/embedding/adapters/openai_compatible.py
+++ b/deeptutor/services/embedding/adapters/openai_compatible.py
@@ -167,8 +167,9 @@ class OpenAICompatibleEmbeddingAdapter(BaseEmbeddingAdapter):
         payload = {
             "input": input_payload,
             "model": model,
-            "encoding_format": request.encoding_format or "float",
         }
+        if request.encoding_format:
+            payload["encoding_format"] = request.encoding_format
 
         # `dimensions` is opt-in. The user's `send_dimensions` flag wins when set
         # explicitly (True/False); otherwise we fall back to a model-family


### PR DESCRIPTION
## Problem
SiliconFlow (and possibly other OpenAI-compatible embedding providers) returns HTTP 400 when receiving the `encoding_format` parameter, which is currently always sent as `"float"` even when the user hasn't explicitly set it.

## Root Cause
In `openai_compatible.py`, the `encoding_format` defaults to `"float"` unconditionally:
```python
"encoding_format": request.encoding_format or "float",
```

Unlike `dimensions` (which has `send_dimensions` flag and model-family heuristics), `encoding_format` has no opt-out mechanism.

## Fix
Only include `encoding_format` in the request payload when the user explicitly sets it via `request.encoding_format`:
```python
if request.encoding_format:
    payload["encoding_format"] = request.encoding_format
```

This matches the existing pattern used for `dimensions` / `send_dimensions`.

## Testing
- Works with SiliconFlow `BAAI/bge-large-zh-v1.5` (previously returned HTTP 400)
- Backward compatible: users who explicitly set `encoding_format` are unaffected
- OpenAI's `text-embedding-3-*` models still work (no `encoding_format` = default behavior)

Closes #651