### PR TITLE
Add Novita AI as a provider option

### DIFF
--- a/deeptutor/services/config/context_window_detection.py
+++ b/deeptutor/services/config/context_window_detection.py
@@ -24,6 +24,7 @@ _CONTEXT_WINDOW_KEYS = (
     "context_window",
     "context_window_tokens",
     "context_length",
+    "context_size",
     "max_context_tokens",
     "max_input_tokens",
     "input_token_limit",

--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -185,6 +185,16 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://api.siliconflow.cn/v1",
     ),
     ProviderSpec(
+        name="novita",
+        keywords=("novita",),
+        env_key="NOVITA_API_KEY",
+        display_name="Novita",
+        backend="openai_compat",
+        is_gateway=True,
+        detect_by_base_keyword="novita",
+        default_api_base="https://api.novita.ai/v3/openai",
+    ),
+    ProviderSpec(
         name="atlascloud",
         keywords=("atlascloud", "atlas-cloud", "atlas cloud"),
         env_key="ATLASCLOUD_API_KEY",

--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -96,6 +96,7 @@ PROVIDER_ALIASES = {
     "atlas_cloud": "atlascloud",
     "atlas-cloud": "atlascloud",
     "eden_ai": "edenai",
+    "novita_ai": "novita",
 }
 
 
@@ -186,9 +187,9 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
     ),
     ProviderSpec(
         name="novita",
-        keywords=("novita",),
+        keywords=("novita", "novita-ai", "novita ai"),
         env_key="NOVITA_API_KEY",
-        display_name="Novita",
+        display_name="Novita AI",
         backend="openai_compat",
         is_gateway=True,
         detect_by_base_keyword="novita",

--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -192,7 +192,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         backend="openai_compat",
         is_gateway=True,
         detect_by_base_keyword="novita",
-        default_api_base="https://api.novita.ai/v3/openai",
+        default_api_base="https://api.novita.ai/openai",
     ),
     ProviderSpec(
         name="atlascloud",

--- a/tests/api/test_settings_router.py
+++ b/tests/api/test_settings_router.py
@@ -482,6 +482,13 @@ def test_llm_provider_choices_include_atlascloud() -> None:
     assert llm["atlascloud"]["base_url"] == "https://api.atlascloud.ai/v1"
 
 
+def test_llm_provider_choices_include_novita() -> None:
+    llm = {item["value"]: item for item in settings_router._provider_choices()["llm"]}
+
+    assert llm["novita"]["label"] == "Novita AI"
+    assert llm["novita"]["base_url"] == "https://api.novita.ai/openai"
+
+
 def test_llm_provider_choices_include_edenai() -> None:
     llm = {item["value"]: item for item in settings_router._provider_choices()["llm"]}
 

--- a/tests/core/test_agentic_client_provider_kwargs.py
+++ b/tests/core/test_agentic_client_provider_kwargs.py
@@ -210,6 +210,7 @@ def test_registered_cloud_openai_compat_providers_enable_native_tools() -> None:
         "aihubmix",
         "atlascloud",
         "edenai",
+        "novita",
         "volcengine_coding_plan",
         "byteplus_coding_plan",
     ):

