### PR TITLE
feat: add OrcaRouter as a named OpenAI-compatible gateway provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ deeptutor start    # starts backend + frontend; keep the terminal open
 
 `deeptutor init` prompts for backend port (default `8001`), frontend port (default `3782`), LLM provider / base URL / API key / model, and an optional embedding provider for Knowledge Base / RAG.
 
+[OrcaRouter](https://www.orcarouter.ai) is supported as a named OpenAI-compatible gateway for both LLM and embedding. With one `ORCAROUTER_API_KEY` (keys start with `sk-orca-`) you get 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. Pick it in the `deeptutor init` provider menu (or **Settings → Models**), use gateway model ids like `anthropic/claude-sonnet-4.6`, `deepseek/deepseek-v4-pro`, or `orcarouter/auto` for OrcaRouter's auto-routing alias, and set embedding models such as `openai/text-embedding-3-large`. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
 After `deeptutor start`, open the frontend URL printed in the terminal — by default [http://127.0.0.1:3782](http://127.0.0.1:3782). Press `Ctrl+C` in that terminal to stop both backend and frontend. Skipping `deeptutor init` is fine for a quick trial; the app boots with default ports and empty model settings, configure them later in **Settings → Models**.
 
 </details>

--- a/deeptutor/services/config/embedding_endpoint.py
+++ b/deeptutor/services/config/embedding_endpoint.py
@@ -101,6 +101,7 @@ EMBEDDING_PROVIDER_LABELS = {
     "openai": "OpenAI",
     "gemini": "Gemini",
     "openrouter": "OpenRouter",
+    "orcarouter": "OrcaRouter",
     "jina": "Jina",
     "vllm": "vLLM / LM Studio",
     "siliconflow": "SiliconFlow",
@@ -112,6 +113,7 @@ EMBEDDING_PROVIDER_DEFAULT_ENDPOINTS = {
     "openai": "https://api.openai.com/v1/embeddings",
     "gemini": gemini_embedding_endpoint(GEMINI_DEFAULT_EMBEDDING_MODEL),
     "openrouter": "https://openrouter.ai/api/v1/embeddings",
+    "orcarouter": "https://api.orcarouter.ai/v1/embeddings",
     "cohere": "https://api.cohere.com/v2/embed",
     "jina": "https://api.jina.ai/v1/embeddings",
     "ollama": "http://localhost:11434/api/embed",
@@ -126,6 +128,7 @@ EMBEDDING_PROVIDER_DEFAULT_ENDPOINTS = {
 EMBEDDING_PROVIDERS_REQUIRING_EMBEDDINGS_PATH = {
     "openai",
     "openrouter",
+    "orcarouter",
     "jina",
     "vllm",
     "siliconflow",

--- a/deeptutor/services/config/provider_runtime.py
+++ b/deeptutor/services/config/provider_runtime.py
@@ -193,6 +193,15 @@ EMBEDDING_PROVIDERS: dict[str, EmbeddingProviderSpec] = {
         keywords=("openrouter",),
         is_local=False,
     ),
+    "orcarouter": EmbeddingProviderSpec(
+        label="OrcaRouter",
+        adapter="openai_compat",
+        default_api_base=EMBEDDING_PROVIDER_DEFAULT_ENDPOINTS["orcarouter"],
+        keywords=("orcarouter", "orca_router"),
+        is_local=False,
+        default_model="openai/text-embedding-3-large",
+        default_dim=3072,
+    ),
 }
 
 

--- a/deeptutor/services/llm/capabilities.py
+++ b/deeptutor/services/llm/capabilities.py
@@ -136,6 +136,14 @@ PROVIDER_CAPABILITIES: dict[str, dict[str, object]] = {
         "supports_vision": True,  # Depends on underlying model
         "system_in_messages": True,
     },
+    # OrcaRouter (aggregator, generally OpenAI-compatible)
+    "orcarouter": {
+        "supports_response_format": True,  # Depends on underlying model
+        "supports_streaming": True,
+        "supports_tools": True,
+        "supports_vision": True,  # Depends on underlying model
+        "system_in_messages": True,
+    },
     # Groq (fast inference)
     "groq": {
         "supports_response_format": True,

--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -97,6 +97,8 @@ PROVIDER_ALIASES = {
     "atlas-cloud": "atlascloud",
     "eden_ai": "edenai",
     "novita_ai": "novita",
+    "orca_router": "orcarouter",
+    "orca-router": "orcarouter",
 }
 
 
@@ -152,6 +154,18 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         detect_by_key_prefix="sk-or-",
         detect_by_base_keyword="openrouter",
         default_api_base="https://openrouter.ai/api/v1",
+        supports_prompt_caching=True,
+    ),
+    ProviderSpec(
+        name="orcarouter",
+        keywords=("orcarouter", "orca_router", "orca router"),
+        env_key="ORCAROUTER_API_KEY",
+        display_name="OrcaRouter",
+        backend="openai_compat",
+        is_gateway=True,
+        detect_by_key_prefix="sk-orca-",
+        detect_by_base_keyword="orcarouter",
+        default_api_base="https://api.orcarouter.ai/v1",
         supports_prompt_caching=True,
     ),
     ProviderSpec(

--- a/deeptutor_cli/init_wizard.py
+++ b/deeptutor_cli/init_wizard.py
@@ -47,6 +47,7 @@ FEATURED_LLM_PROVIDERS: tuple[str, ...] = (
     "gemini",
     "siliconflow",
     "openrouter",
+    "orcarouter",
     "ollama",
 )
 
@@ -74,6 +75,12 @@ LLM_FALLBACK_MODELS: dict[str, tuple[str, ...]] = {
         "anthropic/claude-sonnet-4-6",
         "deepseek/deepseek-chat",
     ),
+    "orcarouter": (
+        "orcarouter/auto",
+        "anthropic/claude-sonnet-4.6",
+        "deepseek/deepseek-v4-pro",
+        "openai/gpt-4o",
+    ),
     "ollama": ("llama3.2", "qwen2.5", "mistral"),
 }
 
@@ -89,6 +96,7 @@ FEATURED_EMBEDDING_PROVIDERS: tuple[str, ...] = (
     "jina",
     "cohere",
     "openrouter",
+    "orcarouter",
     "azure_openai",
     "vllm",  # also covers LM Studio, llama.cpp via the same OpenAI-compatible adapter
     "ollama",
@@ -109,6 +117,7 @@ EMBEDDING_FALLBACK_MODELS: dict[str, tuple[str, ...]] = {
     "jina": ("jina-embeddings-v3", "jina-embeddings-v2-base-en"),
     "cohere": ("embed-v4.0", "embed-multilingual-v3.0", "embed-english-v3.0"),
     "openrouter": ("openai/text-embedding-3-large",),
+    "orcarouter": ("openai/text-embedding-3-large",),
     "vllm": ("BAAI/bge-m3",),
     "ollama": ("nomic-embed-text", "mxbai-embed-large", "snowflake-arctic-embed"),
 }

--- a/tests/services/config/test_embedding_runtime.py
+++ b/tests/services/config/test_embedding_runtime.py
@@ -76,6 +76,33 @@ def test_embedding_explicit_binding_and_headers() -> None:
     assert resolved.dimension == 1024
 
 
+def test_embedding_orcarouter_binding_uses_default_endpoint() -> None:
+    catalog = _build_catalog(
+        embedding_profile={
+            "id": "embedding-p",
+            "name": "Embedding",
+            "binding": "orcarouter",
+            "base_url": "",
+            "api_key": "sk-orca-test-key",
+            "api_version": "",
+            "extra_headers": {},
+            "models": [
+                {
+                    "id": "embedding-m",
+                    "name": "orcarouter",
+                    "model": "openai/text-embedding-3-large",
+                    "dimension": "3072",
+                }
+            ],
+        }
+    )
+    resolved = resolve_embedding_runtime_config(catalog=catalog)
+    assert resolved.provider_name == "orcarouter"
+    assert resolved.provider_mode == "standard"
+    assert resolved.effective_url == "https://api.orcarouter.ai/v1/embeddings"
+    assert resolved.dimension == 3072
+
+
 def test_embedding_alias_canonicalization_google_to_gemini() -> None:
     catalog = _build_catalog(
         embedding_profile={

--- a/tests/services/config/test_provider_runtime.py
+++ b/tests/services/config/test_provider_runtime.py
@@ -114,6 +114,63 @@ def test_llm_api_base_keyword_gateway() -> None:
     assert resolved.extra_headers == {"APP-Code": "x"}
 
 
+def test_llm_orcarouter_binding_uses_default_endpoint() -> None:
+    catalog = _build_catalog(
+        llm_profile={
+            "id": "llm-p",
+            "name": "OrcaRouter",
+            "binding": "orcarouter",
+            "base_url": "",
+            "api_key": "sk-orca-test-key",
+            "api_version": "",
+            "extra_headers": {},
+            "models": [{"id": "llm-m", "name": "m", "model": "orcarouter/auto"}],
+        }
+    )
+    resolved = resolve_llm_runtime_config(catalog=catalog)
+    assert resolved.provider_name == "orcarouter"
+    assert resolved.provider_mode == "gateway"
+    assert resolved.effective_url == "https://api.orcarouter.ai/v1"
+
+
+def test_llm_orcarouter_key_prefix_gateway() -> None:
+    catalog = _build_catalog(
+        llm_profile={
+            "id": "llm-p",
+            "name": "LLM",
+            "binding": "",
+            "base_url": "",
+            "api_key": "sk-orca-test-key",
+            "api_version": "",
+            "extra_headers": {},
+            "models": [{"id": "llm-m", "name": "m", "model": "anthropic/claude-sonnet-4.6"}],
+        }
+    )
+    resolved = resolve_llm_runtime_config(catalog=catalog)
+    assert resolved.provider_name == "orcarouter"
+    assert resolved.provider_mode == "gateway"
+    assert resolved.effective_url == "https://api.orcarouter.ai/v1"
+
+
+def test_llm_orcarouter_base_keyword_gateway() -> None:
+    catalog = _build_catalog(
+        llm_profile={
+            "id": "llm-p",
+            "name": "LLM",
+            "binding": "",
+            "base_url": "https://api.orcarouter.ai/v1",
+            "api_key": "k",
+            "api_version": "",
+            "extra_headers": {},
+            "models": [{"id": "llm-m", "name": "m", "model": "deepseek/deepseek-v4-pro"}],
+        }
+    )
+    resolved = resolve_llm_runtime_config(catalog=catalog)
+    assert resolved.provider_name == "orcarouter"
+    assert resolved.provider_mode == "gateway"
+    assert resolved.effective_url == "https://api.orcarouter.ai/v1"
+
+
 def test_llm_atlascloud_binding_uses_default_openai_compatible_endpoint() -> None:
     catalog = _build_catalog(
         llm_profile={

--- a/tests/services/test_provider_registry.py
+++ b/tests/services/test_provider_registry.py
@@ -71,3 +71,22 @@ def test_github_copilot_is_oauth_backed() -> None:
     assert spec is not None
     assert spec.auth_mode == "oauth"
     assert spec.env_key == ""
+
+
+def test_orcarouter_provider_aliases_and_detection() -> None:
+    spec = find_by_name("orcarouter")
+
+    assert spec is not None
+    assert spec.display_name == "OrcaRouter"
+    assert spec.env_key == "ORCAROUTER_API_KEY"
+    assert spec.backend == "openai_compat"
+    assert spec.mode == "gateway"
+    assert spec.default_api_base == "https://api.orcarouter.ai/v1"
+    assert find_by_name("orca_router") == spec
+    assert find_by_name("orca-router") == spec
+    # sk-orca- keys must resolve to OrcaRouter, not OpenRouter (sk-or-).
+    assert find_gateway(api_key="sk-orca-test-key") == spec
+    assert find_gateway(api_base="https://api.orcarouter.ai/v1") == spec
+    # An OpenRouter key/base must not be claimed by OrcaRouter.
+    assert find_gateway(api_key="sk-or-v1-abcdef") is not None
+    assert find_gateway(api_key="sk-or-v1-abcdef").name != "orcarouter"


### PR DESCRIPTION
### Description

This registers [OrcaRouter](https://www.orcarouter.ai) the same way the existing OpenRouter provider is wired, so the model picker, config reference and docs stay consistent. OrcaRouter is an OpenAI-compatible gateway: one `ORCAROUTER_API_KEY` (keys start with `sk-orca-`) unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

### Related Issues
- N/A

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [x] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [x] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.
