### PR TITLE
fix(llm): mark OpenAI Codex as vision capable

### DIFF
--- a/deeptutor/services/llm/capabilities.py
+++ b/deeptutor/services/llm/capabilities.py
@@ -29,6 +29,11 @@ PROVIDER_CAPABILITIES: dict[str, dict[str, object]] = {
         "system_in_messages": True,  # System prompt goes in messages array
         "newer_models_use_max_completion_tokens": True,
     },
+    # Codex uses OpenAI's Responses API and converts image_url message parts
+    # into native input_image blocks before sending the request.
+    "openai_codex": {
+        "supports_vision": True,
+    },
     # Custom / user-defined OpenAI-compatible endpoints
     "custom": {
         "supports_response_format": True,

--- a/tests/services/llm/test_capabilities.py
+++ b/tests/services/llm/test_capabilities.py
@@ -42,6 +42,11 @@ def test_effective_temperature_override() -> None:
     assert get_effective_temperature("openai", "gpt-4o", requested_temp=0.4) == 0.4
 
 
+def test_openai_codex_provider_is_vision_capable() -> None:
+    """The Codex Responses provider accepts image input for its model catalog."""
+    assert supports_vision("openai_codex", "gpt-5.6-sol") is True
+
+
 def test_moonshot_vision_models() -> None:
     """Per Kimi docs the five vision-capable IDs flip supports_vision to True;
     other Moonshot models stay at the binding default (False).

--- a/tests/services/llm/test_multimodal.py
+++ b/tests/services/llm/test_multimodal.py
@@ -161,6 +161,8 @@ def test_should_degrade_only_for_non_vision_model_with_images() -> None:
     assert should_degrade_to_text("moonshot", "moonshot-v1-8k", msgs) is True
     # Known vision-capable model → keep images, surface the real error.
     assert should_degrade_to_text("openai", "gpt-4o", msgs) is False
+    # Codex uses the Responses API and must not silently retry without its image.
+    assert should_degrade_to_text("openai_codex", "gpt-5.6-sol", msgs) is False
     # Qwen3.8-Max is multimodal even though its model ID has no ``-vl`` suffix.
     assert should_degrade_to_text("dashscope", "qwen3.8-max", msgs) is False
     # An allowlisted provider (VolcEngine) is trusted even for a model we have

--- a/tests/services/llm/test_openai_codex_oauth_provider.py
+++ b/tests/services/llm/test_openai_codex_oauth_provider.py
@@ -58,8 +58,17 @@ async def test_provider_uses_deeptutor_token_service_and_raw_sol_id(
     monkeypatch.setattr(module, "get_codex_oauth_service", lambda: service)
     monkeypatch.setattr(module, "_request_codex", request)
 
+    image_url = "data:image/png;base64,QUJD"
     result = await OpenAICodexProvider().chat(
-        [{"role": "user", "content": "hello"}],
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe"},
+                    {"type": "image_url", "image_url": {"url": image_url}},
+                ],
+            }
+        ],
         model="openai-codex/gpt-5.6-sol",
         reasoning_effort="medium",
         tools=[
@@ -84,6 +93,15 @@ async def test_provider_uses_deeptutor_token_service_and_raw_sol_id(
     assert body["model"] == "gpt-5.6-sol"
     assert body["reasoning"] == {"effort": "medium"}
     assert body["tools"][0]["name"] == "lookup"
+    assert body["input"] == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "describe"},
+                {"type": "input_image", "image_url": image_url, "detail": "auto"},
+            ],
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- declare the `openai_codex` Responses provider as vision-capable
- keep image parts on Codex request failures instead of silently retrying text-only
- verify Codex request conversion emits native Responses API `input_image` blocks

## Why

The Codex provider already converts OpenAI-style `image_url` message parts to Responses API `input_image` blocks, and a live image request succeeds. However, the provider is absent from `PROVIDER_CAPABILITIES`, so `supports_vision("openai_codex", model)` falls back to `False`. That prevents RAG image indexing and allows post-failure multimodal fallback to strip the image.

## Test plan

- `python -m pytest -q tests/services/llm/test_capabilities.py tests/services/llm/test_multimodal.py tests/services/llm/test_openai_codex_oauth_provider.py tests/services/rag/test_llamaindex_document_loader.py`
  - 38 passed
- `pre-commit run --files deeptutor/services/llm/capabilities.py tests/services/llm/test_capabilities.py tests/services/llm/test_multimodal.py tests/services/llm/test_openai_codex_oauth_provider.py`
  - all hooks passed

## Scope

This is a provider capability metadata correction plus regression coverage. It does not change authentication, credential storage, or the Codex HTTP request implementation.
