### PR TITLE
Refresh MiniMax endpoints and add MiniMax-M3 context-window metadata

### DIFF
--- a/deeptutor/services/config/context_window_detection.py
+++ b/deeptutor/services/config/context_window_detection.py
@@ -32,7 +32,11 @@ _CONTEXT_WINDOW_KEYS = (
     "max_sequence_length",
 )
 
-_KNOWN_CONTEXT_WINDOWS: tuple[tuple[str, int], ...] = (("deepseek-v4", 1_000_000),)
+_KNOWN_CONTEXT_WINDOWS: tuple[tuple[str, int], ...] = (
+    ("deepseek-v4", 1_000_000),
+    ("minimax-m3", 1_000_000),
+    ("minimax-m2.7", 204_800),
+)
 
 
 @dataclass(frozen=True)

--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -330,13 +330,18 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         # not contain "kimi" and keeps the caller's temperature.
         model_overrides=(("kimi", {"temperature": None}),),
     ),
+    # MiniMax exposes two current regional endpoints that share one API key:
+    # the global endpoint (api.minimax.io) and the mainland-China endpoint
+    # (api.minimaxi.com). The global endpoint is the default here; users on the
+    # China platform can override base_url to https://api.minimaxi.com/v1 (or
+    # https://api.minimaxi.com/anthropic for the Anthropic-compatible backend).
     ProviderSpec(
         name="minimax",
         keywords=("minimax",),
         env_key="MINIMAX_API_KEY",
         display_name="MiniMax",
         backend="openai_compat",
-        default_api_base="https://api.minimaxi.com/v1",
+        default_api_base="https://api.minimax.io/v1",
         thinking_style="reasoning_split",
     ),
     ProviderSpec(
@@ -345,7 +350,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         env_key="MINIMAX_API_KEY",
         display_name="MiniMax (Anthropic)",
         backend="anthropic",
-        default_api_base="https://api.minimaxi.com/anthropic",
+        default_api_base="https://api.minimax.io/anthropic",
     ),
     ProviderSpec(
         name="mistral",

--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -330,11 +330,12 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         # not contain "kimi" and keeps the caller's temperature.
         model_overrides=(("kimi", {"temperature": None}),),
     ),
