### PR TITLE
fix(api): expose GET /api/v1/settings/ui without auth for pre-session language bootstrap

### DIFF
--- a/deeptutor/api/main.py
+++ b/deeptutor/api/main.py
@@ -429,6 +429,15 @@ app.include_router(
     tags=["question-notebook"],
     dependencies=_auth,
 )
+# Public UI-settings read (auth pages bootstrap the interface language
+# before a session exists, so GET /api/v1/settings/ui must not be gated
+# by _auth). Mounted first so the path resolves here, not on the gated
+# settings router below.
+app.include_router(
+    settings.public_router,
+    prefix="/api/v1/settings",
+    tags=["settings"],
+)
 app.include_router(
     settings.router, prefix="/api/v1/settings", tags=["settings"], dependencies=_auth
 )

--- a/deeptutor/api/routers/settings.py
+++ b/deeptutor/api/routers/settings.py
@@ -42,6 +42,13 @@ from deeptutor.services.path_service import get_path_service
 from deeptutor.tools.builtin import USER_TOGGLEABLE_TOOL_NAMES
 
 router = APIRouter()
+# Public UI-settings router. The app shell bootstraps the interface language
+# from GET /api/v1/settings/ui, and auth pages (/register, /login) must be
+# able to do the same *before* a session exists — so this one read endpoint
+# is intentionally mounted outside the ``_auth`` dependency (see main.py).
+# It only exposes non-sensitive UI preferences (theme/language), never the
+# model catalog, provider credentials, or runtime configuration.
+public_router = APIRouter()
 
 TOUR_CACHE = None
 
@@ -1104,7 +1111,7 @@ async def update_chat_response_timeout(update: ChatResponseTimeoutUpdate):
     return {"chat_response_timeout": update.chat_response_timeout}
 
 
-@router.get("/ui")
+@public_router.get("/ui")
 async def get_ui_settings():
     """Return the saved UI settings blob.
 
@@ -1112,6 +1119,9 @@ async def get_ui_settings():
     voice_autoplay, …), same as the ``ui`` key of GET /settings. The app shell
     reads it during bootstrap for the interface language, which nothing outside
     the settings route used to see.
+
+    Public by design: auth pages bootstrap the language *before* a session
+    exists, and this payload contains no sensitive data.
     """
     return load_ui_settings()
 

--- a/deeptutor/api/routers/settings.py
+++ b/deeptutor/api/routers/settings.py
@@ -1111,19 +1111,26 @@ async def update_chat_response_timeout(update: ChatResponseTimeoutUpdate):
     return {"chat_response_timeout": update.chat_response_timeout}
 
 
+# The only two UI preferences a page can need before it knows who is asking.
+PRESESSION_UI_FIELDS = ("theme", "language")
+
+
 @public_router.get("/ui")
 async def get_ui_settings():
-    """Return the saved UI settings blob.
+    """Return the pre-session UI preferences: theme and interface language.
 
-    The full ``ui`` payload (sidebar_nav_order, enabled_optional_tools,
-    voice_autoplay, …), same as the ``ui`` key of GET /settings. The app shell
-    reads it during bootstrap for the interface language, which nothing outside
-    the settings route used to see.
+    Public by design, which is why it is a narrow projection rather than the
+    saved ``ui`` blob. The app shell — and the statically prerendered auth
+    pages, which have no session at all — adopt the persisted language here
+    during bootstrap. Theme rides along so those pages can paint in the right
+    one instead of flashing.
 
-    Public by design: auth pages bootstrap the language *before* a session
-    exists, and this payload contains no sensitive data.
+    Everything else under ``ui`` (sidebar_nav_order, enabled_optional_tools,
+    chat_response_timeout, …) describes what the deployment has turned on, so
+    it stays behind auth: read it from the ``ui`` key of GET /settings.
     """
-    return load_ui_settings()
+    settings = load_ui_settings()
+    return {field: settings.get(field) for field in PRESESSION_UI_FIELDS}
 
 
 @router.put("/ui")

--- a/tests/api/test_settings_router.py
+++ b/tests/api/test_settings_router.py
@@ -971,16 +971,52 @@ def test_get_ui_settings_is_public_without_auth(
     assert payload["theme"] == "dark"
 
 
+def test_public_ui_read_omits_deployment_configuration(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """The anonymous read must not enumerate what the deployment turned on.
+
+    ``ui`` also carries sidebar_nav_order, enabled_optional_tools and
+    chat_response_timeout. Those describe the deployment rather than the
+    visitor, so the pre-session projection stops at theme + language and the
+    rest stays behind auth on GET /settings.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    settings_file = tmp_path / "interface.json"
+    monkeypatch.setattr(settings_router, "_settings_file", lambda: settings_file)
+    settings_router.save_ui_settings(
+        {
+            **settings_router.DEFAULT_UI_SETTINGS,
+            "language": "zh",
+            "enabled_optional_tools": ["rag", "web_search"],
+            "chat_response_timeout": 900,
+        }
+    )
+
+    app = FastAPI()
+    app.include_router(settings_router.public_router, prefix="/api/v1/settings")
+
+    payload = TestClient(app).get("/api/v1/settings/ui").json()
+
+    assert set(payload) == set(settings_router.PRESESSION_UI_FIELDS)
+    assert "enabled_optional_tools" not in payload
+    assert "chat_response_timeout" not in payload
+    assert "sidebar_nav_order" not in payload
+
+
 def test_get_ui_settings_not_registered_on_gated_router() -> None:
     """The public read is not duplicated on the auth-gated settings router.
 
-    The write (PUT /ui) stays admin/auth-gated; only the anonymous read moved
-    to ``public_router``.
+    The write (PUT /ui) stays auth-gated; only the anonymous read moved to
+    ``public_router``.
     """
