### PR TITLE
fix: return minimal reasoning_effort for Gemini 3 and 2.5 Pro

### DIFF
--- a/deeptutor/services/llm/reasoning_params.py
+++ b/deeptutor/services/llm/reasoning_params.py
@@ -74,6 +74,11 @@ def default_reasoning_effort_for(provider: str | None, model: str | None) -> str
     provider_name = (provider or "").strip().lower()
     off_patterns = _PROVIDER_DEFAULT_OFF_PATTERNS.get(provider_name)
     if off_patterns and _matches(model or "", off_patterns):
+        _m = (model or "").lower()
+        # Gemini 3 and 2.5 Pro reject reasoning_effort="none";
+        # "minimal" is the lowest valid level for those families.
+        if "gemini-3" in _m or "gemini-2.5-pro" in _m:
+            return "minimal"
         return "none"
     return None
 

--- a/tests/services/llm/test_reasoning_params.py
+++ b/tests/services/llm/test_reasoning_params.py
@@ -14,18 +14,21 @@ class TestDefaultReasoningEffortFor:
     """Single source of truth for the implicit per-provider/model effort."""
 
     @pytest.mark.parametrize(
-        "model",
+        "model, expected",
         [
-            "gemini-2.5-flash",
-            "gemini-2.5-pro",
-            "gemini-2.5-flash-lite",
-            "GEMINI-2.5-FLASH",
-            "models/gemini-2.5-flash",
-            "gemini-3.0-pro",
+            ("gemini-2.5-flash", "none"),
+            ("gemini-2.5-flash-lite", "none"),
+            ("GEMINI-2.5-FLASH", "none"),
+            ("models/gemini-2.5-flash", "none"),
+            ("gemini-2.5-pro", "minimal"),
+            ("gemini-3.0-pro", "minimal"),
+            ("gemini-3.6-flash", "minimal"),
+            ("gemini-3.6-flash-latest", "minimal"),
+            ("models/gemini-3.6-flash", "minimal"),
         ],
     )
-    def test_gemini_thinking_models_default_to_none(self, model: str) -> None:
-        assert default_reasoning_effort_for("gemini", model) == "none"
+    def test_gemini_thinking_models_default(self, model: str, expected: str) -> None:
+        assert default_reasoning_effort_for("gemini", model) == expected
 
     @pytest.mark.parametrize(
         "model",


### PR DESCRIPTION
### Description

Gemini 3 models and Gemini 2.5 Pro reject `reasoning_effort="none"` with a 400 INVALID_ARGUMENT error. Per [Google's OpenAI-compatibility docs](https://ai.google.dev/gemini-api/docs/openai), `"none"` is only valid for the Gemini 2.5 non-Pro family.

### Fix

When the model matches the Gemini 3 family or Gemini 2.5 Pro, return `minimal` instead of `none` from the centralized reasoning-effort registry.

### Tests

Updated `tests/services/llm/test_reasoning_params.py` with coverage for Gemini 3 and 2.5 Pro variants (including prefixed and case variants). All 20 tests pass.

Fixes #734