### PR TITLE
fix: preserve Responses tool call arguments

### DIFF
--- a/deeptutor/services/llm/provider_core/openai_responses/parsing.py
+++ b/deeptutor/services/llm/provider_core/openai_responses/parsing.py
@@ -75,31 +75,35 @@ async def consume_sse(
                 call_id = item.get("call_id")
                 if not call_id:
                     continue
-                tool_call_buffers[call_id] = {
+                buffer = {
                     "id": item.get("id") or "fc_0",
                     "name": item.get("name"),
                     "arguments": item.get("arguments") or "",
                 }
+                tool_call_buffers[call_id] = buffer
+                item_id = item.get("id")
+                if item_id:
+                    tool_call_buffers[item_id] = buffer
         elif event_type == "response.output_text.delta":
             delta_text = event.get("delta") or ""
             content += delta_text
             if on_content_delta and delta_text:
                 await on_content_delta(delta_text)
         elif event_type == "response.function_call_arguments.delta":
-            call_id = event.get("call_id")
-            if call_id and call_id in tool_call_buffers:
-                tool_call_buffers[call_id]["arguments"] += event.get("delta") or ""
+            buffer_id = event.get("call_id") or event.get("item_id")
+            if buffer_id and buffer_id in tool_call_buffers:
+                tool_call_buffers[buffer_id]["arguments"] += event.get("delta") or ""
         elif event_type == "response.function_call_arguments.done":
-            call_id = event.get("call_id")
-            if call_id and call_id in tool_call_buffers:
-                tool_call_buffers[call_id]["arguments"] = event.get("arguments") or ""
+            buffer_id = event.get("call_id") or event.get("item_id")
+            if buffer_id and buffer_id in tool_call_buffers:
+                tool_call_buffers[buffer_id]["arguments"] = event.get("arguments") or ""
         elif event_type == "response.output_item.done":
             item = event.get("item") or {}
             if item.get("type") == "function_call":
                 call_id = item.get("call_id")
                 if not call_id:
                     continue
-                buf = tool_call_buffers.get(call_id) or {}
+                buf = tool_call_buffers.get(call_id) or tool_call_buffers.get(item.get("id")) or {}
                 args_raw = buf.get("arguments") or item.get("arguments") or "{}"
                 try:
                     args = json.loads(args_raw)
@@ -226,31 +230,39 @@ async def consume_sdk_stream(
                 call_id = getattr(item, "call_id", None)
                 if not call_id:
                     continue
-                tool_call_buffers[call_id] = {
+                buffer = {
                     "id": getattr(item, "id", None) or "fc_0",
                     "name": getattr(item, "name", None),
                     "arguments": getattr(item, "arguments", None) or "",
                 }
+                tool_call_buffers[call_id] = buffer
+                item_id = getattr(item, "id", None)
+                if item_id:
+                    tool_call_buffers[item_id] = buffer
         elif event_type == "response.output_text.delta":
             delta_text = getattr(event, "delta", "") or ""
             content += delta_text
             if on_content_delta and delta_text:
                 await on_content_delta(delta_text)
         elif event_type == "response.function_call_arguments.delta":
-            call_id = getattr(event, "call_id", None)
-            if call_id and call_id in tool_call_buffers:
-                tool_call_buffers[call_id]["arguments"] += getattr(event, "delta", "") or ""
+            buffer_id = getattr(event, "call_id", None) or getattr(event, "item_id", None)
+            if buffer_id and buffer_id in tool_call_buffers:
+                tool_call_buffers[buffer_id]["arguments"] += getattr(event, "delta", "") or ""
         elif event_type == "response.function_call_arguments.done":
-            call_id = getattr(event, "call_id", None)
-            if call_id and call_id in tool_call_buffers:
-                tool_call_buffers[call_id]["arguments"] = getattr(event, "arguments", "") or ""
+            buffer_id = getattr(event, "call_id", None) or getattr(event, "item_id", None)
+            if buffer_id and buffer_id in tool_call_buffers:
+                tool_call_buffers[buffer_id]["arguments"] = getattr(event, "arguments", "") or ""
         elif event_type == "response.output_item.done":
             item = getattr(event, "item", None)
             if item and getattr(item, "type", None) == "function_call":
                 call_id = getattr(item, "call_id", None)
                 if not call_id:
                     continue
-                buf = tool_call_buffers.get(call_id) or {}
+                buf = (
+                    tool_call_buffers.get(call_id)
+                    or tool_call_buffers.get(getattr(item, "id", None))
+                    or {}
+                )
                 args_raw = buf.get("arguments") or getattr(item, "arguments", None) or "{}"
                 try:
                     args = json.loads(args_raw) if isinstance(args_raw, str) else args_raw

--- a/deeptutor/utils/json_parser.py
+++ b/deeptutor/utils/json_parser.py
@@ -71,10 +71,11 @@ def parse_json_response(
     """
     Safely parse JSON from LLM responses with automatic repair.
 
-    Implements a three-tier parsing strategy:
-    1. Extract JSON from markdown code blocks if present
-    2. Direct JSON parsing
-    3. Automated repair using json-repair library with fallback
+    Implements a four-tier parsing strategy:
+    1. Direct JSON parsing
+    2. Extract JSON from markdown code blocks if present
+    3. Decode JSON embedded in surrounding prose
+    4. Automated repair using json-repair library with fallback
 
     Args:
         response: Raw string response from LLM
@@ -102,21 +103,26 @@ def parse_json_response(
         log.warning("LLM returned empty response")
         return fallback
 
-    # Extract from markdown code blocks if present
+    # A valid JSON payload may legitimately contain Markdown code fences inside
+    # a string value (for example write_note's Markdown ``content`` argument).
+    # Parse the complete payload before treating a fence as a JSON wrapper.
+    try:
+        return json.loads(response)
+    except (json.JSONDecodeError, TypeError) as parse_error:
+        log.debug(f"Direct JSON parse failed: {parse_error}")
+
+    # The complete payload was not JSON. It may be an LLM response wrapping
+    # JSON in a Markdown fence, so extract that wrapper before repair.
     extracted_response = response
     if "```" in response:
         json_match = re.search(r"```(?:json)?\s*\n?(.*?)```", response, re.DOTALL)
         if json_match:
             extracted_response = json_match.group(1).strip()
             log.debug("Extracted JSON from markdown code block")
-
-    # Strategy 1: Direct parsing. Done before any <think> stripping so a valid
-    # JSON payload whose string values legitimately contain "<think>" is
-    # preserved exactly.
-    try:
-        return json.loads(extracted_response)
-    except (json.JSONDecodeError, TypeError) as parse_error:
-        log.debug(f"Direct JSON parse failed: {parse_error}")
+            try:
+                return json.loads(extracted_response)
+            except (json.JSONDecodeError, TypeError) as parse_error:
+                log.debug(f"Markdown-wrapped JSON parse failed: {parse_error}")
 
     # Strategy 1b: strip chain-of-thought <think> reasoning that models like
     # Qwen/DeepSeek emit before the JSON payload, then retry. Only reached once

--- a/tests/services/llm/test_openai_responses_parsing.py
+++ b/tests/services/llm/test_openai_responses_parsing.py
@@ -1,0 +1,119 @@
+"""Regression tests for OpenAI Responses streaming tool arguments."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import AsyncIterator
+
+from deeptutor.services.llm.provider_core.openai_responses.parsing import (
+    consume_sdk_stream,
+    consume_sse,
+)
+
+
+class _FakeResponse:
+    def __init__(self, events: list[dict[str, object]]) -> None:
+        self._events = events
+
+    async def aiter_lines(self) -> AsyncIterator[str]:
+        for event in self._events:
+            yield "data: " + json.dumps(event, ensure_ascii=False)
+            yield ""
+
+
+class _FakeStream:
+    def __init__(self, events: list[SimpleNamespace]) -> None:
+        self._events = events
+
+    async def __aiter__(self) -> AsyncIterator[SimpleNamespace]:
+        for event in self._events:
+            yield event
+
+
+def test_tool_argument_deltas_addressed_by_item_id_are_preserved() -> None:
+    arguments = json.dumps(
+        {
+            "mode": "edit",
+            "notebook_id": "notebook-123",
+            "record_id": "record-123",
+        }
+    )
+    response = _FakeResponse(
+        [
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "id": "fc_123",
+                    "call_id": "call_123",
+                    "name": "write_note",
+                    "arguments": "",
+                },
+            },
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": "fc_123",
+                "delta": arguments,
+            },
+            {
+                "type": "response.function_call_arguments.done",
+                "item_id": "fc_123",
+                "arguments": arguments,
+            },
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "function_call",
+                    "id": "fc_123",
+                    "call_id": "call_123",
+                    "name": "write_note",
+                    "arguments": "",
+                },
+            },
+        ]
+    )
+
+    _content, tool_calls, _finish_reason = asyncio.run(consume_sse(response))
+
+    assert tool_calls[0].arguments == json.loads(arguments)
+
+
+def test_sdk_tool_argument_deltas_addressed_by_item_id_are_preserved() -> None:
+    arguments = json.dumps(
+        {
+            "mode": "edit",
+            "notebook_id": "notebook-123",
+            "record_id": "record-123",
+        }
+    )
+    item = SimpleNamespace(
+        type="function_call",
+        id="fc_123",
+        call_id="call_123",
+        name="write_note",
+        arguments="",
+    )
+    stream = _FakeStream(
+        [
+            SimpleNamespace(type="response.output_item.added", item=item),
+            SimpleNamespace(
+                type="response.function_call_arguments.delta",
+                item_id="fc_123",
+                delta=arguments,
+            ),
+            SimpleNamespace(
+                type="response.function_call_arguments.done",
+                item_id="fc_123",
+                arguments=arguments,
+            ),
+            SimpleNamespace(type="response.output_item.done", item=item),
+        ]
+    )
+
+    _content, tool_calls, _finish_reason, _usage, _reasoning = asyncio.run(
+        consume_sdk_stream(stream)
+    )
+
+    assert tool_calls[0].arguments == json.loads(arguments)

