### PR TITLE
fix(rag): escape $ in GraphRAG file_pattern, fix cache type

### DIFF
--- a/deeptutor/services/rag/pipelines/graphrag/config.py
+++ b/deeptutor/services/rag/pipelines/graphrag/config.py
@@ -170,11 +170,17 @@ def build_settings(*, llm_cfg: Any = None, embedding_cfg: Any = None) -> dict[st
         },
         # Plain-text input: DeepTutor's ingestion writes parsed ``.txt`` files
         # into ``input/`` (see ``ingestion.py``) so GraphRAG never parses
-        # documents itself.
-        "input": {"type": "text", "file_pattern": r".*\.txt$"},
+        # documents itself. The ``$`` is escaped as ``$$`` because GraphRAG's
+        # loader treats the whole config text as a ``string.Template`` and does
+        # env-var substitution on it before parsing the YAML; a bare ``$`` is
+        # an "Invalid placeholder" to that pass.
+        "input": {"type": "text", "file_pattern": r".*\.txt$$"},
         "input_storage": {"type": "file", "base_dir": "input"},
         "output_storage": {"type": "file", "base_dir": "output"},
-        "cache": {"type": "file", "storage": {"type": "file", "base_dir": "cache"}},
+        # "json" is GraphRAG's on-disk cache backend id (registered in
+        # graphrag_cache.CacheFactory); "file" is a *storage* type, not a cache
+        # type, and is rejected the first time the pipeline builds a cache.
+        "cache": {"type": "json", "storage": {"type": "file", "base_dir": "cache"}},
         "reporting": {"type": "file", "base_dir": "logs"},
         # GraphRAG/LanceDB defaults to 3072 dimensions; DeepTutor must stamp the
         # active embedding dimension so Qwen-4096 and other non-default models work.

--- a/tests/services/rag/test_graphrag_pipeline.py
+++ b/tests/services/rag/test_graphrag_pipeline.py
@@ -139,6 +139,35 @@ def test_write_settings_roundtrips(tmp_path) -> None:
     assert "completion_models" in loaded and "embedding_models" in loaded
 
 
+def test_write_settings_loads_and_builds_cache_via_real_graphrag(tmp_path) -> None:
+    """The generated settings.yaml must survive GraphRAG's own config loader and
+    cache factory, not just our own yaml.safe_load roundtrip above.
+
+    GraphRAG's loader treats the config text as a ``string.Template`` and
+    substitutes env vars into it before parsing YAML, so a literal ``$`` in a
+    value (our ``file_pattern`` regex) must be escaped as ``$$`` or
+    ``load_config`` raises ``ValueError: Invalid placeholder``. And GraphRAG's
+    ``CacheFactory`` only registers ``json``/``memory``/``none`` cache types;
+    ``cache.type`` must be ``"json"``, not the ``"file"`` *storage* type.
+    This is not installed in CI (see the module docstring), so it is skipped
+    there; run locally with the ``graphrag`` extra installed to exercise it.
+    """
+    pytest.importorskip("graphrag")
+    from graphrag.config.load_config import load_config
+    from graphrag_cache.cache_factory import create_cache
+
+    gr_config.write_settings(
+        tmp_path,
+        llm_cfg=_Cfg("m", "u", "k"),
+        embedding_cfg=_Cfg("e", "u", "k"),
+    )
+    config = load_config(root_dir=tmp_path)
+    assert config.cache.type == "json"
+
+    cache = create_cache(config.cache)
+    assert type(cache).__name__ == "JsonCache"
+
+
 @pytest.mark.parametrize(
     "given,expected",
     [


### PR DESCRIPTION
GraphRAG's `load_config()` treats the whole `settings.yaml` text as a `string.Template` and substitutes env vars into it before parsing YAML. Our generated `file_pattern` regex, `.*\.txt$`, contains a bare `$`, which is an invalid placeholder to that pass and raises `ValueError: Invalid placeholder in string`, before indexing can even start.

Once that is escaped, the next call to fail is `graphrag_cache.CacheFactory.create_cache` (invoked from GraphRAG's own `run_pipeline.py`): our `cache.type` was set to `"file"`, but `"file"` is a storage type, not a registered cache type. GraphRAG's `CacheFactory` only registers `json`/`memory`/`none`, so the first indexing run raises `ValueError: CacheConfig.type 'file' is not registered in the CacheFactory`.

## Fix

In `deeptutor/services/rag/pipelines/graphrag/config.py`:
- `file_pattern`: `.*\.txt$` → `.*\.txt$$` (escapes the literal `$` for `string.Template`).
- `cache.type`: `"file"` → `"json"` (the storage type stays `"file"`; only the cache backend id was wrong).

## Verification

Installed `graphrag==3.1.1` (the version this repo pins) in a clean Docker container and drove the real path: `write_settings()` → `graphrag.config.load_config.load_config()` → `graphrag_cache.cache_factory.create_cache()`, the same call `graphrag/index/run/run_pipeline.py:45` makes. Both errors reproduce verbatim on unpatched `config.py`; both are gone after the fix, and `create_cache` returns a real `JsonCache`.

Added a regression test in `tests/services/rag/test_graphrag_pipeline.py` that exercises this same real path, guarded with `pytest.importorskip("graphrag")` since the package is not installed in this repo's CI (per the test module's own docstring). Ran it RED against the unpatched file and GREEN after the fix, both with `graphrag` installed; also ran the full existing test file and the full `tests/` suite with `graphrag` uninstalled (matching CI) to confirm no regressions: 2573 passed, 8 skipped, 3 pre-existing failures unrelated to this change (missing `git` binary in the minimal container, confirmed by installing it). `ruff check` and `ruff format --check` (0.16.0, matching CI's lint job) are clean on both changed files.

Did not reproduce or address the issue's third symptom (`uvloop`/`nest_asyncio` event-loop clash) since it is an orthogonal event-loop policy issue, not a config-generation bug, and is not required to fix these two.

Fixes #695
