### PR TITLE
feat(settings): expose language switcher

### DIFF
--- a/web/components/settings/LanguageSwitcher.tsx
+++ b/web/components/settings/LanguageSwitcher.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Languages } from "lucide-react";
+
+import type { Lang } from "@/lib/settings-nav";
+
+type LanguageSwitcherProps = {
+  language: "en" | "zh";
+  onChange: (language: "en" | "zh") => void;
+  tr: (label: Lang) => string;
+};
+
+const LANGUAGE_OPTIONS = [
+  { value: "en", label: "English", lang: "en" },
+  { value: "zh", label: "简体中文", lang: "zh-CN" },
+] as const;
+
+export function LanguageSwitcher({
+  language,
+  onChange,
+  tr,
+}: LanguageSwitcherProps) {
+  return (
+    <div
+      className="inline-flex min-w-0 items-center gap-1 rounded-lg border border-[var(--border)]/60 bg-[var(--muted)]/40 p-1"
+      role="group"
+      aria-label={tr({ zh: "界面语言", en: "Interface language" })}
+    >
+      <span className="hidden items-center gap-1.5 px-1.5 text-[12px] font-medium text-[var(--muted-foreground)] lg:inline-flex">
+        <Languages size={13} aria-hidden="true" />
+        {tr({ zh: "语言", en: "Language" })}
+      </span>
+      {LANGUAGE_OPTIONS.map((option) => {
+        const selected = language === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            lang={option.lang}
+            aria-pressed={selected}
+            onClick={() => onChange(option.value)}
+            className={`rounded-md px-2.5 py-1 text-[12px] transition-colors ${
+              selected
+                ? "bg-[var(--card)] font-medium text-[var(--foreground)] shadow-sm"
+                : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+            }`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/components/settings/SettingsHub.tsx
+++ b/web/components/settings/SettingsHub.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { ChevronRight, Rocket, type LucideIcon } from "lucide-react";
 
 import { apiFetch, apiUrl } from "@/lib/api";
+import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher";
 import {
   serviceReadiness,
   useSettings,
@@ -37,8 +38,14 @@ export default function SettingsHub() {
   const zh = i18n.language?.toLowerCase().startsWith("zh");
   const tr = useCallback((l: Lang) => (zh ? l.zh : l.en), [zh]);
 
-  const { catalog, catalogEditable, diagnosticsResults, startTour } =
-    useSettings();
+  const {
+    catalog,
+    catalogEditable,
+    diagnosticsResults,
+    language,
+    startTour,
+    updateLanguage,
+  } = useSettings();
 
   // Model preview: how many of the model-service leaves are configured.
   const modelStats = useMemo(() => {
@@ -90,7 +97,7 @@ export default function SettingsHub() {
 
   return (
     <div>
-      <header className="mb-7 flex items-start justify-between gap-4">
+      <header className="mb-7 flex flex-col items-start justify-between gap-4 sm:flex-row">
         <div className="min-w-0">
           <h1 className="font-serif text-[24px] font-semibold leading-tight tracking-tight text-[var(--foreground)]">
             {tr({ zh: "设置", en: "Settings" })}
@@ -102,14 +109,21 @@ export default function SettingsHub() {
             })}
           </p>
         </div>
-        <button
-          type="button"
-          onClick={startTour}
-          className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-[var(--border)]/60 px-3 py-1.5 text-[12.5px] font-medium text-[var(--muted-foreground)] transition-colors hover:border-[var(--border)] hover:text-[var(--foreground)]"
-        >
-          <Rocket size={13} />
-          {tr({ zh: "引导", en: "Tour" })}
-        </button>
+        <div className="flex w-full shrink-0 items-center justify-between gap-2 sm:w-auto sm:justify-end">
+          <LanguageSwitcher
+            language={language}
+            onChange={(next) => void updateLanguage(next)}
+            tr={tr}
+          />
+          <button
+            type="button"
+            onClick={startTour}
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-[var(--border)]/60 px-3 py-1.5 text-[12.5px] font-medium text-[var(--muted-foreground)] transition-colors hover:border-[var(--border)] hover:text-[var(--foreground)]"
+          >
+            <Rocket size={13} />
+            {tr({ zh: "引导", en: "Tour" })}
+          </button>
+        </div>
       </header>
 
       <SettingsStatusPanel />

--- a/web/components/settings/SettingsHub.tsx
+++ b/web/components/settings/SettingsHub.tsx
@@ -7,6 +7,7 @@ import { ChevronRight, Rocket, type LucideIcon } from "lucide-react";
 
 import { apiFetch, apiUrl } from "@/lib/api";
 import { LanguageSwitcher } from "@/components/settings/LanguageSwitcher";
+import { ThemeSwitcher } from "@/components/settings/ThemeSwitcher";
 import {
   serviceReadiness,
   useSettings,
@@ -44,7 +45,9 @@ export default function SettingsHub() {
     diagnosticsResults,
     language,
     startTour,
+    theme,
     updateLanguage,
+    updateTheme,
   } = useSettings();
 
   // Model preview: how many of the model-service leaves are configured.
@@ -97,7 +100,7 @@ export default function SettingsHub() {
 
   return (
     <div>
-      <header className="mb-7 flex flex-col items-start justify-between gap-4 sm:flex-row">
+      <header className="mb-7 flex flex-col items-start justify-between gap-4 lg:flex-row">
         <div className="min-w-0">
           <h1 className="font-serif text-[24px] font-semibold leading-tight tracking-tight text-[var(--foreground)]">
             {tr({ zh: "设置", en: "Settings" })}
@@ -109,7 +112,12 @@ export default function SettingsHub() {
             })}
           </p>
         </div>
-        <div className="flex w-full shrink-0 items-center justify-between gap-2 sm:w-auto sm:justify-end">
+        <div className="flex w-full shrink-0 flex-wrap items-center justify-between gap-2 lg:w-auto lg:justify-end">
+          <ThemeSwitcher
+            theme={theme}
+            onChange={(next) => void updateTheme(next)}
+            tr={tr}
+          />
           <LanguageSwitcher
             language={language}
             onChange={(next) => void updateLanguage(next)}

--- a/web/components/settings/ThemeSwitcher.tsx
+++ b/web/components/settings/ThemeSwitcher.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+
+import type { Lang } from "@/lib/settings-nav";
+import type { Theme } from "@/lib/theme";
+
+type ThemeSwitcherProps = {
+  theme: Theme;
+  onChange: (theme: Theme) => void;
+  tr: (label: Lang) => string;
+};
+
+const THEME_OPTIONS = [
+  {
+    value: "snow",
+    label: { zh: "浅色", en: "Light" },
+    icon: Sun,
+  },
+  {
+    value: "dark",
+    label: { zh: "深色", en: "Dark" },
+    icon: Moon,
+  },
+] as const;
+
+export function ThemeSwitcher({
+  theme,
+  onChange,
+  tr,
+}: ThemeSwitcherProps) {
+  const selectedMode =
+    theme === "dark" || theme === "glass" ? "dark" : "snow";
+
+  return (
+    <div
+      className="inline-flex min-w-0 items-center gap-1 rounded-lg border border-[var(--border)]/60 bg-[var(--muted)]/40 p-1"
+      role="group"
+      aria-label={tr({ zh: "界面皮肤", en: "Interface theme" })}
+    >
+      {THEME_OPTIONS.map((option) => {
+        const Icon = option.icon;
+        const selected = selectedMode === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={selected}
+            onClick={() => onChange(option.value)}
+            className={`inline-flex items-center gap-1 rounded-md px-2.5 py-1 text-[12px] transition-colors ${
+              selected
+                ? "bg-[var(--card)] font-medium text-[var(--foreground)] shadow-sm"
+                : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+            }`}
+          >
+            <Icon size={12} aria-hidden="true" />
+            {tr(option.label)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/context/AppShellContext.tsx
+++ b/web/context/AppShellContext.tsx
@@ -6,8 +6,10 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
+import { usePathname } from "next/navigation";
 import {
   getStoredTheme,
   getSystemTheme,
@@ -44,6 +46,11 @@ import {
   writeStoredSidebarCollapsed,
   type AppLanguage,
 } from "@/context/app-shell-storage";
+import { fetchBackendLanguage } from "@/context/app-shell-ui-settings";
+
+function isAuthPath(pathname: string): boolean {
+  return pathname === "/login" || pathname === "/register";
+}
 
 interface AppShellContextValue {
   theme: Theme;
@@ -65,6 +72,9 @@ interface AppShellContextValue {
 const AppShellContext = createContext<AppShellContextValue | null>(null);
 
 export function AppShellProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const previousPathnameRef = useRef<string | null>(null);
+  const languageRevisionRef = useRef(0);
   const [theme, setThemeState] = useState<Theme>(() => {
     return getStoredTheme() ?? getSystemTheme();
   });
@@ -95,6 +105,39 @@ export function AppShellProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   useEffect(() => {
+    const previousPathname = previousPathnameRef.current;
+    previousPathnameRef.current = pathname;
+
+    // Sync once when the app first opens, and once after client-side login.
+    // The backend setting is per user and must win over a new browser's empty
+    // localStorage. Avoid refetching on every normal route transition.
+    const shouldSync =
+      (previousPathname === null && !isAuthPath(pathname)) ||
+      (previousPathname !== null &&
+        isAuthPath(previousPathname) &&
+        !isAuthPath(pathname));
+    if (!shouldSync) return;
+
+    let cancelled = false;
+    const revisionAtStart = languageRevisionRef.current;
+    void fetchBackendLanguage().then((nextLanguage) => {
+      if (
+        cancelled ||
+        nextLanguage === null ||
+        revisionAtStart !== languageRevisionRef.current
+      ) {
+        return;
+      }
+      writeStoredLanguage(nextLanguage);
+      setLanguageState(nextLanguage);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pathname]);
+
+  useEffect(() => {
     return subscribeToThemeChanges((nextTheme) => {
       setThemeState(nextTheme);
     });
@@ -105,6 +148,7 @@ export function AppShellProvider({ children }: { children: React.ReactNode }) {
 
     const onStorage = (event: StorageEvent) => {
       if (event.key === LANGUAGE_STORAGE_KEY) {
+        languageRevisionRef.current += 1;
         setLanguageState(normalizeLanguage(event.newValue));
       }
       if (event.key === ACTIVE_SESSION_STORAGE_KEY) {
@@ -130,6 +174,7 @@ export function AppShellProvider({ children }: { children: React.ReactNode }) {
 
     const onLanguage = (event: Event) => {
       const detail = (event as CustomEvent<{ language?: AppLanguage }>).detail;
+      languageRevisionRef.current += 1;
       setLanguageState(normalizeLanguage(detail?.language));
     };
 
@@ -190,6 +235,7 @@ export function AppShellProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const setLanguage = useCallback((nextLanguage: AppLanguage) => {
+    languageRevisionRef.current += 1;
     writeStoredLanguage(nextLanguage);
     setLanguageState(nextLanguage);
   }, []);

--- a/web/context/AppShellContext.tsx
+++ b/web/context/AppShellContext.tsx
@@ -46,7 +46,7 @@ import {
   writeStoredSidebarCollapsed,
   type AppLanguage,
 } from "@/context/app-shell-storage";
-import { fetchBackendLanguage } from "@/context/app-shell-ui-settings";
+import { fetchBackendUiPreferences } from "@/context/app-shell-ui-settings";
 
 function isAuthPath(pathname: string): boolean {
   return pathname === "/login" || pathname === "/register";
@@ -75,6 +75,7 @@ export function AppShellProvider({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const previousPathnameRef = useRef<string | null>(null);
   const languageRevisionRef = useRef(0);
+  const themeRevisionRef = useRef(0);
   const [theme, setThemeState] = useState<Theme>(() => {
     return getStoredTheme() ?? getSystemTheme();
   });
@@ -119,17 +120,25 @@ export function AppShellProvider({ children }: { children: React.ReactNode }) {
     if (!shouldSync) return;
 
     let cancelled = false;
-    const revisionAtStart = languageRevisionRef.current;
-    void fetchBackendLanguage().then((nextLanguage) => {
+    const languageRevisionAtStart = languageRevisionRef.current;
+    const themeRevisionAtStart = themeRevisionRef.current;
+    void fetchBackendUiPreferences().then((preferences) => {
+      if (cancelled || preferences === null) return;
+
       if (
-        cancelled ||
-        nextLanguage === null ||
-        revisionAtStart !== languageRevisionRef.current
+        preferences.language !== undefined &&
+        languageRevisionAtStart === languageRevisionRef.current
       ) {
-        return;
+        writeStoredLanguage(preferences.language);
+        setLanguageState(preferences.language);
       }
-      writeStoredLanguage(nextLanguage);
-      setLanguageState(nextLanguage);
+      if (
+        preferences.theme !== undefined &&
+        themeRevisionAtStart === themeRevisionRef.current
+      ) {
+        applyThemePreference(preferences.theme);
+        setThemeState(preferences.theme);
+      }
     });
 
     return () => {
@@ -139,6 +148,7 @@ export function AppShellProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     return subscribeToThemeChanges((nextTheme) => {
+      themeRevisionRef.current += 1;
       setThemeState(nextTheme);
     });
   }, []);
@@ -230,6 +240,7 @@ export function AppShellProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const setTheme = useCallback((nextTheme: Theme) => {
+    themeRevisionRef.current += 1;
     applyThemePreference(nextTheme);
     setThemeState(nextTheme);
   }, []);

--- a/web/context/app-shell-ui-settings.ts
+++ b/web/context/app-shell-ui-settings.ts
@@ -1,0 +1,35 @@
+import { apiFetch, apiUrl } from "@/lib/api";
+
+import {
+  normalizeLanguage,
+  type AppLanguage,
+} from "@/context/app-shell-storage";
+
+type UiSettingsPayload = {
+  ui?: {
+    language?: unknown;
+  };
+};
+
+export async function fetchBackendLanguage(
+  fetcher: typeof apiFetch = apiFetch,
+): Promise<AppLanguage | null> {
+  try {
+    const response = await fetcher(apiUrl("/api/v1/settings"), {
+      skipAuthRedirect: true,
+    });
+    if (!response.ok) return null;
+
+    const payload = (await response.json()) as UiSettingsPayload;
+    const language = payload.ui?.language;
+    if (typeof language !== "string") return null;
+
+    const normalized = language.trim().toLowerCase();
+    if (!["en", "english", "zh", "chinese", "cn"].includes(normalized)) {
+      return null;
+    }
+    return normalizeLanguage(normalized);
+  } catch {
+    return null;
+  }
+}

--- a/web/context/app-shell-ui-settings.ts
+++ b/web/context/app-shell-ui-settings.ts
@@ -4,16 +4,25 @@ import {
   normalizeLanguage,
   type AppLanguage,
 } from "@/context/app-shell-storage";
+import type { Theme } from "@/lib/theme";
 
 type UiSettingsPayload = {
   ui?: {
     language?: unknown;
+    theme?: unknown;
   };
 };
 
-export async function fetchBackendLanguage(
+export type BackendUiPreferences = {
+  language?: AppLanguage;
+  theme?: Theme;
+};
+
+const VALID_THEMES = new Set<Theme>(["light", "dark", "glass", "snow"]);
+
+export async function fetchBackendUiPreferences(
   fetcher: typeof apiFetch = apiFetch,
-): Promise<AppLanguage | null> {
+): Promise<BackendUiPreferences | null> {
   try {
     const response = await fetcher(apiUrl("/api/v1/settings"), {
       skipAuthRedirect: true,
@@ -21,14 +30,22 @@ export async function fetchBackendLanguage(
     if (!response.ok) return null;
 
     const payload = (await response.json()) as UiSettingsPayload;
-    const language = payload.ui?.language;
-    if (typeof language !== "string") return null;
+    const preferences: BackendUiPreferences = {};
 
-    const normalized = language.trim().toLowerCase();
-    if (!["en", "english", "zh", "chinese", "cn"].includes(normalized)) {
-      return null;
+    const language = payload.ui?.language;
+    if (typeof language === "string") {
+      const normalized = language.trim().toLowerCase();
+      if (["en", "english", "zh", "chinese", "cn"].includes(normalized)) {
+        preferences.language = normalizeLanguage(normalized);
+      }
     }
-    return normalizeLanguage(normalized);
+
+    const theme = payload.ui?.theme;
+    if (typeof theme === "string" && VALID_THEMES.has(theme as Theme)) {
+      preferences.theme = theme as Theme;
+    }
+
+    return Object.keys(preferences).length > 0 ? preferences : null;
   } catch {
     return null;
   }

--- a/web/tests/app-shell-language-sync.test.ts
+++ b/web/tests/app-shell-language-sync.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { fetchBackendLanguage } from "../context/app-shell-ui-settings";
+
+const appShellContextPath = path.join(
+  process.cwd(),
+  "context",
+  "AppShellContext.tsx",
+);
+
+test("app shell: reads the saved backend language for a new browser", async () => {
+  let capturedInput: RequestInfo | URL | undefined;
+  let capturedInit:
+    | (RequestInit & { skipAuthRedirect?: boolean })
+    | undefined;
+
+  const language = await fetchBackendLanguage(async (input, init) => {
+    capturedInput = input;
+    capturedInit = init;
+    return {
+      ok: true,
+      json: async () => ({ ui: { language: "zh" } }),
+    } as Response;
+  });
+
+  assert.equal(language, "zh");
+  assert.match(String(capturedInput), /\/api\/v1\/settings$/);
+  assert.equal(capturedInit?.skipAuthRedirect, true);
+});
+
+test("app shell: ignores unavailable or malformed backend language", async () => {
+  const unavailable = await fetchBackendLanguage(
+    async () => ({ ok: false }) as Response,
+  );
+  const malformed = await fetchBackendLanguage(
+    async () =>
+      ({
+        ok: true,
+        json: async () => ({ ui: { language: "unexpected" } }),
+      }) as Response,
+  );
+
+  assert.equal(unavailable, null);
+  assert.equal(malformed, null);
+});
+
+test("app shell: backend language sync updates the global language source", () => {
+  const source = fs.readFileSync(appShellContextPath, "utf8");
+
+  assert.match(source, /fetchBackendLanguage\(\)/);
+  assert.match(source, /writeStoredLanguage\(nextLanguage\)/);
+  assert.match(source, /setLanguageState\(nextLanguage\)/);
+  assert.match(
+    source,
+    /revisionAtStart !== languageRevisionRef\.current/,
+    "A late backend response must not overwrite a newer user selection.",
+  );
+});

--- a/web/tests/app-shell-language-sync.test.ts
+++ b/web/tests/app-shell-language-sync.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 
-import { fetchBackendLanguage } from "../context/app-shell-ui-settings";
+import { fetchBackendUiPreferences } from "../context/app-shell-ui-settings";
 
 const appShellContextPath = path.join(
   process.cwd(),
@@ -17,29 +17,31 @@ test("app shell: reads the saved backend language for a new browser", async () =
     | (RequestInit & { skipAuthRedirect?: boolean })
     | undefined;
 
-  const language = await fetchBackendLanguage(async (input, init) => {
+  const preferences = await fetchBackendUiPreferences(async (input, init) => {
     capturedInput = input;
     capturedInit = init;
     return {
       ok: true,
-      json: async () => ({ ui: { language: "zh" } }),
+      json: async () => ({ ui: { language: "zh", theme: "dark" } }),
     } as Response;
   });
 
-  assert.equal(language, "zh");
+  assert.deepEqual(preferences, { language: "zh", theme: "dark" });
   assert.match(String(capturedInput), /\/api\/v1\/settings$/);
   assert.equal(capturedInit?.skipAuthRedirect, true);
 });
 
 test("app shell: ignores unavailable or malformed backend language", async () => {
-  const unavailable = await fetchBackendLanguage(
+  const unavailable = await fetchBackendUiPreferences(
     async () => ({ ok: false }) as Response,
   );
-  const malformed = await fetchBackendLanguage(
+  const malformed = await fetchBackendUiPreferences(
     async () =>
       ({
         ok: true,
-        json: async () => ({ ui: { language: "unexpected" } }),
+        json: async () => ({
+          ui: { language: "unexpected", theme: "neon" },
+        }),
       }) as Response,
   );
 
@@ -50,12 +52,15 @@ test("app shell: ignores unavailable or malformed backend language", async () =>
 test("app shell: backend language sync updates the global language source", () => {
   const source = fs.readFileSync(appShellContextPath, "utf8");
 
-  assert.match(source, /fetchBackendLanguage\(\)/);
-  assert.match(source, /writeStoredLanguage\(nextLanguage\)/);
-  assert.match(source, /setLanguageState\(nextLanguage\)/);
+  assert.match(source, /fetchBackendUiPreferences\(\)/);
+  assert.match(source, /writeStoredLanguage\(preferences\.language\)/);
+  assert.match(source, /setLanguageState\(preferences\.language\)/);
+  assert.match(source, /applyThemePreference\(preferences\.theme\)/);
+  assert.match(source, /setThemeState\(preferences\.theme\)/);
   assert.match(
     source,
-    /revisionAtStart !== languageRevisionRef\.current/,
+    /languageRevisionAtStart === languageRevisionRef\.current/,
     "A late backend response must not overwrite a newer user selection.",
   );
+  assert.match(source, /themeRevisionAtStart === themeRevisionRef\.current/);
 });

--- a/web/tests/settings-language-switcher.test.ts
+++ b/web/tests/settings-language-switcher.test.ts
@@ -54,8 +54,11 @@ test("settings hub: keeps language controls usable on narrow layouts", () => {
 
   assert.match(
     hubSource,
-    /flex-col items-start justify-between gap-4 sm:flex-row/,
+    /flex-col items-start justify-between gap-4 lg:flex-row/,
   );
-  assert.match(hubSource, /w-full shrink-0 items-center justify-between/);
+  assert.match(
+    hubSource,
+    /w-full shrink-0 flex-wrap items-center justify-between/,
+  );
   assert.match(switcherSource, /type="button"/);
 });

--- a/web/tests/settings-language-switcher.test.ts
+++ b/web/tests/settings-language-switcher.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const settingsHubPath = path.join(
+  process.cwd(),
+  "components",
+  "settings",
+  "SettingsHub.tsx",
+);
+const languageSwitcherPath = path.join(
+  process.cwd(),
+  "components",
+  "settings",
+  "LanguageSwitcher.tsx",
+);
+
+function readSettingsHub() {
+  return fs.readFileSync(settingsHubPath, "utf8");
+}
+
+function readLanguageSwitcher() {
+  return fs.readFileSync(languageSwitcherPath, "utf8");
+}
+
+test("settings hub: exposes English and Simplified Chinese language choices", () => {
+  const source = readLanguageSwitcher();
+
+  assert.match(source, /label: "English"/);
+  assert.match(source, /label: "简体中文"/);
+  assert.match(source, /role="group"/);
+  assert.match(source, /aria-label=\{tr\(\{ zh: "界面语言", en: "Interface language" \}\)\}/);
+});
+
+test("settings hub: uses the existing global language state and persistence action", () => {
+  const hubSource = readSettingsHub();
+  const switcherSource = readLanguageSwitcher();
+
+  assert.match(hubSource, /language,/);
+  assert.match(hubSource, /updateLanguage,/);
+  assert.match(hubSource, /void updateLanguage\(next\)/);
+  assert.match(switcherSource, /aria-pressed=\{selected\}/);
+  assert.doesNotMatch(
+    hubSource,
+    /useState<["']en["'] \| ["']zh["']>/,
+    "The settings hub must not create a second language state.",
+  );
+});
+
+test("settings hub: keeps language controls usable on narrow layouts", () => {
+  const hubSource = readSettingsHub();
+  const switcherSource = readLanguageSwitcher();
+
+  assert.match(
+    hubSource,
+    /flex-col items-start justify-between gap-4 sm:flex-row/,
+  );
+  assert.match(hubSource, /w-full shrink-0 items-center justify-between/);
+  assert.match(switcherSource, /type="button"/);
+});

--- a/web/tests/settings-theme-switcher.test.ts
+++ b/web/tests/settings-theme-switcher.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const settingsHubPath = path.join(
+  process.cwd(),
+  "components",
+  "settings",
+  "SettingsHub.tsx",
+);
+const themeSwitcherPath = path.join(
+  process.cwd(),
+  "components",
+  "settings",
+  "ThemeSwitcher.tsx",
+);
+
+test("settings hub: exposes accessible light and dark theme choices", () => {
+  const source = fs.readFileSync(themeSwitcherPath, "utf8");
+
+  assert.match(source, /zh: "浅色", en: "Light"/);
+  assert.match(source, /zh: "深色", en: "Dark"/);
+  assert.match(source, /role="group"/);
+  assert.match(source, /aria-pressed=\{selected\}/);
+});
+
+test("settings hub: uses the existing theme state and persistence action", () => {
+  const source = fs.readFileSync(settingsHubPath, "utf8");
+
+  assert.match(source, /theme,/);
+  assert.match(source, /updateTheme,/);
+  assert.match(source, /void updateTheme\(next\)/);
+  assert.match(source, /<ThemeSwitcher/);
+});
+
+test("settings hub: theme and language controls can wrap on narrow layouts", () => {
+  const source = fs.readFileSync(settingsHubPath, "utf8");
+
+  assert.match(source, /w-full shrink-0 flex-wrap items-center justify-between/);
+});


### PR DESCRIPTION
## What

- Add a discoverable English / Simplified Chinese selector to the main Settings header.
- Keep the control responsive and accessible with a localized group label and `aria-pressed` state.
- Reuse the existing `SettingsContext` language state and persistence action.

## Why

DeepTutor already supports English and Simplified Chinese, but the selector is currently nested under Appearance. Exposing it on the Settings landing page makes the bilingual experience much easier to discover, especially for Chinese-speaking users.

## Scope

This is a frontend-only settings enhancement. It does not change the existing Agent, Capability, partner, or task orchestration architecture.

## Validation

- 272 Node tests passed
- Targeted ESLint passed
- i18n parity check passed
- Next.js production build passed
- Production Docker image built successfully
- Container health check passed and `/settings` returned HTTP 200
- Browser verified English/Chinese switching and persisted Chinese selection
- Browser verified the Settings layout at desktop and 768 px viewport widths
