### PR TITLE
feat(embedding): support Gemini Embedding 2 native RAG

### DIFF
--- a/deeptutor/services/config/embedding_endpoint.py
+++ b/deeptutor/services/config/embedding_endpoint.py
@@ -6,7 +6,65 @@ user-visible Settings value aligned with provider-specific endpoint paths.
 
 from __future__ import annotations
 
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, quote, urlencode, urlparse
+
+GEMINI_DEFAULT_EMBEDDING_MODEL = "gemini-embedding-2"
+GEMINI_EMBEDDING_API_ROOT = "https://generativelanguage.googleapis.com/v1beta/models"
+GEMINI_API_HOST = "generativelanguage.googleapis.com"
+SENSITIVE_ENDPOINT_QUERY_KEYS = frozenset({"access_token", "api_key", "key", "token"})
+
+
+def redact_embedding_endpoint_for_display(endpoint: str | None) -> str:
+    """Hide credential-like query values while retaining endpoint diagnostics."""
+    url = str(endpoint or "")
+    parsed = urlparse(url)
+    if not parsed.query:
+        return url
+    query = urlencode(
+        [
+            (
+                key,
+                "[REDACTED]" if key.lower() in SENSITIVE_ENDPOINT_QUERY_KEYS else value,
+            )
+            for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        ]
+    )
+    return parsed._replace(query=query).geturl()
+
+
+def _gemini_model_id(model: str | None) -> str:
+    """Return a path-safe Gemini model id without the API ``models/`` prefix."""
+    model_id = str(model or GEMINI_DEFAULT_EMBEDDING_MODEL).strip()
+    if model_id.startswith("models/"):
+        model_id = model_id.removeprefix("models/")
+    return model_id or GEMINI_DEFAULT_EMBEDDING_MODEL
+
+
+def gemini_embedding_endpoint(model: str | None) -> str:
+    """Return Gemini's exact native synchronous batch embedding endpoint."""
+    model_id = quote(_gemini_model_id(model), safe="")
+    return f"{GEMINI_EMBEDDING_API_ROOT}/{model_id}:batchEmbedContents"
+
+
+def is_gemini_native_embedding_endpoint(endpoint: str | None) -> bool:
+    """Return whether an exact URL has Gemini's native batch endpoint shape."""
+    path = urlparse(str(endpoint or "")).path.rstrip("/")
+    return "/models/" in path and path.endswith(":batchEmbedContents")
+
+
+def _gemini_endpoint_with_model(endpoint: str, model: str) -> str:
+    """Replace the model path segment while preserving a gateway prefix/query."""
+    has_scheme = "://" in endpoint
+    parsed = urlparse(endpoint if has_scheme else f"https://{endpoint}")
+    marker = "/models/"
+    if marker not in parsed.path or not parsed.path.endswith(":batchEmbedContents"):
+        return endpoint
+    prefix = parsed.path.rsplit(marker, 1)[0]
+    model_id = quote(_gemini_model_id(model), safe="")
+    path = f"{prefix}{marker}{model_id}:batchEmbedContents"
+    updated = parsed._replace(path=path).geturl()
+    return updated if has_scheme else updated.split("://", 1)[1]
+
 
 EMBEDDING_PROVIDER_ALIASES = {
     "google": "gemini",
@@ -29,7 +87,7 @@ EMBEDDING_PROVIDER_LABELS = {
 
 EMBEDDING_PROVIDER_DEFAULT_ENDPOINTS = {
     "openai": "https://api.openai.com/v1/embeddings",
-    "gemini": "https://generativelanguage.googleapis.com/v1beta/openai/embeddings",
+    "gemini": gemini_embedding_endpoint(GEMINI_DEFAULT_EMBEDDING_MODEL),
     "openrouter": "https://openrouter.ai/api/v1/embeddings",
     "cohere": "https://api.cohere.com/v2/embed",
     "jina": "https://api.jina.ai/v1/embeddings",
@@ -44,7 +102,6 @@ EMBEDDING_PROVIDER_DEFAULT_ENDPOINTS = {
 
 EMBEDDING_PROVIDERS_REQUIRING_EMBEDDINGS_PATH = {
     "openai",
-    "gemini",
     "openrouter",
     "jina",
     "vllm",
@@ -93,14 +150,48 @@ def _same_origin_url(url: str, path: str) -> str:
     return url.rstrip("/") + path
 
 
-def normalize_embedding_endpoint_for_display(provider: str | None, base_url: str | None) -> str:
+def _append_endpoint_path(url: str, parsed, suffix: str) -> str:
+    """Append a path suffix without moving query parameters into the path."""
+    if parsed.scheme and parsed.netloc:
+        path = f"{parsed.path.rstrip('/')}{suffix}"
+        appended = parsed._replace(path=path).geturl()
+        return appended if "://" in url else appended.split("://", 1)[1]
+    return f"{url.rstrip('/')}{suffix}"
+
+
+def normalize_embedding_endpoint_for_display(
+    provider: str | None,
+    base_url: str | None,
+    model: str | None = None,
+) -> str:
     """Return the full endpoint URL that should be shown and saved in Settings."""
     provider_name = canonical_embedding_provider_name(provider)
     url = str(base_url or "").strip()
     if not url:
+        if provider_name == "gemini":
+            return gemini_embedding_endpoint(model)
         return EMBEDDING_PROVIDER_DEFAULT_ENDPOINTS.get(provider_name, "")
 
     trimmed = url.rstrip("/")
+    if provider_name == "gemini":
+        parsed = urlparse(trimmed if "://" in trimmed else f"https://{trimmed}")
+        path = parsed.path.rstrip("/")
+        if path.endswith("/embeddings"):
+            return trimmed
+        if path.endswith("/openai"):
+            return _append_endpoint_path(trimmed, parsed, "/embeddings")
+        if path.endswith("/v1"):
+            return _append_endpoint_path(trimmed, parsed, "/embeddings")
+        if path.endswith(":batchEmbedContents"):
+            # The native URL embeds the model id in its path. Synchronize that
+            # segment while retaining custom gateway prefixes and query params.
+            if model:
+                return _gemini_endpoint_with_model(trimmed, model)
+            return trimmed
+        if path.endswith("/v1beta/models"):
+            suffix = f"/{quote(_gemini_model_id(model), safe='')}:batchEmbedContents"
+            return _append_endpoint_path(trimmed, parsed, suffix)
+        return url
     if provider_name in EMBEDDING_PROVIDERS_REQUIRING_EMBEDDINGS_PATH:
         if trimmed.endswith("/embeddings"):
             return trimmed
@@ -133,7 +224,14 @@ def embedding_endpoint_validation_error(provider: str | None, base_url: str | No
     path = parsed.path.rstrip("/")
     label = EMBEDDING_PROVIDER_LABELS.get(provider_name, provider_name or "Embedding provider")
 
-    if provider_name in EMBEDDING_PROVIDERS_REQUIRING_EMBEDDINGS_PATH:
+    if provider_name == "gemini":
+        is_native = is_gemini_native_embedding_endpoint(url)
+        if not (path.endswith("/embeddings") or is_native):
+            return (
+                "Gemini embedding endpoint must end with /embeddings "
+                "or use /models/{model}:batchEmbedContents."
+            )
+    elif provider_name in EMBEDDING_PROVIDERS_REQUIRING_EMBEDDINGS_PATH:
         if not path.endswith("/embeddings"):
             return f"{label} embedding endpoint must end with /embeddings."
     elif provider_name == "ollama":

--- a/deeptutor/services/config/embedding_endpoint.py
+++ b/deeptutor/services/config/embedding_endpoint.py
@@ -10,6 +10,9 @@ from urllib.parse import parse_qsl, quote, urlencode, urlparse
 
 GEMINI_DEFAULT_EMBEDDING_MODEL = "gemini-embedding-2"
 GEMINI_EMBEDDING_API_ROOT = "https://generativelanguage.googleapis.com/v1beta/models"
+GEMINI_OPENAI_COMPAT_EMBEDDING_ENDPOINT = (
+    "https://generativelanguage.googleapis.com/v1beta/openai/embeddings"
+)
 GEMINI_API_HOST = "generativelanguage.googleapis.com"
 SENSITIVE_ENDPOINT_QUERY_KEYS = frozenset({"access_token", "api_key", "key", "token"})
 
@@ -44,6 +47,26 @@ def gemini_embedding_endpoint(model: str | None) -> str:
     """Return Gemini's exact native synchronous batch embedding endpoint."""
     model_id = quote(_gemini_model_id(model), safe="")
     return f"{GEMINI_EMBEDDING_API_ROOT}/{model_id}:batchEmbedContents"
+
+
+def is_gemini_embedding2_model(model: str | None) -> bool:
+    """Return whether a model belongs to the Gemini Embedding 2 family."""
+    return _gemini_model_id(model).lower().startswith("gemini-embedding-2")
+
+
+def gemini_default_embedding_endpoint(model: str | None) -> str:
+    """Return the endpoint a Gemini profile should default to for *model*.
+
+    Only Embedding 2 defaults to the native batch endpoint. Older models stay
+    on the OpenAI-compatible path they have always used: the native route sends
+    a ``taskType`` and L2-normalizes the response, so moving an existing
+    ``gemini-embedding-001`` profile there would change its document vectors
+    and silently invalidate the index built from them. Pointing base_url at the
+    native URL explicitly still opts any model in.
+    """
+    if is_gemini_embedding2_model(model):
+        return gemini_embedding_endpoint(model)
+    return GEMINI_OPENAI_COMPAT_EMBEDDING_ENDPOINT
 
 
 def is_gemini_native_embedding_endpoint(endpoint: str | None) -> bool:
@@ -169,7 +192,7 @@ def normalize_embedding_endpoint_for_display(
     url = str(base_url or "").strip()
     if not url:
         if provider_name == "gemini":
-            return gemini_embedding_endpoint(model)
+            return gemini_default_embedding_endpoint(model)
         return EMBEDDING_PROVIDER_DEFAULT_ENDPOINTS.get(provider_name, "")
 
     trimmed = url.rstrip("/")

--- a/deeptutor/services/config/model_catalog.py
+++ b/deeptutor/services/config/model_catalog.py
@@ -151,15 +151,23 @@ class ModelCatalogService:
                     profile.setdefault("binding", "openai")
                     profile.setdefault("extra_headers", {})
                     if service_name == "embedding":
+                        models = profile.setdefault("models", [])
+                        active_model_id = service.get("active_model_id")
+                        active_model = next(
+                            (item for item in models if item.get("id") == active_model_id),
+                            models[0] if models else {},
+                        )
                         before = str(profile.get("base_url") or "")
                         after = normalize_embedding_endpoint_for_display(
                             profile.get("binding"),
                             before,
+                            model=active_model.get("model"),
                         )
                         if after != before:
                             profile["base_url"] = after
                             changed = True
-                    models = profile.setdefault("models", [])
+                    else:
+                        models = profile.setdefault("models", [])
                     for model in models:
                         model.setdefault("id", f"{service_name}-model-{uuid4().hex[:8]}")
                         model.setdefault("name", model.get("model") or "Untitled Model")

--- a/deeptutor/services/config/provider_runtime.py
+++ b/deeptutor/services/config/provider_runtime.py
@@ -33,6 +33,7 @@ from .embedding_endpoint import (
     EMBEDDING_PROVIDER_DEFAULT_ENDPOINTS,
     dashscope_embedding_endpoint,
     embedding_endpoint_validation_error,
+    gemini_embedding_endpoint,
     normalize_embedding_endpoint_for_display,
 )
 from .loader import load_config_with_main
@@ -90,10 +91,11 @@ EMBEDDING_PROVIDERS: dict[str, EmbeddingProviderSpec] = {
     ),
     "gemini": EmbeddingProviderSpec(
         label="Gemini",
+        adapter="gemini",
         default_api_base=EMBEDDING_PROVIDER_DEFAULT_ENDPOINTS["gemini"],
         keywords=("gemini", "gemini-embedding", "text-embedding"),
         is_local=False,
-        default_model="gemini-embedding-001",
+        default_model="gemini-embedding-2",
         default_dim=3072,
     ),
     "azure_openai": EmbeddingProviderSpec(
@@ -837,8 +839,12 @@ def resolve_embedding_runtime_config(
 
     api_key = active_api_key or (mapped.api_key if mapped else "")
     api_base = active_api_base or ((mapped.api_base or "") if mapped else "")
-    if not api_base and spec.default_api_base:
-        api_base = spec.default_api_base
+    if not api_base:
+        if provider_name == "gemini":
+            # Gemini's native endpoint embeds the selected model in the path.
+            api_base = gemini_embedding_endpoint(resolved_model)
+        elif spec.default_api_base:
+            api_base = spec.default_api_base
     if provider_name == "aliyun":
         # DashScope's SDK derives the endpoint from the model id and ignores any
         # configured URL, so a saved multimodal endpoint would mislead the

--- a/deeptutor/services/config/provider_runtime.py
+++ b/deeptutor/services/config/provider_runtime.py
@@ -33,7 +33,7 @@ from .embedding_endpoint import (
     EMBEDDING_PROVIDER_DEFAULT_ENDPOINTS,
     dashscope_embedding_endpoint,
     embedding_endpoint_validation_error,
-    gemini_embedding_endpoint,
+    gemini_default_embedding_endpoint,
     normalize_embedding_endpoint_for_display,
 )
 from .loader import load_config_with_main
@@ -841,8 +841,10 @@ def resolve_embedding_runtime_config(
     api_base = active_api_base or ((mapped.api_base or "") if mapped else "")
     if not api_base:
         if provider_name == "gemini":
-            # Gemini's native endpoint embeds the selected model in the path.
-            api_base = gemini_embedding_endpoint(resolved_model)
+            # Gemini's native endpoint embeds the selected model in the path,
+            # and only Embedding 2 defaults to it — see
+            # gemini_default_embedding_endpoint for why 001 stays where it was.
+            api_base = gemini_default_embedding_endpoint(resolved_model)
         elif spec.default_api_base:
             api_base = spec.default_api_base
     if provider_name == "aliyun":

--- a/deeptutor/services/config/test_runner.py
+++ b/deeptutor/services/config/test_runner.py
@@ -10,6 +10,7 @@ from typing import Any
 from uuid import uuid4
 
 from .context_window_detection import detect_context_window
+from .embedding_endpoint import redact_embedding_endpoint_for_display
 from .model_catalog import get_model_catalog_service
 from .provider_runtime import (
     resolve_embedding_runtime_config,
@@ -321,7 +322,8 @@ class ConfigTestRunner:
         )
         run.emit(
             "info",
-            f"Request target (POSTed exactly as shown in Settings): {config.base_url}",
+            "Request target (POSTed exactly as shown in Settings): "
+            f"{redact_embedding_endpoint_for_display(config.base_url)}",
         )
         run.emit(
             "info",

--- a/deeptutor/services/embedding/adapters/__init__.py
+++ b/deeptutor/services/embedding/adapters/__init__.py
@@ -8,6 +8,7 @@ from .base import (
 )
 from .cohere import CohereEmbeddingAdapter
 from .dashscope_native import DashScopeMultiModalEmbeddingAdapter
+from .gemini import GeminiEmbeddingAdapter
 from .jina import JinaEmbeddingAdapter
 from .ollama import OllamaEmbeddingAdapter
 from .openai_compatible import OpenAICompatibleEmbeddingAdapter
@@ -20,6 +21,7 @@ ADAPTER_BACKENDS: dict[str, type[BaseEmbeddingAdapter]] = {
     "jina": JinaEmbeddingAdapter,
     "ollama": OllamaEmbeddingAdapter,
     "dashscope_native": DashScopeMultiModalEmbeddingAdapter,
+    "gemini": GeminiEmbeddingAdapter,
 }
 
 __all__ = [
@@ -31,6 +33,7 @@ __all__ = [
     "OpenAICompatibleEmbeddingAdapter",
     "OpenAISDKEmbeddingAdapter",
     "DashScopeMultiModalEmbeddingAdapter",
+    "GeminiEmbeddingAdapter",
     "JinaEmbeddingAdapter",
     "CohereEmbeddingAdapter",
     "OllamaEmbeddingAdapter",

--- a/deeptutor/services/embedding/adapters/base.py
+++ b/deeptutor/services/embedding/adapters/base.py
@@ -132,6 +132,12 @@ class BaseEmbeddingAdapter(ABC):
     (OpenAI, Cohere, Ollama, etc.) while exposing a unified interface.
     """
 
+    # Whether this adapter turns ``EmbeddingRequest.input_type`` into a
+    # provider parameter. Opt-in, because doing so changes the vectors a
+    # provider returns for the same text: switching it on for a backend that
+    # previously sent no role invalidates every index already built with it.
+    SUPPORTS_INPUT_TYPE: bool = False
+
     def __init__(self, config: Dict[str, Any]):
         """
         Initialize the adapter with configuration.

--- a/deeptutor/services/embedding/adapters/base.py
+++ b/deeptutor/services/embedding/adapters/base.py
@@ -42,6 +42,7 @@ class EmbeddingRequest:
         input_type: Input type hint for task-aware embeddings (optional)
             - Cohere: Maps to 'input_type' ("search_document", "search_query", "classification", "clustering")
             - Jina: Maps to 'task' ("retrieval.passage", "retrieval.query", etc.)
+            - Gemini Embedding 2: Maps to retrieval-specific text instructions
             - OpenAI/Ollama: Ignored
         encoding_format: Output format ("float" or "base64"). ``None`` (the
             default) lets each adapter decide: OpenAI-compatible gateways omit

--- a/deeptutor/services/embedding/adapters/cohere.py
+++ b/deeptutor/services/embedding/adapters/cohere.py
@@ -15,6 +15,10 @@ logger = logging.getLogger(__name__)
 class CohereEmbeddingAdapter(BaseEmbeddingAdapter):
     """Adapter for Cohere Embed API (v1 and v2)."""
 
+    # Cohere requires input_type and already defaults to "search_document",
+    # so document vectors are unchanged and only queries gain the right role.
+    SUPPORTS_INPUT_TYPE = True
+
     MODELS_INFO = {
         "embed-v4.0": {
             "dimensions": [256, 512, 1024, 1536],

--- a/deeptutor/services/embedding/adapters/gemini.py
+++ b/deeptutor/services/embedding/adapters/gemini.py
@@ -28,6 +28,8 @@ logger = logging.getLogger(__name__)
 class GeminiEmbeddingAdapter(OpenAICompatibleEmbeddingAdapter):
     """Use Gemini's native API while preserving saved OpenAI-compatible setups."""
 
+    SUPPORTS_INPUT_TYPE = True
+
     MODELS_INFO: dict[str, object] = {
         "gemini-embedding-2": {
             "default": 3072,

--- a/deeptutor/services/embedding/adapters/gemini.py
+++ b/deeptutor/services/embedding/adapters/gemini.py
@@ -1,0 +1,365 @@
+"""Gemini embeddings via the native batch API with legacy compatibility."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+import json
+import logging
+import math
+from typing import Any, Dict
+from urllib.parse import parse_qsl, unquote, urlparse
+
+import httpx
+
+from deeptutor.services.config.embedding_endpoint import (
+    GEMINI_API_HOST,
+    SENSITIVE_ENDPOINT_QUERY_KEYS,
+    redact_embedding_endpoint_for_display,
+)
+from deeptutor.services.llm.openai_http_client import disable_ssl_verify_enabled
+
+from .base import EmbeddingProviderError, EmbeddingRequest, EmbeddingResponse
+from .openai_compatible import OpenAICompatibleEmbeddingAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class GeminiEmbeddingAdapter(OpenAICompatibleEmbeddingAdapter):
+    """Use Gemini's native API while preserving saved OpenAI-compatible setups."""
+
+    MODELS_INFO: dict[str, object] = {
+        "gemini-embedding-2": {
+            "default": 3072,
+            "dimensions": [128, 256, 512, 768, 1536, 3072],
+        },
+        "gemini-embedding-2-preview": {
+            "default": 3072,
+            "dimensions": [128, 256, 512, 768, 1536, 3072],
+        },
+        "gemini-embedding-001": {
+            "default": 3072,
+            "dimensions": [128, 256, 512, 768, 1536, 3072],
+        },
+    }
+
+    _QUERY_PREFIX = "task: search result | query: "
+    _DOCUMENT_PREFIX = "title: none | text: "
+    _NATIVE_SUFFIX = ":batchEmbedContents"
+    _SENSITIVE_QUERY_KEYS = SENSITIVE_ENDPOINT_QUERY_KEYS
+
+    @staticmethod
+    def _model_id(model_name: str | None) -> str:
+        normalized = str(model_name or "").strip()
+        return normalized.removeprefix("models/")
+
+    @classmethod
+    def _is_embedding2(cls, model_name: str | None) -> bool:
+        """Return whether a model uses Gemini Embedding 2 prompt instructions."""
+        return cls._model_id(model_name).lower().startswith("gemini-embedding-2")
+
+    @classmethod
+    def _format_retrieval_texts(
+        cls,
+        texts: list[str],
+        input_type: str | None,
+    ) -> list[str]:
+        """Return new strings using Gemini 2's asymmetric retrieval format."""
+        if input_type == "search_query":
+            return [f"{cls._QUERY_PREFIX}{text}" for text in texts]
+        if input_type == "search_document":
+            return [f"{cls._DOCUMENT_PREFIX}{text}" for text in texts]
+        return list(texts)
+
+    @classmethod
+    def _native_endpoint_model(cls, endpoint: str | None) -> str | None:
+        path = urlparse(str(endpoint or "")).path.rstrip("/")
+        if not path.endswith(cls._NATIVE_SUFFIX) or "/models/" not in path:
+            return None
+        model_segment = path.rsplit("/models/", 1)[1]
+        return unquote(model_segment.removesuffix(cls._NATIVE_SUFFIX))
+
+    def _should_send_dimensions(self, model_name: str | None) -> bool:
+        """Only send OpenAI-style dimensions when a legacy user opted in."""
+        del model_name
+        return self.send_dimensions is True
+
+    @staticmethod
+    def _task_type(input_type: str | None) -> str | None:
+        return {
+            "search_query": "RETRIEVAL_QUERY",
+            "search_document": "RETRIEVAL_DOCUMENT",
+        }.get(input_type)
+
+    @staticmethod
+    def _normalize_vectors(vectors: list[list[float]]) -> list[list[float]]:
+        """L2-normalize vectors without mutating the provider response."""
+        normalized: list[list[float]] = []
+        for vector in vectors:
+            norm = math.sqrt(sum(value * value for value in vector))
+            normalized.append([value / norm for value in vector] if norm else list(vector))
+        return normalized
+
+    @classmethod
+    def _redacted_url(cls, url: str) -> str:
+        del cls
+        return redact_embedding_endpoint_for_display(url)
+
+    def _redacted_body(
+        self,
+        body: str,
+        *,
+        api_key: str,
+        url: str,
+        sensitive_texts: list[str],
+    ) -> str:
+        secrets = [api_key, *sensitive_texts]
+        secrets.extend(
+            value
+            for key, value in parse_qsl(urlparse(url).query, keep_blank_values=True)
+            if key.lower() in self._SENSITIVE_QUERY_KEYS
+        )
+        for key, value in self.extra_headers.items():
+            if str(key).lower() not in {"authorization", "x-goog-api-key"}:
+                continue
+            secret = str(value)
+            secrets.extend([secret, secret.encode("unicode_escape").decode("ascii")])
+            if secret.lower().startswith("bearer "):
+                token = secret[7:].strip()
+                secrets.extend([token, token.encode("unicode_escape").decode("ascii")])
+        redacted = body
+        for secret in secrets:
+            if secret:
+                redacted = redacted.replace(secret, "[REDACTED]")
+        return redacted[:500]
+
+    def _native_payload(
+        self,
+        request: EmbeddingRequest,
+        model: str,
+    ) -> dict[str, Any]:
+        model_id = self._model_id(model)
+        texts = (
+            self._format_retrieval_texts(request.texts, request.input_type)
+            if self._is_embedding2(model_id)
+            else list(request.texts)
+        )
+        dimension = request.dimensions or self.dimensions
+        task_type = self._task_type(request.input_type)
+        native_requests: list[dict[str, Any]] = []
+        for text in texts:
+            item: dict[str, Any] = {
+                "model": f"models/{model_id}",
+                "content": {"parts": [{"text": text}]},
+            }
+            if dimension and self.send_dimensions is not False:
+                item["outputDimensionality"] = dimension
+            # Gemini Embedding 2 removed task_type in favour of prompt
+            # instructions. The text-only 001 model still supports it.
+            if task_type and not self._is_embedding2(model_id):
+                item["taskType"] = task_type
+            native_requests.append(item)
+        return {"requests": native_requests}
+
+    async def _embed_native(
+        self,
+        request: EmbeddingRequest,
+        model: str,
+    ) -> EmbeddingResponse:
+        endpoint_model = self._native_endpoint_model(self.base_url)
+        model_id = self._model_id(model)
+        if endpoint_model != model_id:
+            raise ValueError(
+                f"Gemini endpoint model '{endpoint_model}' does not match selected "
+                f"model '{model_id}'. Update the visible embedding Endpoint URL."
+            )
+        if request.contents:
+            raise ValueError(
+                "DeepTutor's Gemini embedding adapter currently supports text only; "
+                "multimodal `contents` require a dedicated native content mapper."
+            )
+
+        payload = self._native_payload(request, model_id)
+        headers = {"Content-Type": "application/json"}
+        api_key = self._auth_api_key()
+        explicit_auth = {str(key).lower() for key in self.extra_headers} & {
+            "authorization",
+            "x-goog-api-key",
+        }
+        if api_key and not explicit_auth:
+            if urlparse(str(self.base_url)).hostname == GEMINI_API_HOST:
+                headers["x-goog-api-key"] = api_key
+            else:
+                headers["Authorization"] = f"Bearer {api_key}"
+        headers.update({str(key): str(value) for key, value in self.extra_headers.items()})
+        url = str(self.base_url)
+        safe_url = self._redacted_url(url)
+        timeout = httpx.Timeout(
+            connect=10.0,
+            read=max(self.request_timeout, 60),
+            write=10.0,
+            pool=10.0,
+        )
+
+        data: Any = None
+        last_error: Exception | None = None
+        for attempt in range(1 + self._MAX_RETRIES):
+            try:
+                async with httpx.AsyncClient(
+                    timeout=timeout,
+                    verify=not disable_ssl_verify_enabled(),
+                ) as client:
+                    response = await client.post(url, json=payload, headers=headers)
+                if response.status_code == 429:
+                    try:
+                        retry_after = float(response.headers.get("Retry-After", 0))
+                    except (TypeError, ValueError):
+                        retry_after = 0
+                    wait = max(
+                        retry_after,
+                        self._RATE_LIMIT_BACKOFF * (2**attempt),
+                    )
+                    logger.warning(
+                        "Gemini embedding rate limited on attempt %s/%s; retrying in %.1fs",
+                        attempt + 1,
+                        1 + self._MAX_RETRIES,
+                        wait,
+                    )
+                    await asyncio.sleep(wait)
+                    last_error = EmbeddingProviderError(
+                        "Gemini embedding provider returned HTTP 429",
+                        status=429,
+                        model=model_id,
+                        url=safe_url,
+                        provider="gemini",
+                    )
+                    continue
+                if response.status_code >= 400:
+                    raise EmbeddingProviderError(
+                        f"Gemini embedding provider returned HTTP {response.status_code}",
+                        status=response.status_code,
+                        body=self._redacted_body(
+                            response.text,
+                            api_key=api_key,
+                            url=url,
+                            sensitive_texts=request.texts,
+                        ),
+                        model=model_id,
+                        url=safe_url,
+                        provider="gemini",
+                    )
+                try:
+                    data = response.json()
+                except (json.JSONDecodeError, ValueError) as exc:
+                    raise EmbeddingProviderError(
+                        f"Gemini embedding provider returned non-JSON response: {exc}",
+                        status=response.status_code,
+                        body=self._redacted_body(
+                            response.text,
+                            api_key=api_key,
+                            url=url,
+                            sensitive_texts=request.texts,
+                        ),
+                        model=model_id,
+                        url=safe_url,
+                        provider="gemini",
+                    ) from exc
+                break
+            except httpx.TransportError as exc:
+                last_error = exc
+                if attempt >= self._MAX_RETRIES:
+                    safe_error = self._redacted_body(
+                        str(exc),
+                        api_key=api_key,
+                        url=url,
+                        sensitive_texts=request.texts,
+                    )
+                    raise EmbeddingProviderError(
+                        f"Gemini embedding transport error: {safe_error}",
+                        model=model_id,
+                        url=safe_url,
+                        provider="gemini",
+                    ) from None
+                wait = self._RETRY_BACKOFF * (2**attempt)
+                logger.warning(
+                    "Gemini embedding transport error on attempt %s/%s; retrying in %.1fs",
+                    attempt + 1,
+                    1 + self._MAX_RETRIES,
+                    wait,
+                )
+                await asyncio.sleep(wait)
+        else:
+            if last_error is not None:
+                raise last_error
+
+        raw_embeddings = data.get("embeddings") if isinstance(data, dict) else None
+        if not isinstance(raw_embeddings, list):
+            raise ValueError("Gemini native embedding response is missing the `embeddings` list.")
+        embeddings = [item.get("values") or [] for item in raw_embeddings if isinstance(item, dict)]
+        if not embeddings or any(
+            not isinstance(vector, list) or not vector for vector in embeddings
+        ):
+            raise ValueError("Gemini native embedding response contains no usable vectors.")
+        if len(embeddings) != len(request.texts):
+            raise ValueError(
+                "Gemini native embedding response count does not match the request: "
+                f"expected {len(request.texts)}, got {len(embeddings)}."
+            )
+
+        requested_dimension = request.dimensions or self.dimensions
+        if (
+            request.normalized
+            and model_id == "gemini-embedding-001"
+            and requested_dimension
+            and requested_dimension != 3072
+        ):
+            embeddings = self._normalize_vectors(embeddings)
+
+        actual_dimension = len(embeddings[0])
+        return EmbeddingResponse(
+            embeddings=embeddings,
+            model=model_id,
+            dimensions=actual_dimension,
+            usage=(data.get("usageMetadata", {}) if isinstance(data, dict) else {}),
+        )
+
+    async def embed(self, request: EmbeddingRequest) -> EmbeddingResponse:
+        """Embed text through native Gemini or a saved legacy-compatible URL."""
+        model = self._model_id(request.model or self.model)
+        if self._native_endpoint_model(self.base_url) is not None:
+            return await self._embed_native(request, model)
+
+        prepared = request
+        if not request.contents and self._is_embedding2(model):
+            prepared = replace(
+                request,
+                model=model,
+                texts=self._format_retrieval_texts(request.texts, request.input_type),
+            )
+        return await super().embed(prepared)
+
+    def get_model_info(self) -> Dict[str, Any]:
+        """Return Gemini embedding dimensions exposed to Settings diagnostics."""
+        model_name = self._model_id(self.model)
+        model_info = self.MODELS_INFO.get(model_name)
+        if model_info is None and self._is_embedding2(model_name):
+            model_info = self.MODELS_INFO["gemini-embedding-2"]
+        if not isinstance(model_info, dict):
+            return {
+                "model": model_name,
+                "dimensions": self.dimensions,
+                "supported_dimensions": [],
+                "supports_variable_dimensions": False,
+                "multimodal": False,
+                "provider": "gemini",
+            }
+        return {
+            "model": model_name,
+            "dimensions": model_info["default"],
+            "supported_dimensions": list(model_info["dimensions"]),
+            "supports_variable_dimensions": True,
+            # The current DeepTutor content contract is text-only. Advertising
+            # multimodal here would route images into an unsupported payload.
+            "multimodal": False,
+            "provider": "gemini",
+        }

--- a/deeptutor/services/embedding/client.py
+++ b/deeptutor/services/embedding/client.py
@@ -78,6 +78,11 @@ class EmbeddingClient:
         if not texts:
             return []
 
+        # Only adapters that opted in receive the role. Forwarding it to every
+        # backend would change the request Jina has always sent (no `task`) and
+        # silently invalidate the indexes built from it.
+        role = input_type if getattr(self.adapter, "SUPPORTS_INPUT_TYPE", False) else None
+
         import asyncio
 
         # Clamp configured batch size against the provider's per-request item
@@ -103,7 +108,7 @@ class EmbeddingClient:
                 texts=batch,
                 model=self.config.model,
                 dimensions=self.config.dim or None,
-                input_type=input_type,
+                input_type=role,
             )
             try:
                 response = await self.adapter.embed(request)
@@ -246,12 +251,6 @@ class EmbeddingClient:
         with concurrent.futures.ThreadPoolExecutor() as executor:
             future = executor.submit(asyncio.run, self.embed(texts))
             return future.result()
-
-    def get_embedding_func(self):
-        async def embedding_wrapper(texts: List[str]) -> List[List[float]]:
-            return await self.embed(texts)
-
-        return embedding_wrapper
 
 
 _client: Optional[EmbeddingClient] = None

--- a/deeptutor/services/embedding/client.py
+++ b/deeptutor/services/embedding/client.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional
 
+from deeptutor.services.config.embedding_endpoint import (
+    redact_embedding_endpoint_for_display,
+)
 from deeptutor.services.config.provider_runtime import (
     EMBEDDING_PROVIDERS,
     embedding_endpoint_validation_error,
@@ -40,8 +43,9 @@ class EmbeddingClient:
         endpoint = self.config.effective_url or self.config.base_url
         problem = embedding_endpoint_validation_error(self.config.binding, endpoint)
         if problem:
+            displayed_endpoint = redact_embedding_endpoint_for_display(endpoint)
             raise ValueError(
-                f"{problem} Current Settings endpoint is {endpoint!r}. "
+                f"{problem} Current Settings endpoint is {displayed_endpoint!r}. "
                 "DeepTutor sends embedding requests to the Settings URL exactly; "
                 "update the visible Endpoint URL instead of relying on hidden path appending."
             )
@@ -63,7 +67,14 @@ class EmbeddingClient:
             f"(model: {self.config.model}, dimensions: {self.config.dim})"
         )
 
-    async def embed(self, texts: List[str], progress_callback=None) -> List[List[float]]:
+    async def embed(
+        self,
+        texts: List[str],
+        progress_callback=None,
+        *,
+        input_type: str | None = None,
+    ) -> List[List[float]]:
+        """Embed text batches, optionally identifying their retrieval role."""
         if not texts:
             return []
 
@@ -92,6 +103,7 @@ class EmbeddingClient:
                 texts=batch,
                 model=self.config.model,
                 dimensions=self.config.dim or None,
+                input_type=input_type,
             )
             try:
                 response = await self.adapter.embed(request)

--- a/deeptutor/services/rag/pipelines/lightrag/config.py
+++ b/deeptutor/services/rag/pipelines/lightrag/config.py
@@ -147,19 +147,32 @@ def build_embedding_func():
             "Settings → Catalog before using a LightRAG knowledge base."
         )
 
-    base_embedding_func = get_embedding_client().get_embedding_func()
+    client = get_embedding_client()
 
-    async def embedding_func(texts):
+    async def embedding_func(texts, context="document", **_ignored):
         import numpy as np
 
-        vectors = await base_embedding_func(texts)
+        input_type = {
+            "query": "search_query",
+            "document": "search_document",
+        }.get(str(context or "").strip().lower())
+        vectors = await client.embed(texts, input_type=input_type)
         return np.asarray(vectors, dtype=np.float32)
 
-    return EmbeddingFunc(
-        embedding_dim=dim,
-        max_token_size=int(getattr(cfg, "max_tokens", 0) or _DEFAULT_MAX_TOKEN_SIZE),
-        func=embedding_func,
-    )
+    kwargs = {
+        "embedding_dim": dim,
+        "max_token_size": int(getattr(cfg, "max_tokens", 0) or _DEFAULT_MAX_TOKEN_SIZE),
+        "func": embedding_func,
+    }
+    try:
+        # Current LightRAG forwards context="query" / "document" only when
+        # this flag is set. Retain a constructor fallback for older optional
+        # raganything releases that predate asymmetric-embedding support.
+        return EmbeddingFunc(**kwargs, supports_asymmetric=True)
+    except TypeError as exc:
+        if "supports_asymmetric" not in str(exc):
+            raise
+        return EmbeddingFunc(**kwargs)
 
 
 __all__ = [

--- a/deeptutor/services/rag/pipelines/lightrag/config.py
+++ b/deeptutor/services/rag/pipelines/lightrag/config.py
@@ -149,9 +149,11 @@ def build_embedding_func():
 
     client = get_embedding_client()
 
-    async def embedding_func(texts, context="document", **_ignored):
+    async def embedding_func(texts, context=None, **_ignored):
         import numpy as np
 
+        # No context means no role, which is what the pinned LightRAG always
+        # passes — defaulting to "document" would label queries as passages.
         input_type = {
             "query": "search_query",
             "document": "search_document",
@@ -159,20 +161,11 @@ def build_embedding_func():
         vectors = await client.embed(texts, input_type=input_type)
         return np.asarray(vectors, dtype=np.float32)
 
-    kwargs = {
-        "embedding_dim": dim,
-        "max_token_size": int(getattr(cfg, "max_tokens", 0) or _DEFAULT_MAX_TOKEN_SIZE),
-        "func": embedding_func,
-    }
-    try:
-        # Current LightRAG forwards context="query" / "document" only when
-        # this flag is set. Retain a constructor fallback for older optional
-        # raganything releases that predate asymmetric-embedding support.
-        return EmbeddingFunc(**kwargs, supports_asymmetric=True)
-    except TypeError as exc:
-        if "supports_asymmetric" not in str(exc):
-            raise
-        return EmbeddingFunc(**kwargs)
+    return EmbeddingFunc(
+        embedding_dim=dim,
+        max_token_size=int(getattr(cfg, "max_tokens", 0) or _DEFAULT_MAX_TOKEN_SIZE),
+        func=embedding_func,
+    )
 
 
 __all__ = [

--- a/deeptutor/services/rag/pipelines/llamaindex/embedding_adapter.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/embedding_adapter.py
@@ -89,7 +89,7 @@ class CustomEmbedding(BaseEmbedding):
 
     async def _aget_query_embedding(self, query: str) -> List[float]:
         client = self.refresh_client()
-        embeddings = await client.embed([query])
+        embeddings = await client.embed([query], input_type="search_query")
         return validate_embedding_batch(
             embeddings,
             expected_count=1,
@@ -99,7 +99,7 @@ class CustomEmbedding(BaseEmbedding):
 
     async def _aget_text_embedding(self, text: str) -> List[float]:
         client = self.refresh_client()
-        embeddings = await client.embed([text])
+        embeddings = await client.embed([text], input_type="search_document")
         return validate_embedding_batch(
             embeddings,
             expected_count=1,
@@ -109,7 +109,11 @@ class CustomEmbedding(BaseEmbedding):
 
     async def _aget_text_embeddings(self, texts: List[str]) -> List[List[float]]:
         client = self.refresh_client()
-        embeddings = await client.embed(texts, progress_callback=self._progress_callback)
+        embeddings = await client.embed(
+            texts,
+            progress_callback=self._progress_callback,
+            input_type="search_document",
+        )
         return validate_embedding_batch(
             embeddings,
             expected_count=len(texts),

--- a/deeptutor_cli/init_cmd.py
+++ b/deeptutor_cli/init_cmd.py
@@ -11,6 +11,7 @@ intentionally thin so the order of steps is easy to read top-to-bottom.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from rich.console import Console
 import typer
@@ -187,6 +188,22 @@ def _probe_llm_with_retry(console: Console, strings: dict, choice: wiz.LLMChoice
         )
 
 
+def _embedding_default_endpoint(
+    *,
+    provider: str,
+    current_binding: str,
+    current_profile: dict[str, Any],
+    spec: Any,
+) -> str:
+    """Keep a saved endpoint when rerunning setup for the same provider."""
+    saved = str(current_profile.get("base_url") or "")
+    if provider == current_binding and saved:
+        return saved
+    if spec is not None:
+        return str(spec.default_api_base or "")
+    return saved
+
+
 def _embedding_step(
     console: Console,
     strings: dict,
@@ -198,6 +215,7 @@ def _embedding_step(
     from deeptutor.services.config.embedding_endpoint import (
         EMBEDDING_PROVIDER_LABELS,
         normalize_embedding_endpoint_for_display,
+        redact_embedding_endpoint_for_display,
     )
     from deeptutor.services.config.provider_runtime import EMBEDDING_PROVIDERS
 
@@ -219,7 +237,12 @@ def _embedding_step(
     display_provider = (
         spec.label if spec else EMBEDDING_PROVIDER_LABELS.get(provider, provider.title())
     )
-    default_endpoint = spec.default_api_base if spec else str(current_profile.get("base_url") or "")
+    default_endpoint = _embedding_default_endpoint(
+        provider=provider,
+        current_binding=current_binding,
+        current_profile=current_profile,
+        spec=spec,
+    )
 
     edit_endpoint = typer.confirm(strings["init.edit_base_url"], default=not bool(default_endpoint))
     endpoint = (
@@ -229,7 +252,8 @@ def _embedding_step(
     )
     endpoint = normalize_embedding_endpoint_for_display(provider, endpoint)
     if not edit_endpoint:
-        wiz.info(console, f"Endpoint · {endpoint or '(empty)'}")
+        displayed_endpoint = redact_embedding_endpoint_for_display(endpoint)
+        wiz.info(console, f"Endpoint · {displayed_endpoint or '(empty)'}")
 
     # Reuse the LLM key by default — most users share creds across services.
     masked = wiz._mask_secret(llm_api_key)
@@ -258,6 +282,11 @@ def _embedding_step(
         current=str((current_profile.get("models") or [{}])[0].get("model") or ""),
         custom_prompt_label=strings["init.embedding_model"],
     )
+    endpoint = normalize_embedding_endpoint_for_display(
+        provider,
+        endpoint,
+        model=model,
+    )
     dimension = typer.prompt(strings["init.embedding_dimension"], default="")
 
     choice = wiz.EmbeddingChoice(
@@ -272,7 +301,10 @@ def _embedding_step(
     if typer.confirm(strings["init.probe_offer"], default=True):
         wiz.info(console, strings["init.probe_running"].format(what=display_provider))
         ok_result, elapsed_ms, error = wiz.probe_embedding(
-            base_url=choice.base_url, api_key=choice.api_key, model=choice.model
+            base_url=choice.base_url,
+            api_key=choice.api_key,
+            model=choice.model,
+            provider=choice.binding,
         )
         choice.probed = True
         choice.probe_ok = ok_result

--- a/deeptutor_cli/init_wizard.py
+++ b/deeptutor_cli/init_wizard.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 import os
 import time
 from typing import Any
+from urllib.parse import parse_qsl, urlparse
 
 import httpx
 from rich.console import Console
@@ -23,6 +24,12 @@ from rich.table import Table
 from rich.text import Text
 import typer
 
+from deeptutor.services.config.embedding_endpoint import (
+    GEMINI_API_HOST,
+    SENSITIVE_ENDPOINT_QUERY_KEYS,
+    is_gemini_native_embedding_endpoint,
+    redact_embedding_endpoint_for_display,
+)
 from deeptutor.services.llm.config import get_token_limit_kwargs
 from deeptutor.services.provider_registry import PROVIDERS, ProviderSpec, find_by_name
 
@@ -92,7 +99,7 @@ FEATURED_EMBEDDING_PROVIDERS: tuple[str, ...] = (
 # preferred and these are extras.
 EMBEDDING_FALLBACK_MODELS: dict[str, tuple[str, ...]] = {
     "openai": ("text-embedding-3-large", "text-embedding-3-small"),
-    "gemini": ("gemini-embedding-001", "text-embedding-004"),
+    "gemini": ("gemini-embedding-2",),
     "aliyun": ("qwen3-vl-embedding", "text-embedding-v3", "text-embedding-v2"),
     "siliconflow": (
         "Qwen/Qwen3-Embedding-8B",
@@ -629,6 +636,22 @@ def _derive_embedding_models_url(endpoint: str, provider: str) -> str:
     """
     url = endpoint.rstrip("/")
 
+    if provider == "gemini":
+        parsed = urlparse(url)
+        if parsed.scheme and parsed.netloc:
+            path = parsed.path.rstrip("/")
+            if "/models/" in path and path.endswith(":batchEmbedContents"):
+                prefix = path.rsplit("/models/", 1)[0]
+                models_path = f"{prefix}/models"
+            elif path.endswith("/embeddings"):
+                prefix = path.removesuffix("/embeddings")
+                if prefix.endswith("/openai"):
+                    prefix = prefix.removesuffix("/openai")
+                models_path = f"{prefix}/models"
+            else:
+                models_path = f"{path}/models"
+            return parsed._replace(path=models_path, fragment="").geturl()
+
     if provider == "ollama" or url.endswith("/api/embed"):
         base = url
         for suffix in ("/api/embed", "/api/embeddings"):
@@ -674,16 +697,21 @@ def fetch_embedding_models(
     models_url = _derive_embedding_models_url(endpoint, provider)
     headers: dict[str, str] = {}
     if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
+        if provider == "gemini" and urlparse(endpoint).hostname == GEMINI_API_HOST:
+            headers["x-goog-api-key"] = api_key
+        else:
+            headers["Authorization"] = f"Bearer {api_key}"
 
-    info(console, strings["init.fetch_models"].format(url=models_url))
+    displayed_models_url = redact_embedding_endpoint_for_display(models_url)
+    info(console, strings["init.fetch_models"].format(url=displayed_models_url))
     try:
         with httpx.Client(timeout=5.0) as client:
             response = client.get(models_url, headers=headers)
         response.raise_for_status()
         payload = response.json()
     except Exception as exc:
-        warn(console, strings["init.fetch_models_fail"].format(error=str(exc)[:160]))
+        error = str(exc).replace(models_url, displayed_models_url)[:160]
+        warn(console, strings["init.fetch_models_fail"].format(error=error))
         return []
 
     raw_items: list[Any] = []
@@ -703,6 +731,8 @@ def fetch_embedding_models(
         elif isinstance(item, dict):
             name = item.get("id") or item.get("name") or item.get("model")
             if isinstance(name, str) and name:
+                if provider == "gemini" and name.startswith("models/"):
+                    name = name.removeprefix("models/")
                 names.append(name)
     if not names:
         warn(console, strings["init.fetch_models_fail"].format(error="empty model list"))
@@ -811,26 +841,63 @@ def probe_llm(*, base_url: str, api_key: str, binding: str, model: str) -> tuple
         return False, elapsed, str(exc)[:200]
 
 
-def probe_embedding(*, base_url: str, api_key: str, model: str) -> tuple[bool, int, str]:
+def probe_embedding(
+    *,
+    base_url: str,
+    api_key: str,
+    model: str,
+    provider: str = "",
+) -> tuple[bool, int, str]:
     """POST a tiny embedding request. Returns ``(ok, elapsed_ms, error)``."""
     if not base_url or not model:
         return False, 0, "missing base_url or model"
     started = time.monotonic()
+
+    def _safe_error(text: str) -> str:
+        secrets = [api_key]
+        secrets.extend(
+            value
+            for key, value in parse_qsl(urlparse(base_url).query, keep_blank_values=True)
+            if key.lower() in SENSITIVE_ENDPOINT_QUERY_KEYS
+        )
+        safe = text.replace(
+            base_url,
+            redact_embedding_endpoint_for_display(base_url),
+        )
+        for secret in secrets:
+            if secret:
+                safe = safe.replace(secret, "[REDACTED]")
+        return safe[:200]
+
     try:
-        headers = {
-            "Authorization": f"Bearer {api_key or 'sk-no-key-required'}",
-            "Content-Type": "application/json",
-        }
-        body = {"model": model, "input": "ping"}
+        headers = {"Content-Type": "application/json"}
+        body: dict[str, Any]
+        if provider == "gemini" and is_gemini_native_embedding_endpoint(base_url):
+            if api_key and urlparse(base_url).hostname == GEMINI_API_HOST:
+                headers["x-goog-api-key"] = api_key
+            elif api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+            model_id = model.removeprefix("models/")
+            body = {
+                "requests": [
+                    {
+                        "model": f"models/{model_id}",
+                        "content": {"parts": [{"text": "ping"}]},
+                    }
+                ]
+            }
+        else:
+            headers["Authorization"] = f"Bearer {api_key or 'sk-no-key-required'}"
+            body = {"model": model, "input": "ping"}
         with httpx.Client(timeout=15.0) as client:
             response = client.post(base_url, headers=headers, json=body)
         elapsed = int((time.monotonic() - started) * 1000)
         if response.status_code >= 400:
-            return False, elapsed, f"HTTP {response.status_code} · {response.text[:200]}"
+            return False, elapsed, f"HTTP {response.status_code} · {_safe_error(response.text)}"
         return True, elapsed, ""
     except Exception as exc:
         elapsed = int((time.monotonic() - started) * 1000)
-        return False, elapsed, str(exc)[:200]
+        return False, elapsed, _safe_error(str(exc))
 
 
 # --- Review panel --------------------------------------------------------------
@@ -869,7 +936,10 @@ def render_review_panel(
     if embedding:
         _row(
             strings["init.review_embedding"],
-            f"{embedding.display_provider} · {embedding.model} · {embedding.base_url}",
+            (
+                f"{embedding.display_provider} · {embedding.model} · "
+                f"{redact_embedding_endpoint_for_display(embedding.base_url)}"
+            ),
             probe=(embedding.probed, embedding.probe_ok),
         )
     if search:

--- a/deeptutor_cli/init_wizard.py
+++ b/deeptutor_cli/init_wizard.py
@@ -99,7 +99,7 @@ FEATURED_EMBEDDING_PROVIDERS: tuple[str, ...] = (
 # preferred and these are extras.
 EMBEDDING_FALLBACK_MODELS: dict[str, tuple[str, ...]] = {
     "openai": ("text-embedding-3-large", "text-embedding-3-small"),
-    "gemini": ("gemini-embedding-2",),
+    "gemini": ("gemini-embedding-2", "gemini-embedding-001"),
     "aliyun": ("qwen3-vl-embedding", "text-embedding-v3", "text-embedding-v2"),
     "siliconflow": (
         "Qwen/Qwen3-Embedding-8B",

--- a/tests/cli/test_init_wizard_probe.py
+++ b/tests/cli/test_init_wizard_probe.py
@@ -9,7 +9,12 @@ from rich.console import Console
 def test_gemini_embedding_fallback_prefers_stable_embedding2() -> None:
     from deeptutor_cli.init_wizard import EMBEDDING_FALLBACK_MODELS
 
-    assert EMBEDDING_FALLBACK_MODELS["gemini"] == ("gemini-embedding-2",)
+    # Embedding 2 leads, but 001 stays offered: it is still a current model and
+    # dropping it left the offline wizard with a single choice.
+    assert EMBEDDING_FALLBACK_MODELS["gemini"] == (
+        "gemini-embedding-2",
+        "gemini-embedding-001",
+    )
 
 
 def test_embedding_setup_preserves_saved_endpoint_for_same_provider() -> None:

--- a/tests/cli/test_init_wizard_probe.py
+++ b/tests/cli/test_init_wizard_probe.py
@@ -1,6 +1,83 @@
 from __future__ import annotations
 
+from io import StringIO
 from types import SimpleNamespace
+
+from rich.console import Console
+
+
+def test_gemini_embedding_fallback_prefers_stable_embedding2() -> None:
+    from deeptutor_cli.init_wizard import EMBEDDING_FALLBACK_MODELS
+
+    assert EMBEDDING_FALLBACK_MODELS["gemini"] == ("gemini-embedding-2",)
+
+
+def test_embedding_setup_preserves_saved_endpoint_for_same_provider() -> None:
+    from deeptutor.services.config.provider_runtime import EMBEDDING_PROVIDERS
+    from deeptutor_cli.init_cmd import _embedding_default_endpoint
+
+    saved = "https://proxy.example.com/google/v1/embeddings"
+    endpoint = _embedding_default_endpoint(
+        provider="gemini",
+        current_binding="gemini",
+        current_profile={"base_url": saved},
+        spec=EMBEDDING_PROVIDERS["gemini"],
+    )
+    switched = _embedding_default_endpoint(
+        provider="gemini",
+        current_binding="openai",
+        current_profile={"base_url": "https://api.openai.com/v1/embeddings"},
+        spec=EMBEDDING_PROVIDERS["gemini"],
+    )
+
+    assert endpoint == saved
+    assert switched.endswith("gemini-embedding-2:batchEmbedContents")
+
+
+def test_gemini_native_embedding_endpoint_derives_native_models_url() -> None:
+    from deeptutor_cli.init_wizard import _derive_embedding_models_url
+
+    assert (
+        _derive_embedding_models_url(
+            (
+                "https://generativelanguage.googleapis.com/v1beta/models/"
+                "gemini-embedding-2:batchEmbedContents"
+            ),
+            "gemini",
+        )
+        == "https://generativelanguage.googleapis.com/v1beta/models"
+    )
+
+
+def test_gemini_models_url_preserves_custom_gateway_path_prefix() -> None:
+    from deeptutor_cli.init_wizard import _derive_embedding_models_url
+
+    assert (
+        _derive_embedding_models_url(
+            (
+                "https://proxy.example.com/google/v1beta/models/"
+                "gemini-embedding-2:batchEmbedContents?tenant=demo"
+            ),
+            "gemini",
+        )
+        == "https://proxy.example.com/google/v1beta/models?tenant=demo"
+    )
+
+    assert (
+        _derive_embedding_models_url(
+            "https://proxy.example.com/google/v1beta/openai/embeddings",
+            "gemini",
+        )
+        == "https://proxy.example.com/google/v1beta/models"
+    )
+
+    assert (
+        _derive_embedding_models_url(
+            "https://proxy.example.com/google/v1/embeddings",
+            "gemini",
+        )
+        == "https://proxy.example.com/google/v1/models"
+    )
 
 
 class _FakeClient:
@@ -18,6 +95,147 @@ class _FakeClient:
     def post(self, url: str, *, headers: dict, json: dict):
         self.captured.append({"url": url, "headers": headers, "json": json})
         return SimpleNamespace(status_code=200, text="")
+
+    def get(self, url: str, *, headers: dict):
+        self.captured.append({"url": url, "headers": headers})
+
+        class _Response:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"models": [{"name": "models/gemini-embedding-2"}]}
+
+        return _Response()
+
+
+def test_fetch_gemini_models_uses_auth_matching_endpoint_host(monkeypatch) -> None:
+    from deeptutor_cli import init_wizard
+
+    _FakeClient.captured = []
+    monkeypatch.setattr(init_wizard.httpx, "Client", _FakeClient)
+    output = StringIO()
+    console = Console(file=output)
+    strings = {
+        "init.fetch_models": "fetch {url}",
+        "init.fetch_models_fail": "failed {error}",
+        "init.fetch_models_ok": "found {count}",
+    }
+
+    official = init_wizard.fetch_embedding_models(
+        console,
+        strings,
+        endpoint=(
+            "https://generativelanguage.googleapis.com/v1beta/models/"
+            "gemini-embedding-2:batchEmbedContents"
+        ),
+        api_key="credential",
+        provider="gemini",
+    )
+    custom = init_wizard.fetch_embedding_models(
+        console,
+        strings,
+        endpoint="https://proxy.example.com/google/v1/embeddings?key=url-secret",
+        api_key="credential",
+        provider="gemini",
+    )
+
+    assert official == ["gemini-embedding-2"]
+    assert custom == ["gemini-embedding-2"]
+    assert _FakeClient.captured[0]["headers"] == {"x-goog-api-key": "credential"}
+    assert _FakeClient.captured[1]["headers"] == {"Authorization": "Bearer credential"}
+    assert "url-secret" not in output.getvalue()
+    assert "%5BREDACTED%5D" in output.getvalue()
+
+
+def test_review_panel_redacts_embedding_endpoint_query_key() -> None:
+    from deeptutor_cli.init_wizard import EmbeddingChoice, render_review_panel
+
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, width=160)
+    render_review_panel(
+        console,
+        {
+            "init.review_embedding": "Embedding",
+            "init.review_title": "Review",
+        },
+        llm=None,
+        embedding=EmbeddingChoice(
+            binding="gemini",
+            base_url=("https://proxy.example.com/v1/embeddings?tenant=demo&key=secret"),
+            api_key="credential",
+            model="gemini-embedding-2",
+            dimension="768",
+            display_provider="Gemini",
+        ),
+        search=None,
+        backend_port=None,
+        frontend_port=None,
+    )
+
+    rendered = output.getvalue()
+    assert "secret" not in rendered
+    assert "%5BREDACTED%5D" in rendered
+
+
+def test_probe_embedding_uses_gemini_native_request_shape(monkeypatch) -> None:
+    from deeptutor_cli import init_wizard
+
+    _FakeClient.captured = []
+    monkeypatch.setattr(init_wizard.httpx, "Client", _FakeClient)
+
+    endpoint = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        "gemini-embedding-2:batchEmbedContents"
+    )
+    ok, _elapsed_ms, error = init_wizard.probe_embedding(
+        base_url=endpoint,
+        api_key="credential",
+        model="gemini-embedding-2",
+        provider="gemini",
+    )
+
+    assert ok is True
+    assert error == ""
+    request = _FakeClient.captured[0]
+    assert request["headers"]["x-goog-api-key"] == "credential"
+    assert "Authorization" not in request["headers"]
+    assert request["json"] == {
+        "requests": [
+            {
+                "model": "models/gemini-embedding-2",
+                "content": {"parts": [{"text": "ping"}]},
+            }
+        ]
+    }
+
+
+def test_probe_embedding_detects_native_custom_url_with_query(monkeypatch) -> None:
+    from deeptutor_cli import init_wizard
+
+    _FakeClient.captured = []
+    monkeypatch.setattr(init_wizard.httpx, "Client", _FakeClient)
+
+    endpoint = (
+        "https://proxy.example.com/google/v1beta/models/"
+        "gemini-embedding-2:batchEmbedContents?tenant=demo"
+    )
+    ok, _elapsed_ms, error = init_wizard.probe_embedding(
+        base_url=endpoint,
+        api_key="credential",
+        model="gemini-embedding-2",
+        provider="gemini",
+    )
+
+    assert ok is True
+    assert error == ""
+    request = _FakeClient.captured[0]
+    assert request["url"] == endpoint
+    assert request["headers"] == {
+        "Authorization": "Bearer credential",
+        "Content-Type": "application/json",
+    }
+    assert "requests" in request["json"]
 
 
 def test_probe_llm_uses_max_completion_tokens_for_gpt5(monkeypatch) -> None:

--- a/tests/services/config/test_embedding_endpoint.py
+++ b/tests/services/config/test_embedding_endpoint.py
@@ -34,6 +34,19 @@ def test_blank_gemini_endpoint_defaults_to_native_stable_model() -> None:
     )
 
 
+def test_blank_gemini_endpoint_keeps_older_models_on_the_openai_path() -> None:
+    """Only Embedding 2 defaults to the native route: the native one sends a
+    taskType and L2-normalizes, so defaulting an existing 001 profile there
+    would change its document vectors and invalidate its index."""
+    endpoint = normalize_embedding_endpoint_for_display(
+        "gemini",
+        "",
+        model="gemini-embedding-001",
+    )
+
+    assert endpoint == "https://generativelanguage.googleapis.com/v1beta/openai/embeddings"
+
+
 def test_official_gemini_native_endpoint_tracks_model_selection() -> None:
     endpoint = normalize_embedding_endpoint_for_display(
         "gemini",

--- a/tests/services/config/test_embedding_endpoint.py
+++ b/tests/services/config/test_embedding_endpoint.py
@@ -1,0 +1,115 @@
+"""Tests for exact, user-visible embedding endpoint normalization."""
+
+from deeptutor.services.config.embedding_endpoint import (
+    embedding_endpoint_validation_error,
+    gemini_embedding_endpoint,
+    normalize_embedding_endpoint_for_display,
+    redact_embedding_endpoint_for_display,
+)
+
+
+def test_gemini_native_endpoint_uses_selected_model() -> None:
+    endpoint = gemini_embedding_endpoint("models/gemini-embedding-001")
+
+    assert endpoint == (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        "gemini-embedding-001:batchEmbedContents"
+    )
+
+
+def test_embedding_endpoint_display_redacts_query_credentials() -> None:
+    displayed = redact_embedding_endpoint_for_display(
+        "https://proxy.example.com/v1/embeddings?tenant=demo&key=secret"
+    )
+
+    assert displayed == ("https://proxy.example.com/v1/embeddings?tenant=demo&key=%5BREDACTED%5D")
+
+
+def test_blank_gemini_endpoint_defaults_to_native_stable_model() -> None:
+    endpoint = normalize_embedding_endpoint_for_display("gemini", "")
+
+    assert endpoint == (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        "gemini-embedding-2:batchEmbedContents"
+    )
+
+
+def test_official_gemini_native_endpoint_tracks_model_selection() -> None:
+    endpoint = normalize_embedding_endpoint_for_display(
+        "gemini",
+        (
+            "https://generativelanguage.googleapis.com/v1beta/models/"
+            "gemini-embedding-2:batchEmbedContents"
+        ),
+        model="gemini-embedding-001",
+    )
+
+    assert endpoint.endswith("/models/gemini-embedding-001:batchEmbedContents")
+
+
+def test_custom_gemini_native_gateway_preserves_prefix_and_tracks_model() -> None:
+    endpoint = normalize_embedding_endpoint_for_display(
+        "gemini",
+        (
+            "https://proxy.example.com/google/v1beta/models/"
+            "gemini-embedding-001:batchEmbedContents?tenant=demo"
+        ),
+        model="gemini-embedding-2",
+    )
+
+    assert endpoint == (
+        "https://proxy.example.com/google/v1beta/models/"
+        "gemini-embedding-2:batchEmbedContents?tenant=demo"
+    )
+
+
+def test_gemini_legacy_openai_endpoint_is_preserved() -> None:
+    endpoint = normalize_embedding_endpoint_for_display(
+        "gemini",
+        "https://generativelanguage.googleapis.com/v1beta/openai/embeddings",
+        model="gemini-embedding-001",
+    )
+
+    assert endpoint.endswith("/v1beta/openai/embeddings")
+
+
+def test_gemini_custom_v1_base_keeps_legacy_normalization() -> None:
+    endpoint = normalize_embedding_endpoint_for_display(
+        "gemini",
+        "https://proxy.example.com/google/v1",
+        model="gemini-embedding-2",
+    )
+
+    assert endpoint == "https://proxy.example.com/google/v1/embeddings"
+
+    no_scheme = normalize_embedding_endpoint_for_display(
+        "gemini",
+        "localhost:8000/v1?tenant=demo",
+        model="gemini-embedding-2",
+    )
+    assert no_scheme == "localhost:8000/v1/embeddings?tenant=demo"
+
+
+def test_gemini_validation_accepts_native_and_legacy_endpoint_shapes() -> None:
+    native = gemini_embedding_endpoint("gemini-embedding-2")
+    legacy = "https://generativelanguage.googleapis.com/v1beta/openai/embeddings"
+    custom_legacy = "https://proxy.example.com/google/v1/embeddings"
+
+    assert embedding_endpoint_validation_error("gemini", native) is None
+    assert embedding_endpoint_validation_error("gemini", legacy) is None
+    assert embedding_endpoint_validation_error("gemini", custom_legacy) is None
+
+
+def test_gemini_validation_rejects_non_embedding_endpoint() -> None:
+    problem = embedding_endpoint_validation_error(
+        "gemini", "https://generativelanguage.googleapis.com/v1beta/models"
+    )
+
+    assert problem is not None
+    assert ":batchEmbedContents" in problem
+
+    malformed_native = embedding_endpoint_validation_error(
+        "gemini", "https://proxy.example.com/embed:batchEmbedContents"
+    )
+    assert malformed_native is not None
+    assert "/models/" in malformed_native

--- a/tests/services/config/test_embedding_runtime.py
+++ b/tests/services/config/test_embedding_runtime.py
@@ -95,12 +95,15 @@ def test_embedding_alias_canonicalization_google_to_gemini() -> None:
 
 
 def test_embedding_gemini_default_base_and_profile_key() -> None:
+    """An existing gemini-embedding-001 profile with no explicit endpoint must
+    keep the OpenAI-compatible URL — the native route sends a taskType and
+    L2-normalizes, so moving it would invalidate the index built from it."""
     catalog = _build_catalog(
         embedding_profile={
             "id": "embedding-p",
             "name": "Embedding",
             "binding": "gemini",
-            "base_url": ("https://generativelanguage.googleapis.com/v1beta/openai/embeddings"),
+            "base_url": "",
             "api_key": "gemini-test-key",
             "api_version": "",
             "extra_headers": {},
@@ -126,7 +129,9 @@ def test_embedding_gemini_defaults_to_stable_embedding2() -> None:
     assert spec.default_api_base == NATIVE_GEMINI2_ENDPOINT
 
 
-def test_embedding_gemini_native_default_tracks_selected_model() -> None:
+def test_embedding_gemini_embedding2_defaults_to_the_native_endpoint() -> None:
+    """Embedding 2 is new, so nothing has an index on it yet — it can default
+    straight to the native batch endpoint that carries its features."""
     catalog = _build_catalog(
         embedding_profile={
             "id": "embedding-p",
@@ -140,7 +145,7 @@ def test_embedding_gemini_native_default_tracks_selected_model() -> None:
                 {
                     "id": "embedding-m",
                     "name": "m",
-                    "model": "gemini-embedding-001",
+                    "model": "gemini-embedding-2",
                 }
             ],
         }
@@ -148,7 +153,34 @@ def test_embedding_gemini_native_default_tracks_selected_model() -> None:
 
     resolved = resolve_embedding_runtime_config(catalog=catalog)
 
-    assert resolved.effective_url.endswith("/models/gemini-embedding-001:batchEmbedContents")
+    assert resolved.effective_url == NATIVE_GEMINI2_ENDPOINT
+
+
+def test_embedding_gemini_explicit_native_endpoint_opts_any_model_in() -> None:
+    """A saved native URL is used verbatim, which is how an older model can
+    still be pointed at the native route deliberately."""
+    catalog = _build_catalog(
+        embedding_profile={
+            "id": "embedding-p",
+            "name": "Embedding",
+            "binding": "gemini",
+            "base_url": NATIVE_GEMINI2_ENDPOINT,
+            "api_key": "gemini-test-key",
+            "api_version": "",
+            "extra_headers": {},
+            "models": [
+                {
+                    "id": "embedding-m",
+                    "name": "m",
+                    "model": "gemini-embedding-2",
+                }
+            ],
+        }
+    )
+
+    resolved = resolve_embedding_runtime_config(catalog=catalog)
+
+    assert resolved.effective_url == NATIVE_GEMINI2_ENDPOINT
 
 
 def test_embedding_local_fallback_from_base_url() -> None:

--- a/tests/services/config/test_embedding_runtime.py
+++ b/tests/services/config/test_embedding_runtime.py
@@ -9,6 +9,10 @@ from deeptutor.services.config.provider_runtime import (
     resolve_embedding_runtime_config,
 )
 
+NATIVE_GEMINI2_ENDPOINT = (
+    "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2:batchEmbedContents"
+)
+
 
 def _build_catalog(
     *,
@@ -96,7 +100,7 @@ def test_embedding_gemini_default_base_and_profile_key() -> None:
             "id": "embedding-p",
             "name": "Embedding",
             "binding": "gemini",
-            "base_url": "",
+            "base_url": ("https://generativelanguage.googleapis.com/v1beta/openai/embeddings"),
             "api_key": "gemini-test-key",
             "api_version": "",
             "extra_headers": {},
@@ -111,6 +115,40 @@ def test_embedding_gemini_default_base_and_profile_key() -> None:
         resolved.effective_url
         == "https://generativelanguage.googleapis.com/v1beta/openai/embeddings"
     )
+
+
+def test_embedding_gemini_defaults_to_stable_embedding2() -> None:
+    spec = EMBEDDING_PROVIDERS["gemini"]
+
+    assert spec.adapter == "gemini"
+    assert spec.default_model == "gemini-embedding-2"
+    assert spec.default_dim == 3072
+    assert spec.default_api_base == NATIVE_GEMINI2_ENDPOINT
+
+
+def test_embedding_gemini_native_default_tracks_selected_model() -> None:
+    catalog = _build_catalog(
+        embedding_profile={
+            "id": "embedding-p",
+            "name": "Embedding",
+            "binding": "gemini",
+            "base_url": "",
+            "api_key": "gemini-test-key",
+            "api_version": "",
+            "extra_headers": {},
+            "models": [
+                {
+                    "id": "embedding-m",
+                    "name": "m",
+                    "model": "gemini-embedding-001",
+                }
+            ],
+        }
+    )
+
+    resolved = resolve_embedding_runtime_config(catalog=catalog)
+
+    assert resolved.effective_url.endswith("/models/gemini-embedding-001:batchEmbedContents")
 
 
 def test_embedding_local_fallback_from_base_url() -> None:

--- a/tests/services/config/test_test_runner_dim_autofill.py
+++ b/tests/services/config/test_test_runner_dim_autofill.py
@@ -135,6 +135,33 @@ async def test_non_numeric_catalog_dim_does_not_block_probe() -> None:
 
 
 @pytest.mark.asyncio
+async def test_probe_event_redacts_endpoint_query_credentials() -> None:
+    runner = ConfigTestRunner()
+    run = _make_run()
+    catalog: dict[str, Any] = {}
+    model: dict[str, Any] = {"dimension": ""}
+    resolved = _resolved_stub(dim=0)
+    resolved.base_url = "https://api.example.test/v1/embeddings?key=secret"
+    resolved.effective_url = resolved.base_url
+    fake_client = MagicMock()
+    fake_client.embed = AsyncMock(return_value=[[0.5] * 8, [0.6] * 8])
+
+    with (
+        patch(
+            "deeptutor.services.config.test_runner.resolve_embedding_runtime_config",
+            return_value=resolved,
+        ),
+        patch("deeptutor.services.embedding.client.EmbeddingClient", return_value=fake_client),
+        patch.object(runner, "_persist_embedding_dimension", return_value=catalog),
+    ):
+        await runner._test_embedding(run, model, catalog)
+
+    messages = "\n".join(str(event.get("message", "")) for event in run.events)
+    assert "secret" not in messages
+    assert "%5BREDACTED%5D" in messages
+
+
+@pytest.mark.asyncio
 async def test_empty_vector_still_fatal() -> None:
     runner = ConfigTestRunner()
     run = _make_run()

--- a/tests/services/embedding/test_client_runtime.py
+++ b/tests/services/embedding/test_client_runtime.py
@@ -75,6 +75,23 @@ async def test_embedding_client_batches_requests(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_embedding_client_forwards_input_type_to_every_batch(monkeypatch) -> None:
+    _FakeAdapter.instances = []
+    monkeypatch.setattr(
+        "deeptutor.services.embedding.client._resolve_adapter_class", lambda _b: _FakeAdapter
+    )
+    client = EmbeddingClient(_build_config("openai"))
+
+    await client.embed(["a", "b", "c"], input_type="search_query")
+
+    adapter = _FakeAdapter.instances[0]
+    assert [request.input_type for request in adapter.calls] == [
+        "search_query",
+        "search_query",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_embedding_client_rejects_null_vector_values(monkeypatch) -> None:
     class _NullValueAdapter(_FakeAdapter):
         async def embed(self, request):
@@ -134,6 +151,7 @@ def test_resolve_adapter_class_supports_canonical_providers() -> None:
     assert _resolve_adapter_class("ollama").__name__ == "OllamaEmbeddingAdapter"
     assert _resolve_adapter_class("vllm").__name__ == "OpenAICompatibleEmbeddingAdapter"
     assert _resolve_adapter_class("openrouter").__name__ == "OpenAICompatibleEmbeddingAdapter"
+    assert _resolve_adapter_class("gemini").__name__ == "GeminiEmbeddingAdapter"
 
 
 def test_resolve_adapter_class_rejects_unknown_provider() -> None:
@@ -169,6 +187,21 @@ def test_embedding_client_rejects_openrouter_base_endpoint() -> None:
 
     with pytest.raises(ValueError, match="/embeddings"):
         EmbeddingClient(cfg)
+
+
+def test_embedding_client_redacts_endpoint_query_credentials_in_validation_error() -> None:
+    cfg = _build_config(
+        "gemini",
+        model="gemini-embedding-2",
+        base_url="https://proxy.example.com/not-embedding?key=secret",
+    )
+
+    with pytest.raises(ValueError) as caught:
+        EmbeddingClient(cfg)
+
+    rendered = str(caught.value)
+    assert "secret" not in rendered
+    assert "%5BREDACTED%5D" in rendered
 
 
 def test_get_embedding_client_refreshes_when_config_changes(monkeypatch) -> None:

--- a/tests/services/embedding/test_client_runtime.py
+++ b/tests/services/embedding/test_client_runtime.py
@@ -17,6 +17,7 @@ from deeptutor.services.embedding.config import EmbeddingConfig
 
 class _FakeAdapter:
     instances: list["_FakeAdapter"] = []
+    SUPPORTS_INPUT_TYPE = False
 
     def __init__(self, config: dict[str, Any]):
         self.config = config
@@ -76,9 +77,12 @@ async def test_embedding_client_batches_requests(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_embedding_client_forwards_input_type_to_every_batch(monkeypatch) -> None:
+    class _RoleAwareAdapter(_FakeAdapter):
+        SUPPORTS_INPUT_TYPE = True
+
     _FakeAdapter.instances = []
     monkeypatch.setattr(
-        "deeptutor.services.embedding.client._resolve_adapter_class", lambda _b: _FakeAdapter
+        "deeptutor.services.embedding.client._resolve_adapter_class", lambda _b: _RoleAwareAdapter
     )
     client = EmbeddingClient(_build_config("openai"))
 
@@ -89,6 +93,24 @@ async def test_embedding_client_forwards_input_type_to_every_batch(monkeypatch) 
         "search_query",
         "search_query",
     ]
+
+
+@pytest.mark.asyncio
+async def test_embedding_client_withholds_input_type_from_opted_out_adapters(
+    monkeypatch,
+) -> None:
+    """Sending a role to a backend that never received one changes the vectors
+    it returns, which would invalidate every index already built with it."""
+    _FakeAdapter.instances = []
+    monkeypatch.setattr(
+        "deeptutor.services.embedding.client._resolve_adapter_class", lambda _b: _FakeAdapter
+    )
+    client = EmbeddingClient(_build_config("jina"))
+
+    await client.embed(["a"], input_type="search_document")
+
+    adapter = _FakeAdapter.instances[0]
+    assert [request.input_type for request in adapter.calls] == [None]
 
 
 @pytest.mark.asyncio

--- a/tests/services/embedding/test_gemini_adapter.py
+++ b/tests/services/embedding/test_gemini_adapter.py
@@ -1,0 +1,313 @@
+"""Tests for Gemini native and legacy-compatible embedding requests."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from deeptutor.services.embedding.adapters.base import (
+    EmbeddingProviderError,
+    EmbeddingRequest,
+)
+from deeptutor.services.embedding.adapters.gemini import GeminiEmbeddingAdapter
+
+NATIVE_GEMINI2_ENDPOINT = (
+    "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2:batchEmbedContents"
+)
+NATIVE_GEMINI001_ENDPOINT = (
+    "https://generativelanguage.googleapis.com/v1beta/models/"
+    "gemini-embedding-001:batchEmbedContents"
+)
+LEGACY_OPENAI_ENDPOINT = "https://generativelanguage.googleapis.com/v1beta/openai/embeddings"
+
+
+class _CapturingTransport(httpx.AsyncBaseTransport):
+    """Capture outbound requests and return deterministic embeddings."""
+
+    def __init__(self, dimension: int = 768) -> None:
+        self.requests: list[dict[str, Any]] = []
+        self.dimension = dimension
+        self.status_code = 200
+        self.error_body = ""
+        self.transport_error: httpx.TransportError | None = None
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        if self.transport_error is not None:
+            raise self.transport_error
+        payload = json.loads(request.content.decode("utf-8"))
+        self.requests.append(
+            {
+                "url": str(request.url),
+                "headers": dict(request.headers),
+                "json": payload,
+            }
+        )
+        if self.status_code >= 400:
+            return httpx.Response(self.status_code, text=self.error_body)
+
+        if "requests" in payload:
+            embeddings = [{"values": [0.1] * self.dimension} for _ in payload["requests"]]
+            return httpx.Response(200, json={"embeddings": embeddings})
+
+        inputs = payload["input"] if isinstance(payload["input"], list) else [payload["input"]]
+        embeddings = [
+            {"index": index, "embedding": [0.1] * self.dimension} for index, _ in enumerate(inputs)
+        ]
+        return httpx.Response(
+            200,
+            json={"data": embeddings, "model": payload["model"], "usage": {}},
+        )
+
+
+@pytest.fixture
+def capturing_httpx(monkeypatch: pytest.MonkeyPatch) -> _CapturingTransport:
+    """Route adapter HTTP calls through an in-memory transport."""
+
+    transport = _CapturingTransport()
+    real_client_init = httpx.AsyncClient.__init__
+
+    def _patched_init(self: httpx.AsyncClient, *args: Any, **kwargs: Any) -> None:
+        kwargs["transport"] = transport
+        real_client_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", _patched_init)
+    return transport
+
+
+def _adapter(
+    *,
+    model: str = "gemini-embedding-2",
+    base_url: str = NATIVE_GEMINI2_ENDPOINT,
+    dimensions: int = 768,
+    send_dimensions: bool | None = None,
+    extra_headers: dict[str, str] | None = None,
+) -> GeminiEmbeddingAdapter:
+    return GeminiEmbeddingAdapter(
+        {
+            "api_key": "gemini-test-key",
+            "base_url": base_url,
+            "model": model,
+            "dimensions": dimensions,
+            "send_dimensions": send_dimensions,
+            "request_timeout": 5,
+            "extra_headers": extra_headers or {},
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_gemini2_native_formats_retrieval_query_and_output_dimension(
+    capturing_httpx: _CapturingTransport,
+) -> None:
+    response = await _adapter().embed(
+        EmbeddingRequest(
+            texts=["현재완료와 과거시제는 어떻게 달라?"],
+            model="gemini-embedding-2",
+            dimensions=768,
+            input_type="search_query",
+        )
+    )
+
+    captured = capturing_httpx.requests[-1]
+    assert captured["url"] == NATIVE_GEMINI2_ENDPOINT
+    assert captured["headers"]["x-goog-api-key"] == "gemini-test-key"
+    assert "authorization" not in captured["headers"]
+    assert captured["json"] == {
+        "requests": [
+            {
+                "model": "models/gemini-embedding-2",
+                "content": {
+                    "parts": [
+                        {
+                            "text": (
+                                "task: search result | query: 현재완료와 과거시제는 어떻게 달라?"
+                            )
+                        }
+                    ]
+                },
+                "outputDimensionality": 768,
+            }
+        ]
+    }
+    assert response.dimensions == 768
+
+
+@pytest.mark.asyncio
+async def test_gemini2_native_formats_retrieval_documents(
+    capturing_httpx: _CapturingTransport,
+) -> None:
+    await _adapter().embed(
+        EmbeddingRequest(
+            texts=[
+                "The present perfect connects a past event to the present.",
+                "The simple past describes a completed event in the past.",
+            ],
+            model="gemini-embedding-2",
+            dimensions=768,
+            input_type="search_document",
+        )
+    )
+
+    requests = capturing_httpx.requests[-1]["json"]["requests"]
+    assert [item["content"]["parts"][0]["text"] for item in requests] == [
+        "title: none | text: The present perfect connects a past event to the present.",
+        "title: none | text: The simple past describes a completed event in the past.",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gemini001_native_maps_retrieval_role_to_task_type(
+    capturing_httpx: _CapturingTransport,
+) -> None:
+    await _adapter(
+        model="gemini-embedding-001",
+        base_url=NATIVE_GEMINI001_ENDPOINT,
+    ).embed(
+        EmbeddingRequest(
+            texts=["legacy document"],
+            model="gemini-embedding-001",
+            dimensions=768,
+            input_type="search_document",
+        )
+    )
+
+    native_request = capturing_httpx.requests[-1]["json"]["requests"][0]
+    assert native_request["content"] == {"parts": [{"text": "legacy document"}]}
+    assert native_request["taskType"] == "RETRIEVAL_DOCUMENT"
+    assert native_request["outputDimensionality"] == 768
+
+
+@pytest.mark.asyncio
+async def test_saved_gemini001_openai_compatible_endpoint_still_works(
+    capturing_httpx: _CapturingTransport,
+) -> None:
+    await _adapter(
+        model="gemini-embedding-001",
+        base_url=LEGACY_OPENAI_ENDPOINT,
+    ).embed(
+        EmbeddingRequest(
+            texts=["legacy document"],
+            model="gemini-embedding-001",
+            dimensions=768,
+            input_type="search_document",
+        )
+    )
+
+    captured = capturing_httpx.requests[-1]
+    assert captured["json"]["input"] == ["legacy document"]
+    assert captured["headers"]["authorization"] == "Bearer gemini-test-key"
+    assert "dimensions" not in captured["json"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_gemini2_openai_compatible_endpoint_remains_available(
+    capturing_httpx: _CapturingTransport,
+) -> None:
+    await _adapter(base_url=LEGACY_OPENAI_ENDPOINT).embed(
+        EmbeddingRequest(
+            texts=["query"],
+            model="gemini-embedding-2",
+            dimensions=768,
+            input_type="search_query",
+        )
+    )
+
+    captured = capturing_httpx.requests[-1]
+    assert captured["json"]["input"] == ["task: search result | query: query"]
+    assert "dimensions" not in captured["json"]
+    assert captured["headers"]["authorization"] == "Bearer gemini-test-key"
+
+
+@pytest.mark.asyncio
+async def test_native_endpoint_model_must_match_selected_model() -> None:
+    adapter = _adapter(model="gemini-embedding-001")
+
+    with pytest.raises(ValueError, match="endpoint model .* does not match"):
+        await adapter.embed(EmbeddingRequest(texts=["query"], model="gemini-embedding-001"))
+
+
+@pytest.mark.asyncio
+async def test_native_dimension_can_be_explicitly_omitted(
+    capturing_httpx: _CapturingTransport,
+) -> None:
+    await _adapter(send_dimensions=False).embed(
+        EmbeddingRequest(
+            texts=["query"],
+            model="gemini-embedding-2",
+            dimensions=768,
+        )
+    )
+
+    native_request = capturing_httpx.requests[-1]["json"]["requests"][0]
+    assert "outputDimensionality" not in native_request
+
+
+@pytest.mark.asyncio
+async def test_custom_native_gateway_keeps_bearer_auth_compatibility(
+    capturing_httpx: _CapturingTransport,
+) -> None:
+    await _adapter(
+        base_url=(
+            "https://proxy.example.com/google/v1beta/models/gemini-embedding-2:batchEmbedContents"
+        )
+    ).embed(EmbeddingRequest(texts=["query"], model="gemini-embedding-2"))
+
+    headers = capturing_httpx.requests[-1]["headers"]
+    assert headers["authorization"] == "Bearer gemini-test-key"
+    assert "x-goog-api-key" not in headers
+
+
+@pytest.mark.asyncio
+async def test_native_provider_error_redacts_credentials(
+    capturing_httpx: _CapturingTransport,
+) -> None:
+    capturing_httpx.status_code = 400
+    capturing_httpx.error_body = "invalid key gemini-test-key url-secret oauth-secret for query"
+    adapter = _adapter(
+        base_url=f"{NATIVE_GEMINI2_ENDPOINT}?key=url-secret",
+        extra_headers={"Authorization": "Bearer oauth-secret"},
+    )
+
+    with pytest.raises(EmbeddingProviderError) as caught:
+        await adapter.embed(EmbeddingRequest(texts=["query"], model="gemini-embedding-2"))
+
+    rendered = str(caught.value)
+    assert "gemini-test-key" not in rendered
+    assert "url-secret" not in rendered
+    assert "oauth-secret" not in rendered
+    assert "for query" not in rendered
+    assert "[REDACTED]" in rendered
+
+
+@pytest.mark.asyncio
+async def test_native_transport_error_redacts_explicit_auth_header(
+    capturing_httpx: _CapturingTransport,
+) -> None:
+    capturing_httpx.transport_error = httpx.LocalProtocolError(
+        "Illegal header value b'Bearer oauth-secret\\nbad'"
+    )
+    adapter = _adapter(
+        extra_headers={"Authorization": "Bearer oauth-secret\nbad"},
+    )
+    adapter._MAX_RETRIES = 0
+
+    with pytest.raises(EmbeddingProviderError) as caught:
+        await adapter.embed(EmbeddingRequest(texts=["private query"], model="gemini-embedding-2"))
+
+    rendered = str(caught.value)
+    assert "oauth-secret" not in rendered
+    assert "private query" not in rendered
+    assert caught.value.__cause__ is None
+
+
+def test_gemini2_model_info_advertises_matryoshka_dimensions() -> None:
+    info = _adapter().get_model_info()
+
+    assert info["provider"] == "gemini"
+    assert info["dimensions"] == 3072
+    assert 768 in info["supported_dimensions"]
+    assert info["supports_variable_dimensions"] is True
+    assert info["multimodal"] is False

--- a/tests/services/rag/test_lightrag_pipeline.py
+++ b/tests/services/rag/test_lightrag_pipeline.py
@@ -10,6 +10,7 @@ index/search orchestration without the heavy deps.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 from pathlib import Path
 import sys
@@ -131,26 +132,52 @@ def test_storage_meta_and_has_output(tmp_path) -> None:
     assert meta["provider"] == "lightrag"
 
 
-def test_embedding_func_returns_numpy_array(monkeypatch) -> None:
-    class _FakeEmbeddingFunc:
-        def __init__(
-            self,
-            *,
-            embedding_dim,
-            max_token_size,
-            func,
-            supports_asymmetric=False,
-        ) -> None:
-            self.embedding_dim = embedding_dim
-            self.max_token_size = max_token_size
-            self.func = func
-            self.supports_asymmetric = supports_asymmetric
+class _FakeEmbeddingFunc:
+    """Stands in for ``lightrag.utils.EmbeddingFunc``.
 
+    Its signature is deliberately limited to the real dataclass's fields, so a
+    constructor kwarg the pinned dependency does not accept fails here too.
+    ``test_fake_embedding_func_matches_the_real_dataclass`` pins the two
+    together whenever LightRAG is installed.
+    """
+
+    def __init__(
+        self,
+        *,
+        embedding_dim,
+        func,
+        max_token_size=8192,
+        send_dimensions=None,
+        model_name=None,
+    ) -> None:
+        self.embedding_dim = embedding_dim
+        self.func = func
+        self.max_token_size = max_token_size
+        self.send_dimensions = send_dimensions
+        self.model_name = model_name
+
+
+def _install_fake_lightrag(monkeypatch) -> None:
     fake_lightrag = types.ModuleType("lightrag")
     fake_utils = types.ModuleType("lightrag.utils")
     fake_utils.EmbeddingFunc = _FakeEmbeddingFunc
     monkeypatch.setitem(sys.modules, "lightrag", fake_lightrag)
     monkeypatch.setitem(sys.modules, "lightrag.utils", fake_utils)
+
+
+def test_fake_embedding_func_matches_the_real_dataclass() -> None:
+    """Guard against the stub drifting from the dependency it stands in for."""
+    import dataclasses
+
+    lightrag_utils = pytest.importorskip("lightrag.utils")
+
+    real_fields = {field.name for field in dataclasses.fields(lightrag_utils.EmbeddingFunc)}
+    stub_fields = set(inspect.signature(_FakeEmbeddingFunc.__init__).parameters.keys() - {"self"})
+    assert stub_fields == real_fields
+
+
+def test_embedding_func_returns_numpy_array(monkeypatch) -> None:
+    _install_fake_lightrag(monkeypatch)
 
     class _Config:
         dim = 3
@@ -168,24 +195,13 @@ def test_embedding_func_returns_numpy_array(monkeypatch) -> None:
     vectors = asyncio.run(embedding.func(["a", "b"]))
     assert embedding.embedding_dim == 3
     assert embedding.max_token_size == 99
-    assert embedding.supports_asymmetric is True
     assert vectors.shape == (2, 3)
     assert hasattr(vectors, "size")
 
 
 def test_embedding_func_maps_lightrag_query_and_document_context(monkeypatch) -> None:
     calls: list[tuple[list[str], str | None]] = []
-
-    class _FakeEmbeddingFunc:
-        def __init__(self, **kwargs) -> None:
-            self.func = kwargs["func"]
-            self.supports_asymmetric = kwargs.get("supports_asymmetric", False)
-
-    fake_lightrag = types.ModuleType("lightrag")
-    fake_utils = types.ModuleType("lightrag.utils")
-    fake_utils.EmbeddingFunc = _FakeEmbeddingFunc
-    monkeypatch.setitem(sys.modules, "lightrag", fake_lightrag)
-    monkeypatch.setitem(sys.modules, "lightrag.utils", fake_utils)
+    _install_fake_lightrag(monkeypatch)
 
     class _Config:
         dim = 3
@@ -202,11 +218,14 @@ def test_embedding_func_maps_lightrag_query_and_document_context(monkeypatch) ->
     embedding = lr_config.build_embedding_func()
     asyncio.run(embedding.func(["question"], context="query", _priority=1))
     asyncio.run(embedding.func(["passage"], context="document"))
+    # The pinned LightRAG passes no context at all; that must mean "no role",
+    # not "document", or every query would be embedded as a passage.
+    asyncio.run(embedding.func(["unlabelled"]))
 
-    assert embedding.supports_asymmetric is True
     assert calls == [
         (["question"], "search_query"),
         (["passage"], "search_document"),
+        (["unlabelled"], None),
     ]
 
 

--- a/tests/services/rag/test_lightrag_pipeline.py
+++ b/tests/services/rag/test_lightrag_pipeline.py
@@ -133,10 +133,18 @@ def test_storage_meta_and_has_output(tmp_path) -> None:
 
 def test_embedding_func_returns_numpy_array(monkeypatch) -> None:
     class _FakeEmbeddingFunc:
-        def __init__(self, *, embedding_dim, max_token_size, func) -> None:
+        def __init__(
+            self,
+            *,
+            embedding_dim,
+            max_token_size,
+            func,
+            supports_asymmetric=False,
+        ) -> None:
             self.embedding_dim = embedding_dim
             self.max_token_size = max_token_size
             self.func = func
+            self.supports_asymmetric = supports_asymmetric
 
     fake_lightrag = types.ModuleType("lightrag")
     fake_utils = types.ModuleType("lightrag.utils")
@@ -149,11 +157,9 @@ def test_embedding_func_returns_numpy_array(monkeypatch) -> None:
         max_tokens = 99
 
     class _Client:
-        def get_embedding_func(self):
-            async def embed(texts):
-                return [[1, 2, 3] for _ in texts]
-
-            return embed
+        async def embed(self, texts, *, input_type=None):
+            del input_type
+            return [[1, 2, 3] for _ in texts]
 
     monkeypatch.setattr("deeptutor.services.embedding.get_embedding_config", lambda: _Config())
     monkeypatch.setattr("deeptutor.services.embedding.get_embedding_client", lambda: _Client())
@@ -162,8 +168,46 @@ def test_embedding_func_returns_numpy_array(monkeypatch) -> None:
     vectors = asyncio.run(embedding.func(["a", "b"]))
     assert embedding.embedding_dim == 3
     assert embedding.max_token_size == 99
+    assert embedding.supports_asymmetric is True
     assert vectors.shape == (2, 3)
     assert hasattr(vectors, "size")
+
+
+def test_embedding_func_maps_lightrag_query_and_document_context(monkeypatch) -> None:
+    calls: list[tuple[list[str], str | None]] = []
+
+    class _FakeEmbeddingFunc:
+        def __init__(self, **kwargs) -> None:
+            self.func = kwargs["func"]
+            self.supports_asymmetric = kwargs.get("supports_asymmetric", False)
+
+    fake_lightrag = types.ModuleType("lightrag")
+    fake_utils = types.ModuleType("lightrag.utils")
+    fake_utils.EmbeddingFunc = _FakeEmbeddingFunc
+    monkeypatch.setitem(sys.modules, "lightrag", fake_lightrag)
+    monkeypatch.setitem(sys.modules, "lightrag.utils", fake_utils)
+
+    class _Config:
+        dim = 3
+        max_tokens = 99
+
+    class _Client:
+        async def embed(self, texts, *, input_type=None):
+            calls.append((list(texts), input_type))
+            return [[1, 2, 3] for _ in texts]
+
+    monkeypatch.setattr("deeptutor.services.embedding.get_embedding_config", lambda: _Config())
+    monkeypatch.setattr("deeptutor.services.embedding.get_embedding_client", lambda: _Client())
+
+    embedding = lr_config.build_embedding_func()
+    asyncio.run(embedding.func(["question"], context="query", _priority=1))
+    asyncio.run(embedding.func(["passage"], context="document"))
+
+    assert embedding.supports_asymmetric is True
+    assert calls == [
+        (["question"], "search_query"),
+        (["passage"], "search_document"),
+    ]
 
 
 def test_lightrag_llm_adapter_preserves_messages_and_drops_extra_kwargs(

--- a/tests/services/rag/test_llamaindex_embedding_failures.py
+++ b/tests/services/rag/test_llamaindex_embedding_failures.py
@@ -15,7 +15,8 @@ def test_custom_embedding_rejects_null_coordinates(monkeypatch: pytest.MonkeyPat
     class _FakeClient:
         config = SimpleNamespace(binding="openai", model="bad-embed")
 
-        async def embed(self, texts, progress_callback=None):
+        async def embed(self, texts, progress_callback=None, *, input_type=None):
+            del progress_callback, input_type
             return [[0.1, None, 0.3] for _ in texts]
 
     monkeypatch.setattr(embedding_module, "get_embedding_client", lambda: _FakeClient())
@@ -45,7 +46,8 @@ def test_custom_embedding_refreshes_stale_client(monkeypatch: pytest.MonkeyPatch
             self.value = value
             self.calls: list[list[str]] = []
 
-        async def embed(self, texts, progress_callback=None):
+        async def embed(self, texts, progress_callback=None, *, input_type=None):
+            del progress_callback, input_type
             self.calls.append(list(texts))
             return [[self.value] for _ in texts]
 

--- a/tests/services/rag/test_llamaindex_embedding_roles.py
+++ b/tests/services/rag/test_llamaindex_embedding_roles.py
@@ -1,0 +1,49 @@
+"""Tests for query/document roles in the LlamaIndex embedding bridge."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def test_custom_embedding_passes_query_and_document_roles(monkeypatch) -> None:
+    from deeptutor.services.rag.pipelines.llamaindex import (
+        embedding_adapter as embedding_module,
+    )
+
+    class _FakeClient:
+        config = SimpleNamespace(
+            binding="gemini",
+            model="gemini-embedding-2",
+            dim=768,
+            effective_url="https://example.test/v1/embeddings",
+            base_url="https://example.test/v1/embeddings",
+            api_version=None,
+            send_dimensions=None,
+        )
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[list[str], str | None]] = []
+
+        async def embed(
+            self,
+            texts,
+            progress_callback=None,
+            *,
+            input_type: str | None = None,
+        ):
+            del progress_callback
+            self.calls.append((list(texts), input_type))
+            return [[1.0] for _ in texts]
+
+    client = _FakeClient()
+    monkeypatch.setattr(embedding_module, "get_embedding_client", lambda config=None: client)
+    embedding = embedding_module.CustomEmbedding()
+
+    assert embedding._get_query_embedding("question") == [1.0]
+    assert embedding._get_text_embedding("document") == [1.0]
+    assert embedding._get_text_embeddings(["one", "two"]) == [[1.0], [1.0]]
+    assert client.calls == [
+        (["question"], "search_query"),
+        (["document"], "search_document"),
+        (["one", "two"], "search_document"),
+    ]

--- a/tests/services/test_model_catalog.py
+++ b/tests/services/test_model_catalog.py
@@ -119,6 +119,44 @@ def test_load_recovers_invalid_catalog_with_defaults(tmp_path: Path):
     assert set(saved["services"]) == expected_services
 
 
+def test_load_sets_gemini_native_endpoint_from_active_embedding_model(tmp_path: Path):
+    catalog_path = tmp_path / "model_catalog.json"
+    catalog_path.write_text(
+        json.dumps(
+            {
+                "services": {
+                    "embedding": {
+                        "active_profile_id": "gemini-profile",
+                        "active_model_id": "gemini-model",
+                        "profiles": [
+                            {
+                                "id": "gemini-profile",
+                                "name": "Gemini",
+                                "binding": "gemini",
+                                "base_url": "",
+                                "api_key": "test-key",
+                                "models": [
+                                    {
+                                        "id": "gemini-model",
+                                        "name": "Gemini 001",
+                                        "model": "gemini-embedding-001",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    catalog = ModelCatalogService(path=catalog_path).load()
+
+    profile = catalog["services"]["embedding"]["profiles"][0]
+    assert profile["base_url"].endswith("/models/gemini-embedding-001:batchEmbedContents")
+
+
 def test_load_persists_normalized_active_ids(tmp_path: Path):
     catalog_path = tmp_path / "model_catalog.json"
     catalog_path.write_text(


### PR DESCRIPTION
### Description

- Add a dedicated Gemini embedding adapter using the native `:batchEmbedContents` API.
- Default new Gemini embedding configurations to `gemini-embedding-2` while retaining legacy OpenAI-compatible endpoints and custom gateways.
- Support `outputDimensionality`, batching, model-aware endpoint normalization, and retrieval query/document input roles.
- Propagate asymmetric retrieval roles through the shared embedding client, LightRAG, and LlamaIndex integrations.
- Update CLI setup, discovery, and probe behavior for native Gemini endpoints.
- Redact API keys, query credentials, authorization headers, and request text from validation and transport errors.

### Related Issues

- Related to #424

### Module(s) Affected

- [ ] `agents`
- [ ] `api`
- [x] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [x] Other: `deeptutor_cli`

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Test Plan

- `PATH="$PWD/.venv/bin:$PATH" ./.venv/bin/pytest -q`
  - `3567 passed, 7 skipped, 24 warnings`
- All configured pre-commit hooks pass for the files changed by this PR.
- `git diff --check` passes.

### Additional Notes

- The official Google native endpoint is the default for Gemini Embedding 2. Existing OpenAI-compatible endpoints remain available for backward compatibility and custom gateways.
- A repository-wide `pre-commit run --all-files` currently encounters unrelated baseline failures: Prettier drift in existing web files and an existing Bandit finding in `deeptutor/services/cli_apps/runner.py`. Those unrelated files are not modified by this PR.
- Multimodal embedding input is intentionally out of scope; this contribution covers the text RAG pipeline.
