### PR TITLE
fix: resolve generated-output downloads per user

### DIFF
--- a/deeptutor/api/main.py
+++ b/deeptutor/api/main.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 import logging
 import sys
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
@@ -18,6 +18,13 @@ from deeptutor.services.path_service import get_path_service
 
 ensure_runtime_settings_files()
 export_runtime_settings_to_env(overwrite=True)
+
+# Auth settings are exported above before this module reads their derived
+# constants. Keep this ordering aligned with the deferred router imports below.
+from deeptutor.multi_user.context import user_from_token_payload  # noqa: E402
+from deeptutor.multi_user.paths import get_path_service_for_scope  # noqa: E402
+from deeptutor.services.auth import AUTH_ENABLED, decode_token  # noqa: E402
+
 configure_logging()
 logger = logging.getLogger(__name__)
 
@@ -49,9 +56,28 @@ class SafeOutputStaticFiles(StaticFiles):
         self._path_service = path_service
 
     async def get_response(self, path: str, scope):
-        if not self._path_service.is_public_output_path(path):
+        path_service = self._path_service_for_request(scope)
+        if path_service is None or not path_service.is_public_output_path(path):
             raise HTTPException(status_code=404, detail="Output not found")
-        return await super().get_response(path, scope)
+
+        request_files = StaticFiles(
+            directory=str(path_service.get_public_outputs_root()),
+            check_dir=False,
+            follow_symlink=self.follow_symlink,
+        )
+        return await request_files.get_response(path, scope)
+
+    def _path_service_for_request(self, scope):
+        if not AUTH_ENABLED:
+            return self._path_service
+
+        token = Request(scope).cookies.get("dt_token")
+        payload = decode_token(token) if token else None
+        if payload is None:
+            return None
+
+        user = user_from_token_payload(payload)
+        return get_path_service_for_scope(user.scope)
 
 
 def validate_tool_consistency():

