### PR TITLE
fix(question): parse quiz JSON with raw_decode

### DIFF
--- a/deeptutor/agents/question/pipeline.py
+++ b/deeptutor/agents/question/pipeline.py
@@ -1299,8 +1299,7 @@ class QuestionPipeline:
         try:
             parsed = json.loads(text)
         except json.JSONDecodeError:
-            # raw_decode stops at the first complete value so trailing prose
-            # that itself contains braces cannot poison the slice.
+            # First JSON object only; trailing brace-prose must not extend the slice.
             start = text.find("{")
             if start == -1:
                 return {}

--- a/deeptutor/agents/question/pipeline.py
+++ b/deeptutor/agents/question/pipeline.py
@@ -1299,11 +1299,13 @@ class QuestionPipeline:
         try:
             parsed = json.loads(text)
         except json.JSONDecodeError:
-            obj = re.search(r"\{[\s\S]*\}", text)
-            if obj is None:
+            # raw_decode stops at the first complete value so trailing prose
+            # that itself contains braces cannot poison the slice.
+            start = text.find("{")
+            if start == -1:
                 return {}
             try:
-                parsed = json.loads(obj.group(0))
+                parsed, _end = json.JSONDecoder().raw_decode(text[start:])
             except json.JSONDecodeError:
                 return {}
         return parsed if isinstance(parsed, dict) else {}

--- a/tests/agents/question/test_pipeline.py
+++ b/tests/agents/question/test_pipeline.py
@@ -984,3 +984,14 @@ def test_parse_exam_paper_to_templates_happy_path(monkeypatch, tmp_path: Path) -
     assert templates[1].question_type == "choice"
     assert trace["template_count"] == "2"
     assert trace["question_file"].endswith("exam_questions.json")
+
+
+def test_parse_quiz_payload_tolerates_trailing_brace_prose() -> None:
+    raw = (
+        '{"question":"What is 2+2?","correct_answer":"4",'
+        '"explanation":"basic arithmetic"} note: see {docs}'
+    )
+    parsed = QuestionPipeline._parse_quiz_payload(raw)
+    assert parsed["question"] == "What is 2+2?"
+    assert parsed["correct_answer"] == "4"
+    assert parsed["explanation"] == "basic arithmetic"


### PR DESCRIPTION
Quiz payloads with trailing prose after the JSON object were dropped to `{}` by greedy brace matching, losing the generated questions.

Parse with `raw_decode` so the leading object is kept.