### PR TITLE
fix(launcher): auto-run npm ci when web/node_modules is missing on source install

### DIFF
--- a/deeptutor/runtime/launcher.py
+++ b/deeptutor/runtime/launcher.py
@@ -578,6 +578,21 @@ def _resolve_frontend(
             raise SystemExit(
                 "npm not found. Source installs require Node.js/npm and `cd web && npm install`."
             )
+        if not (source / "node_modules").exists():
+            # node_modules is absent — install deps before starting the dev server.
+            # Use `npm ci` when a lockfile is present (reproducible, faster) and
+            # fall back to `npm install` otherwise.
+            has_lockfile = (source / "package-lock.json").exists()
+            install_cmd = [npm, "ci" if has_lockfile else "install"]
+            _log(
+                f"web/node_modules not found — running `{' '.join(install_cmd[1:])}` in {source} ..."
+            )
+            result = subprocess.run(install_cmd, cwd=source)
+            if result.returncode != 0:
+                raise SystemExit(
+                    f"`npm {'ci' if has_lockfile else 'install'}` failed (exit {result.returncode}). "
+                    "Fix the error above, then retry `deeptutor start`."
+                )
         return FrontendRuntime(
             "source", [npm, "run", "dev", "--", "--port", str(frontend_port)], source
         )


### PR DESCRIPTION
## Problem

Running `deeptutor start` on a fresh source checkout crashes immediately with a Node.js `MODULE_NOT_FOUND` error:

```
frontend Error: Cannot find module '.../web/node_modules/next/dist/bin/next'
RuntimeError: Frontend exited with code 1
```

This happens because `_resolve_frontend()` in `launcher.py` detects the source `web/` directory and runs `npm run dev` without first checking whether `web/node_modules` exists. Since a plain `git clone` + `pip install -e ".[cli]"` does **not** install frontend npm dependencies, every new source install fails on first run.

Fixes #709.

## Solution

In `_resolve_frontend()`, before returning the `FrontendRuntime` for source mode, check whether `node_modules` is absent and — if so — run `npm ci` automatically (or `npm install` when no lockfile exists). A non-zero exit raises a clear `SystemExit` so the user sees the npm error and knows what to fix.

```diff
     source = _source_web_dir(home)
     if source is not None:
         npm = shutil.which("npm")
         if not npm:
             raise SystemExit(
                 "npm not found. Source installs require Node.js/npm and `cd web && npm install`."
             )
+        if not (source / "node_modules").exists():
+            has_lockfile = (source / "package-lock.json").exists()
+            install_cmd = [npm, "ci" if has_lockfile else "install"]
+            _log(f"web/node_modules not found — running `{' '.join(install_cmd[1:])}` in {source} ...")
+            result = subprocess.run(install_cmd, cwd=source)
+            if result.returncode != 0:
+                raise SystemExit(
+                    f"`npm {'ci' if has_lockfile else 'install'}` failed (exit {result.returncode}). "
+                    "Fix the error above, then retry `deeptutor start`."
+                )
         return FrontendRuntime(
             "source", [npm, "run", "dev", "--", "--port", str(frontend_port)], source
         )
```

## Why this approach

- **`npm ci`** is used when `package-lock.json` is present (always the case in this repo) — it's faster and more reproducible than `npm install`.
- **`npm install`** is the fallback for non-standard setups without a lockfile.
- The check is intentionally cheap: just `Path.exists()` — no subprocess overhead when `node_modules` is already there.
- `subprocess` is already imported at the top of `launcher.py`.

## Testing

Verified on Windows 11 / Python 3.11.9 / Node.js 24.9.0:

1. Fresh `git clone` + `pip install -e ".[cli]"`
2. **Before patch:** `deeptutor start` → `MODULE_NOT_FOUND` crash
3. **After patch:** `deeptutor start` → automatically runs `npm ci`, then starts backend + frontend cleanly at `http://localhost:3782`
