### PR TITLE
feat: mark Kimi K3 as vision capable

### DIFF
--- a/deeptutor/services/llm/capabilities.py
+++ b/deeptutor/services/llm/capabilities.py
@@ -314,6 +314,7 @@ MODEL_OVERRIDES: dict[str, dict[str, object]] = {
     "moonshot-v1-128k-vision": {"supports_vision": True},
     "kimi-k2.5": {"supports_vision": True},
     "kimi-k2.6": {"supports_vision": True},
+    "kimi-k3": {"supports_vision": True},
 }
 
 

--- a/tests/services/llm/test_capabilities.py
+++ b/tests/services/llm/test_capabilities.py
@@ -91,3 +91,9 @@ def test_qwen_model_override_enables_vision() -> None:
     assert supports_vision("openai", "Qwen/Qwen3-VL-235B-A22B-Instruct") is True
     assert supports_vision("openai", "qwen-plus") is False
     assert supports_vision("openai", "Qwen/Qwen3-235B-A22B-Instruct") is False
+
+
+def test_kimi_k3_is_vision_capable() -> None:
+    """Kimi K3 is natively multimodal, like the K2.5/K2.6 entries above it."""
+    assert supports_vision("moonshot", "kimi-k3") is True
+    assert supports_vision("custom", "kimi-k3") is True


### PR DESCRIPTION
## Summary

`kimi-k2.5` and `kimi-k2.6` are listed as vision capable but `kimi-k3` is not, so it reported `supports_vision=False` and image input was skipped for it. K3 is natively multimodal.

One entry alongside the existing Kimi ones, plus a test. Ruff and format are clean.
