### PR TITLE
Create auth secret and token files with owner-only permissions

### DIFF
--- a/deeptutor/multi_user/identity.py
+++ b/deeptutor/multi_user/identity.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 from .models import Role
 from .paths import PROJECT_ROOT, SYSTEM_ROOT, migrate_legacy_multi_user_tree
+from deeptutor.utils.secret_files import write_secret_text
 
 logger = logging.getLogger(__name__)
 
@@ -110,12 +111,7 @@ def _migrate_secret() -> None:
     try:
         secret = LEGACY_SECRET_FILE.read_text(encoding="utf-8").strip()
         if secret:
-            SECRET_FILE.parent.mkdir(parents=True, exist_ok=True)
-            SECRET_FILE.write_text(secret, encoding="utf-8")
-            try:
-                SECRET_FILE.chmod(0o600)
-            except OSError:
-                pass
+            write_secret_text(SECRET_FILE, secret)
             logger.info("Migrated auth secret from %s to %s", LEGACY_SECRET_FILE, SECRET_FILE)
     except Exception as exc:
         logger.warning("Failed to migrate legacy auth secret: %s", exc)
@@ -308,13 +304,8 @@ def load_or_create_auth_secret() -> str:
             existing = SECRET_FILE.read_text(encoding="utf-8").strip()
             if existing:
                 return existing
-        SECRET_FILE.parent.mkdir(parents=True, exist_ok=True)
         generated = secrets.token_hex(32)
-        SECRET_FILE.write_text(generated, encoding="utf-8")
-        try:
-            SECRET_FILE.chmod(0o600)
-        except OSError:
-            pass
+        write_secret_text(SECRET_FILE, generated)
         logger.warning(
             "Auth is enabled and no auth_secret file exists. Generated a stable local secret at %s.",
             SECRET_FILE,

--- a/deeptutor/services/skill/credentials.py
+++ b/deeptutor/services/skill/credentials.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from deeptutor.services.path_service import get_path_service
+from deeptutor.utils.secret_files import write_secret_text
 
 logger = logging.getLogger(__name__)
 
@@ -77,12 +78,7 @@ def store_token(
         tokens = {}
         data["tokens"] = tokens
     tokens[hub] = {"token": token, "login": login, "name": name}
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-    try:
-        path.chmod(0o600)
-    except OSError:
-        pass
+    write_secret_text(path, json.dumps(data, indent=2, ensure_ascii=False) + "\n")
 
 
 def clear_token(hub: str) -> bool:

--- a/deeptutor/utils/secret_files.py
+++ b/deeptutor/utils/secret_files.py
@@ -1,0 +1,35 @@
+"""Helpers for writing files that hold secrets."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from pathlib import Path
+
+SECRET_FILE_MODE = 0o600
+SECRET_DIR_MODE = 0o700
+
+
+def write_secret_text(path: Path, text: str) -> None:
+    """Write *text* to *path*, readable only by the owner.
+
+    The mode is applied at creation rather than by a later ``chmod``, which
+    would leave the contents world-readable in between.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with contextlib.suppress(OSError):
+        path.parent.chmod(SECRET_DIR_MODE)
+
+    # O_CREAT does not apply the mode to an existing file, so a leftover from an
+    # interrupted run must be replaced rather than truncated.
+    with contextlib.suppress(FileNotFoundError):
+        path.unlink()
+
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, SECRET_FILE_MODE)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            path.unlink()
+        raise

--- a/tests/utils/test_secret_files.py
+++ b/tests/utils/test_secret_files.py
@@ -1,0 +1,79 @@
+"""write_secret_text must never leave a secret readable by other users."""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+
+import pytest
+
+from deeptutor.utils.secret_files import (
+    SECRET_FILE_MODE,
+    write_secret_text,
+)
+
+posix_only = pytest.mark.skipif(
+    os.name != "posix", reason="POSIX permission bits are not modelled on Windows"
+)
+
+
+def test_writes_the_content(tmp_path):
+    target = tmp_path / "secret.txt"
+    write_secret_text(target, "token-value")
+    assert target.read_text(encoding="utf-8") == "token-value"
+
+
+def test_creates_missing_parent(tmp_path):
+    target = tmp_path / "nested" / "deeper" / "secret.txt"
+    write_secret_text(target, "token-value")
+    assert target.exists()
+
+
+@posix_only
+def test_file_is_owner_only(tmp_path):
+    target = tmp_path / "secret.txt"
+    write_secret_text(target, "token-value")
+    assert stat.S_IMODE(target.stat().st_mode) == SECRET_FILE_MODE
+
+
+@posix_only
+def test_replaces_a_wide_open_leftover(tmp_path):
+    """O_CREAT does not narrow an existing file, so a leftover must be replaced."""
+    target = tmp_path / "secret.txt"
+    target.write_text("old", encoding="utf-8")
+    target.chmod(0o644)
+
+    write_secret_text(target, "new")
+
+    assert target.read_text(encoding="utf-8") == "new"
+    assert stat.S_IMODE(target.stat().st_mode) == SECRET_FILE_MODE
+
+
+@posix_only
+def test_never_widens_via_umask(tmp_path):
+    previous = os.umask(0)
+    try:
+        target = tmp_path / "secret.txt"
+        write_secret_text(target, "token-value")
+        assert stat.S_IMODE(target.stat().st_mode) == SECRET_FILE_MODE
+    finally:
+        os.umask(previous)
+
+
+def test_no_partial_file_when_writing_fails(tmp_path, monkeypatch):
+    """A failed write must not leave a secret behind."""
+    target = tmp_path / "secret.txt"
+
+    real_fdopen = os.fdopen
+
+    def exploding_fdopen(fd, *args, **kwargs):
+        handle = real_fdopen(fd, *args, **kwargs)
+        handle.close()
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "fdopen", exploding_fdopen)
+
+    with pytest.raises(OSError):
+        write_secret_text(target, "token-value")
+    assert not target.exists()


### PR DESCRIPTION
Secret files were written and then chmod'd:

```python
SECRET_FILE.write_text(secret, encoding="utf-8")
try:
    SECRET_FILE.chmod(0o600)
except OSError:
    pass
```

The file exists with the default umask (usually 0644) between those two calls, so the secret is briefly readable by any local user. And the chmod is swallowed, so if it fails the file stays 0644 and nothing says so.

Adds `deeptutor/utils/secret_files.py` with `write_secret_text`, which opens with `O_CREAT | O_EXCL` and mode 0600 so the file is never wider than intended, and uses it in `services/skill/credentials.py` and `multi_user/identity.py`.

It also unlinks a leftover first, since `O_CREAT` does not narrow the mode of an existing file — an interrupted earlier run would otherwise keep its old permissions.

Tests in `tests/utils/test_secret_files.py`; the permission assertions are POSIX-only and skip on Windows, where I ran them (3 passed, 3 skipped). The rest of the suite doesn't collect in my environment — 124 import errors from missing optional deps (`pydantic_settings`, `openai`, `aiohttp`), all pre-existing and unrelated.