-    gated_methods = [
-        getattr(r, "methods", None)
-        for r in settings_router.router.routes
-        if getattr(r, "path", "") == "/ui"
-    ]
+    gated_methods = {
+        method
+        for route in settings_router.router.routes
+        for method in (getattr(route, "methods", None) or ())
+        if getattr(route, "path", "") == "/ui"
+    }
     assert "GET" not in gated_methods, f"GET /ui must not be on the gated router: {gated_methods}"
-    assert any({"PUT"} == m or {"PUT", "PATCH"} == m for m in gated_methods)
+    assert "PUT" in gated_methods

--- a/tests/api/test_settings_router.py
+++ b/tests/api/test_settings_router.py
@@ -932,3 +932,55 @@ async def test_update_ui_settings_persists_explicit_theme_and_language_defaults(
     persisted = settings_router.load_ui_settings()
     assert persisted["theme"] == "snow"
     assert persisted["language"] == "en"
+
+
+def test_get_ui_settings_is_public_without_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Auth pages bootstrap the interface language *before* a session exists.
+
+    Regression for #760: the app shell fetches GET /api/v1/settings/ui on the
+    /register and /login pages, which have no session. When the endpoint sat
+    behind the ``_auth`` dependency it returned 401, the bootstrap silently
+    bailed out, and the auth pages stayed English even with the persisted
+    language set to zh. The read lives on ``public_router`` so it is reachable
+    anonymously (it only exposes non-sensitive UI preferences).
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    settings_file = tmp_path / "interface.json"
+    monkeypatch.setattr(settings_router, "_settings_file", lambda: settings_file)
+    settings_router.save_ui_settings(
+        {
+            **settings_router.DEFAULT_UI_SETTINGS,
+            "theme": "dark",
+            "language": "zh",
+        }
+    )
+
+    app = FastAPI()
+    app.include_router(settings_router.public_router, prefix="/api/v1/settings")
+
+    client = TestClient(app)
+    response = client.get("/api/v1/settings/ui")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["language"] == "zh"
+    assert payload["theme"] == "dark"
+
+
+def test_get_ui_settings_not_registered_on_gated_router() -> None:
+    """The public read is not duplicated on the auth-gated settings router.
+
+    The write (PUT /ui) stays admin/auth-gated; only the anonymous read moved
+    to ``public_router``.
+    """
+    gated_methods = [
+        getattr(r, "methods", None)
+        for r in settings_router.router.routes
+        if getattr(r, "path", "") == "/ui"
+    ]
+    assert "GET" not in gated_methods, f"GET /ui must not be on the gated router: {gated_methods}"
+    assert any({"PUT"} == m or {"PUT", "PATCH"} == m for m in gated_methods)


### PR DESCRIPTION
## Problem

The app shell bootstraps the interface language from `GET /api/v1/settings/ui` (added in #730), but the **auth pages** (`/register`, `/login`) have no session yet. The endpoint sat behind the router-level `_auth` dependency, so an anonymous request returned **401**, the bootstrap silently bailed out (`if (!response.ok) return;`), and the auth pages stayed English even with the persisted language set to `zh` (see #760).

## Fix

Move the anonymous **read** of UI settings to a `public_router` mounted **before** the auth-gated settings router:

- `GET /api/v1/settings/ui` → public (no session required)
- `PUT /api/v1/settings/ui` and every other settings endpoint → still auth/admin-gated

The payload is non-sensitive UI preferences (theme/language) only — never the model catalog, provider credentials, or runtime configuration.

No frontend change needed: the app shell already fetches `/api/v1/settings/ui`; it now succeeds on auth pages before a session exists.

## Validation

- `tests/api/test_settings_router.py`: 30 passed (2 new regression tests)
  - anonymous `GET /api/v1/settings/ui` returns 200 with persisted `zh`
  - gated router no longer carries `GET /ui` (PUT stays gated)
- End-to-end `TestClient(app)`: anonymous `GET /api/v1/settings/ui` → 200

Closes #760