--- a/tests/api/test_output_static_files.py
+++ b/tests/api/test_output_static_files.py
@@ -1,0 +1,152 @@
+"""Request-scoped regression coverage for generated-output downloads."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from deeptutor.services.auth import TokenPayload
+from deeptutor.services.path_service import PathService
+
+OutputAppFactory = Callable[[dict[str, TokenPayload | None]], tuple[TestClient, PathService, Path]]
+
+
+@pytest.fixture
+def output_app(monkeypatch, tmp_path) -> OutputAppFactory:
+    from deeptutor.api import main as api_main
+    from deeptutor.multi_user import paths as multi_user_paths
+
+    admin_root = tmp_path / "data"
+    users_root = admin_root / "users"
+    admin_service = PathService(workspace_root=admin_root)
+    admin_service.get_public_outputs_root().mkdir(parents=True)
+
+    monkeypatch.setattr(api_main, "AUTH_ENABLED", True)
+    monkeypatch.setattr(multi_user_paths, "USERS_ROOT", users_root)
+    monkeypatch.setattr(multi_user_paths, "_path_services", {})
+
+    def make_app(tokens: dict[str, TokenPayload | None]) -> tuple[TestClient, PathService, Path]:
+        monkeypatch.setattr(api_main, "decode_token", lambda token: tokens.get(token))
+        app = FastAPI()
+        app.mount(
+            "/api/outputs",
+            api_main.SafeOutputStaticFiles(
+                directory=str(admin_service.get_public_outputs_root()),
+                path_service=admin_service,
+            ),
+        )
+        return TestClient(app), admin_service, users_root
+
+    return make_app
+
+
+def _write_output(root: Path, relative_path: str, contents: bytes) -> None:
+    output = root / "user" / relative_path
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(contents)
+
+
+def test_authenticated_user_downloads_output_from_own_workspace(output_app) -> None:
+    relative_path = "workspace/chat/chat/session-1/code_runs/report.pdf"
+    alice = TokenPayload(username="alice", role="user", user_id="u_alice")
+    client, _admin_service, users_root = output_app({"alice-token": alice})
+    _write_output(users_root / "u_alice", relative_path, b"alice report")
+
+    with client:
+        response = client.get(f"/api/outputs/{relative_path}", cookies={"dt_token": "alice-token"})
+
+    assert response.status_code == 200
+    assert response.content == b"alice report"
+
+
+def test_same_output_url_is_isolated_between_users(output_app) -> None:
+    relative_path = "workspace/chat/chat/session-1/code_runs/report.docx"
+    tokens = {
+        "alice-token": TokenPayload(username="alice", role="user", user_id="u_alice"),
+        "bob-token": TokenPayload(username="bob", role="user", user_id="u_bob"),
+        "carol-token": TokenPayload(username="carol", role="user", user_id="u_carol"),
+    }
+    client, _admin_service, users_root = output_app(tokens)
+    _write_output(users_root / "u_alice", relative_path, b"alice document")
+    _write_output(users_root / "u_bob", relative_path, b"bob document")
+
+    with client:
+        alice_response = client.get(
+            f"/api/outputs/{relative_path}", cookies={"dt_token": "alice-token"}
+        )
+        bob_response = client.get(
+            f"/api/outputs/{relative_path}", cookies={"dt_token": "bob-token"}
+        )
+        missing_response = client.get(
+            f"/api/outputs/{relative_path}", cookies={"dt_token": "carol-token"}
+        )
+
+    assert alice_response.content == b"alice document"
+    assert bob_response.content == b"bob document"
+    assert missing_response.status_code == 404
+    assert "u_alice" not in missing_response.text
+    assert "u_bob" not in missing_response.text
+
+
+@pytest.mark.parametrize("cookie", [None, "malformed-token", "expired-token"])
+def test_invalid_auth_does_not_fall_back_to_admin_output(output_app, cookie) -> None:
+    relative_path = "workspace/chat/chat/session-1/code_runs/admin.pdf"
+    client, admin_service, _users_root = output_app(
+        {"malformed-token": None, "expired-token": None}
+    )
+    _write_output(admin_service.workspace_root, relative_path, b"admin secret")
+    cookies = {} if cookie is None else {"dt_token": cookie}
+
+    with client:
+        response = client.get(f"/api/outputs/{relative_path}", cookies=cookies)
+
+    assert response.status_code == 404
+    assert "admin secret" not in response.text
+    assert str(admin_service.workspace_root) not in response.text
+
+
+def test_auth_disabled_uses_local_admin_output(output_app, monkeypatch) -> None:
+    from deeptutor.api import main as api_main
+
+    relative_path = "workspace/chat/chat/session-1/code_runs/local.pdf"
+    client, admin_service, _users_root = output_app({})
+    monkeypatch.setattr(api_main, "AUTH_ENABLED", False)
+    _write_output(admin_service.workspace_root, relative_path, b"local output")
+
+    with client:
+        response = client.get(f"/api/outputs/{relative_path}")
+
+    assert response.status_code == 200
+    assert response.content == b"local output"
+
+
+def test_private_suffix_is_rejected_for_authenticated_user(output_app) -> None:
+    relative_path = "workspace/chat/chat/session-1/code_runs/private.json"
+    alice = TokenPayload(username="alice", role="user", user_id="u_alice")
+    client, _admin_service, users_root = output_app({"alice-token": alice})
+    _write_output(users_root / "u_alice", relative_path, b'{"secret": true}')
+
+    with client:
+        response = client.get(f"/api/outputs/{relative_path}", cookies={"dt_token": "alice-token"})
+
+    assert response.status_code == 404
+    assert "secret" not in response.text
+
+
+def test_traversal_is_rejected_for_authenticated_user(output_app) -> None:
+    alice = TokenPayload(username="alice", role="user", user_id="u_alice")
+    client, _admin_service, users_root = output_app({"alice-token": alice})
+    user_root = users_root / "u_alice"
+    escaped_file = user_root / "secret.pdf"
+    escaped_file.parent.mkdir(parents=True, exist_ok=True)
+    escaped_file.write_bytes(b"outside public root")
+
+    with client:
+        response = client.get("/api/outputs/%2E%2E/secret.pdf", cookies={"dt_token": "alice-token"})
+
+    assert response.status_code == 404
+    assert "outside public root" not in response.text


### PR DESCRIPTION
### Description

Update `SafeOutputStaticFiles` in `deeptutor/api/main.py` to select a `PathService` for each request instead of delegating lookup to the startup-bound `StaticFiles.directory`: read the `dt_token` cookie from the ASGI request, decode it through the existing auth service, convert the payload through the existing multi-user identity mapping, and resolve that scope with `get_path_service_for_scope`. Resolve and serve the requested file against that service's public-output root only after `is_public_output_path` accepts it, so validation and physical lookup use the same account root. Preserve the default service only for auth-disabled/local-admin operation; when authentication is enabled, a missing or invalid credential should return the same non-revealing 404 rather than falling back to another account's files.

`SafeOutputStaticFiles` is constructed at application startup with the default `PathService`, so its Starlette directory remains rooted at the admin output tree for every request. Generated files for authenticated non-admin users are written beneath `data/users/<uid>/user`, causing otherwise valid `/api/outputs/...` links to return 404 even though the artifact exists. The bundle provides a concrete reproduction and diagnosis, and the current code still contains the startup-bound mount; there are no competing or prior cross-referenced PRs. The fix must preserve the existing public-output whitelist, private-suffix rejection, traversal protection, and account isolation.

Closes #790

### Related Issues

- Closes #...
- Related to #...

### Module(s) Affected

- [ ] `agents`
  Not claimed: the workspace test run did not pass; see the notes above.
- [ ] `api`
  Not claimed: the workspace test run did not pass; see the notes above.
- [ ] `config`
  Not claimed: the workspace test run did not pass; see the notes above.
- [ ] `core`
  Not claimed: the workspace test run did not pass; see the notes above.
- [ ] `knowledge`
  Not claimed: the workspace test run did not pass; see the notes above.
- [ ] `logging`
  Not claimed: the workspace test run did not pass; see the notes above.
- [ ] `services`
  Not claimed: the workspace test run did not pass; see the notes above.
- [ ] `tools`
  Not claimed: the workspace test run did not pass; see the notes above.
- [ ] `utils`
  Not claimed: the workspace test run did not pass; see the notes above.
- [ ] `web` (Frontend)
  Not claimed: the workspace test run did not pass; see the notes above.
- [ ] `docs` (Documentation)
  Not claimed: the workspace test run did not pass; see the notes above.
- [ ] `scripts`
  Not claimed: the workspace test run did not pass; see the notes above.
- [ ] `tests`
  Not claimed: the workspace test run did not pass; see the notes above.
- [ ] Other: `...`
  Not claimed: the workspace test run did not pass; see the notes above.

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
  Not claimed: the workspace test run did not pass; see the notes above.
- [x] I have added relevant tests for my changes.
- [ ] My changes do not introduce any new security vulnerabilities.

### Additional Notes

*Add any other context or screenshots about the pull request here.*
