### PR TITLE
fix(cli): catch UnicodeDecodeError in REPL input loop

### DIFF
--- a/deeptutor_cli/chat.py
+++ b/deeptutor_cli/chat.py
@@ -129,6 +129,12 @@ async def _chat_repl(state: ChatState) -> None:
             except (EOFError, KeyboardInterrupt):
                 console.print()
                 break
+            except UnicodeDecodeError:
+                console.print(
+                    "[yellow]Input contains invalid UTF-8 characters."
+                    " Please check your input and try again.[/]"
+                )
+                continue
 
             if not user_input:
                 continue


### PR DESCRIPTION
## Description

When inputting non-ASCII characters (e.g. Chinese) via the terminal/PTY,
the UTF-8 byte stream can occasionally be truncated mid-character due to a
PTY buffer boundary race condition. Python's `input()` raises
`UnicodeDecodeError` in such cases, crashing the entire REPL.

This is **not** a deterministic bug — it depends on typing speed, PTY buffer
size, and kernel scheduling. Most Chinese inputs go through fine, but when
the PTY boundary happens to split a multi-byte character (e.g. 能 = 3 bytes
`\xe8\x83\xbd`, but only the first 2 bytes arrive), the REPL crashes
without this fix.

This PR catches the exception gracefully and shows a warning instead,
allowing the user to re-enter their input without losing their session.

## Changes

- `deeptutor_cli/chat.py`: Added `UnicodeDecodeError` handler in the REPL
  input loop alongside the existing `EOFError` and `KeyboardInterrupt` handlers.

## Steps to Reproduce

1. Run `deeptutor chat`
2. Type a Chinese message (e.g. `你有什么功能`) — under certain PTY timing
   conditions the UTF-8 stream is truncated and the REPL crashes
3. The bug is intermittent; it may take several tries to trigger
4. With this fix, the error is caught and the user is prompted to try again

## Related

None reported on GitHub Issues yet.