### PR TITLE
fix(partners): keep leading/trailing empty Feishu table cells

### DIFF
--- a/deeptutor/partners/channels/feishu.py
+++ b/deeptutor/partners/channels/feishu.py
@@ -485,7 +485,13 @@ class FeishuChannel(BaseChannel):
             return None
 
         def split(_line: str) -> list[str]:
-            return [c.strip() for c in _line.strip("|").split("|")]
+            # strip("|") collapses leading/trailing empty cells (||col|| → one cell).
+            line = _line.strip()
+            if line.startswith("|"):
+                line = line[1:]
+            if line.endswith("|"):
+                line = line[:-1]
+            return [c.strip() for c in line.split("|")]
 
         headers = split(lines[0])
         rows = [split(_line) for _line in lines[2:]]

--- a/tests/partners/test_feishu_md_table_empty_edge_cells.py
+++ b/tests/partners/test_feishu_md_table_empty_edge_cells.py
@@ -1,0 +1,37 @@
+"""Feishu markdown tables must keep leading/trailing empty cells."""
+
+from __future__ import annotations
+
+from deeptutor.partners.channels.feishu import FeishuChannel
+
+
+def test_leading_empty_header_keeps_column_alignment() -> None:
+    table = (
+        "|| Name | Age |\n"
+        "| --- | --- | --- |\n"
+        "| id1 | Alice | 30 |\n"
+        "| id2 | Bob | 25 |\n"
+    )
+    parsed = FeishuChannel._parse_md_table(table)
+    assert parsed is not None
+    assert [c["display_name"] for c in parsed["columns"]] == ["", "Name", "Age"]
+    assert parsed["rows"] == [
+        {"c0": "id1", "c1": "Alice", "c2": "30"},
+        {"c0": "id2", "c1": "Bob", "c2": "25"},
+    ]
+
+
+def test_trailing_empty_header_keeps_row_values() -> None:
+    table = (
+        "| Name | Age ||\n"
+        "| --- | --- | --- |\n"
+        "| Alice | 30 | VIP |\n"
+        "| Bob | 25 | |\n"
+    )
+    parsed = FeishuChannel._parse_md_table(table)
+    assert parsed is not None
+    assert [c["display_name"] for c in parsed["columns"]] == ["Name", "Age", ""]
+    assert parsed["rows"] == [
+        {"c0": "Alice", "c1": "30", "c2": "VIP"},
+        {"c0": "Bob", "c1": "25", "c2": ""},
+    ]


### PR DESCRIPTION
Feishu markdown table parsing used strip("|"), so leading or trailing empty cells collapsed. A header like ||Name|Age| lost a column and shifted row values.

Split cells without stripping edge pipes so empty edge cells are preserved.