### PR TITLE
fix: use IPv4 loopback for frontend proxy

### DIFF
--- a/deeptutor/runtime/launcher.py
+++ b/deeptutor/runtime/launcher.py
@@ -955,7 +955,7 @@ def start(home: str | Path | None = None, *, dev: bool = False) -> None:
 
     backend_port = settings.backend_port
     frontend_port = settings.frontend_port
-    backend_url = f"http://localhost:{backend_port}"
+    backend_url = f"http://127.0.0.1:{backend_port}"
     api_base = (
         runtime_env.get("NEXT_PUBLIC_API_BASE_EXTERNAL")
         or runtime_env.get("NEXT_PUBLIC_API_BASE")
@@ -991,7 +991,7 @@ def start(home: str | Path | None = None, *, dev: bool = False) -> None:
     if (resolved_backend, resolved_frontend) != (backend_port, frontend_port):
         backend_port, frontend_port = resolved_backend, resolved_frontend
         runtime_env = export_runtime_settings_to_env(overwrite=True)
-        backend_url = f"http://localhost:{backend_port}"
+        backend_url = f"http://127.0.0.1:{backend_port}"
         api_base = (
             runtime_env.get("NEXT_PUBLIC_API_BASE_EXTERNAL")
             or runtime_env.get("NEXT_PUBLIC_API_BASE")
@@ -1032,7 +1032,7 @@ def start(home: str | Path | None = None, *, dev: bool = False) -> None:
     # The Next.js middleware (web/proxy.ts) runs in the frontend's Node runtime
     # and reads these at request time to forward /api/* and /ws/* to the backend
     # and to gate the login redirect. The browser uses relative paths, so the
-    # frontend server reaches the backend on localhost at the resolved port —
+    # frontend server reaches the backend on the IPv4 loopback at the resolved port —
     # use backend_url (not api_base, which may be an external browser URL).
     common_env["DEEPTUTOR_API_BASE_URL"] = backend_url
     common_env["DEEPTUTOR_AUTH_ENABLED"] = "true" if auth_enabled else "false"

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -401,3 +401,71 @@ def test_source_production_build_is_reused_until_an_input_changes(
         (["npm", "run", "build"], source, launcher.SOURCE_PRODUCTION_DIST_DIR),
     ]
     assert next_env.read_text(encoding="utf-8") == "// developer dist types\n"
+
+
+@pytest.mark.parametrize("resolved_backend_port", [8001, 8123])
+def test_start_uses_ipv4_loopback_for_frontend_proxy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    resolved_backend_port: int,
+) -> None:
+    from deeptutor.services import config as config_module
+    from deeptutor.services import setup as setup_module
+
+    settings_dir = tmp_path / "data" / "user" / "settings"
+    settings = config_module.LaunchSettings(
+        backend_port=8001,
+        frontend_port=3782,
+        language="en",
+        source="test",
+        settings_dir=settings_dir,
+        interface_json_path=settings_dir / "interface.json",
+        system_json_path=settings_dir / "system.json",
+    )
+    captured_env: dict[str, str] = {}
+
+    monkeypatch.setattr(launcher, "_relax_console_encoding", lambda: None)
+    monkeypatch.setattr(launcher, "_reset_runtime_singletons", lambda: None)
+    monkeypatch.setattr(config_module, "ensure_runtime_settings_files", lambda: None)
+    monkeypatch.setattr(config_module, "load_launch_settings", lambda _home: settings)
+    monkeypatch.setattr(
+        config_module,
+        "export_runtime_settings_to_env",
+        lambda **_kwargs: {},
+    )
+    monkeypatch.setattr(config_module, "load_auth_settings", lambda: {"enabled": False})
+    monkeypatch.setattr(config_module, "get_ws_max_size", lambda: 1024)
+    monkeypatch.setattr(setup_module, "init_user_directories", lambda _home: None)
+    monkeypatch.setattr(launcher, "resolve_language", lambda: "en")
+    monkeypatch.setattr(launcher, "print_banner", lambda **_kwargs: None)
+    monkeypatch.setattr(launcher, "_log", lambda _message: None)
+    monkeypatch.setattr(
+        launcher,
+        "_resolve_frontend",
+        lambda *_args, **_kwargs: launcher.FrontendRuntime("source", ["npm"], tmp_path),
+    )
+    monkeypatch.setattr(launcher, "_detect_existing_source_frontend", lambda _runtime: None)
+    monkeypatch.setattr(
+        launcher,
+        "_resolve_port_conflicts",
+        lambda **_kwargs: (resolved_backend_port, 3782),
+    )
+    monkeypatch.setattr(launcher, "_install_signal_handlers", lambda _callback: None)
+    monkeypatch.setattr(launcher.atexit, "register", lambda _callback: None)
+    monkeypatch.setattr(launcher, "_wait_for_http", lambda **_kwargs: None)
+    monkeypatch.setattr(launcher, "_terminate", lambda _process: None)
+
+    def _capture_spawn(_command, *, cwd, env, name):
+        assert cwd == tmp_path
+        if name == "backend":
+            return launcher.ManagedProcess("backend", object(), None)
+        assert name == "frontend"
+        captured_env.update(env)
+        raise RuntimeError("captured launch environment")
+
+    monkeypatch.setattr(launcher, "_spawn", _capture_spawn)
+
+    with pytest.raises(RuntimeError, match="captured launch environment"):
+        launcher.start(tmp_path)
+
+    assert captured_env["DEEPTUTOR_API_BASE_URL"] == (f"http://127.0.0.1:{resolved_backend_port}")


### PR DESCRIPTION
<!--
Thank you for contributing to DeepTutor! 🚀
Please ensure your PR is ready for review and follows our contribution guidelines.
For more details, see our [CONTRIBUTING.md](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
-->

### Description

The native launcher currently gives the frontend's Node proxy a `localhost` backend URL. On affected Windows hosts, Node resolves that hostname to `::1` while the locally launched uvicorn backend is reachable over IPv4, so proxied API requests fail with HTTP 500.

This change uses `127.0.0.1` for that internal proxy connection, both for the configured backend port and after port-conflict resolution. Browser-facing URLs remain unchanged. A regression test covers both launcher paths.

### Related Issues

- Closes #782

### Module(s) Affected

- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [x] Other: `runtime launcher`

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

Regression evidence:

- Before the fix, both cases failed because the exported values were `http://localhost:8001` and `http://localhost:8123`.
- After the fix, the focused regression passes: 2 passed.

Verification:

- Launcher suite: 19 passed.
- Full Python suite: 3621 passed, 9 skipped.
- Web Node tests on Node 22: 380 passed.
- Ruff lint and format checks: passed.
- CI import checks: passed.
- All pre-commit hooks on the two changed files, including Ruff, mypy, Bandit, and detect-secrets: passed.

The repository-wide pre-commit command is not clean on the current `dev` baseline because formatting hooks rewrite unrelated tracked frontend build artifacts and existing web source files. Those unrelated changes are not included in this PR; all CI-equivalent non-mutating checks and all hooks covering the changed files pass.