-    # MiniMax exposes two current regional endpoints that share one API key:
-    # the global endpoint (api.minimax.io) and the mainland-China endpoint
-    # (api.minimaxi.com). The global endpoint is the default here; users on the
-    # China platform can override base_url to https://api.minimaxi.com/v1 (or
-    # https://api.minimaxi.com/anthropic for the Anthropic-compatible backend).
+    # MiniMax runs two separate platforms: global (platform.minimax.io /
+    # api.minimax.io) and mainland China (platform.minimaxi.com /
+    # api.minimaxi.com). Keys are issued per platform and are NOT
+    # interchangeable. The global endpoint is the default here; China-platform
+    # users must override base_url to https://api.minimaxi.com/v1 (or
+    # https://api.minimaxi.com/anthropic) *and* use a China-platform key.
     ProviderSpec(
         name="minimax",
         keywords=("minimax",),

--- a/tests/services/config/test_context_window_detection.py
+++ b/tests/services/config/test_context_window_detection.py
@@ -72,6 +72,19 @@ def test_detect_context_window_uses_known_model_metadata_when_provider_omits_win
     assert result.source == "known_model"
 
 
+def test_detect_context_window_uses_known_minimax_m3_window(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "deeptutor.services.config.context_window_detection._detect_from_models_endpoint",
+        _metadata_none,
+    )
+    result = asyncio.run(detect_context_window(_config(model="MiniMax-M3")))
+
+    assert result.context_window == 1_000_000
+    assert result.source == "known_model"
+
+
 def test_models_endpoint_probe_honors_disable_ssl_verify(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/tests/services/config/test_provider_runtime.py
+++ b/tests/services/config/test_provider_runtime.py
@@ -235,7 +235,7 @@ def test_llm_local_fallback() -> None:
     assert resolved.api_key == "sk-no-key-required"
 
 
-def test_llm_minimax_binding_uses_minimaxi_endpoint() -> None:
+def test_llm_minimax_binding_uses_global_endpoint() -> None:
     catalog = _build_catalog(
         llm_profile={
             "id": "llm-p",
@@ -251,7 +251,7 @@ def test_llm_minimax_binding_uses_minimaxi_endpoint() -> None:
     resolved = resolve_llm_runtime_config(catalog=catalog)
     assert resolved.provider_name == "minimax"
     assert resolved.provider_mode == "standard"
-    assert resolved.effective_url == "https://api.minimaxi.com/v1"
+    assert resolved.effective_url == "https://api.minimax.io/v1"
 
 
 def test_llm_minimax_anthropic_binding_uses_anthropic_endpoint() -> None:
@@ -270,7 +270,7 @@ def test_llm_minimax_anthropic_binding_uses_anthropic_endpoint() -> None:
     resolved = resolve_llm_runtime_config(catalog=catalog)
     assert resolved.provider_name == "minimax_anthropic"
     assert resolved.provider_mode == "standard"
-    assert resolved.effective_url == "https://api.minimaxi.com/anthropic"
+    assert resolved.effective_url == "https://api.minimax.io/anthropic"
 
 
 def test_llm_custom_anthropic_binding_stays_direct() -> None:

--- a/tests/services/llm/test_capabilities.py
+++ b/tests/services/llm/test_capabilities.py
@@ -61,7 +61,7 @@ def test_moonshot_vision_models() -> None:
 def test_minimax_openai_compat_supports_tools_without_response_format() -> None:
     """MiniMax M-series models support OpenAI-compatible tool calls, but
     the provider still should not receive json_object response_format."""
-    # M3 is the current default model (512K context, image input support).
+    # M3 is the current default model (1M-token context window).
     assert supports_tools("minimax", "MiniMax-M3") is True
     assert supports_response_format("minimax", "MiniMax-M3") is False
     # M2.7 and M2.7-highspeed remain as alternatives.

--- a/tests/services/llm/test_capabilities.py
+++ b/tests/services/llm/test_capabilities.py
@@ -61,7 +61,9 @@ def test_moonshot_vision_models() -> None:
 def test_minimax_openai_compat_supports_tools_without_response_format() -> None:
     """MiniMax M-series models support OpenAI-compatible tool calls, but
     the provider still should not receive json_object response_format."""
-    # M3 is the current default model (1M-token context window).
+    # M3 is the current default model (1M-token context window, image input
+    # support — note PROVIDER_CAPABILITIES["minimax"]["supports_vision"] is
+    # still False while minimax_anthropic's is True).
     assert supports_tools("minimax", "MiniMax-M3") is True
     assert supports_response_format("minimax", "MiniMax-M3") is False
     # M2.7 and M2.7-highspeed remain as alternatives.


### PR DESCRIPTION
Reason: Point the first-class MiniMax bindings at the current global endpoints and record MiniMax-M3's built-in 1,000,000-token context window.

The MiniMax bindings previously defaulted to only the mainland-China base URLs, and the built-in context-window metadata had no entry for the current default model, so its window fell back to the runtime default while a test comment still described a 512K window.

## Changes
- `deeptutor/services/provider_registry.py`: default both MiniMax bindings (OpenAI-compatible and Anthropic-compatible) to the global endpoints (`https://api.minimax.io/v1` and `https://api.minimax.io/anthropic`), with a comment documenting the mainland-China endpoints (`https://api.minimaxi.com/...`) for users who override `base_url`.
- `deeptutor/services/config/context_window_detection.py`: add built-in context-window metadata for MiniMax-M3 (1,000,000 tokens) and MiniMax-M2.7 (204,800 tokens).
- Tests: update the provider-runtime endpoint assertions to the global URLs, correct the stale 512K context comment, and add a detection test asserting MiniMax-M3 resolves to a 1,000,000-token window.

## Checks
- `python3 -m pytest tests/services/config/test_context_window_detection.py tests/services/config/test_provider_runtime.py tests/services/llm/test_capabilities.py tests/core/test_agentic_client_provider_kwargs.py` — 54 passed
- `python3 -m ruff check` on the changed files — passed
- `python3 -m ruff format --check` on the changed files — passed
