### PR TITLE
fix(chat): restore scroll position when switching sessions

### DIFF
--- a/web/app/(workspace)/home/[[...sessionId]]/page.tsx
+++ b/web/app/(workspace)/home/[[...sessionId]]/page.tsx
@@ -852,6 +852,7 @@ export default function ChatPage() {
     messageCount: state.messages.length,
     lastMessageContent: lastMessage?.content,
     lastEventCount: lastMessage?.events?.length,
+    scrollKey: state.sessionId,
   });
   const copyAssistantMessage = useCallback(async (content: string) => {
     if (!content.trim()) return;

--- a/web/components/partners/PartnerChat.tsx
+++ b/web/components/partners/PartnerChat.tsx
@@ -250,6 +250,7 @@ export default function PartnerChat({
     messageCount: messages.length + (draft ? 1 : 0),
     lastMessageContent: draft?.content ?? lastMessage?.content,
     lastEventCount: draft?.events.length ?? lastMessage?.events?.length,
+    scrollKey: `${partnerId}:${sessionKey ?? ""}`,
   });
 
   const tryAttach = useCallback(() => {

--- a/web/hooks/useChatAutoScroll.ts
+++ b/web/hooks/useChatAutoScroll.ts
@@ -9,6 +9,8 @@ interface AutoScrollOptions {
   messageCount: number;
   lastMessageContent?: string;
   lastEventCount?: number;
+  /** Identity of the transcript whose position should be remembered. */
+  scrollKey?: string | null;
 }
 
 /**
@@ -54,10 +56,24 @@ export function useChatAutoScroll({
   messageCount,
   lastMessageContent,
   lastEventCount,
+  scrollKey,
 }: AutoScrollOptions) {
   const containerRef = useRef<HTMLDivElement>(null);
   const endRef = useRef<HTMLDivElement>(null);
   const shouldAutoScrollRef = useRef(true);
+  const scrollPositionsRef = useRef(new Map<string, number>());
+  const activeScrollKeyRef = useRef(scrollKey);
+  const pendingRestoreRef = useRef<{
+    key: string;
+    position: number;
+  } | null>(null);
+
+  const saveScrollPosition = useCallback(() => {
+    const container = containerRef.current;
+    const key = activeScrollKeyRef.current;
+    if (!container || !key) return;
+    scrollPositionsRef.current.set(key, container.scrollTop);
+  }, []);
 
   const pinToBottom = useCallback(() => {
     const container = containerRef.current;
@@ -67,7 +83,44 @@ export function useChatAutoScroll({
     // means the user never sees the in-between frame where new
     // content has rendered but the scroll position is still stale.
     container.scrollTop = container.scrollHeight;
-  }, []);
+    saveScrollPosition();
+  }, [saveScrollPosition]);
+
+  // The scroll container is shared while navigating history. Save the outgoing
+  // session before its content changes, then arrange to restore the returning
+  // session after its transcript has rendered.
+  useLayoutEffect(() => {
+    if (Object.is(activeScrollKeyRef.current, scrollKey)) return;
+    saveScrollPosition();
+    activeScrollKeyRef.current = scrollKey;
+    const position = scrollKey
+      ? scrollPositionsRef.current.get(scrollKey)
+      : undefined;
+    pendingRestoreRef.current =
+      scrollKey && position !== undefined ? { key: scrollKey, position } : null;
+    // A session not seen before keeps the normal live-follow default.
+    shouldAutoScrollRef.current = position === undefined;
+  }, [saveScrollPosition, scrollKey]);
+
+  useLayoutEffect(() => {
+    const pending = pendingRestoreRef.current;
+    const container = containerRef.current;
+    if (!pending || !container || !hasMessages) return;
+    if (pending.key !== activeScrollKeyRef.current) return;
+    container.scrollTop = pending.position;
+    const distanceFromBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight;
+    shouldAutoScrollRef.current = distanceFromBottom < 80;
+    saveScrollPosition();
+    pendingRestoreRef.current = null;
+  }, [
+    hasMessages,
+    lastEventCount,
+    lastMessageContent,
+    messageCount,
+    saveScrollPosition,
+    scrollKey,
+  ]);
 
   // Primary pin: runs in layout phase after every render that bumps
   // message count / streaming content / events / composer height /
@@ -135,6 +188,7 @@ export function useChatAutoScroll({
         return;
       }
       container.scrollTop = container.scrollHeight;
+      saveScrollPosition();
       lastPinned = container.scrollTop;
     };
     const schedule = () => {
@@ -163,7 +217,7 @@ export function useChatAutoScroll({
       container.removeEventListener("scroll", onScroll);
       if (rafId) cancelAnimationFrame(rafId);
     };
-  }, [isStreaming, hasMessages]);
+  }, [isStreaming, hasMessages, saveScrollPosition]);
 
   // After streaming ends, capability viewers loaded via ``next/dynamic``
   // (MathAnimatorViewer, QuizViewer, VisualizationViewer, RichCodeBlock,
@@ -219,7 +273,8 @@ export function useChatAutoScroll({
     const distanceFromBottom =
       container.scrollHeight - container.scrollTop - container.clientHeight;
     shouldAutoScrollRef.current = distanceFromBottom < 80;
-  }, []);
+    saveScrollPosition();
+  }, [saveScrollPosition]);
 
   // Intent-based release. During dense streaming the pin above re-snaps to
   // ``scrollHeight`` on every content change, so the position-only

--- a/web/tests/chat-session-autoscroll.test.ts
+++ b/web/tests/chat-session-autoscroll.test.ts
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const hookSource = readFileSync(
+  path.resolve(process.cwd(), "hooks/useChatAutoScroll.ts"),
+  "utf8",
+);
+const chatSource = readFileSync(
+  path.resolve(
+    process.cwd(),
+    "app/(workspace)/home/[[...sessionId]]/page.tsx",
+  ),
+  "utf8",
+);
+const partnerSource = readFileSync(
+  path.resolve(process.cwd(), "components/partners/PartnerChat.tsx"),
+  "utf8",
+);
+
+test("switching chat sessions stores and restores the transcript position", () => {
+  assert.match(hookSource, /scrollPositionsRef = useRef\(new Map<string, number>\(\)\)/);
+  assert.match(
+    hookSource,
+    /saveScrollPosition\(\);[\s\S]*pendingRestoreRef\.current =[\s\S]*position !== undefined/,
+  );
+  assert.match(hookSource, /container\.scrollTop = pending\.position;/);
+});
+
+test("main and partner chats identify their active transcript", () => {
+  assert.match(chatSource, /scrollKey: state\.sessionId/);
+  assert.match(
+    partnerSource,
+    /scrollKey: `\$\{partnerId\}:\$\{sessionKey \?\? ""\}`/,
+  );
+});


### PR DESCRIPTION
## What changed

- Store a scroll position for each rendered transcript in `useChatAutoScroll`.
- Save the outgoing session's position and restore a returning session's position after its messages render.
- Pass stable session identities from both the main chat and Partner chat.
- Add regression coverage for main and Partner session identity handling.

## Why

The main chat reuses one scroll container as users navigate session history. Its raw `scrollTop` was therefore shared between transcripts: a user could leave chat A at the bottom, scroll chat B to the middle, then return to chat A and see B's middle position.

The saved position is now scoped to the transcript. A chat that was read in the middle returns to the middle; a chat left at the bottom returns to the bottom. A newly opened session retains normal live-follow behavior.

## Validation

- `npx tsc --noEmit`
- Focused Node tests: 5/5 passed
- Browser-like behavioral reproduction: release behavior returned A at B's position; the fixed hook restored both a middle position and the bottom position for their original sessions.
