### PR TITLE
feat: add Eden AI as an LLM provider

### DIFF
--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -149,6 +149,16 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         supports_prompt_caching=True,
     ),
     ProviderSpec(
+        name="edenai",
+        keywords=("edenai", "eden_ai", "eden-ai"),
+        env_key="EDENAI_API_KEY",
+        display_name="Eden AI",
+        backend="openai_compat",
+        is_gateway=True,
+        detect_by_base_keyword="edenai",
+        default_api_base="https://api.edenai.run/v3",
+    ),
+    ProviderSpec(
         name="aihubmix",
         keywords=("aihubmix",),
         env_key="OPENAI_API_KEY",


### PR DESCRIPTION
## What

Adds [Eden AI](https://www.edenai.co/) as an LLM provider.

Eden AI is an OpenAI-compatible gateway (`https://api.edenai.run/v3`) that routes to many upstream providers behind a single key. Models are addressed as `<provider>/<model>`, e.g. `openai/gpt-5.5` or `mistral/mistral-large-latest`.

## Changes

A single `ProviderSpec` in `deeptutor/services/provider_registry.py` (per the module's "adding a new provider" note — env vars, config matching and status display all derive from the registry):

- `backend="openai_compat"`, `is_gateway=True`, `env_key="EDENAI_API_KEY"`, `default_api_base="https://api.edenai.run/v3"`.

Placed among the gateways (after OpenRouter), matching the existing order.

## Testing

- `ruff format --check` and `ruff check` pass on the changed file.
- Import smoke test: the registry loads and `edenai` resolves (`canonical_provider_name("edenai") -> "edenai"`).
- Verified live against `https://api.edenai.run/v3`: chat completions return 200 and tool/function calling works for `openai/gpt-5.5` and `mistral/mistral-large-latest`; `GET /models` returns an OpenAI-style list.

Embedding support (Eden AI also exposes `/v3/embeddings`) can follow as a separate change to `EMBEDDING_PROVIDERS` if useful.

Targeting `dev` per CONTRIBUTING.
