### PR TITLE
fix(json_parser): strip <think> reasoning tags before parsing

### DIFF
--- a/deeptutor/utils/json_parser.py
+++ b/deeptutor/utils/json_parser.py
@@ -78,11 +78,43 @@ def parse_json_response(
             extracted_response = json_match.group(1).strip()
             log.debug("Extracted JSON from markdown code block")
 
-    # Strategy 1: Direct parsing
+    # Strategy 1: Direct parsing. Done before any <think> stripping so a valid
+    # JSON payload whose string values legitimately contain "<think>" is
+    # preserved exactly.
     try:
         return json.loads(extracted_response)
     except (json.JSONDecodeError, TypeError) as parse_error:
         log.debug(f"Direct JSON parse failed: {parse_error}")
+
+    # Strategy 1b: strip chain-of-thought <think> reasoning that models like
+    # Qwen/DeepSeek emit before the JSON payload, then retry. Only reached once
+    # direct parsing has failed, so it never rewrites already-valid JSON. Left
+    # in place, a brace inside the reasoning is picked up by the raw_decode scan
+    # below and returned instead of the real object (see issue #673).
+    if "<think" in extracted_response.lower():
+        cleaned = re.sub(
+            r"<think\b[^>]*>.*?</think>",
+            "",
+            extracted_response,
+            flags=re.DOTALL | re.IGNORECASE,
+        )
+        # Also drop an unclosed leading <think> prelude up to the first opener.
+        cleaned = re.sub(
+            r"^\s*<think\b[^>]*>.*?(?=[{\[])",
+            "",
+            cleaned,
+            count=1,
+            flags=re.DOTALL | re.IGNORECASE,
+        )
+        cleaned = cleaned.strip()
+        if cleaned != extracted_response.strip():
+            if not cleaned:
+                log.warning("LLM response contained only <think> reasoning, no JSON payload")
+                return fallback
+            try:
+                return json.loads(cleaned)
+            except (json.JSONDecodeError, TypeError):
+                extracted_response = cleaned
 
     # Prefer raw_decode before repair so trailing brace-prose cannot become a wrapping array.
     if isinstance(extracted_response, str):

--- a/tests/utils/test_json_parser.py
+++ b/tests/utils/test_json_parser.py
@@ -128,3 +128,58 @@ class TestParseJsonResponseTrailingProse:
         raw = '[{"id":1},{"id":2}] trailing {x}'
         result = parse_json_response(raw, fallback=None)
         assert result == [{"id": 1}, {"id": 2}]
+
+
+# ---------------------------------------------------------------------------
+# parse_json_response — <think> reasoning tags (issue #673)
+# ---------------------------------------------------------------------------
+
+
+class TestParseJsonResponseThinkTags:
+    def test_think_block_before_json(self) -> None:
+        response = (
+            "<think>\n1. Analyze user intent...\n2. Determine target audience...\n</think>\n"
+            '{"title":"T","description":"D","scope":"S","rationale":"R"}'
+        )
+        assert parse_json_response(response) == {
+            "title": "T",
+            "description": "D",
+            "scope": "S",
+            "rationale": "R",
+        }
+
+    def test_think_block_containing_braces_does_not_leak(self) -> None:
+        """Braces inside the reasoning must not be returned instead of the real object."""
+        response = (
+            '<think>maybe output {"draft": true} or [a, b]</think>\n'
+            '{"title":"Real","description":"D"}'
+        )
+        assert parse_json_response(response) == {"title": "Real", "description": "D"}
+
+    def test_think_block_with_markdown_fence(self) -> None:
+        response = '<think>reasoning here</think>\n```json\n{"answer": 42}\n```'
+        assert parse_json_response(response) == {"answer": 42}
+
+    def test_think_tag_case_insensitive(self) -> None:
+        response = '<THINK>step by step</THINK>{"ok": true}'
+        assert parse_json_response(response) == {"ok": True}
+
+    def test_only_think_block_returns_fallback(self) -> None:
+        response = "<think>just reasoning, no payload</think>"
+        assert parse_json_response(response) == {}
+        assert parse_json_response(response, fallback=None) is None
+
+    def test_multiple_think_blocks_stripped(self) -> None:
+        response = '<think>one</think>{"a":1}<think>two {b}</think>'
+        assert parse_json_response(response) == {"a": 1}
+
+    def test_literal_think_in_valid_json_preserved(self) -> None:
+        """A valid JSON string value that literally contains <think> must not be altered."""
+        response = '{"x":"literal <think>keep</think> value"}'
+        assert parse_json_response(response, fallback=None) == {
+            "x": "literal <think>keep</think> value"
+        }
+
+    def test_unclosed_think_prelude_without_braces(self) -> None:
+        response = '<think>reasoning here, no JSON yet\n{"real":1}'
+        assert parse_json_response(response, fallback=None) == {"real": 1}


### PR DESCRIPTION
## Summary

`parse_json_response()` did not account for chain-of-thought `<think>...</think>` blocks that reasoning models (Qwen, DeepSeek, etc.) emit before the JSON payload. A brace **inside** the reasoning was picked up by the `raw_decode` scan and returned instead of the real object, silently yielding wrong or empty data (e.g. empty BookEngine proposal `description` / `scope` / `rationale`).

Fixes #673

## Root cause

For input like:
```
<think>
1. Analyze user intent, maybe output {"draft": true}
</think>
{"title":"T","description":"D",...}
```
direct `json.loads` fails (the `<think>` prefix), so the `raw_decode` scan runs and stops at the **first** `{` — which is the `{"draft": true}` inside the reasoning — returning that instead of the real object.

## Fix

Strip `<think>` blocks **only on the direct-parse failure path**, then retry. Key properties:

- **No regression for valid JSON**: direct `json.loads` runs *before* any stripping, so a valid payload whose string values legitimately contain the substring `<think>` (e.g. `{"x":"a <think>b</think> c"}`) is preserved exactly.
- Handles closed `<think>...</think>` blocks (one or many), case-insensitively.
- Drops an **unclosed** leading `<think>` prelude up to the first JSON opener.
- Returns the caller's `fallback` when the response is reasoning-only with no JSON payload.

## Testing

New `TestParseJsonResponseThinkTags` class (8 cases) covering: think-before-json, brace-in-reasoning-does-not-leak, markdown-fenced payload, case-insensitivity, reasoning-only fallback, multiple blocks, **literal `<think>` inside valid JSON preserved**, and unclosed prelude.

- `pytest tests/utils/` → **90 passed**
- `ruff check` / `ruff format --check` → clean
- `mypy deeptutor/utils/json_parser.py` → clean
- Verified the brace-leak regression test fails on `dev` without the fix.
