### PR TITLE
fix: persist DONE event ids before a completed turn's execution is popped

### DIFF
--- a/deeptutor/services/session/turn_runtime.py
+++ b/deeptutor/services/session/turn_runtime.py
@@ -1766,7 +1766,6 @@ class TurnRuntimeManager:
                     events=assistant_events,
                     attachments=generated_attachments or None,
                 )
-            await self._flush_buffered_events(execution)
             turn_status, turn_error = _resolve_turn_outcome(
                 assistant_events,
                 pending_done_event,
@@ -1812,6 +1811,17 @@ class TurnRuntimeManager:
                     )
                 except Exception:
                     logger.debug("Failed to generate session title", exc_info=True)
+            # Flush once every terminal/post-turn event (DONE, and the title
+            # ``session_meta`` above) has been published, not before: a
+            # client that reconnects after this task's ``finally`` pops
+            # ``execution`` from ``_executions`` falls back entirely to this
+            # persisted backlog, and ``subscribe_turn`` synthesises an
+            # id-less DONE when it finds none there -- permanently orphaning
+            # the just-persisted assistant reply from that client's
+            # reconcile path (it can still see the message after a full
+            # session reload, since the row itself is fine; only the
+            # targeted in-place swap is unreachable).
+            await self._flush_buffered_events(execution)
         except asyncio.CancelledError:
             if not stream_done_sent:
                 await self._publish_live_event(

--- a/tests/services/session/test_turn_event_flush.py
+++ b/tests/services/session/test_turn_event_flush.py
@@ -1,10 +1,11 @@
 """Post-stream turn-event flush: batching, workspace mirror, PocketBase upload.
 
 The turn runtime buffers every live event in memory and persists the whole
-batch after the stream drains, right before publishing DONE. Everything on
-that path must stay O(1) round-trips w.r.t. the event count — per-event
-commits/opens/POSTs sat between the last streamed token and the client's
-spinner clearing (the "stuck on generating" report).
+batch, including DONE and any post-turn ``session_meta`` title update, once
+the turn has fully finished. Everything on that path must stay O(1) round
+trips w.r.t. the event count — per-event commits/opens/POSTs sat between the
+last streamed token and the client's spinner clearing (the "stuck on
+generating" report).
 """
 
 from __future__ import annotations

--- a/tests/services/session/test_turn_runtime_subscribe.py
+++ b/tests/services/session/test_turn_runtime_subscribe.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -147,3 +148,89 @@ async def test_start_turn_clears_orphan_running_turn_before_create(
     persisted = await store.get_turn(stale["id"])
     assert persisted is not None
     assert persisted["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_reconnect_after_turn_completion_still_carries_message_ids(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """A client that (re)subscribes after the turn already finished and its
+    in-process execution was cleaned up must still get the persisted-id
+    metadata on DONE, not just the bare status.
+
+    This is the ``resume_from`` path: the WS drops mid-turn (network blip,
+    backgrounded tab) and reconnects after the turn has already completed
+    server-side. Without persisted ids on DONE, the reconnecting client can
+    never run its optimistic-id reconcile swap for that turn -- the
+    assistant reply stays a real, correctly-persisted row, but the client's
+    local tree treats it as unreachable until a full session reload.
+    """
+
+    store = SQLiteSessionStore(tmp_path / "reconnect.db")
+    runtime = TurnRuntimeManager(store)
+
+    class FakeContextBuilder:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def build(self, **_kwargs):
+            return SimpleNamespace(
+                conversation_history=[],
+                conversation_summary="",
+                context_text="",
+                token_count=0,
+                budget=0,
+            )
+
+    class FakeOrchestrator:
+        async def handle(self, _context):
+            yield StreamEvent(
+                type=StreamEventType.CONTENT,
+                source="chat",
+                stage="responding",
+                content="hello there",
+                metadata={"call_kind": "llm_final_response"},
+            )
+
+    async def _noop_title(**_kwargs):
+        return None
+
+    monkeypatch.setattr("deeptutor.services.llm.config.get_llm_config", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        "deeptutor.services.session.context_builder.ContextBuilder",
+        FakeContextBuilder,
+    )
+    monkeypatch.setattr("deeptutor.runtime.orchestrator.ChatOrchestrator", FakeOrchestrator)
+    monkeypatch.setattr(runtime, "_maybe_generate_session_title", _noop_title)
+
+    session, turn = await runtime.start_turn(
+        {
+            "type": "start_turn",
+            "content": "what is 2+2?",
+            "session_id": None,
+            "capability": "chat",
+            "tools": [],
+            "knowledge_bases": [],
+            "attachments": [],
+            "language": "en",
+            "config": {},
+        }
+    )
+    turn_id = turn["id"]
+
+    # No one ever subscribed while the turn ran -- ``_run_turn`` is an
+    # independent task started inside ``start_turn``, so it runs (and its
+    # ``finally`` pops ``execution`` from ``_executions``) regardless.
+    execution = runtime._executions[turn_id]
+    await execution.task
+    assert turn_id not in runtime._executions
+
+    messages = await store.get_messages(session["id"])
+    assert [m["role"] for m in messages] == ["user", "assistant"]
+    real_assistant_id = messages[1]["id"]
+
+    # The client reconnects now and asks to catch up from the start.
+    events = [event async for event in runtime.subscribe_turn(turn_id, after_seq=0)]
+    done_events = [e for e in events if e["type"] == "done"]
+    assert len(done_events) == 1
+    assert done_events[0]["metadata"].get("assistant_message_id") == real_assistant_id


### PR DESCRIPTION
### Description

Root cause and fix for #698 (assistant replies intermittently disappear; the next turn loses context via a stale parent id). Companion issue: #705.

`_run_turn`'s normal-completion path persisted the buffered turn events to the store *before* constructing and publishing the terminal `done` event. `_publish_live_event` only appends to the in-memory per-turn event buffer and pushes to whatever websocket subscribers are connected at that instant; it never persists anything itself. So the `done` event, carrying `user_message_id`/`assistant_message_id`, was only ever delivered live, never persisted.

Once the turn finishes, its execution is unconditionally popped from `_executions`. A client that reconnects after that (heartbeat timeout, a backgrounded tab, a network blip) calls `subscribe_turn` via the `resume_from` path, finds no live execution and no persisted `done` in the backlog, and gets a synthesized fallback `done` (`_synthesize_done_event`) with no ids. The frontend's `RECONCILE_TURN` dispatch never fires for that turn, so the assistant reply, correctly persisted in the database the whole time, stays outside the client's optimistic-id-reconciled local tree, and the following turn's `parent_message_id` never advances past it. A full session reload re-fetches from the database and the reply reappears, which matches the "switching to another conversation and back" workaround reported in #698.

Fix: move the flush to run once, after the `done` event (and the post-turn `session_meta` title update) have been published, matching the ordering already used on the cancelled and exception paths. `events_flushed` is a single-writer, lock-guarded flag with exactly one `_flush_buffered_events` call site per branch, so this changes what a branch's one flush captures, not how many times it runs.

### Verification

Added `test_reconnect_after_turn_completion_still_carries_message_ids` (`tests/services/session/test_turn_runtime_subscribe.py`), driving the real `TurnRuntimeManager.start_turn` / `_run_turn` / `subscribe_turn` end to end (only the LLM orchestrator boundary is stubbed, same pattern as the existing `test_regenerate.py::test_end_to_end_skips_memory_refresh_and_no_duplicate_user`):

1. Start a turn and let it run to completion with **no subscriber ever attached** (`_run_turn` is an independent task, so it runs regardless).
2. Confirm both messages persisted with real ids and the execution was popped from `_executions`.
3. Call `subscribe_turn(turn_id, after_seq=0)` fresh (the reconnect path) and assert the yielded `done` event's metadata carries the real `assistant_message_id`.

Confirmed this fails on `dev` HEAD (`{"status": "completed", "synthesized": True}`, no id) and passes on this branch, both in a clean `python:3.13-slim` Docker container with an editable install. Also ran the full `tests/services/session/` suite (153 tests) and `tests/api/test_unified_ws_turn_runtime.py` in the same container: all pass, no regressions.

Updated a stale docstring in `test_turn_event_flush.py` that documented the old (buggy) "flush right before DONE" ordering.

`ruff check` and `ruff format --check` clean on the changed files (this repo's CI only runs Ruff for Python; I did not run `mypy`/`bandit`/`interrogate`, which are configured in `pre-commit` but are not invoked by any `.github/workflows/*.yml` job). Did not run the Web Node Tests job since no frontend files changed.

**Invariant check** (`events_flushed` / `_executions`, both shared mutable state): `events_flushed` has exactly one writer (`_flush_buffered_events`, under `self._lock`); `_executions` has exactly one insertion site (`start_turn`) and one removal site (`_run_turn`'s `finally`), both under the same lock. No test in this PR mocks any of those three sites: the real lock, the real dict, and the real flag are exercised.

### Related Issues
- Fixes #705
- Root cause of #698

### Module(s) Affected
- [x] `services`
- [x] `tests`

### Checklist
- [x] I have read and followed the contribution guidelines.
- [x] My code follows the project's coding standards.
- [x] `ruff check` / `ruff format --check` clean (see Verification).
- [x] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary): none needed, internal runtime behavior only.
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

Targeting `dev` per CONTRIBUTING.md (general bug fix, not multi-user-specific).
