### PR TITLE
fix: update lazy imports to use absolute paths for service modules

### DIFF
--- a/deeptutor/services/__init__.py
+++ b/deeptutor/services/__init__.py
@@ -64,21 +64,21 @@ def __getattr__(name: str):
     import importlib
 
     if name == "llm":
-        return importlib.import_module(f"{__name__}.llm")
+        return importlib.import_module("deeptutor.services.llm")
     if name == "prompt":
-        return importlib.import_module(f"{__name__}.prompt")
+        return importlib.import_module("deeptutor.services.prompt")
     if name == "search":
-        return importlib.import_module(f"{__name__}.search")
+        return importlib.import_module("deeptutor.services.search")
     if name == "setup":
-        return importlib.import_module(f"{__name__}.setup")
+        return importlib.import_module("deeptutor.services.setup")
     if name == "session":
-        return importlib.import_module(f"{__name__}.session")
+        return importlib.import_module("deeptutor.services.session")
     if name == "config":
-        return importlib.import_module(f"{__name__}.config")
+        return importlib.import_module("deeptutor.services.config")
     if name == "rag":
-        return importlib.import_module(f"{__name__}.rag")
+        return importlib.import_module("deeptutor.services.rag")
     if name == "embedding":
-        return importlib.import_module(f"{__name__}.embedding")
+        return importlib.import_module("deeptutor.services.embedding")
     if name == "BaseSessionManager":
         from .session import BaseSessionManager
 

--- a/deeptutor/services/llm/cloud_provider.py
+++ b/deeptutor/services/llm/cloud_provider.py
@@ -128,6 +128,8 @@ def _get_aiohttp_connector() -> aiohttp.TCPConnector | None:
         A TCPConnector with SSL verification disabled when DISABLE_SSL_VERIFY
         is truthy; otherwise None to use aiohttp defaults.
     """
+    global _ssl_warning_logged
+
     # Thread-safe check and one-time warning emission
     disable_flag = bool(load_system_settings()["disable_ssl_verify"])
     if not disable_flag:
@@ -135,12 +137,12 @@ def _get_aiohttp_connector() -> aiohttp.TCPConnector | None:
 
     # Emit warning once across threads
     with _ssl_warning_lock:
-        if not globals().get("_ssl_warning_logged", False):
+        if not _ssl_warning_logged:
             logger.warning(
                 "SSL verification is disabled via DISABLE_SSL_VERIFY. This is unsafe and must "
                 "not be used in production environments."
             )
-            globals()["_ssl_warning_logged"] = True
+            _ssl_warning_logged = True
     return aiohttp.TCPConnector(ssl=False)
 
 


### PR DESCRIPTION
### Description

Replace two unsafe Python patterns:

1. **`services/__init__.py`** – 8 `importlib.import_module(f"{__name__}.{name}")` calls demoted to static literal paths. Fixes 8x `non-literal-import` findings. Same lazy-loading behavior, no dynamic injection vector from `__name__`.

2. **`services/llm/cloud_provider.py`** – `globals().get()` / `globals()["_ssl_warning_logged"]` replaced with explicit module-level variable + `global` declaration. 

### Related Issues

- n/a (general cleanup)

### Module(s) Affected

- [x] `services`

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes. _(no behavioral change — existing tests cover both paths)._
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.
