### PR TITLE
fix: parse_language() collapses non-English codes to Chinese

### DIFF
--- a/deeptutor/services/config/loader.py
+++ b/deeptutor/services/config/loader.py
@@ -168,31 +168,36 @@ def get_path_from_config(config: dict[str, Any], path_key: str, default: str = N
     return default
 
 
+_LANGUAGE_ALIASES = {
+    "english": "en",
+    "chinese": "zh",
+    "cn": "zh",
+    "japanese": "ja",
+    "korean": "ko",
+    "spanish": "es",
+    "french": "fr",
+    "german": "de",
+    "russian": "ru",
+    "portuguese": "pt",
+    "italian": "it",
+}
+
+
 def parse_language(language: Any) -> str:
     """
     Unified language configuration parser, supports multiple input formats
 
-    Supported language representations:
-    - English: "en", "english", "English"
-    - Chinese: "zh", "chinese", "Chinese"
-
     Args:
-        language: Language configuration value (can be "zh"/"en"/"Chinese"/"English" etc.)
+        language: Language configuration value (ISO 639 code or full name)
 
     Returns:
-        Standardized language code: 'zh' or 'en', defaults to 'zh'
+        Standardized language code, defaults to 'en'
     """
-    if not language:
-        return "zh"
+    if not isinstance(language, str) or not language.strip():
+        return "en"
 
-    if isinstance(language, str):
-        lang_lower = language.lower()
-        if lang_lower in ["en", "english"]:
-            return "en"
-        if lang_lower in ["zh", "chinese", "cn"]:
-            return "zh"
-
-    return "zh"  # Default Chinese
+    lang_lower = language.strip().lower()
+    return _LANGUAGE_ALIASES.get(lang_lower, lang_lower)
 
 
 def get_agent_params(module_name: str) -> dict:

--- a/deeptutor/services/prompt/manager.py
+++ b/deeptutor/services/prompt/manager.py
@@ -100,7 +100,7 @@ class PromptManager:
     ) -> dict[str, Any]:
         """Load prompt file with language fallback."""
         prompt_dirs = self._candidate_prompt_dirs(module_name)
-        fallback_chain = self.LANGUAGE_FALLBACKS.get(lang_code, ["en"])
+        fallback_chain = self.LANGUAGE_FALLBACKS.get(lang_code, [lang_code, "en"])
 
         for prompts_dir in prompt_dirs:
             for lang in fallback_chain:

--- a/tests/services/config/test_parse_language.py
+++ b/tests/services/config/test_parse_language.py
@@ -1,0 +1,43 @@
+import pytest
+
+from deeptutor.services.config.loader import parse_language
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        ("en", "en"),
+        ("English", "en"),
+        ("ENGLISH", "en"),
+        ("zh", "zh"),
+        ("Chinese", "zh"),
+        ("cn", "zh"),
+        ("CN", "zh"),
+        ("ja", "ja"),
+        ("ko", "ko"),
+        ("fr", "fr"),
+        ("de", "de"),
+        ("es", "es"),
+        ("ru", "ru"),
+        ("pt", "pt"),
+        ("it", "it"),
+        ("Japanese", "ja"),
+        ("Korean", "ko"),
+        ("French", "fr"),
+        ("German", "de"),
+        ("Spanish", "es"),
+        ("Russian", "ru"),
+        ("Portuguese", "pt"),
+        ("Italian", "it"),
+        (None, "en"),
+        ("", "en"),
+        (42, "en"),
+        ({}, "en"),
+        ("pt-BR", "pt-br"),
+        ("zh-TW", "zh-tw"),
+        ("  en  ", "en"),
+        (" ja ", "ja"),
+    ],
+)
+def test_parse_language(input_val, expected):
+    assert parse_language(input_val) == expected


### PR DESCRIPTION
## Problem

`parse_language()` in `loader.py` is a binary zh/en classifier — any language code other than `"en"` (including `"ja"`, `"ko"`, `"fr"`, `"de"`, etc.) silently returns `"zh"`. This causes mixed-language output: for example, Japanese book prose renders correctly, but quizzes come back in Chinese.

```python
parse_language('ja')  # → 'zh' (wrong!)
parse_language('ko')  # → 'zh' (wrong!)
parse_language('fr')  # → 'zh' (wrong!)
```

## Root Cause

`parse_language()` only recognizes `"en"` and `"zh"`, with a hardcoded `return "zh"` fallback. A correct multi-language implementation exists in `language.py` (`_LANGUAGE_LABELS`), but `parse_language()` doesn't use it.

## Changes

### 1. `deeptutor/services/config/loader.py`
- Rewrite `parse_language()` with an alias table for common full names (`"japanese"→"ja"`, `"korean"→"ko"`, etc.) matching the codes already in `_LANGUAGE_LABELS`
- Pass through unknown ISO 639 codes lowercased (forward-compatible)
- Change default from `"zh"` to `"en"` to align with `config.system.language` and `UISettings` defaults

### 2. `deeptutor/services/prompt/manager.py`
- Improve fallback chain for unknown codes: try the requested language's prompt directory before falling back to English (`[lang_code, "en"]` instead of `["en"]`)

### 3. `tests/services/config/test_parse_language.py` (new)
- 31 parametrized tests covering aliases, ISO codes, edge cases (None, empty, non-string, whitespace), and regional codes

## Design Notes

- **No import from `language.py`** in `loader.py` to avoid circular imports (`config` is a lower-level module imported by `prompt`)
- **Default change zh→en**: Aligns with the system's own defaults. Users who explicitly set `"zh"` are unaffected
- **Pass-through for unknown codes**: Acceptable because `PromptManager` already falls back to `"en"` when no prompt YAML exists for a code
- Downstream `== "zh"` checks: non-Chinese users correctly get English templates, while `append_language_directive()` handles LLM output language

Closes #712