### PR TITLE
fix(visualize): allow code fences without a blank closing line

### DIFF
--- a/deeptutor/agents/visualize/utils.py
+++ b/deeptutor/agents/visualize/utils.py
@@ -38,10 +38,11 @@ def extract_code_block(text: str, language: str = "") -> str:
     If *language* is given the block must start with that tag;
     otherwise any triple-backtick fence is accepted.
     """
+    # Closing fence may sit on the same line as the last content line.
     if language:
-        pattern = rf"```{re.escape(language)}\s*\n([\s\S]*?)\n```"
+        pattern = rf"```{re.escape(language)}\s*\n([\s\S]*?)\n?```"
     else:
-        pattern = r"```[A-Za-z]*\s*\n([\s\S]*?)\n```"
+        pattern = r"```[A-Za-z]*\s*\n([\s\S]*?)\n?```"
     match = re.search(pattern, text or "", re.IGNORECASE)
     if match:
         return match.group(1).strip()

--- a/tests/agents/visualize/test_extract_code_block.py
+++ b/tests/agents/visualize/test_extract_code_block.py
@@ -1,0 +1,16 @@
+"""Regression tests for visualize.utils.extract_code_block."""
+
+from __future__ import annotations
+
+from deeptutor.agents.visualize.utils import extract_code_block
+
+
+def test_extract_code_block_closing_fence_without_leading_newline() -> None:
+    raw = "```mermaid\ngraph TD\n  A-->B```"
+    assert extract_code_block(raw, "mermaid") == "graph TD\n  A-->B"
+    assert extract_code_block(raw) == "graph TD\n  A-->B"
+
+
+def test_extract_code_block_normal_fenced_block() -> None:
+    raw = "```javascript\nconst x = 1;\n```"
+    assert extract_code_block(raw, "javascript") == "const x = 1;"


### PR DESCRIPTION
Fenced code blocks that closed without a blank line before the closing fence were missed, so visualize dropped the code.

Accept closers that do not require a blank preceding line.