### PR TITLE
fix(research): handle list-shaped RAG sources

### DIFF
--- a/deeptutor/agents/research/utils/citation_manager.py
+++ b/deeptutor/agents/research/utils/citation_manager.py
@@ -305,33 +305,53 @@ class CitationManager:
             # Extract source documents if available
             # Common fields in RAG responses: chunks, documents, sources, context
             sources = []
+            source_list: list[Any] = []
+            kb_name = ""
 
-            # Try different field names for source documents
-            for field_name in ["chunks", "documents", "sources", "context", "retrieved_docs"]:
-                if field_name in answer_data:
-                    source_list = answer_data[field_name]
-                    if isinstance(source_list, list):
-                        for i, doc in enumerate(source_list[:5]):  # Limit to 5 sources
-                            source_info = {}
-                            if isinstance(doc, dict):
-                                source_info["title"] = doc.get("title", doc.get("doc_title", ""))
-                                source_info["content_preview"] = doc.get(
-                                    "content", doc.get("text", "")
-                                )[:200]
-                                source_info["source_file"] = doc.get(
-                                    "source", doc.get("file_path", doc.get("filename", ""))
-                                )
-                                source_info["page"] = doc.get("page", doc.get("page_number", ""))
-                                source_info["chunk_id"] = doc.get("chunk_id", doc.get("id", i))
-                                source_info["score"] = doc.get("score", doc.get("similarity", ""))
-                            elif isinstance(doc, str):
-                                source_info["content_preview"] = doc[:200]
-                            if source_info:
-                                sources.append(source_info)
-                    break
+            if isinstance(answer_data, dict):
+                kb_name = answer_data.get("kb_name", "")
+                # Try different field names for source documents
+                for field_name in ["chunks", "documents", "sources", "context", "retrieved_docs"]:
+                    if field_name in answer_data:
+                        candidate_sources = answer_data[field_name]
+                        if isinstance(candidate_sources, list):
+                            source_list = candidate_sources
+                        break
+            elif isinstance(answer_data, list):
+                source_list = answer_data
+
+            document_source_fields = (
+                "title",
+                "doc_title",
+                "content",
+                "text",
+                "source",
+                "file_path",
+                "filename",
+            )
+            for i, doc in enumerate(source_list[:5]):  # Limit to 5 sources
+                source_info = {}
+                if isinstance(doc, dict):
+                    if not any(
+                        doc.get(field_name) not in (None, "")
+                        for field_name in document_source_fields
+                    ):
+                        continue
+                    source_info["title"] = doc.get("title", doc.get("doc_title", ""))
+                    source_info["content_preview"] = doc.get("content", doc.get("text", ""))[:200]
+                    source_info["source_file"] = doc.get(
+                        "source", doc.get("file_path", doc.get("filename", ""))
+                    )
+                    source_info["page"] = doc.get("page", doc.get("page_number", ""))
+                    source_info["chunk_id"] = doc.get("chunk_id", doc.get("id", i))
+                    source_info["score"] = doc.get("score", doc.get("similarity", ""))
+                elif isinstance(doc, str):
+                    source_info["content_preview"] = doc[:200]
+                if source_info:
+                    sources.append(source_info)
 
             # Also extract kb_name if available
-            citation_info["kb_name"] = answer_data.get("kb_name", "")
+            citation_info["kb_name"] = kb_name
             citation_info["sources"] = sources
             citation_info["total_sources"] = len(sources)
 

