### PR TITLE
fix(partners): strip control chars in safe_filename

### DIFF
--- a/deeptutor/partners/helpers.py
+++ b/deeptutor/partners/helpers.py
@@ -30,11 +30,13 @@ def timestamp() -> str:
 
 
 _UNSAFE_CHARS = re.compile(r'[<>:"/\\|?*]')
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
 
 
 def safe_filename(name: str) -> str:
-    """Replace unsafe path characters with underscores."""
-    return _UNSAFE_CHARS.sub("_", name).strip()
+    """Replace unsafe path / control characters; ``.`` / ``..`` become empty."""
+    cleaned = _CONTROL_CHARS.sub("", _UNSAFE_CHARS.sub("_", name or "")).strip().strip(".")
+    return cleaned
 
 
 def split_message(content: str, max_len: int = 2000) -> list[str]:

--- a/tests/services/partners/test_safe_filename.py
+++ b/tests/services/partners/test_safe_filename.py
@@ -1,0 +1,23 @@
+"""Regression tests for partners.helpers.safe_filename."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from deeptutor.partners.helpers import safe_filename
+
+
+def test_safe_filename_strips_embedded_null_byte() -> None:
+    cleaned = safe_filename("photo\x00.png")
+    assert "\x00" not in cleaned
+    assert cleaned.endswith(".png")
+    path = Path("/tmp") / f"abc_{cleaned}"
+    path.write_bytes(b"x")
+    assert path.read_bytes() == b"x"
+    path.unlink()
+
+
+def test_safe_filename_strips_newlines_and_dot_names() -> None:
+    assert "\n" not in safe_filename("a\nb.png")
+    assert safe_filename(".") == ""
+    assert safe_filename("..") == ""


### PR DESCRIPTION
Partner filenames that contained ASCII control characters survived `safe_filename` and could break downstream path handling.

Strip control characters while keeping the sanitized basename.