### PR TITLE
fix: recognize Qwen3.8-Max as vision-capable

### DIFF
--- a/deeptutor/services/llm/capabilities.py
+++ b/deeptutor/services/llm/capabilities.py
@@ -259,6 +259,11 @@ MODEL_OVERRIDES: dict[str, dict[str, object]] = {
     # Qwen text models often share the same provider/gateway as Qwen-VL.
     # Keep thinking-tag handling broad, but only mark explicit VL/vision model
     # names as image-capable so RAG image indexing can fail closed.
+    # Qwen3.8-Max is natively multimodal despite not using the historical
+    # ``-vl`` suffix. Keep this override narrow so other Qwen text models remain
+    # fail-closed.
+    # https://help.aliyun.com/zh/model-studio/vision-model
+    "qwen3.8-max": {"supports_vision": True},
     "qwen/qwen2.5-vl": {"has_thinking_tags": True, "supports_vision": True},
     "qwen/qwen3-vl": {"has_thinking_tags": True, "supports_vision": True},
     "qwen/qwen2-vl": {"has_thinking_tags": True, "supports_vision": True},

--- a/tests/services/llm/test_capabilities.py
+++ b/tests/services/llm/test_capabilities.py
@@ -91,3 +91,8 @@ def test_qwen_model_override_enables_vision() -> None:
     assert supports_vision("openai", "Qwen/Qwen3-VL-235B-A22B-Instruct") is True
     assert supports_vision("openai", "qwen-plus") is False
     assert supports_vision("openai", "Qwen/Qwen3-235B-A22B-Instruct") is False
+
+
+def test_qwen38_max_enables_vision_without_legacy_vl_suffix() -> None:
+    """Qwen3.8-Max is multimodal despite not carrying the legacy ``-vl`` suffix."""
+    assert supports_vision("dashscope", "qwen3.8-max") is True

--- a/tests/services/llm/test_multimodal.py
+++ b/tests/services/llm/test_multimodal.py
@@ -161,6 +161,8 @@ def test_should_degrade_only_for_non_vision_model_with_images() -> None:
     assert should_degrade_to_text("moonshot", "moonshot-v1-8k", msgs) is True
     # Known vision-capable model → keep images, surface the real error.
     assert should_degrade_to_text("openai", "gpt-4o", msgs) is False
+    # Qwen3.8-Max is multimodal even though its model ID has no ``-vl`` suffix.
+    assert should_degrade_to_text("dashscope", "qwen3.8-max", msgs) is False
     # An allowlisted provider (VolcEngine) is trusted even for a model we have
     # no per-model entry for.
     assert should_degrade_to_text("volcengine", "doubao-1.5-vision-pro", msgs) is False

--- a/tests/services/rag/test_llamaindex_document_loader.py
+++ b/tests/services/rag/test_llamaindex_document_loader.py
@@ -175,12 +175,14 @@ def test_loader_skips_images_when_embedding_provider_is_text_only(
     assert documents == []
 
 
-def test_loader_embeds_images_when_embedding_provider_is_multimodal(
+def test_loader_embeds_images_with_qwen38_max_vision_capability(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     pytest.importorskip("llama_index.core")
     from llama_index.core.schema import ImageNode
 
+    from deeptutor.services.llm.client import LLMClient
+    from deeptutor.services.llm.config import LLMConfig
     from deeptutor.services.rag.pipelines.llamaindex import document_loader as loader_module
 
     image_path = tmp_path / "photo.png"
@@ -197,19 +199,24 @@ def test_loader_embeds_images_when_embedding_provider_is_multimodal(
             captured["contents"] = contents
             return [[0.1, 0.2, 0.3]]
 
-    class _VisionClient:
-        config = type("Config", (), {"binding": "openai", "model": "gpt-4o"})()
+    vision_client = LLMClient(
+        LLMConfig(
+            binding="dashscope",
+            model="qwen3.8-max",
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+        )
+    )
 
-        def supports_multimodal_images(self) -> bool:
-            return True
+    async def _complete(prompt: str, **kwargs: object) -> str:
+        captured["llm_prompt"] = prompt
+        captured["llm_kwargs"] = kwargs
+        return "A logo image with visible HKU text."
 
-        async def complete(self, prompt, **kwargs):
-            captured["llm_prompt"] = prompt
-            captured["llm_kwargs"] = kwargs
-            return "A logo image with visible HKU text."
+    monkeypatch.setattr(vision_client, "complete", _complete)
 
     monkeypatch.setattr(loader_module, "get_embedding_client", lambda: _MultimodalClient())
-    monkeypatch.setattr(loader_module, "get_llm_client", lambda: _VisionClient())
+    monkeypatch.setattr(loader_module, "get_llm_client", lambda: vision_client)
 
     documents = asyncio.run(loader_module.LlamaIndexDocumentLoader().load([str(image_path)]))
 


### PR DESCRIPTION
### Description

Qwen3.8-Max supports native image input even though its model ID does not use the historical `-vl` suffix.

DeepTutor currently lets this model fall through to the generic Qwen capability override and reports `supports_vision=False`. As a result:

- LlamaIndex image indexing skips images during its multimodal capability preflight.
- Post-failure multimodal fallback can incorrectly strip image content and retry as text-only.

This PR adds a narrow `qwen3.8-max` model override that marks the model family as vision-capable while keeping other Qwen text models fail-closed.

It also updates regression coverage for:

- capability resolution for `qwen3.8-max`;
- preservation of image content in multimodal fallback decisions;
- LlamaIndex image ingestion through a real `LLMClient` configured with `qwen3.8-max`, rather than a hand-written vision stub.

Official references:

- [Alibaba Cloud Model Studio — Visual understanding](https://help.aliyun.com/zh/model-studio/vision-model)
- [Alibaba Cloud Model Studio — Function Calling](https://help.aliyun.com/zh/model-studio/qwen-function-calling)

### Related Issues

N/A

### Module(s) Affected

- [x] `services`
- [x] `tests`

### Testing

```text
python -m pytest -q tests/services/llm tests/services/rag/test_llamaindex_document_loader.py
159 passed
```

Ruff lint and format checks also pass for all changed files.

Credentialed live validation was performed locally against the actual model endpoint for:

- text completion;
- image understanding;
- function/tool calling;
- LlamaIndex image indexing with multimodal embedding.

The live checks are intentionally not part of CI because they require paid API access and credentials.

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues. (Targeted Ruff and test checks pass.)
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (not required for this capability-table fix).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

- No API key, endpoint credential, or user configuration is included.
- No context-window metadata is changed; that concern is intentionally kept outside this focused fix.
- Generic Qwen text models remain classified as non-vision models.