--- a/tests/services/config/test_context_window_detection.py
+++ b/tests/services/config/test_context_window_detection.py
@@ -85,6 +85,20 @@ def test_detect_context_window_uses_known_minimax_m3_window(
     assert result.source == "known_model"
 
 
+def test_extract_context_window_reads_novita_context_size_key() -> None:
+    """Novita's /openai/models advertises the window as ``context_size``."""
+    payload = {
+        "data": [
+            {"id": "deepseek/deepseek-v3.2", "context_size": 1_000_000},
+        ]
+    }
+
+    assert (
+        detection_module._extract_context_window_from_payload(payload, "deepseek/deepseek-v3.2")
+        == 1_000_000
+    )
+
+
 def test_models_endpoint_probe_honors_disable_ssl_verify(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/tests/services/config/test_provider_runtime.py
+++ b/tests/services/config/test_provider_runtime.py
@@ -165,6 +165,57 @@ def test_llm_atlascloud_base_url_detection_preserves_openai_binding_compatibilit
     assert resolved.effective_url == "https://api.atlascloud.ai/v1"
 
 
+def test_llm_novita_binding_uses_default_openai_compatible_endpoint() -> None:
+    catalog = _build_catalog(
+        llm_profile={
+            "id": "llm-p",
+            "name": "Novita AI",
+            "binding": "novita",
+            "base_url": "",
+            "api_key": "novita-key",
+            "api_version": "",
+            "extra_headers": {},
+            "models": [
+                {
+                    "id": "llm-m",
+                    "name": "DeepSeek V3.2",
+                    "model": "deepseek/deepseek-v3.2",
+                }
+            ],
+        }
+    )
+
+    resolved = resolve_llm_runtime_config(catalog=catalog)
+
+    assert resolved.provider_name == "novita"
+    assert resolved.provider_mode == "gateway"
+    assert resolved.binding == "novita"
+    assert resolved.model == "deepseek/deepseek-v3.2"
+    assert resolved.api_key == "novita-key"
+    assert resolved.effective_url == "https://api.novita.ai/openai"
+
+
+def test_llm_novita_base_url_detection_preserves_openai_binding_compatibility() -> None:
+    catalog = _build_catalog(
+        llm_profile={
+            "id": "llm-p",
+            "name": "OpenAI Compatible",
+            "binding": "openai",
+            "base_url": "https://api.novita.ai/openai",
+            "api_key": "novita-key",
+            "api_version": "",
+            "extra_headers": {},
+            "models": [{"id": "llm-m", "name": "DeepSeek", "model": "deepseek/deepseek-v3.2"}],
+        }
+    )
+
+    resolved = resolve_llm_runtime_config(catalog=catalog)
+
+    assert resolved.provider_name == "novita"
+    assert resolved.provider_mode == "gateway"
+    assert resolved.effective_url == "https://api.novita.ai/openai"
+
+
 def test_llm_edenai_binding_uses_default_openai_compatible_endpoint() -> None:
     catalog = _build_catalog(
         llm_profile={

--- a/tests/services/test_provider_registry.py
+++ b/tests/services/test_provider_registry.py
@@ -43,11 +43,13 @@ def test_novita_provider_aliases_and_base_detection() -> None:
     spec = find_by_name("novita")
 
     assert spec is not None
-    assert spec.display_name == "Novita"
+    assert spec.display_name == "Novita AI"
     assert spec.env_key == "NOVITA_API_KEY"
     assert spec.backend == "openai_compat"
     assert spec.mode == "gateway"
     assert spec.default_api_base == "https://api.novita.ai/openai"
+    assert find_by_name("novita-ai") == spec
+    assert find_by_name("novita_ai") == spec
     assert find_gateway(api_base="https://api.novita.ai/openai") == spec
 
 

--- a/tests/services/test_provider_registry.py
+++ b/tests/services/test_provider_registry.py
@@ -39,6 +39,18 @@ def test_edenai_provider_aliases_and_base_detection() -> None:
     assert find_gateway(api_base="https://api.edenai.run/v3") == spec
 
 
+def test_novita_provider_aliases_and_base_detection() -> None:
+    spec = find_by_name("novita")
+
+    assert spec is not None
+    assert spec.display_name == "Novita"
+    assert spec.env_key == "NOVITA_API_KEY"
+    assert spec.backend == "openai_compat"
+    assert spec.mode == "gateway"
+    assert spec.default_api_base == "https://api.novita.ai/v3/openai"
+    assert find_gateway(api_base="https://api.novita.ai/v3/openai") == spec
+
+
 def test_openai_codex_is_not_detected_from_api_base() -> None:
     assert find_gateway(api_base="https://codex.example.com/v1") is None
 

--- a/tests/services/test_provider_registry.py
+++ b/tests/services/test_provider_registry.py
@@ -47,8 +47,8 @@ def test_novita_provider_aliases_and_base_detection() -> None:
     assert spec.env_key == "NOVITA_API_KEY"
     assert spec.backend == "openai_compat"
     assert spec.mode == "gateway"
-    assert spec.default_api_base == "https://api.novita.ai/v3/openai"
-    assert find_gateway(api_base="https://api.novita.ai/v3/openai") == spec
+    assert spec.default_api_base == "https://api.novita.ai/openai"
+    assert find_gateway(api_base="https://api.novita.ai/openai") == spec
 
 
 def test_openai_codex_is_not_detected_from_api_base() -> None:


### PR DESCRIPTION
## Summary

- Adds Novita AI as a provider option.
- Follows the existing provider pattern rather than introducing a new abstraction.

## Validation

Compared against the baseline on `740ec413a0ce`: compared_to_baseline. Pre-existing failures are left as-is.

## Reviewer Notes

- **Only the targeted unit test module was run**, not the full suite. Installing the complete dependency set (faiss-cpu, torch, and the rest of `requirements.txt`) did not finish in our sandbox (each shell call is capped and long installs get killed mid-way). `tests/services/test_provider_registry.py` passed before (6/6) and after (7/7) the original change, and was re-run after this revision's base-URL correction — still 7/7 passing, no regressions on that file, but the wider suite, lint, and type-checking were not run, so CI may surface issues this PR did not check for.
- **`default_api_base` uses `/openai`, not the `/v1` suffix seen on the other gateways** (OpenRouter's `/api/v1`, SiliconFlow's `/v1`). This is Novita's currently documented OpenAI-compatible path — verified live with a real API key against both `/models` and `/chat/completions` returning 200 — but the shape difference from sibling entries may be worth double-checking against your own account if you have one.
- **No end-to-end call through the running application was made** (e.g. an actual chat completion via the app's UI or API with a live `NOVITA_API_KEY`). Only the `ProviderSpec` declaration and the `find_by_name` / `find_gateway` static matching logic were exercised by the added test; the runtime request path through the `openai_compat` backend was not independently verified for this provider.
- **No documentation file was touched.** Prior provider additions (Eden AI, Atlas Cloud) were only mentioned in changelog-style release notes rather than a standalone "supported providers" doc, so none exists to update here; you may still want to mention Novita in the next release note.
- **The `default_api_base` literal was corrected in this revision.** The original commit used `https://api.novita.ai/v3/openai`, an older path that Novita's current documentation (novita.ai/docs/guides/llm-api) no longer shows; the currently documented endpoint is `https://api.novita.ai/openai`. Both paths return identical, working results today (verified against `/models` and `/chat/completions` with a live key), and `tests/services/test_provider_registry.py` was re-run after this change — still 7/7 passing — so this was a stale citation rather than a functional break. If your own testing shows Novita's API surface has moved again since 2026-08-01, please treat your own verification as authoritative over this PR's claim.
