### PR TITLE
Add Atlas Cloud LLM provider

### DIFF
--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -88,6 +88,9 @@ PROVIDER_ALIASES = {
     "github-copilot": "github_copilot",
     "openai-codex": "openai_codex",
     "lm-studio": "lm_studio",
+    "atlas": "atlascloud",
+    "atlas_cloud": "atlascloud",
+    "atlas-cloud": "atlascloud",
 }
 
 
@@ -165,6 +168,16 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         is_gateway=True,
         detect_by_base_keyword="siliconflow",
         default_api_base="https://api.siliconflow.cn/v1",
+    ),
+    ProviderSpec(
+        name="atlascloud",
+        keywords=("atlascloud", "atlas-cloud", "atlas cloud"),
+        env_key="ATLASCLOUD_API_KEY",
+        display_name="Atlas Cloud",
+        backend="openai_compat",
+        is_gateway=True,
+        detect_by_base_keyword="atlascloud",
+        default_api_base="https://api.atlascloud.ai/v1",
     ),
     ProviderSpec(
         name="volcengine",

--- a/tests/api/test_settings_router.py
+++ b/tests/api/test_settings_router.py
@@ -433,6 +433,13 @@ def test_embedding_provider_choices_use_full_endpoint_urls() -> None:
     assert "custom_openai_sdk" not in embedding
 
 
+def test_llm_provider_choices_include_atlascloud() -> None:
+    llm = {item["value"]: item for item in settings_router._provider_choices()["llm"]}
+
+    assert llm["atlascloud"]["label"] == "Atlas Cloud"
+    assert llm["atlascloud"]["base_url"] == "https://api.atlascloud.ai/v1"
+
+
 @pytest.mark.asyncio
 async def test_get_llm_options_returns_redacted_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
     catalog = _build_catalog(

--- a/tests/core/test_agentic_client_provider_kwargs.py
+++ b/tests/core/test_agentic_client_provider_kwargs.py
@@ -207,6 +207,7 @@ def test_registered_cloud_openai_compat_providers_enable_native_tools() -> None:
         "xiaomi_mimo",
         "nvidia_nim",
         "aihubmix",
+        "atlascloud",
         "volcengine_coding_plan",
         "byteplus_coding_plan",
     ):

--- a/tests/services/config/test_provider_runtime.py
+++ b/tests/services/config/test_provider_runtime.py
@@ -114,6 +114,57 @@ def test_llm_api_base_keyword_gateway() -> None:
     assert resolved.extra_headers == {"APP-Code": "x"}
 
 
+def test_llm_atlascloud_binding_uses_default_openai_compatible_endpoint() -> None:
+    catalog = _build_catalog(
+        llm_profile={
+            "id": "llm-p",
+            "name": "Atlas Cloud",
+            "binding": "atlascloud",
+            "base_url": "",
+            "api_key": "atlas-key",
+            "api_version": "",
+            "extra_headers": {},
+            "models": [
+                {
+                    "id": "llm-m",
+                    "name": "Qwen 3.5 Flash",
+                    "model": "qwen/qwen3.5-flash",
+                }
+            ],
+        }
+    )
+
+    resolved = resolve_llm_runtime_config(catalog=catalog)
+
+    assert resolved.provider_name == "atlascloud"
+    assert resolved.provider_mode == "gateway"
+    assert resolved.binding == "atlascloud"
+    assert resolved.model == "qwen/qwen3.5-flash"
+    assert resolved.api_key == "atlas-key"
+    assert resolved.effective_url == "https://api.atlascloud.ai/v1"
+
+
+def test_llm_atlascloud_base_url_detection_preserves_openai_binding_compatibility() -> None:
+    catalog = _build_catalog(
+        llm_profile={
+            "id": "llm-p",
+            "name": "OpenAI Compatible",
+            "binding": "openai",
+            "base_url": "https://api.atlascloud.ai/v1",
+            "api_key": "atlas-key",
+            "api_version": "",
+            "extra_headers": {},
+            "models": [{"id": "llm-m", "name": "Qwen", "model": "qwen/qwen3.5-flash"}],
+        }
+    )
+
+    resolved = resolve_llm_runtime_config(catalog=catalog)
+
+    assert resolved.provider_name == "atlascloud"
+    assert resolved.provider_mode == "gateway"
+    assert resolved.effective_url == "https://api.atlascloud.ai/v1"
+
+
 def test_llm_local_fallback() -> None:
     catalog = _build_catalog(
         llm_profile={

--- a/tests/services/test_provider_registry.py
+++ b/tests/services/test_provider_registry.py
@@ -8,3 +8,18 @@ def test_nvidia_nim_gateway_detection_by_key_and_base() -> None:
     assert spec.supports_stream_options is False
     assert find_gateway(api_key="nvapi-test-key") == spec
     assert find_gateway(api_base="https://integrate.api.nvidia.com/v1") == spec
+
+
+def test_atlascloud_provider_aliases_and_base_detection() -> None:
+    spec = find_by_name("atlascloud")
+
+    assert spec is not None
+    assert spec.display_name == "Atlas Cloud"
+    assert spec.env_key == "ATLASCLOUD_API_KEY"
+    assert spec.backend == "openai_compat"
+    assert spec.mode == "gateway"
+    assert spec.default_api_base == "https://api.atlascloud.ai/v1"
+    assert find_by_name("atlas-cloud") == spec
+    assert find_by_name("atlas_cloud") == spec
+    assert find_by_name("atlas") == spec
+    assert find_gateway(api_base="https://api.atlascloud.ai/v1") == spec


### PR DESCRIPTION
## Summary
- add Atlas Cloud to the shared LLM provider registry as an OpenAI-compatible gateway
- support ATLASCLOUD_API_KEY, the default https://api.atlascloud.ai/v1 endpoint, and atlas/atlas-cloud aliases
- cover provider lookup, runtime config resolution, settings provider choices, and native tool capability behavior

## Validation
- /Users/zby/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile deeptutor/services/provider_registry.py deeptutor/services/config/provider_runtime.py tests/services/test_provider_registry.py tests/services/config/test_provider_runtime.py tests/api/test_settings_router.py tests/core/test_agentic_client_provider_kwargs.py
- uv run --python 3.12 --extra dev pytest tests/services/test_provider_registry.py tests/services/config/test_provider_runtime.py tests/api/test_settings_router.py::test_llm_provider_choices_include_atlascloud tests/core/test_agentic_client_provider_kwargs.py::test_registered_cloud_openai_compat_providers_enable_native_tools -q
- git diff --check
- live Atlas Cloud model catalog check returned 425 models and confirmed qwen/qwen3.5-flash and deepseek-ai/deepseek-v4-pro

No README changes; no sponsor, logo, credits, partner, or promotional section changes.