### PR TITLE
fix(partners): keep empty cells when converting Slack markdown tables

### DIFF
--- a/deeptutor/partners/channels/slack.py
+++ b/deeptutor/partners/channels/slack.py
@@ -15,6 +15,7 @@ from slackify_markdown import slackify_markdown
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
+from deeptutor.partners.helpers import convert_markdown_table_to_labeled_rows
 from deeptutor.partners.config.schema import Base, DeliveryOverrides
 
 # Slack's WSS endpoint can be blocked while HTTPS still works (auth_test
@@ -317,16 +318,4 @@ class SlackChannel(BaseChannel):
     @staticmethod
     def _convert_table(match: re.Match) -> str:
         """Convert a Markdown table to a Slack-readable list."""
-        lines = [ln.strip() for ln in match.group(0).strip().splitlines() if ln.strip()]
-        if len(lines) < 2:
-            return match.group(0)
-        headers = [h.strip() for h in lines[0].strip("|").split("|")]
-        start = 2 if re.fullmatch(r"[|\s:\-]+", lines[1]) else 1
-        rows: list[str] = []
-        for line in lines[start:]:
-            cells = [c.strip() for c in line.strip("|").split("|")]
-            cells = (cells + [""] * len(headers))[: len(headers)]
-            parts = [f"**{headers[i]}**: {cells[i]}" for i in range(len(headers)) if cells[i]]
-            if parts:
-                rows.append(" · ".join(parts))
-        return "\n".join(rows)
+        return convert_markdown_table_to_labeled_rows(match.group(0))

--- a/deeptutor/partners/helpers.py
+++ b/deeptutor/partners/helpers.py
@@ -72,3 +72,22 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
         chunks.append(content[:pos])
         content = content[pos:].lstrip()
     return chunks
+
+def convert_markdown_table_to_labeled_rows(table_text: str) -> str:
+    """Convert a Markdown pipe table to labeled rows (for Slack-style text).
+
+    Empty cells are kept so blank columns are not dropped.
+    """
+    lines = [ln.strip() for ln in table_text.strip().splitlines() if ln.strip()]
+    if len(lines) < 2:
+        return table_text
+    headers = [h.strip() for h in lines[0].strip('|').split('|')]
+    start = 2 if re.fullmatch(r'[|\s:\-]+', lines[1]) else 1
+    rows: list[str] = []
+    for line in lines[start:]:
+        cells = [c.strip() for c in line.strip('|').split('|')]
+        cells = (cells + [''] * len(headers))[: len(headers)]
+        parts = [f'**{headers[i]}**: {cells[i]}' for i in range(len(headers))]
+        if parts:
+            rows.append(' · '.join(parts))
+    return chr(10).join(rows)

--- a/tests/partners/test_markdown_table_empty_cells.py
+++ b/tests/partners/test_markdown_table_empty_cells.py
@@ -1,0 +1,20 @@
+"""Empty markdown table cells must still appear in labeled-row conversion."""
+
+from __future__ import annotations
+
+from deeptutor.partners.helpers import convert_markdown_table_to_labeled_rows
+
+
+def test_empty_cells_kept_in_converted_table() -> None:
+    table = (
+        "| Name | Score | Note |\n"
+        "| --- | --- | --- |\n"
+        "| Alice |  | ok |\n"
+        "| Bob | 10 |  |\n"
+    )
+    out = convert_markdown_table_to_labeled_rows(table)
+    assert out.count("**Name**:") == 2
+    assert out.count("**Score**:") == 2
+    assert out.count("**Note**:") == 2
+    assert "**Score**: " in out  # Alice empty score kept
+    assert out.endswith("**Note**: ") or "**Note**: " in out.split("\n")[1]


### PR DESCRIPTION
Blank cells in markdown tables were dropped when rendering for Slack, so a Score column with an empty value disappeared from the message.

Repro: convert a table row like `| Alice |  | ok |` and the Score label is missing.

Keep empty cells in the labeled-row conversion and pad short rows to the header width.