### PR TITLE
fix: stop Partner responses with Escape

### DIFF
--- a/web/components/partners/PartnerChat.tsx
+++ b/web/components/partners/PartnerChat.tsx
@@ -453,6 +453,16 @@ export default function PartnerChat({
     }
   }, [sessionKey]);
 
+  useEffect(() => {
+    if (!streaming) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      sendStop();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [streaming, sendStop]);
+
   // Session-management commands run client-side: they switch the active
   // session or stop the turn — things a server text reply can't do. Returns
   // true when handled (so the caller skips the normal send).

--- a/web/components/partners/PartnerChat.tsx
+++ b/web/components/partners/PartnerChat.tsx
@@ -453,10 +453,21 @@ export default function PartnerChat({
     }
   }, [sessionKey]);
 
+  // Escape interrupts a streaming answer. Bound on `window` rather than the
+  // chat container because the composer is disabled mid-stream, so focus
+  // usually sits on <body> and a scoped listener would never see the key.
+  // An open overlay owns Escape first — Modal, PickerShell, ConfirmDialog and
+  // the preview drawers all close on it — so bail while one is mounted
+  // instead of killing the turn behind a dismissal the user meant for the
+  // dialog. Every overlay marks itself with a dialog role and unmounts when
+  // closed, which makes the DOM the single source of truth here.
   useEffect(() => {
     if (!streaming) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
+      if (document.querySelector('[role="dialog"], [role="alertdialog"]')) {
+        return;
+      }
       sendStop();
     };
     window.addEventListener("keydown", onKeyDown);

--- a/web/tests/partner-chat-stop.test.ts
+++ b/web/tests/partner-chat-stop.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const source = readFileSync(
+  path.resolve(process.cwd(), "components/partners/PartnerChat.tsx"),
+  "utf8",
+);
+
+function escapeStopEffect(): string {
+  const sendStopStart = source.indexOf("const sendStop = useCallback");
+  const commandStart = source.indexOf(
+    "// Session-management commands",
+    sendStopStart,
+  );
+
+  assert.notEqual(sendStopStart, -1, "sendStop callback should exist");
+  assert.notEqual(commandStart, -1, "client command handler should follow");
+  return source.slice(sendStopStart, commandStart);
+}
+
+test("partner chat listens for Escape only while streaming", () => {
+  const effect = escapeStopEffect();
+
+  assert.match(effect, /useEffect\(\(\) => \{/);
+  assert.match(effect, /if \(!streaming\) return;/);
+  assert.match(effect, /if \(event\.key !== "Escape"\) return;/);
+  assert.match(effect, /sendStop\(\);/);
+  assert.match(effect, /\}, \[streaming, sendStop\]\);/);
+});
+
+test("partner chat removes its streaming Escape listener", () => {
+  const effect = escapeStopEffect();
+
+  assert.match(effect, /window\.addEventListener\("keydown", onKeyDown\);/);
+  assert.match(
+    effect,
+    /return \(\) => window\.removeEventListener\("keydown", onKeyDown\);/,
+  );
+});

--- a/web/tests/partner-chat-stop.test.ts
+++ b/web/tests/partner-chat-stop.test.ts
@@ -39,3 +39,21 @@ test("partner chat removes its streaming Escape listener", () => {
     /return \(\) => window\.removeEventListener\("keydown", onKeyDown\);/,
   );
 });
+
+test("partner chat lets an open overlay keep Escape for itself", () => {
+  const effect = escapeStopEffect();
+
+  // Modal / PickerShell / ConfirmDialog / preview drawers all close on Escape
+  // and all mark themselves with a dialog role. Without this guard, dismissing
+  // any of them mid-stream would also stop the partner's answer.
+  assert.match(
+    effect,
+    /document\.querySelector\('\[role="dialog"\], \[role="alertdialog"\]'\)/,
+  );
+  const guardIndex = effect.indexOf("document.querySelector");
+  const stopIndex = effect.indexOf("sendStop();");
+  assert.ok(
+    guardIndex !== -1 && guardIndex < stopIndex,
+    "the overlay guard must run before sendStop()",
+  );
+});


### PR DESCRIPTION
### Description

In `PartnerChat`, register a document- or window-level keydown listener only while `streaming` is true so Escape remains observable even though `PartnerComposer` is disabled. Route Escape through the existing `sendStop` callback used by the stop button and `/stop`, preventing duplicate cancellation logic or a test-only abstraction. Remove the listener when streaming ends or the component unmounts, and ignore non-Escape keys so normal keyboard behavior is unchanged.

Partner chat disables its textarea while a response is streaming, so the composer cannot receive an Escape key event and the user remains locked out until the turn completes. The Partner WebSocket flow already supports cancellation: `PartnerChat` sends an `action: "stop"` frame through `sendStop`, and the server returns a `stopped` frame that clears streaming state while preserving any partial response. The missing behavior is therefore frontend keyboard wiring, not a new cancellation protocol. The issue is limited to the active Partner chat surface and does not require changes to main Chat or partner backend lifecycle code.

Closes #766

### Related Issues

- Closes #...
- Related to #...

### Module(s) Affected

- [ ] `agents`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `api`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `config`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `core`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `knowledge`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `logging`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `services`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `tools`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `utils`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `web` (Frontend)
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `docs` (Documentation)
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `scripts`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `tests`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] Other: `...`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [x] I have added relevant tests for my changes.
- [ ] My changes do not introduce any new security vulnerabilities.

### Additional Notes

*Add any other context or screenshots about the pull request here.*
