### PR TITLE
fix: return minimal reasoning_effort for Gemini 3 and 2.5 Pro

### DIFF
--- a/deeptutor/services/llm/reasoning_params.py
+++ b/deeptutor/services/llm/reasoning_params.py
@@ -74,6 +74,11 @@ def default_reasoning_effort_for(provider: str | None, model: str | None) -> str
     provider_name = (provider or "").strip().lower()
     off_patterns = _PROVIDER_DEFAULT_OFF_PATTERNS.get(provider_name)
     if off_patterns and _matches(model or "", off_patterns):
+        _m = (model or "").lower()
+        # Gemini 3 and 2.5 Pro reject reasoning_effort="none";
+        # "minimal" is the lowest valid level for those families.
+        if "gemini-3" in _m or "gemini-2.5-pro" in _m:
+            return "minimal"
         return "none"
     return None
 

--- a/tests/services/llm/test_reasoning_params.py
+++ b/tests/services/llm/test_reasoning_params.py
@@ -14,18 +14,21 @@ class TestDefaultReasoningEffortFor:
     """Single source of truth for the implicit per-provider/model effort."""
 
     @pytest.mark.parametrize(
-        "model",
+        "model, expected",
         [
-            "gemini-2.5-flash",
-            "gemini-2.5-pro",
-            "gemini-2.5-flash-lite",
-            "GEMINI-2.5-FLASH",
-            "models/gemini-2.5-flash",
-            "gemini-3.0-pro",
+            ("gemini-2.5-flash", "none"),
+            ("gemini-2.5-flash-lite", "none"),
+            ("GEMINI-2.5-FLASH", "none"),
+            ("models/gemini-2.5-flash", "none"),
+            ("gemini-2.5-pro", "minimal"),
+            ("gemini-3.0-pro", "minimal"),
+            ("gemini-3.6-flash", "minimal"),
+            ("gemini-3.6-flash-latest", "minimal"),
+            ("models/gemini-3.6-flash", "minimal"),
         ],
     )
-    def test_gemini_thinking_models_default_to_none(self, model: str) -> None:
-        assert default_reasoning_effort_for("gemini", model) == "none"
+    def test_gemini_thinking_models_default(self, model: str, expected: str) -> None:
+        assert default_reasoning_effort_for("gemini", model) == expected
 
     @pytest.mark.parametrize(
         "model",


### PR DESCRIPTION
### Description

Gemini 3 models and Gemini 2.5 Pro reject `reasoning_effort="none"` with a 400 INVALID_ARGUMENT error. Per [Google's OpenAI-compatibility docs](https://ai.google.dev/gemini-api/docs/openai), `"none"` is only valid for the Gemini 2.5 non-Pro family.

### Fix

When the model matches a Gemini default-off pattern, check whether it is a Gemini 3 or 2.5 Pro variant and return `"minimal"` (the lowest valid level) instead of `"none"`. This preserves the cost-intent (minimal thinking) while avoiding the API error.

| Model family | Old value | New value |
|---|---|---|
| Gemini 2.5 Flash / Flash-Lite | `"none"` | `"none"` (unchanged) |
| Gemini 2.5 Pro | `"none"` ❌ 400 | `"minimal"` ✅ |
| Gemini 3.x (all) | `"none"` ❌ 400 | `"minimal"` ✅ |

### Testing

- Verified 20 test cases covering all model families, case sensitivity, prefix variants, legacy unaffected models, nil/empty inputs, and edge cases.
- Verified the integration path through `build_openai_compatible_reasoning_kwargs` produces correct kwargs.
- Existing test parametrization updated to reflect the new expected values.

Fixes #734