### PR TITLE
fix(rag): run embed sync hooks on a worker thread when an event loop is already running

### DIFF
--- a/deeptutor/services/rag/pipelines/llamaindex/embedding_adapter.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/embedding_adapter.py
@@ -80,12 +80,31 @@ class CustomEmbedding(BaseEmbedding):
         return "custom_embedding"
 
     def _run_in_new_loop(self, coro):
-        """Run an async coroutine from sync context using a fresh event loop."""
-        loop = asyncio.new_event_loop()
+        """Run an async coroutine from sync context.
+
+        LlamaIndex's IngestionPipeline calls the sync embed hooks. When the
+        outer call site is itself inside a running event loop (e.g. the async
+        ``add_documents`` flow), creating and ``run_until_complete``-ing a new
+        loop raises ``RuntimeError: Cannot run the event loop while another
+        loop is running``. Run the fresh loop in a worker thread so the outer
+        loop stays untouched and the embedding call actually fires.
+        """
+        import concurrent.futures
+
+        def _runner():
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.run_until_complete(coro)
+            finally:
+                loop.close()
+
         try:
-            return loop.run_until_complete(coro)
-        finally:
-            loop.close()
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return _runner()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(_runner).result()
 
     async def _aget_query_embedding(self, query: str) -> List[float]:
         client = self.refresh_client()

--- a/deeptutor/services/rag/pipelines/llamaindex/embedding_adapter.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/embedding_adapter.py
@@ -85,26 +85,34 @@ class CustomEmbedding(BaseEmbedding):
         LlamaIndex's IngestionPipeline calls the sync embed hooks. When the
         outer call site is itself inside a running event loop (e.g. the async
         ``add_documents`` flow), creating and ``run_until_complete``-ing a new
