### PR TITLE
fix: prevent sending messages while AI is streaming response

### DIFF
--- a/web/components/chat/home/ChatComposer.tsx
+++ b/web/components/chat/home/ChatComposer.tsx
@@ -619,6 +619,7 @@ export default memo(function ChatComposer({
             ref={inputHandleRef}
             textareaRef={textareaRef}
             isVisualizeMode={isVisualizeMode}
+            isStreaming={isStreaming}
             canSendEmpty={hasReferences}
             onSend={doSend}
             onInputChange={handleInputChange}

--- a/web/components/chat/home/ComposerInput.tsx
+++ b/web/components/chat/home/ComposerInput.tsx
@@ -24,6 +24,7 @@ import { useImeComposing } from "@/lib/use-ime-composing";
 interface ComposerInputProps {
   textareaRef: RefObject<HTMLTextAreaElement | null>;
   isVisualizeMode: boolean;
+  isStreaming?: boolean;
   // When true, parent has attachments/references queued and will accept a
   // send even if the text body is empty. Without this, Enter would silently
   // do nothing for an attachment-only message.
@@ -128,6 +129,7 @@ export const ComposerInput = memo(
     {
       textareaRef,
       isVisualizeMode,
+      isStreaming = false,
       canSendEmpty,
       onSend,
       onInputChange,
@@ -309,7 +311,7 @@ export const ComposerInput = memo(
         }
         if (shouldSubmitOnEnter(e, isComposingRef.current)) {
           e.preventDefault();
-          doSend();
+          if (!isStreaming) doSend();
         } else if (e.key === "Escape") {
           setShowAtPopup(false);
           setShowSlashPopup(false);
@@ -317,6 +319,7 @@ export const ComposerInput = memo(
       },
       [
         doSend,
+        isStreaming,
         showSlashPopup,
         handleSelectSlashPersona,
         showAtPopup,


### PR DESCRIPTION
<!--
Thank you for contributing to DeepTutor! 🚀
Please ensure your PR is ready for review and follows our contribution guidelines.
For more details, see our [CONTRIBUTING.md](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
-->

### Description
*fix: prevent sending messages while AI is streaming response*

### Related Issues
- Closes #...
- Related to #...

### Module(s) Affected
- [ ] `web` (Frontend)


### Checklist
- [ ] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [ ] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [ ] My changes do not introduce any new security vulnerabilities.

### Additional Notes
*Add any other context or screenshots about the pull request here.*
