### PR TITLE
fix: preserve chat input focus after sending

### DIFF
--- a/web/components/chat/home/ChatComposer.tsx
+++ b/web/components/chat/home/ChatComposer.tsx
@@ -389,9 +389,13 @@ export default memo(function ChatComposer({
     [onAddFiles],
   );
 
+  const focusTextarea = useCallback(() => {
+    requestAnimationFrame(() => textareaRef.current?.focus());
+  }, []);
+
   useEffect(() => {
-    if (!hasMessages) textareaRef.current?.focus();
-  }, [hasMessages]);
+    if (!hasMessages) focusTextarea();
+  }, [hasMessages, focusTextarea]);
 
   const handleSelectCapability = useCallback(
     (value: string) => {
@@ -414,8 +418,12 @@ export default memo(function ChatComposer({
       onSend(content);
       setHasContent(false);
       inputHandleRef.current?.clear();
+      // Sending can move focus to the button or rerender the empty-state
+      // composer into the conversation layout. Restore it after that update
+      // so the user can keep typing, including after switching back to the tab.
+      focusTextarea();
     },
-    [onSend],
+    [focusTextarea, onSend],
   );
 
   const hasReferences =

--- a/web/components/chat/home/ChatComposer.tsx
+++ b/web/components/chat/home/ChatComposer.tsx
@@ -327,6 +327,7 @@ export default memo(function ChatComposer({
   const [moreCapsOpen, setMoreCapsOpen] = useState(false);
   const [lastCapMenuOpen, setLastCapMenuOpen] = useState(capMenuOpen);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const restoreFocusOnReturnRef = useRef(false);
   const inputHandleRef = useRef<ComposerInputHandle>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   if (lastCapMenuOpen !== capMenuOpen) {
@@ -392,6 +393,30 @@ export default memo(function ChatComposer({
   const focusTextarea = useCallback(() => {
     requestAnimationFrame(() => textareaRef.current?.focus());
   }, []);
+
+  useEffect(() => {
+    const rememberFocus = () => {
+      restoreFocusOnReturnRef.current =
+        document.activeElement === textareaRef.current;
+    };
+    const restoreFocus = () => {
+      if (
+        restoreFocusOnReturnRef.current &&
+        document.visibilityState === "visible"
+      ) {
+        focusTextarea();
+      }
+    };
+
+    window.addEventListener("blur", rememberFocus);
+    window.addEventListener("focus", restoreFocus);
+    document.addEventListener("visibilitychange", restoreFocus);
+    return () => {
+      window.removeEventListener("blur", rememberFocus);
+      window.removeEventListener("focus", restoreFocus);
+      document.removeEventListener("visibilitychange", restoreFocus);
+    };
+  }, [focusTextarea]);
 
   useEffect(() => {
     if (!hasMessages) focusTextarea();


### PR DESCRIPTION
### Description

Restores focus to the main chat composer after a message is sent.

The composer previously cleared its text but did not restore focus after the send button took focus or the empty-state composer transitioned into the conversation layout. The textarea is now focused on the next animation frame after a successful send, so users can continue typing immediately and retain that focus when returning to the browser tab.

### Related Issues

- Fixes #697

### Module(s) Affected

- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Validation

- `npx eslint components/chat/home/ChatComposer.tsx`
- `npm run test:node` (258 passed)
- `npm run lint` (0 errors; 59 pre-existing warnings)
- `npm run build`
- `git diff --check`
- Local browser: send a chat message, switch to another tab and return; the composer remains focused.

### Additional Notes

The local `pre-commit` run passed every applicable hook except its bundled Prettier 4 alpha hook, which reformats existing untouched code in this file. That unrelated reformat was not included in this PR.