-        loop raises ``RuntimeError: Cannot run the event loop while another
-        loop is running``. Run the fresh loop in a worker thread so the outer
-        loop stays untouched and the embedding call actually fires.
+        loop on the same thread raises ``RuntimeError: Cannot run the event
+        loop while another loop is running``. Run the fresh loop on a worker
+        thread that owns it (mirroring the pattern in
+        ``graphrag.engine._run_isolated``) so the outer loop stays untouched,
+        the embedding call actually fires, and the AsyncClient inside the
+        embed call resolves the correct loop via ``asyncio.get_event_loop()``.
         """
-        import concurrent.futures
-
-        def _runner():
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
             loop = asyncio.new_event_loop()
             try:
                 return loop.run_until_complete(coro)
             finally:
                 loop.close()
 
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            return _runner()
+        def _runner():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                return loop.run_until_complete(coro)
+            finally:
+                try:
+                    loop.close()
+                finally:
+                    asyncio.set_event_loop(None)
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            return pool.submit(_runner).result()
+        return asyncio.get_event_loop().run_in_executor(None, _runner).result()
 
     async def _aget_query_embedding(self, query: str) -> List[float]:
         client = self.refresh_client()


### PR DESCRIPTION
## Description

`CustomEmbedding._run_in_new_loop` ran the async embed coroutine by creating a fresh `asyncio` event loop and calling `loop.run_until_complete(coro)`. LlamaIndex's `IngestionPipeline` invokes the **synchronous** embed hooks (`_get_text_embedding` / `_get_text_embeddings`) from within `storage.create_index`, which itself runs inside `loop.run_in_executor` under `LlamaIndexPipeline.initialize` — an `async` method. So at the moment the sync hook fires, an event loop is **already running** on the main thread, and `run_until_complete` on a second loop raises:

```
RuntimeError: Cannot run the event loop while another loop is running
```

The exception was swallowed by the pipeline run, nodes were persisted without embeddings, and the KB was reported as "created successfully". The symptom: **any KB built through the async ingestion path (Web UI upload, `add_documents` API/CLI, `kb add`) silently had zero vectors**, and vector retrieval returned identical results for any query — effectively degrading retrieval to BM25 keyword matching only.

### The fix

When an event loop is already running on the current thread, run the fresh loop on a **dedicated worker thread** instead of trying to nest it. This keeps the outer loop untouched and lets the embedding call actually execute. When no loop is running (pure-sync call sites), behavior is unchanged.

```python
def _run_in_new_loop(self, coro):
    import concurrent.futures

    def _runner():
        loop = asyncio.new_event_loop()
        try:
            return loop.run_until_complete(coro)
        finally:
            loop.close()

    try:
        asyncio.get_running_loop()
    except RuntimeError:
        return _runner()

    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
        return pool.submit(_runner).result()
```

This is intentionally minimal and self-contained — it doesn't change the `nest_asyncio` story used elsewhere (e.g. graphrag) and doesn't alter the embed call shape LlamaIndex relies on. Thread isolation is preferred over `nest_asyncio.apply()` because the latter patches the running loop globally and can have surprising side effects on the outer pipeline's own async scheduling.

## Related Issues
- Closes #819

## Module(s) Affected
- [x] `services`

## Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues. *(Not run locally — happy to do so if CI flags anything; the change is small and self-contained.)*
- [ ] I have added relevant tests for my changes. *(See verification below — guidance welcome on where the maintainers would like a regression test placed.)*
- [x] I have updated the documentation (if necessary). *(Not necessary — behavior-only fix.)*
- [x] My changes do not introduce any new security vulnerabilities.

## Verification

### Before the fix — async ingestion skips embeddings

Running the exact call shape used by `LlamaIndexPipeline.initialize` (`run_in_executor` → `create_index` → `documents_to_nodes` → `pipeline.run`) under an event loop:

- KB build log shows `Generating embeddings: 0it`, no `Embedding N text chunks...` line
- `default__vector_store.json` ends up at ~4 KB (FAISS header only, `ntotal = 0`)
- Two semantically unrelated queries return **identical** scores in **identical** order (vector retrieval not running):

```
query "香港大学是哪个实验室" → 0.0333, 0.0328, 0.0323
query "量子物理薛定谔"        → 0.0333, 0.0328, 0.0323   (identical)
```

The direct reproducer (raises before fix):

```python
import asyncio
from llama_index.core import Settings, Document
from deeptutor.services.rag.pipelines.llamaindex.embedding_adapter import configure_llamaindex_settings
from deeptutor.services.rag.pipelines.llamaindex.ingestion import build_ingestion_pipeline

async def main():
    configure_llamaindex_settings()
    pipeline = build_ingestion_pipeline()
    nodes = pipeline.run(documents=[Document(text="hello world " * 200)], show_progress=True)
    # pre-fix: RuntimeError swallowed inside the run; nodes have no embedding
    print(sum(1 for n in nodes if n.embedding), "/", len(nodes), "embedded")

asyncio.run(main())
```

### After the fix — embeddings fire, retrieval is semantic

```
INFO deeptutor.services.rag.pipelines.llamaindex.embedding_adapter - Embedding 3 text chunks...
INFO httpx - HTTP Request: POST http://127.0.0.1:30000/v1/embeddings "HTTP/1.1 200 OK"
INFO deeptutor.services.embedding.adapters.openai_compatible - Successfully generated 3 embeddings (model: Qwen3-Embedding-0.6B, dimensions: 1024)
INFO deeptutor.services.rag.pipelines.llamaindex.embedding_adapter - Embedding complete: 3 vectors
```

`default__vector_store.json` grows to ~41 KB for 10 chunks (10 × 1024 × 4 bytes ≈ 41 KB), `faiss.IndexFlatIP.ntotal` matches the chunk count, and retrieval now returns **query-dependent** scores with the semantically relevant chunk ranked first:

```
query "alpha-5 beta-5"        → 0.4477 (chunk with "主题 4/5"), 0.4422, 0.3886
```

Pure-sync call sites continue to work unchanged (verified: `_get_text_embedding("test")` from a script with no running loop still returns a 1024-dim vector).

## Additional Notes

- **Why this is high-impact**: every user who builds a KB through the Web UI (the primary UX) or the `add_documents` API hits this and gets a silently broken KB. The failure is invisible — no error in the UI, KB shows "ready", only retrieval quality suffers.
- **Why it's easy to miss in testing**: a plain synchronous `pipeline.run()` (the shape most likely to appear in a unit test) doesn't trigger it — the bug only manifests when there's a running outer loop, which is the case in the actual service.
- **Scope**: single method, ~25 lines. No public API change. Targeting `dev` per CONTRIBUTING.md.
