### PR TITLE
fix(math-animator): do not treat ms as minutes in duration parsing

### DIFF
--- a/deeptutor/agents/math_animator/duration_utils.py
+++ b/deeptutor/agents/math_animator/duration_utils.py
@@ -9,7 +9,7 @@ _SECOND_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _MINUTE_PATTERN = re.compile(
-    r"(?P<value>\d+(?:\.\d+)?)\s*(?:m|min|mins|minute|minutes|分钟)",
+    r"(?P<value>\d+(?:\.\d+)?)\s*(?:min(?:ute)?s?|分钟|m(?![sS]))",
     re.IGNORECASE,
 )
 

--- a/tests/agents/math_animator/test_duration_ms_not_minute.py
+++ b/tests/agents/math_animator/test_duration_ms_not_minute.py
@@ -1,0 +1,15 @@
+"""Millisecond suffixes must not be parsed as minutes."""
+
+from deeptutor.agents.math_animator.duration_utils import parse_target_duration_seconds
+
+
+def test_ms_suffix_is_not_a_minute() -> None:
+    # "1ms" previously matched bare "m" and became 60s.
+    assert parse_target_duration_seconds("1ms") is None
+    assert parse_target_duration_seconds("500ms") is None
+
+
+def test_minute_and_second_still_parse() -> None:
+    assert parse_target_duration_seconds("1m") == 60.0
+    assert parse_target_duration_seconds("1 min") == 60.0
+    assert parse_target_duration_seconds("1s") == 1.0


### PR DESCRIPTION
Bare "m" in the minute pattern matched inside "1ms", so millisecond targets were parsed as 60 seconds.

Require that "m" is not followed by "s"/"S" so "1ms" is ignored by the minute parser (and "1m" / "1 min" still work).