### PR TITLE
fix: require explicit OpenAI Codex selection

### DIFF
--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -236,7 +236,6 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         env_key="",
         display_name="OpenAI Codex",
         backend="openai_codex",
-        detect_by_base_keyword="codex",
         is_oauth=True,
         default_api_base="https://chatgpt.com/backend-api",
     ),

--- a/tests/services/test_provider_registry.py
+++ b/tests/services/test_provider_registry.py
@@ -8,3 +8,7 @@ def test_nvidia_nim_gateway_detection_by_key_and_base() -> None:
     assert spec.supports_stream_options is False
     assert find_gateway(api_key="nvapi-test-key") == spec
     assert find_gateway(api_base="https://integrate.api.nvidia.com/v1") == spec
+
+
+def test_openai_codex_is_not_detected_from_api_base() -> None:
+    assert find_gateway(api_base="https://codex.example.com/v1") is None


### PR DESCRIPTION
### Description
OpenAI-compatible endpoints whose URL contains `codex` now remain on their configured provider instead of being forced through the OpenAI Codex OAuth backend.

### Related Issues
- Closes #656
- Related to: N/A

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
Focused provider-registry tests and Ruff checks pass.
