### PR TITLE
fix(partners): do not treat empty markdown rows as table separators

### DIFF
--- a/deeptutor/partners/channels/telegram.py
+++ b/deeptutor/partners/channels/telegram.py
@@ -21,7 +21,7 @@ from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
 from deeptutor.partners.config.paths import get_media_dir
 from deeptutor.partners.config.schema import DeliveryOverrides, StreamingSupport
-from deeptutor.partners.helpers import split_message
+from deeptutor.partners.helpers import is_markdown_table_separator_row, split_message
 from deeptutor.services.partners.commands import build_partner_help_text, partner_command_palette
 
 TELEGRAM_MAX_MESSAGE_LEN = 4000  # Telegram message character limit
@@ -81,7 +81,7 @@ def _render_table_box(table_lines: list[str]) -> str:
     has_sep = False
     for line in table_lines:
         cells = [_strip_md(c) for c in line.strip().strip("|").split("|")]
-        if all(re.match(r"^:?-+:?$", c) for c in cells if c):
+        if is_markdown_table_separator_row(cells):
             has_sep = True
             continue
         rows.append(cells)

--- a/deeptutor/partners/helpers.py
+++ b/deeptutor/partners/helpers.py
@@ -72,3 +72,13 @@ def split_message(content: str, max_len: int = 2000) -> list[str]:
         chunks.append(content[:pos])
         content = content[pos:].lstrip()
     return chunks
+
+
+def is_markdown_table_separator_row(cells: list[str]) -> bool:
+    """True if *cells* look like a markdown table separator row.
+
+    An all-empty row is not a separator (`all([])` would otherwise be True).
+    """
+    return bool(any(c for c in cells)) and all(
+        re.match(r"^:?-+:?$", c) for c in cells if c
+    )

--- a/tests/partners/test_markdown_table_separator_row.py
+++ b/tests/partners/test_markdown_table_separator_row.py
@@ -1,0 +1,18 @@
+"""All-empty markdown table rows are not separators."""
+
+from deeptutor.partners.helpers import is_markdown_table_separator_row
+
+
+def test_empty_row_is_not_separator() -> None:
+    assert is_markdown_table_separator_row(["", "", ""]) is False
+    assert is_markdown_table_separator_row([]) is False
+
+
+def test_dash_row_is_separator() -> None:
+    assert is_markdown_table_separator_row(["---", "---"]) is True
+    assert is_markdown_table_separator_row([":---", "---:"]) is True
+
+
+def test_data_row_is_not_separator() -> None:
+    assert is_markdown_table_separator_row(["1", "2"]) is False
+    assert is_markdown_table_separator_row(["1", "", "3"]) is False


### PR DESCRIPTION
Telegram table rendering treated a fully empty row as a separator because all([]) is True in Python, which dropped the row and broke alignment.

Require at least one cell before classifying a row as a separator.