--- a/tests/utils/test_json_parser.py
+++ b/tests/utils/test_json_parser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from unittest.mock import patch
 
@@ -23,6 +24,16 @@ class TestParseJsonResponseDirect:
 
     def test_valid_json_string(self) -> None:
         assert parse_json_response('"hello"') == "hello"
+
+    def test_valid_tool_arguments_preserve_markdown_code_fence_in_content(self) -> None:
+        payload = {
+            "mode": "edit",
+            "notebook_id": "notebook-123",
+            "record_id": "record-123",
+            "content": "# RecyclerView\n\n```text\ndata -> bind -> draw\n```",
+        }
+
+        assert parse_json_response(json.dumps(payload, ensure_ascii=False)) == payload
 
     def test_empty_string_returns_fallback(self) -> None:
         assert parse_json_response("") == {}


### PR DESCRIPTION
### Description

Fixes two parser failures that can reduce valid OpenAI Responses tool arguments to an empty object:

- Index raw SSE and SDK function-call buffers by both `call_id` and `item_id`, because argument delta/done events may carry only `item_id`.
- Parse a complete valid JSON payload before treating Markdown fences as an outer JSON wrapper. This preserves `write_note.content` when it contains fenced code.
- Add regression coverage for raw SSE, SDK streams, and Markdown-containing serialized tool arguments.

### Related Issues

- Closes #825
- Related to #779
- Related to #708

### Module(s) Affected

- [x] `services`
- [x] `utils`
- [x] `tests`

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] Documentation is not required for this behavior-only bug fix.
- [x] My changes do not introduce any new security vulnerabilities.

### Validation

- `tests/services/llm/test_openai_responses_parsing.py`: 2 passed
- `tests/utils/test_json_parser.py`: 35 passed
- Targeted Ruff lint and format checks: passed
- `git diff --check`: passed
- Local end-to-end `write_note` request with fenced Markdown reached tool dispatch with populated arguments.

### Additional Notes

Targeted `pre-commit run --files ...` could not initialize the repository's Prettier hook because the host npm policy rejected its local git dependency with `EALLOWGIT`. No source failure was reported; direct Ruff and pytest checks above passed.