### PR TITLE
fix(codex): preserve OAuth model context window metadata

### DIFF
--- a/deeptutor/services/codex_auth/catalog.py
+++ b/deeptutor/services/codex_auth/catalog.py
@@ -76,6 +76,8 @@ def parse_models_response(payload: Mapping[str, Any]) -> tuple[CodexModel, ...]:
                     raw_model.get("supports_parallel_tool_calls") is True
                 ),
                 use_responses_lite=raw_model.get("use_responses_lite") is True,
+                context_window=_optional_positive_int(raw_model.get("context_window")),
+                max_context_window=_optional_positive_int(raw_model.get("max_context_window")),
             )
         )
 
@@ -84,6 +86,12 @@ def parse_models_response(payload: Mapping[str, Any]) -> tuple[CodexModel, ...]:
 
 def _optional_string(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
+
+
+def _optional_positive_int(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value
 
 
 def _reasoning_levels(value: object) -> tuple[str, ...]:

--- a/deeptutor/services/codex_auth/contracts.py
+++ b/deeptutor/services/codex_auth/contracts.py
@@ -125,6 +125,8 @@ class CodexModel:
     supports_reasoning_summary: bool
     supports_parallel_tool_calls: bool
     use_responses_lite: bool
+    context_window: int | None = None
+    max_context_window: int | None = None
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -137,6 +139,8 @@ class CodexModel:
             "supports_reasoning_summary": self.supports_reasoning_summary,
             "supports_parallel_tool_calls": self.supports_parallel_tool_calls,
             "use_responses_lite": self.use_responses_lite,
+            "context_window": self.context_window,
+            "max_context_window": self.max_context_window,
         }
 
     @classmethod
@@ -159,6 +163,8 @@ class CodexModel:
                 supports_reasoning_summary=bool(payload["supports_reasoning_summary"]),
                 supports_parallel_tool_calls=bool(payload["supports_parallel_tool_calls"]),
                 use_responses_lite=bool(payload["use_responses_lite"]),
+                context_window=_optional_positive_int(payload.get("context_window")),
+                max_context_window=_optional_positive_int(payload.get("max_context_window")),
             )
         except (KeyError, TypeError, ValueError) as exc:
             raise CodexAuthError(
@@ -166,6 +172,14 @@ class CodexModel:
                 "Stored Codex model data is invalid.",
                 500,
             ) from exc
+
+
+def _optional_positive_int(value: object) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError
+    return value
 
 
 @dataclass(frozen=True)

--- a/deeptutor/services/codex_auth/service.py
+++ b/deeptutor/services/codex_auth/service.py
@@ -85,7 +85,7 @@ def codex_model_id(slug: str) -> str:
 
 
 def _managed_model(model: CodexModel) -> dict[str, Any]:
-    return {
+    managed = {
         "id": codex_model_id(model.slug),
         "name": model.display_name,
         "model": model.slug,
@@ -97,6 +97,11 @@ def _managed_model(model: CodexModel) -> dict[str, Any]:
         "codex_supports_parallel_tool_calls": model.supports_parallel_tool_calls,
         "codex_use_responses_lite": model.use_responses_lite,
     }
+    context_window = model.context_window or model.max_context_window
+    if context_window is not None:
+        managed["context_window"] = str(context_window)
+        managed["context_window_source"] = "metadata"
+    return managed
 
 
 def _managed_profile(snapshot: CatalogSnapshot) -> dict[str, Any]:

--- a/tests/services/codex_auth/fixtures/models-response.json
+++ b/tests/services/codex_auth/fixtures/models-response.json
@@ -5,6 +5,8 @@
       "display_name": "GPT-5.6-Sol",
       "visibility": "list",
       "priority": 1,
+      "context_window": 272000,
+      "max_context_window": 272000,
       "default_reasoning_level": "medium",
       "supported_reasoning_levels": [
         {

--- a/tests/services/codex_auth/test_catalog.py
+++ b/tests/services/codex_auth/test_catalog.py
@@ -71,6 +71,8 @@ def test_parse_catalog_keeps_only_picker_visible_raw_models() -> None:
 
     assert [model.slug for model in models] == ["gpt-5.6-sol"]
     assert models[0].display_name == "GPT-5.6-Sol"
+    assert models[0].context_window == 272_000
+    assert models[0].max_context_window == 272_000
     assert models[0].supported_reasoning_levels == ("medium", "high")
     assert models[0].supports_reasoning_summary is True
 

--- a/tests/services/codex_auth/test_contracts.py
+++ b/tests/services/codex_auth/test_contracts.py
@@ -161,3 +161,34 @@ def test_catalog_snapshot_round_trip_preserves_tuples() -> None:
     assert restored == snapshot
     assert isinstance(restored.models, tuple)
     assert isinstance(restored.models[0].supported_reasoning_levels, tuple)
+
+
+def test_codex_model_round_trip_preserves_context_windows() -> None:
+    model = CodexModel(
+        slug="gpt-5.6-sol",
+        display_name="GPT-5.6-Sol",
+        priority=10,
+        visibility="list",
+        default_reasoning_level="medium",
+        supported_reasoning_levels=("low", "medium", "high"),
+        supports_reasoning_summary=True,
+        supports_parallel_tool_calls=True,
+        use_responses_lite=False,
+        context_window=272_000,
+        max_context_window=272_000,
+    )
+
+    restored = CodexModel.from_dict(model.to_dict())
+
+    assert restored == model
+
+
+def test_codex_model_accepts_cache_without_context_windows() -> None:
+    payload = _model().to_dict()
+    payload.pop("context_window")
+    payload.pop("max_context_window")
+
+    restored = CodexModel.from_dict(payload)
+
+    assert restored.context_window is None
+    assert restored.max_context_window is None

--- a/tests/services/codex_auth/test_service.py
+++ b/tests/services/codex_auth/test_service.py
@@ -164,6 +164,8 @@ def _model(
     *,
     display_name: str | None = None,
     priority: int = 1,
+    context_window: int | None = None,
+    max_context_window: int | None = None,
 ) -> CodexModel:
     return CodexModel(
         slug=slug,
@@ -175,6 +177,8 @@ def _model(
         supports_reasoning_summary=True,
         supports_parallel_tool_calls=True,
         use_responses_lite=False,
+        context_window=context_window,
+        max_context_window=max_context_window,
     )
 
 
@@ -244,7 +248,15 @@ def test_sync_publishes_a_read_only_owner_bound_codex_profile(tmp_path: Path) ->
 
     result = sync_codex_catalog(
         service,
-        _snapshot("live", _model("gpt-5.6-sol"), _model("gpt-5.6-terra", priority=2)),
+        _snapshot(
+            "live",
+            _model(
+                "gpt-5.6-sol",
+                context_window=272_000,
+                max_context_window=272_000,
+            ),
+            _model("gpt-5.6-terra", priority=2),
+        ),
     )
 
     profile = _managed_profile(result.catalog)
@@ -258,6 +270,24 @@ def test_sync_publishes_a_read_only_owner_bound_codex_profile(tmp_path: Path) ->
         "gpt-5.6-sol",
         "gpt-5.6-terra",
     ]
+    assert profile["models"][0]["context_window"] == "272000"
+    assert profile["models"][0]["context_window_source"] == "metadata"
+
+
+def test_sync_uses_max_context_window_when_current_window_is_missing(tmp_path: Path) -> None:
+    service = ModelCatalogService(tmp_path / "model_catalog.json")
+
+    result = sync_codex_catalog(
+        service,
+        _snapshot(
+            "live",
+            _model("gpt-5.6-sol", max_context_window=272_000),
+        ),
+    )
+
+    model = _managed_profile(result.catalog)["models"][0]
+    assert model["context_window"] == "272000"
+    assert model["context_window_source"] == "metadata"
 
 
 def test_signing_in_never_replaces_a_model_the_operator_already_chose(


### PR DESCRIPTION
### Description

Codex OAuth model discovery currently drops `context_window` and `max_context_window` from the `/codex/models` response before publishing the read-only managed model profile. As a result, downstream runtime configuration cannot use the provider metadata and may fall back to a conservative default, encouraging users to create a second manual profile.

This PR:

- parses optional positive `context_window` and `max_context_window` values from Codex model metadata;
- preserves both fields in the cached `CodexModel` contract while remaining compatible with caches written before these fields existed;
- publishes `context_window` to managed catalog models with `context_window_source: metadata`;
- falls back to `max_context_window` when the current context field is absent;
- adds parser, serialization, backward-compatibility, and managed-profile regression tests.

No context-window value is hardcoded in production code.

### Related Issues

- None found.

### Module(s) Affected

- [ ] `agents`
- [ ] `api`
- [x] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (not necessary: no user-facing workflow or configuration syntax changes).
- [x] My changes do not introduce any new security vulnerabilities.

### Verification

- `pre-commit run --files <changed files>`: passed (including Ruff, format, JSON, detect-secrets, Bandit, and MyPy)
- `pytest -q tests/services/codex_auth tests/services/test_model_catalog.py tests/services/config/test_provider_runtime.py tests/services/config/test_context_window_detection.py`: `139 passed`
- A read-only live metadata probe confirmed the endpoint returns integer context-window fields and that the updated parser publishes them into a temporary managed catalog. No credentials or account data are included in this PR.

The all-files pre-commit run was attempted. It rewrites tracked `web/.next-deeptutor` build artifacts and unrelated pre-existing frontend formatting; those unrelated changes were reverted rather than included here.

### Additional Notes

This intentionally does not add editable reasoning-effort overrides to the read-only OAuth-managed profile. That is a separate UI/configuration design change and should be reviewed independently.

Design sync: not applicable — this preserves the existing OAuth-managed catalog architecture and restores provider metadata that was already present upstream.
