### PR TITLE
fix: avoid repeated knowledge-base scans in list endpoint

### DIFF
--- a/deeptutor/api/routers/knowledge.py
+++ b/deeptutor/api/routers/knowledge.py
@@ -1744,6 +1744,7 @@ async def list_knowledge_bases():
     try:
         manager = get_kb_manager()
         kb_names = manager.list_knowledge_bases()
+        default_name = manager.get_default(available_names=kb_names)
         access_items = list_visible_kb_access()
         access_by_id = {str(item.get("id") or ""): item for item in access_items}
         own_prefix = "admin:kb:" if get_current_user().is_admin else "user:kb:"
@@ -1755,7 +1756,11 @@ async def list_knowledge_bases():
 
         for name in kb_names:
             try:
-                info = manager.get_info(name)
+                info = manager.get_info(
+                    name,
+                    refresh_config=False,
+                    default_name=default_name,
+                )
                 logger.debug(f"Successfully got info for KB '{name}': {info.get('statistics', {})}")
                 result.append(
                     KnowledgeBaseInfo(
@@ -1792,7 +1797,7 @@ async def list_knowledge_bases():
                             KnowledgeBaseInfo(
                                 id=f"{own_prefix}{name}",
                                 name=name,
-                                is_default=name == manager.get_default(),
+                                is_default=name == default_name,
                                 statistics={
                                     "raw_documents": 0,
                                     "images": 0,
@@ -1821,6 +1826,7 @@ async def list_knowledge_bases():
 
         logger.debug(f"Returning {len(result)} knowledge bases")
         if not get_current_user().is_admin:
+            assigned_snapshots: dict[str, str | None] = {}
             own_ids = {item.id for item in result}
             for access in access_items:
                 if access.get("source") != "admin" or access.get("id") in own_ids:
@@ -1847,7 +1853,17 @@ async def list_knowledge_bases():
                 resource = resolve_kb(str(access.get("id") or access.get("name") or ""))
                 assigned_manager = manager_for_resource(resource)
                 try:
-                    info = assigned_manager.get_info(resource.name)
+                    manager_key = str(assigned_manager.base_dir.resolve())
+                    if manager_key not in assigned_snapshots:
+                        assigned_names = assigned_manager.list_knowledge_bases()
+                        assigned_snapshots[manager_key] = assigned_manager.get_default(
+                            available_names=assigned_names
+                        )
+                    info = assigned_manager.get_info(
+                        resource.name,
+                        refresh_config=False,
+                        default_name=assigned_snapshots[manager_key],
+                    )
                     result.append(
                         KnowledgeBaseInfo(
                             id=resource.id,

--- a/deeptutor/knowledge/manager.py
+++ b/deeptutor/knowledge/manager.py
@@ -1004,27 +1004,33 @@ class KnowledgeBaseManager:
         except Exception as e:
             logger.warning(f"Failed to save default to centralized config: {e}")
 
-    def get_default(self) -> str | None:
+    def get_default(self, *, available_names: list[str] | None = None) -> str | None:
         """
         Get default knowledge base name.
 
         Priority:
         1. Canonical KB config service (`data/knowledge_bases/kb_config.json`)
         2. First knowledge base in the list (auto-fallback)
+
+        Args:
+            available_names: An already-reconciled knowledge-base list. Passing
+                this avoids rescanning every index when the caller just listed
+                the available knowledge bases.
         """
+        kb_list = available_names if available_names is not None else self.list_knowledge_bases()
+
         # Try centralized config first
         try:
             from deeptutor.services.config import get_kb_config_service
 
             kb_config_service = get_kb_config_service()
             default_kb = kb_config_service.get_default_kb()
-            if default_kb and default_kb in self.list_knowledge_bases():
+            if default_kb and default_kb in kb_list:
                 return default_kb
         except Exception:
             pass
 
         # Fallback to first knowledge base in sorted list
-        kb_list = self.list_knowledge_bases()
         if kb_list:
             return kb_list[0]
 
@@ -1093,7 +1099,13 @@ class KnowledgeBaseManager:
 
         return {}
 
-    def get_info(self, name: str | None = None) -> dict:
+    def get_info(
+        self,
+        name: str | None = None,
+        *,
+        refresh_config: bool = True,
+        default_name: str | None = None,
+    ) -> dict:
         """Get detailed information about a knowledge base.
 
         This method:
@@ -1101,11 +1113,24 @@ class KnowledgeBaseManager:
         2. Reads all config from kb_config.json (authoritative source)
         3. Falls back to metadata.json for legacy KBs
         4. Collects statistics about files and RAG status
+
+        Args:
+            name: Knowledge-base name, or the configured default when omitted.
+            refresh_config: Reload and reconcile the complete configuration.
+                Bulk callers that just invoked :meth:`list_knowledge_bases`
+                can reuse that snapshot by passing ``False``.
+            default_name: A pre-resolved default name for bulk callers. This
+                avoids rescanning the knowledge-base list for every item.
         """
         # Reload config to get latest status
-        self.config = self._load_config()
+        if refresh_config:
+            self.config = self._load_config()
 
-        kb_name = name or self.get_default()
+        resolved_default = default_name
+        if resolved_default is None:
+            resolved_default = self.get_default()
+
+        kb_name = name or resolved_default
         if kb_name is None:
             raise ValueError("No knowledge base name provided and no default set")
 
@@ -1225,7 +1250,7 @@ class KnowledgeBaseManager:
         info = {
             "name": kb_name,
             "path": str(kb_dir),
-            "is_default": kb_name == self.get_default(),
+            "is_default": kb_name == resolved_default,
             "metadata": metadata,
             "status": status,
             "progress": progress,

--- a/tests/api/test_knowledge_router.py
+++ b/tests/api/test_knowledge_router.py
@@ -55,8 +55,8 @@ class _FakeKBManager:
         entry["status"] = status
         entry["progress"] = progress or {}
 
-    def get_default(self) -> str | None:
-        names = self.list_knowledge_bases()
+    def get_default(self, *, available_names: list[str] | None = None) -> str | None:
+        names = available_names if available_names is not None else self.list_knowledge_bases()
         return names[0] if names else None
 
     def get_knowledge_base_path(self, name: str) -> Path:
@@ -503,6 +503,57 @@ def test_list_fallback_reports_error_status(monkeypatch, tmp_path: Path) -> None
     assert item["status"] == "error"
     assert item["progress"]["stage"] == "error"
     assert "get_info" in item["progress"]["error"]
+
+
+def test_list_reuses_manager_config_snapshot(monkeypatch, tmp_path: Path) -> None:
+    class _CountingKBManager:
+        def __init__(self) -> None:
+            self.base_dir = tmp_path / "knowledge_bases"
+            self.base_dir.mkdir(parents=True)
+            self.names = ["kb-a", "kb-b", "kb-c"]
+            self.list_calls = 0
+            self.default_calls = 0
+            self.info_calls: list[tuple[str, bool, str | None]] = []
+
+        def list_knowledge_bases(self) -> list[str]:
+            self.list_calls += 1
+            return self.names
+
+        def get_default(self, *, available_names: list[str] | None = None) -> str:
+            self.default_calls += 1
+            assert available_names == self.names
+            return self.names[0]
+
+        def get_info(
+            self,
+            name: str,
+            *,
+            refresh_config: bool,
+            default_name: str | None,
+        ) -> dict:
+            self.info_calls.append((name, refresh_config, default_name))
+            return {
+                "name": name,
+                "path": str(self.base_dir / name),
+                "is_default": name == default_name,
+                "statistics": {},
+                "metadata": {"name": name},
+                "status": "ready",
+                "progress": None,
+            }
+
+    manager = _CountingKBManager()
+    monkeypatch.setattr(knowledge_router_module, "get_kb_manager", lambda: manager)
+    monkeypatch.setattr(knowledge_router_module, "list_visible_kb_access", lambda: [])
+
+    with TestClient(_build_app()) as client:
+        response = client.get("/api/v1/knowledge/list")
+
+    assert response.status_code == 200
+    assert [item["name"] for item in response.json()] == manager.names
+    assert manager.list_calls == 1
+    assert manager.default_calls == 1
+    assert manager.info_calls == [(name, False, "kb-a") for name in manager.names]
 
 
 def _ready_kb_manager(tmp_path: Path, name: str = "kb") -> "_FakeKBManager":

--- a/tests/knowledge/test_manager_list.py
+++ b/tests/knowledge/test_manager_list.py
@@ -56,6 +56,17 @@ def test_list_keeps_entries_when_directory_present(tmp_path: Path) -> None:
     assert "kept" in _read_config(manager.config_file).get("knowledge_bases", {})
 
 
+def test_get_default_reuses_available_names(monkeypatch, tmp_path: Path) -> None:
+    manager = KnowledgeBaseManager(base_dir=str(tmp_path))
+
+    def _unexpected_rescan() -> list[str]:
+        raise AssertionError("available names should avoid another KB scan")
+
+    monkeypatch.setattr(manager, "list_knowledge_bases", _unexpected_rescan)
+
+    assert manager.get_default(available_names=["first", "second"]) == "first"
+
+
 def test_list_keeps_recent_entry_with_missing_dir(tmp_path: Path) -> None:
     """During KB creation the config entry is written before the directory
     exists. A concurrent ``list`` must not delete that in-flight entry —


### PR DESCRIPTION
### Description

`GET /api/v1/knowledge/list` reloaded and reconciled the complete knowledge-base configuration for every returned item: `get_info()` refreshed configuration, then resolved the default by listing all knowledge bases again. As the library grows, this makes the endpoint effectively quadratic, can exceed the web proxy timeout, and leaves the Knowledge Center appearing empty.

This PR:

- reuses the reconciled names and configuration snapshot while building one list response;
- resolves the default knowledge base once per manager snapshot;
- preserves refresh-by-default behavior for standalone `get_info()` callers;
- applies the same snapshot reuse when resolving assigned administrator knowledge bases;
- adds regression tests that prove the list route performs one list/default resolution without per-item rescans.

On the affected local deployment with 58 knowledge bases, the old manager loop took about 112.3 seconds. The patched read-only benchmark returned all 58 ready knowledge bases, including exactly one default, in 2.114 seconds.

### Related Issues

No matching existing issue was found.

### Module(s) Affected

- [ ] agents
- [x] api
- [ ] cli
- [ ] config
- [ ] core
- [ ] guides
- [x] knowledge
- [ ] memory
- [ ] partners
- [ ] providers
- [ ] tools
- [ ] ui
- [x] tests

### Checklist

- [x] I have read the contribution guidelines.
- [x] The change follows existing coding and typing conventions.
- [x] Regression tests cover the repeated-scan behavior.
- [x] Documentation is not required because the external API contract is unchanged.
- [x] No dependency or security boundary was added.
- [ ] The full repository-wide pre-commit suite was run.

### Validation

- Confirmed the new API regression test fails against the previous route implementation and passes with this patch.
- 53 focused API and knowledge-manager tests passed.
- `ruff check` passed for all four changed files.
- `ruff format --check` passed for all four changed files.
- A read-only 58-knowledge-base benchmark completed in 2.114 seconds.

### Additional Notes

This targets `dev` as required by the contribution guide. Increasing the proxy timeout was deliberately avoided because it would hide the repeated full-index scans instead of fixing their cause.