--- a/tests/agents/research/test_citation_manager_rag_sources.py
+++ b/tests/agents/research/test_citation_manager_rag_sources.py
@@ -1,0 +1,133 @@
+"""Focused coverage for RAG source extraction in the citation manager."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from deeptutor.agents.research.utils.citation_manager import CitationManager
+
+
+def _extract_rag_sources(tmp_path: Path, payload: Any) -> dict[str, Any]:
+    manager = CitationManager("test-research", cache_dir=tmp_path)
+    tool_trace = SimpleNamespace(
+        query="What is gravity?",
+        summary="Retrieved supporting material.",
+        timestamp="2026-08-11T00:00:00Z",
+    )
+    return manager._extract_rag_citation(
+        "CIT-1-01",
+        "rag",
+        json.dumps(payload),
+        tool_trace,
+    )
+
+
+def test_rag_dict_payload_preserves_source_mapping_and_kb_name(tmp_path: Path) -> None:
+    citation = _extract_rag_sources(
+        tmp_path,
+        {
+            "kb_name": "physics",
+            "documents": [
+                {
+                    "doc_title": "Gravity notes",
+                    "text": "Evidence from the course notes.",
+                    "filename": "gravity.pdf",
+                    "page_number": 7,
+                    "id": "chunk-7",
+                    "similarity": 0.91,
+                }
+            ],
+        },
+    )
+
+    assert citation["kb_name"] == "physics"
+    assert citation["sources"] == [
+        {
+            "title": "Gravity notes",
+            "content_preview": "Evidence from the course notes.",
+            "source_file": "gravity.pdf",
+            "page": 7,
+            "chunk_id": "chunk-7",
+            "score": 0.91,
+        }
+    ]
+    assert citation["total_sources"] == 1
+
+
+def test_rag_top_level_list_maps_document_and_string_sources(tmp_path: Path) -> None:
+    citation = _extract_rag_sources(
+        tmp_path,
+        [
+            {
+                "title": "Lecture transcript",
+                "content": "A" * 210,
+                "source": "lecture.txt",
+                "page": 3,
+                "chunk_id": "chunk-3",
+                "score": 0.8,
+            },
+            "Plain-text supporting evidence.",
+        ],
+    )
+
+    assert citation["kb_name"] == ""
+    assert citation["sources"] == [
+        {
+            "title": "Lecture transcript",
+            "content_preview": "A" * 200,
+            "source_file": "lecture.txt",
+            "page": 3,
+            "chunk_id": "chunk-3",
+            "score": 0.8,
+        },
+        {"content_preview": "Plain-text supporting evidence."},
+    ]
+    assert citation["total_sources"] == 2
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        {
+            "entity_name": "Newton",
+            "description": "A scientist in the knowledge graph.",
+            "id": "entity-1",
+            "score": 0.99,
+        },
+        {
+            "src_id": "force",
+            "tgt_id": "acceleration",
+            "relation_id": "force->acceleration",
+            "description": "A graph relationship, not a document source.",
+        },
+        {
+            "title": "",
+            "content": "",
+            "source": "",
+            "id": "chunk-0",
+            "page": 1,
+            "score": 0.5,
+        },
+    ],
+    ids=["entity-with-id", "relationship", "empty-document-fields"],
+)
+def test_rag_top_level_list_ignores_non_document_records(
+    tmp_path: Path,
+    record: dict[str, Any],
+) -> None:
+    citation = _extract_rag_sources(tmp_path, [record])
+
+    assert citation["kb_name"] == ""
+    assert citation["sources"] == []
+    assert citation["total_sources"] == 0
+
+
+def test_rag_scalar_payload_has_no_sources(tmp_path: Path) -> None:
+    citation = _extract_rag_sources(tmp_path, 42)
+
+    assert citation["kb_name"] == ""
+    assert citation["sources"] == []
+    assert citation["total_sources"] == 0


### PR DESCRIPTION
### Description

`parse_json_response()` can return a top-level list, but the RAG citation extractor assumed a mapping and later called `.get()`. The broad exception handler then returned a partial citation without the supported sources.

This change keeps the scope limited to the existing source-mapping contract:

- dictionary envelopes retain their current field aliases and `kb_name` handling;
- top-level lists feed document dictionaries and strings into the existing mapper;
- scalar payloads return stable empty source metadata;
- entity, relationship, ID-only, and empty document records do not become blank pseudo-citations.

The existing positional five-record window and source-field mapping remain unchanged.

### Related Issues

- Closes #808

### Module(s) Affected

- [x] `agents`
- [x] `tests`

### Checklist

- [x] I have read and followed the contribution guidelines.
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` — all configured hooks pass on both changed files; the repository-wide command was not run.
- [x] I have added relevant tests for my changes.
- [x] Documentation is unchanged because this fixes internal parsing behavior without changing the public API.
- [x] My changes do not introduce any new security vulnerabilities.

### Test Results

```text
Focused RAG citation shape tests: 6 passed
Adjacent JSON/parser/storage tests: 61 passed
Targeted pre-commit (both changed files): all hooks passed
Ruff check: passed
Ruff format --check: 2 files already formatted
git diff --check: passed
```

The broader `tests/agents/research` collection is blocked in this local environment by a missing `loguru` dependency in four unrelated pipeline test modules. A runtime-storage test also has an existing missing `data/user/settings/main.yaml` fixture failure. Neither failure is introduced by this patch.

### Additional Notes

This intentionally does not broaden validation for malformed document field values such as `content=None`, and it preserves the current raw first-five source limit. Those behaviors predate this list-shape fix.
