### PR TITLE
fix: match Claude model ids in vision capability overrides

### DIFF
--- a/deeptutor/services/llm/capabilities.py
+++ b/deeptutor/services/llm/capabilities.py
@@ -298,8 +298,12 @@ MODEL_OVERRIDES: dict[str, dict[str, object]] = {
     "gpt-4o": {"supports_vision": True},
     "gpt-4-turbo": {"supports_vision": True},
     "gpt-4-vision": {"supports_vision": True},
-    "claude-3": {"supports_vision": True},
-    "claude-4": {"supports_vision": True},
+    # Anthropic moved to `claude-<family>-<version>` after Claude 3, so no model id
+    # begins with "claude-4" and that prefix matched nothing. Every Claude model from
+    # 3 onward is multimodal, so match the vendor prefix rather than enumerating
+    # versions that go stale. A future text-only model can be excluded by adding a
+    # longer, more specific key (longest prefix wins in get_capability).
+    "claude-": {"supports_vision": True},
     "gemini": {"supports_vision": True},
     "gemma": {"supports_vision": False, "supports_response_format": False},
     "llava": {"supports_vision": True},

--- a/tests/services/llm/test_capabilities.py
+++ b/tests/services/llm/test_capabilities.py
@@ -91,3 +91,31 @@ def test_qwen_model_override_enables_vision() -> None:
     assert supports_vision("openai", "Qwen/Qwen3-VL-235B-A22B-Instruct") is True
     assert supports_vision("openai", "qwen-plus") is False
     assert supports_vision("openai", "Qwen/Qwen3-235B-A22B-Instruct") is False
+
+
+def test_claude_model_ids_are_vision_capable() -> None:
+    """Anthropic's post-Claude-3 ids are `claude-<family>-<version>`.
+
+    The old "claude-4" override matched no real id, so every model from Sonnet 4
+    onward fell through to the binding default and reported no vision support on
+    OpenAI-compatible endpoints, including the Anthropic adapter's own default
+    model.
+    """
+    for model in (
+        "claude-3-5-sonnet-20241022",
+        "claude-sonnet-4-20250514",
+        "claude-sonnet-4-6",
+        "claude-opus-4-1",
+        "claude-opus-4-6",
+        "claude-opus-4-7",
+        "claude-haiku-4-5-20251001",
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-fable-5",
+    ):
+        assert supports_vision("custom", model) is True, model
+
+
+def test_claude_override_does_not_leak_to_other_vendors() -> None:
+    assert supports_vision("custom", "gpt-3.5-turbo") is False
+    assert supports_vision("lm_studio", "gemma-2-9b") is False


### PR DESCRIPTION
## Summary

`MODEL_OVERRIDES` keyed vision support on `claude-3` and `claude-4`. Anthropic moved to `claude-<family>-<version>` after Claude 3, so nothing is named `claude-4-*` and that entry matched no model id.

Every Claude model from Sonnet 4 onward therefore fell through to the binding default. On `binding="custom"` that default is `supports_vision: False`, with the comment "Per-model; set True via MODEL_OVERRIDES", so image input was reported unsupported for all of them, including `AnthropicProvider.default_model` (`claude-sonnet-4-20250514`).

Before:

```
claude-sonnet-4-20250514    False   (no prefix matched)
claude-opus-4-6             False   (none)
claude-opus-5               False   (none)
claude-haiku-4-5-20251001   False   (none)
claude-3-5-sonnet-20241022  True    (claude-3)
```

Only the legacy Claude 3 naming still matched.

## Fix

Replace both version-keyed entries with a single `claude-` prefix. Enumerating versions is what drifted here, and every Claude model from 3 onward is multimodal. A future text-only model can be excluded with a longer, more specific key, since `get_capability` sorts patterns by length and the most specific one wins.

## Tests

`test_claude_model_ids_are_vision_capable` covers the current ids across Claude 3, 4, 4.6 and 5. `test_claude_override_does_not_leak_to_other_vendors` pins that the broader prefix doesn't affect `gpt-3.5` or `gemma`. The first fails on `dev` and passes with the change.

Ruff check, ruff format and mypy are clean on both files.
