### PR TITLE
fix(visualize): update iframe height when content shrinks

### DIFF
--- a/web/lib/iframe-html.ts
+++ b/web/lib/iframe-html.ts
@@ -88,16 +88,18 @@ export function sanitizeIframeHtml(html: string): string {
  * via postMessage:
  *   - `window.sendPrompt(text)` → posts a follow-up question; the host prefills
  *     it into the composer (the widget analogue of an SVG node's data-prompt).
- *   - a ResizeObserver posts the content height so the host can grow the iframe
- *     to fit instead of clipping at a fixed height.
+ *   - observers post the body content height so the host can grow and shrink the
+ *     iframe to fit instead of clipping at a fixed height or retaining an old
+ *     viewport height.
  */
 const BRIDGE_SCRIPT =
   "<script data-dt-bridge>" +
   "(function(){" +
   'window.sendPrompt=function(t){try{parent.postMessage({type:"dt:visualize-prompt",text:String(t||"")},"*")}catch(e){}};' +
-  'function rh(){try{var b=document.body,h=Math.max(document.documentElement.scrollHeight,b?b.scrollHeight:0);parent.postMessage({type:"dt:visualize-height",height:h},"*")}catch(e){}}' +
-  'if(typeof ResizeObserver!=="undefined"){var ro=new ResizeObserver(rh);document.addEventListener("DOMContentLoaded",function(){ro.observe(document.documentElement);rh()})}' +
-  'document.addEventListener("DOMContentLoaded",rh);window.addEventListener("load",rh);' +
+  'function rh(){try{var b=document.body,de=document.documentElement,h=b&&b.scrollHeight>0?b.scrollHeight:de.scrollHeight;if(!h||!isFinite(h))h=de.scrollHeight||0;parent.postMessage({type:"dt:visualize-height",height:h},"*")}catch(e){}}' +
+  'var raf=0;function schedule(){if(raf)return;var run=function(){raf=0;rh()};if(typeof requestAnimationFrame!=="undefined"){raf=requestAnimationFrame(run)}else{raf=setTimeout(run,0)}}' +
+  'function start(){try{var b=document.body;if(typeof ResizeObserver!=="undefined"&&b){var ro=new ResizeObserver(schedule);ro.observe(b)}if(typeof MutationObserver!=="undefined"&&b){var mo=new MutationObserver(schedule);mo.observe(b,{attributes:true,childList:true,subtree:true})}schedule()}catch(e){rh()}}' +
+  'if(document.readyState==="loading"){document.addEventListener("DOMContentLoaded",start,{once:true})}else{start()}window.addEventListener("load",schedule);' +
   "})();" +
   "<" +
   "/script>";

--- a/web/tests/e2e/visualize-height.audit.ts
+++ b/web/tests/e2e/visualize-height.audit.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "@playwright/test";
+import { prepareIframeHtml } from "../../lib/iframe-html";
+
+test("HTML visualization iframe shrinks and grows with tab content", async ({
+  page,
+}) => {
+  await page.setContent(
+    '<iframe id="visualization" style="width:640px;height:560px;border:0"></iframe>',
+  );
+
+  await page.evaluate(() => {
+    const iframe = document.querySelector<HTMLIFrameElement>("#visualization");
+    if (!iframe) throw new Error("Visualization iframe was not created");
+
+    window.addEventListener("message", (event) => {
+      if (event.source !== iframe.contentWindow) return;
+      const data = event.data as { type?: string; height?: number };
+      if (data?.type !== "dt:visualize-height" || typeof data.height !== "number") {
+        return;
+      }
+      iframe.style.height = `${Math.min(2400, Math.max(240, Math.ceil(data.height) + 8))}px`;
+    });
+  });
+
+  const html = prepareIframeHtml(`
+    <!doctype html>
+    <html>
+      <head>
+        <style>
+          body { margin: 0; }
+          #long-panel { height: 720px; background: #fee2e2; }
+          #short-panel { height: 120px; background: #dbeafe; }
+        </style>
+      </head>
+      <body>
+        <button id="toggle" type="button">Toggle tab</button>
+        <div id="long-panel"></div>
+        <div id="short-panel" hidden></div>
+        <script>
+          const longPanel = document.querySelector("#long-panel");
+          const shortPanel = document.querySelector("#short-panel");
+          document.querySelector("#toggle").addEventListener("click", () => {
+            longPanel.hidden = !longPanel.hidden;
+            shortPanel.hidden = !shortPanel.hidden;
+          });
+          setTimeout(() => {
+            const image = new Image();
+            image.alt = "";
+            image.src = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='320' height='160'%3E%3Crect width='320' height='160' fill='%23bfdbfe'/%3E%3C/svg%3E";
+            image.onload = () => shortPanel.appendChild(image);
+          }, 25);
+        </script>
+      </body>
+    </html>
+  `);
+
+  const iframe = page.locator("#visualization");
+  await iframe.evaluate((element, srcdoc) => {
+    (element as HTMLIFrameElement).srcdoc = srcdoc;
+  }, html);
+
+  const frame = page.frames().find((candidate) => candidate !== page.mainFrame());
+  if (!frame) throw new Error("Visualization iframe document was not created");
+
+  await frame.locator("#short-panel img").waitFor({ state: "attached" });
+
+  await expect
+    .poll(() => iframe.evaluate((element) => parseFloat(element.style.height)))
+    .toBeGreaterThan(700);
+  const expandedHeight = await iframe.evaluate((element) =>
+    parseFloat(element.style.height),
+  );
+
+  await frame.locator("#toggle").click();
+  await expect
+    .poll(() => iframe.evaluate((element) => parseFloat(element.style.height)))
+    .toBeLessThan(expandedHeight - 100);
+  const collapsedHeight = await iframe.evaluate((element) =>
+    parseFloat(element.style.height),
+  );
+  expect(collapsedHeight).toBeGreaterThanOrEqual(240);
+
+  await frame.locator("#toggle").click();
+  await expect
+    .poll(() => iframe.evaluate((element) => parseFloat(element.style.height)))
+    .toBeGreaterThan(collapsedHeight + 100);
+
+  await frame.locator("#toggle").evaluate((button) => {
+    const toggle = button as HTMLButtonElement;
+    toggle.click();
+    toggle.click();
+    toggle.click();
+  });
+  await expect
+    .poll(() => iframe.evaluate((element) => parseFloat(element.style.height)))
+    .toBeLessThan(expandedHeight - 100);
+});


### PR DESCRIPTION
## Summary

Fixes [HKUDS/DeepTutor#801](https://github.com/HKUDS/DeepTutor/issues/801).

This change fixes the HTML visualization iframe retaining the largest height previously displayed when users switch from a long tab/page to a shorter one. The visualization container now follows the current content height and can both grow and shrink.

## Problem

In the Visual Teaching / HTML visualization experience, switching to a shorter tab after viewing a long tab left a large empty area below the current content. The iframe continued to use the historical maximum height instead of recalculating the active tab's content height.

### Screen Shot
<img width="1582" height="1035" alt="修复前" src="https://github.com/user-attachments/assets/2819d57b-34eb-4c94-9d9d-ca90eebc029e" />

## Root Cause

The injected iframe bridge calculated height with:

`Math.max(document.documentElement.scrollHeight, document.body.scrollHeight)`

After the host iframe had been expanded, `document.documentElement.scrollHeight` could represent the expanded viewport height rather than the current body content height. That value then remained the maximum even after the active tab became shorter.

The bridge also observed `document.documentElement`, which does not reliably emit resize notifications when tab content changes inside the body.

## Changes

- Measure `document.body.scrollHeight` as the primary content height.
- Fall back to the document element only when the body is unavailable or reports an invalid height.
- Observe the body with `ResizeObserver` so natural layout changes continue to resize the iframe.
- Observe body DOM, class, and style mutations with `MutationObserver` to catch tab switches and dynamically rendered content.
- Coalesce repeated measurements with `requestAnimationFrame` to avoid flooding the parent with redundant height messages.
- Preserve the existing `dt:visualize-height` message contract, `sendPrompt` bridge, sandbox isolation, and parent-side 240–2400px height bounds.
- Add a browser regression test covering:
  - long content to short content;
  - short content back to long content;
  - asynchronously loaded image content;
  - rapid repeated tab changes.

## Validation

- `npm run test:node` — 386 tests passed.
- `npm run lint` — passed with the repository's existing 56 warnings and no errors.
- `git diff --check` — passed.
- Browser behavior was verified with the installed Google Chrome: the test fixture resized from 751px to 240px and back to 751px, including rapid switching.
- The standard Playwright command is included in the test workflow, but this environment does not have Playwright's bundled Chromium executable installed.

### Screen Shot:
<img width="1582" height="1035" alt="修复结果" src="https://github.com/user-attachments/assets/eb6d0b34-e805-48a4-b126-b42f9fa910df" />

## Scope

Only the iframe height bridge and its regression test are included. Existing generated `web/.next-deeptutor` changes in the local workspace are intentionally excluded.

Closes #801.

## Related Issues
Closes [#801](https://github.com/HKUDS/DeepTutor/issues/801)

## Module(s) Affected
- [ ] agents
- [ ] api
- [ ] config
- [ ] core
- [ ] knowledge
- [ ] logging
- [ ] services
- [ ] tools
- [ ] utils
- [x] web (Frontend)
- [ ] docs (Documentation)
- [ ] scripts
- [x] tests
- [ ] Other: ...

## Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run pre-commit run --all-files and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.
