### PR TITLE
fix: propagate Responses stream failures

### DIFF
--- a/deeptutor/services/llm/provider_core/openai_responses/parsing.py
+++ b/deeptutor/services/llm/provider_core/openai_responses/parsing.py
@@ -129,6 +129,23 @@ def _build_tool_call(
     )
 
 
+def _response_error_detail(event: Any) -> str:
+    """Extract a useful message from raw or SDK Responses error events."""
+
+    def _field(value: Any, name: str) -> Any:
+        return value.get(name) if isinstance(value, dict) else getattr(value, name, None)
+
+    response = _field(event, "response")
+    error = _field(response, "error") if response is not None else _field(event, "error")
+    if error is not None:
+        code = _field(error, "code")
+        message = _field(error, "message")
+        if code and message:
+            return f"{code}: {message}"
+        return str(message or error)
+    return str(_field(event, "message") or event)
+
+
 async def iter_sse(response: httpx.Response) -> AsyncGenerator[dict[str, Any], None]:
     """Yield parsed JSON events from a Responses API SSE stream."""
     buffer: list[str] = []
@@ -226,8 +243,7 @@ async def consume_sse(
             status = (event.get("response") or {}).get("status")
             finish_reason = map_finish_reason(status)
         elif event_type in {"error", "response.failed"}:
-            detail = event.get("error") or event.get("message") or event
-            raise RuntimeError(f"Response failed: {str(detail)[:500]}")
+            raise RuntimeError(f"Response failed: {_response_error_detail(event)[:500]}")
 
     return content, tool_calls, finish_reason
 
@@ -377,5 +393,7 @@ async def consume_sdk_stream(
                     "completion_tokens": int(getattr(usage_obj, "output_tokens", 0) or 0),
                     "total_tokens": int(getattr(usage_obj, "total_tokens", 0) or 0),
                 }
+        elif event_type in {"error", "response.failed"}:
+            raise RuntimeError(f"Response failed: {_response_error_detail(event)[:500]}")
 
     return content, tool_calls, finish_reason, usage, reasoning_content

--- a/tests/services/llm/test_openai_responses_parsing.py
+++ b/tests/services/llm/test_openai_responses_parsing.py
@@ -102,6 +102,76 @@ async def test_sdk_arguments_can_be_correlated_by_item_id() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("consumer", ["sse", "sdk"])
+async def test_argument_deltas_are_preserved_without_a_done_event(consumer: str) -> None:
+    """Cover delta accumulation independently from the final replacement event."""
+    item = {
+        "type": "function_call",
+        "id": "fc_1",
+        "call_id": "call_1",
+        "name": "lookup",
+    }
+    events = [
+        {"type": "response.output_item.added", "item": item},
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "fc_1",
+            "delta": '{"topic":',
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "fc_1",
+            "delta": '"calculus"}',
+        },
+        {"type": "response.output_item.done", "item": item},
+    ]
+
+    if consumer == "sse":
+        _, tool_calls, _ = await consume_sse(_SSEFixture(events))
+    else:
+        sdk_events = [
+            SimpleNamespace(
+                **{
+                    **event,
+                    "item": SimpleNamespace(**event["item"]),
+                }
+            )
+            if "item" in event
+            else SimpleNamespace(**event)
+            for event in events
+        ]
+        _, tool_calls, _, _, _ = await consume_sdk_stream(_sdk_events(sdk_events))
+
+    assert tool_calls[0].arguments == {"topic": "calculus"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("consumer", ["sse", "sdk"])
+async def test_response_failed_raises_the_provider_error(consumer: str) -> None:
+    error = {"code": "server_error", "message": "The model failed to generate a response."}
+
+    with pytest.raises(RuntimeError, match="server_error: The model failed"):
+        if consumer == "sse":
+            await consume_sse(
+                _SSEFixture([{"type": "response.failed", "response": {"error": error}}])
+            )
+        else:
+            event = SimpleNamespace(
+                type="response.failed",
+                response=SimpleNamespace(error=SimpleNamespace(**error)),
+            )
+            await consume_sdk_stream(_sdk_events([event]))
+
+
+@pytest.mark.asyncio
+async def test_sdk_top_level_error_event_raises() -> None:
+    event = SimpleNamespace(type="error", code="rate_limit_exceeded", message="Try again later")
+
+    with pytest.raises(RuntimeError, match="Try again later"):
+        await consume_sdk_stream(_sdk_events([event]))
+
+
+@pytest.mark.asyncio
 async def test_a_call_without_an_item_id_does_not_inherit_another_calls_identity() -> None:
     """The placeholder item id is not an identity, and must never resolve one.
 


### PR DESCRIPTION
### Description

Hardens OpenAI Responses stream failure handling in both raw SSE and SDK consumers:

- Raise on SDK `response.failed` and top-level `error` events instead of silently returning a successful-looking empty response.
- Extract the documented nested `response.error` details for raw SSE failures so callers receive the provider code and message.
- Add independent raw SSE and SDK regression coverage for item-id-only argument deltas without a later `done` event masking the append path.

This is a focused follow-up to #825 and the superseded #826 after rebasing onto the stream parser now on `dev`.

### Related Issues

- Follow-up to #825
- Supersedes the remaining stream-reliability work from #826

### Module(s) Affected

- [x] `services`
- [x] `tests`

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] Documentation is not required for this behavior-only bug fix.
- [x] My changes do not introduce any new security vulnerabilities.

### Validation

- `tests/services/llm/test_openai_responses_parsing.py` and `tests/utils/test_json_parser.py`: 43 passed
- Targeted Ruff lint and format checks: passed
- `git diff --check`: passed

### Additional Notes

The Responses API documents `response.failed` errors under `event.response.error`. The SDK consumer previously ignored both failure event forms, while the raw SSE path surfaced the whole event instead of the provider error.
