### PR TITLE
fix(llm): add opus-5 to the Anthropic effort-based family list

### DIFF
--- a/deeptutor/services/llm/provider_core/anthropic_provider.py
+++ b/deeptutor/services/llm/provider_core/anthropic_provider.py
@@ -28,6 +28,7 @@ _ALNUM = string.ascii_letters + string.digits
 _EFFORT_BASED_FAMILIES: tuple[str, ...] = (
     "opus-4-7",
     "opus-4-8",
+    "opus-5",
     "sonnet-5",
     "fable-5",
     "mythos-5",

--- a/tests/services/llm/test_anthropic_provider_fixes.py
+++ b/tests/services/llm/test_anthropic_provider_fixes.py
@@ -48,7 +48,13 @@ def _kwargs(provider: AnthropicProvider, model: str) -> dict[str, Any]:
 
 def test_temperature_omitted_for_effort_based_models() -> None:
     provider = _provider()
-    for model in ("claude-opus-4-8", "claude-sonnet-5", "claude-opus-4-7", "claude-fable-5"):
+    for model in (
+        "claude-opus-4-8",
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-opus-4-7",
+        "claude-fable-5",
+    ):
         assert "temperature" not in _kwargs(provider, model), model
 
 
@@ -104,10 +110,16 @@ def _kwargs_with_effort(provider: AnthropicProvider, model: str, effort: str) ->
 
 
 def test_effort_based_families_map_real_effort_to_adaptive_thinking() -> None:
-    """Opus 4.7+/Sonnet 5/Fable 5 reject enabled+budget_tokens with a 400 —
-    a configured effort level must become adaptive thinking there."""
+    """Opus 4.7+/Opus 5/Sonnet 5/Fable 5 reject enabled+budget_tokens with a
+    400 — a configured effort level must become adaptive thinking there."""
     provider = _provider()
-    for model in ("claude-opus-4-8", "claude-sonnet-5", "claude-opus-4-7", "claude-fable-5"):
+    for model in (
+        "claude-opus-4-8",
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-opus-4-7",
+        "claude-fable-5",
+    ):
         kwargs = _kwargs_with_effort(provider, model, "high")
         assert kwargs["thinking"] == {"type": "adaptive"}, model
         assert "temperature" not in kwargs, model


### PR DESCRIPTION
Fixes #701.

## Problem

Every turn on `claude-opus-5` through the `anthropic` provider fails with HTTP 400:

```
invalid_request_error: `temperature` is deprecated for this model.
```

`_EFFORT_BASED_FAMILIES` (`anthropic_provider.py:28`) is matched by substring:

```python
effort_based = any(family in model_name for family in _EFFORT_BASED_FAMILIES)
```

No listed family is a substring of `claude-opus-5`, so `effort_based` is `False` and the caller's `temperature` is attached to the request. Opus 5 shipped after the list was last extended — the neighbouring comment already anticipates this ("Extend as new families ship").

The same flag also selects how thinking is expressed, so the miss is not limited to `temperature`: with an effort level configured, Opus 5 would have been sent `thinking: {"type": "enabled", "budget_tokens": N}`, the other form that generation rejects. One entry fixes both paths.

## Change

- `deeptutor/services/llm/provider_core/anthropic_provider.py` — add `"opus-5"` to `_EFFORT_BASED_FAMILIES`.
- `tests/services/llm/test_anthropic_provider_fixes.py` — add `claude-opus-5` to the two model tuples that already assert this behaviour.

The tests were the reason this went unnoticed: `test_temperature_omitted_for_effort_based_models` and `test_effort_based_families_map_real_effort_to_adaptive_thinking` cover exactly this contract, but were never extended with the new model. With `claude-opus-5` added they fail on `dev` and pass with the fix, so the regression is genuinely covered rather than just described.

## Verification

Without the provider fix (test change only):

```
FAILED test_temperature_omitted_for_effort_based_models
FAILED test_effort_based_families_map_real_effort_to_adaptive_thinking
2 failed, 6 passed
```

With both changes:

```
8 passed
```

Also exercised end-to-end against the live Anthropic API on a real workspace — `deeptutor run chat` and the Web UI turn path both return normal replies on `claude-opus-5` where they previously returned the 400.

## Note on the underlying mechanism

Not part of this PR, but worth flagging: a hardcoded substring list needs an edit for every new model family and fails closed-with-a-400 when it misses one, with no signal until a user hits it in production. The file's own comment names the better fix ("a capability lookup is the longer-term fix"), and this class of bug has recurred on the OpenAI-compatible side too (#141, #54). Happy to look at a capability-driven approach separately if that's a direction you'd want.

Targeting `dev` per CONTRIBUTING.md.
