### PR TITLE
fix(mcp): preserve image content for multimodal tools

### DIFF
--- a/deeptutor/agents/chat/agent_loop.py
+++ b/deeptutor/agents/chat/agent_loop.py
@@ -410,6 +410,9 @@ class AgentLoop:
             )
             state.tool_steps += 1
             state.sources.extend(dispatch.sources)
+            self.pipeline._attach_tool_images(
+                dispatch.tool_messages, dispatch.tool_attachments_by_id
+            )
             messages.extend(dispatch.tool_messages)
 
             if dispatch.pause:

--- a/deeptutor/agents/chat/agentic_pipeline.py
+++ b/deeptutor/agents/chat/agentic_pipeline.py
@@ -32,7 +32,7 @@ from deeptutor.core.agentic import (
     dispatch_tool_calls,
 )
 from deeptutor.core.agentic.tool_dispatch import MAX_PARALLEL_TOOL_CALLS
-from deeptutor.core.context import UnifiedContext
+from deeptutor.core.context import Attachment, UnifiedContext
 from deeptutor.core.stream_bus import StreamBus
 from deeptutor.core.tool_protocol import ToolLookup
 from deeptutor.core.trace import (
@@ -458,6 +458,37 @@ class AgenticChatPipeline:
             binding=self.binding,
             model=self.model,
         ).messages
+
+    def _attach_tool_images(
+        self,
+        messages: list[dict[str, Any]],
+        attachments_by_call_id: dict[str, list[Attachment]],
+    ) -> None:
+        """Attach tool-returned images where the Codex Responses API accepts them."""
+        if self.binding != "openai_codex" or not attachments_by_call_id:
+            return
+        for message in messages:
+            if message.get("role") != "tool":
+                continue
+            attachments = attachments_by_call_id.get(str(message.get("tool_call_id") or ""))
+            if not attachments:
+                continue
+            content: list[dict[str, Any]] = [
+                {"type": "text", "text": str(message.get("content") or "")}
+            ]
+            for attachment in attachments:
+                if attachment.type != "image" or not attachment.base64 or not attachment.mime_type:
+                    continue
+                content.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": f"data:{attachment.mime_type};base64,{attachment.base64}"
+                        },
+                    }
+                )
+            if len(content) > 1:
+                message["content"] = content
 
     # ---- deferred tools / tool composition ------------------------------
 

--- a/deeptutor/core/agentic/tool_dispatch.py
+++ b/deeptutor/core/agentic/tool_dispatch.py
@@ -30,7 +30,7 @@ from deeptutor.core.agentic.tool_arg_guard import (
     missing_args_message,
     missing_required_args,
 )
-from deeptutor.core.context import UnifiedContext
+from deeptutor.core.context import Attachment, UnifiedContext
 from deeptutor.core.stream_bus import StreamBus
 from deeptutor.core.tool_protocol import ToolLookup, provider_identity
 from deeptutor.core.trace import (
@@ -67,6 +67,7 @@ class DispatchOutcome:
 
     sources: list[dict[str, Any]] = field(default_factory=list)
     tool_messages: list[dict[str, Any]] = field(default_factory=list)
+    tool_attachments_by_id: dict[str, list[Attachment]] = field(default_factory=dict)
     tool_metadata_by_id: dict[str, dict[str, Any]] = field(default_factory=dict)
     terminate: bool = False
     terminate_payload: dict[str, Any] | None = None
@@ -539,6 +540,7 @@ async def execute_tool_call(
             "result_text": result.content or empty_tool_result_message,
             "success": result.success,
             "sources": result.sources,
+            "attachments": result.attachments,
             "metadata": result.metadata,
             "terminate_turn": getattr(result, "terminate_turn", False),
             "pause_for_user": getattr(result, "pause_for_user", None),
@@ -582,6 +584,7 @@ async def execute_tool_call(
             "result_text": unknown_msg,
             "success": False,
             "sources": [],
+            "attachments": [],
             "metadata": {"error": str(exc)},
             "terminate_turn": False,
             "pause_for_user": None,
@@ -607,6 +610,7 @@ async def _collect_outcome(
     """
     aggregated_sources: list[dict[str, Any]] = []
     tool_messages: list[dict[str, Any]] = []
+    tool_attachments_by_id: dict[str, list[Attachment]] = {}
     tool_metadata_by_id: dict[str, dict[str, Any]] = {}
     terminate = False
     terminate_payload: dict[str, Any] | None = None
@@ -635,6 +639,9 @@ async def _collect_outcome(
                 metadata=result_event_meta,
             )
         aggregated_sources.extend(result.get("sources") or [])
+        result_attachments = result.get("attachments") or []
+        if result_attachments:
+            tool_attachments_by_id[tool_call_id] = list(result_attachments)
         tool_messages.append(
             {
                 "role": "tool",
@@ -664,6 +671,7 @@ async def _collect_outcome(
     return DispatchOutcome(
         sources=aggregated_sources,
         tool_messages=tool_messages,
+        tool_attachments_by_id=tool_attachments_by_id,
         tool_metadata_by_id=tool_metadata_by_id,
         terminate=terminate,
         terminate_payload=terminate_payload,

--- a/deeptutor/core/tool_protocol.py
+++ b/deeptutor/core/tool_protocol.py
@@ -12,6 +12,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
+from deeptutor.core.context import Attachment
+
 
 @dataclass
 class ToolParameter:
@@ -128,6 +130,8 @@ class ToolResult:
         metadata: Free-form payload — also used by the chat pipeline as a
             channel for structured UI hints (e.g. ``ask_user.options``
             for chip rendering).
+        attachments: Binary evidence returned by a tool. These stay structured
+            and are never serialized into the ``role=tool`` text body.
         success: ``False`` marks an explicit failure path; the LLM is
             still allowed to read ``content`` (often an error message).
         terminate_turn: When ``True`` the agentic chat loop must stop
@@ -148,6 +152,7 @@ class ToolResult:
     content: str = ""
     sources: list[dict[str, Any]] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
+    attachments: list[Attachment] = field(default_factory=list)
     success: bool = True
     terminate_turn: bool = False
     pause_for_user: dict[str, Any] | None = None

--- a/deeptutor/services/llm/provider_core/openai_responses/converters.py
+++ b/deeptutor/services/llm/provider_core/openai_responses/converters.py
@@ -53,14 +53,31 @@ def convert_messages(messages: list[dict[str, Any]]) -> tuple[str, list[dict[str
 
         if role == "tool":
             call_id, _ = split_tool_call_id(msg.get("tool_call_id"))
-            output_text = (
-                content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
-            )
+            output = _convert_tool_output(content)
             input_items.append(
-                {"type": "function_call_output", "call_id": call_id, "output": output_text}
+                {"type": "function_call_output", "call_id": call_id, "output": output}
             )
 
     return system_prompt, input_items
+
+
+def _convert_tool_output(content: Any) -> str | list[dict[str, Any]]:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return json.dumps(content, ensure_ascii=False)
+
+    converted: list[dict[str, Any]] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "text":
+            converted.append({"type": "input_text", "text": str(item.get("text") or "")})
+        elif item.get("type") == "image_url":
+            url = (item.get("image_url") or {}).get("url")
+            if url:
+                converted.append({"type": "input_image", "image_url": url, "detail": "auto"})
+    return converted or json.dumps(content, ensure_ascii=False)
 
 
 def convert_user_message(content: Any) -> dict[str, Any]:

--- a/deeptutor/services/mcp/manager.py
+++ b/deeptutor/services/mcp/manager.py
@@ -30,14 +30,18 @@ path executes them.
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+import hashlib
 import logging
 import re
 from typing import Any
 
 import httpx
 
+from deeptutor.core.context import Attachment
 from deeptutor.core.tool_protocol import BaseTool, ToolDefinition, ToolResult
 from deeptutor.services.mcp.config import (
     MCPConfig,
@@ -79,6 +83,15 @@ _TRANSIENT_ERRORS = (
     BrokenPipeError,
     ConnectionResetError,
 )
+
+_MAX_IMAGE_BYTES = 10 * 1024 * 1024
+_MAX_IMAGE_BASE64_CHARS = ((_MAX_IMAGE_BYTES + 2) // 3) * 4
+_IMAGE_MIME_EXTENSIONS = {
+    "image/gif": "gif",
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+}
 
 
 def wrapped_tool_name(server: str, tool: str) -> str:
@@ -140,7 +153,7 @@ class MCPToolAdapter(BaseTool):
         # notifications during a long call, and that is the only thing a reader
         # has to look at while a five-minute render or crawl is running.
         event_sink = kwargs.pop("event_sink", None)
-        text = await self._manager.call_tool(
+        result = await self._manager.call_tool(
             self._owner,
             self._server_name,
             self._original_name,
@@ -148,10 +161,12 @@ class MCPToolAdapter(BaseTool):
             timeout=self._tool_timeout,
             on_progress=_progress_reporter(event_sink, self._server_name) if event_sink else None,
         )
-        return ToolResult(
-            content=text,
-            metadata={"mcp_server": self._server_name, "mcp_tool": self._original_name},
-        )
+        result.metadata = {
+            **result.metadata,
+            "mcp_server": self._server_name,
+            "mcp_tool": self._original_name,
+        }
+        return result
 
 
 def _progress_reporter(event_sink: Any, server_name: str) -> "ProgressCallback":
@@ -410,11 +425,11 @@ class MCPConnectionManager:
         *,
         timeout: int,
         on_progress: "ProgressCallback | None" = None,
-    ) -> str:
+    ) -> ToolResult:
         """Invoke a tool on a connected server; one retry on transient errors."""
         conn = self._connections.get((owner, server_name))
         if conn is None or conn.session is None or conn.status != "connected":
-            return f"(MCP server {server_name!r} is not connected)"
+            return ToolResult(content=f"(MCP server {server_name!r} is not connected)")
         try:
             return await self._call_once(conn, tool_name, arguments, timeout, on_progress)
         except _TRANSIENT_ERRORS:
@@ -426,19 +441,25 @@ class MCPConnectionManager:
             try:
                 return await self._call_once(conn, tool_name, arguments, timeout, on_progress)
             except Exception as exc:
-                return f"(MCP tool call failed after retry: {type(exc).__name__})"
+                return ToolResult(
+                    content=f"(MCP tool call failed after retry: {type(exc).__name__})",
+                )
         except asyncio.TimeoutError:
-            return f"(MCP tool call timed out after {timeout}s)"
+            return ToolResult(
+                content=f"(MCP tool call timed out after {timeout}s)",
+            )
         except asyncio.CancelledError:
             # The MCP SDK's anyio scopes can leak CancelledError on internal
             # failures; re-raise only when our own task was cancelled.
             task = asyncio.current_task()
             if task is not None and task.cancelling() > 0:
                 raise
-            return "(MCP tool call was cancelled)"
+            return ToolResult(content="(MCP tool call was cancelled)")
         except Exception as exc:
             logger.exception("MCP tool %s/%s failed", server_name, tool_name)
-            return f"(MCP tool call failed: {type(exc).__name__}: {exc})"
+            return ToolResult(
+                content=f"(MCP tool call failed: {type(exc).__name__}: {exc})",
+            )
 
     @staticmethod
     async def _call_once(
@@ -447,7 +468,7 @@ class MCPConnectionManager:
         arguments: dict[str, Any],
         timeout: int,
         on_progress: "ProgressCallback | None" = None,
-    ) -> str:
+    ) -> ToolResult:
         from mcp import types
 
         result = await asyncio.wait_for(
@@ -462,12 +483,56 @@ class MCPConnectionManager:
             timeout=timeout,
         )
         parts: list[str] = []
+        attachments: list[Attachment] = []
+        image_metadata: list[dict[str, Any]] = []
         for block in result.content:
             if isinstance(block, types.TextContent):
                 parts.append(block.text)
+            elif isinstance(block, types.ImageContent):
+                mime_type = str(block.mimeType or "").lower()
+                extension = _IMAGE_MIME_EXTENSIONS.get(mime_type)
+                if len(block.data) > _MAX_IMAGE_BASE64_CHARS:
+                    parts.append(f"[MCP image omitted: exceeds {_MAX_IMAGE_BYTES} byte limit]")
+                    continue
+                try:
+                    raw = base64.b64decode(block.data, validate=True)
+                except (binascii.Error, TypeError, ValueError):
+                    parts.append("[MCP image omitted: invalid base64]")
+                    continue
+                if not extension:
+                    parts.append(
+                        f"[MCP image omitted: unsupported MIME type {mime_type or 'unknown'}]"
+                    )
+                    continue
+                if len(raw) > _MAX_IMAGE_BYTES:
+                    parts.append(f"[MCP image omitted: exceeds {_MAX_IMAGE_BYTES} byte limit]")
+                    continue
+                index = len(attachments) + 1
+                digest = hashlib.sha256(raw).hexdigest()
+                attachments.append(
+                    Attachment(
+                        type="image",
+                        base64=block.data,
+                        filename=f"mcp-image-{index}.{extension}",
+                        mime_type=mime_type,
+                        id=digest[:16],
+                    )
+                )
+                image_metadata.append(
+                    {
+                        "mime_type": mime_type,
+                        "bytes": len(raw),
+                        "sha256": digest,
+                    }
+                )
+                parts.append(f"[MCP image attached: {mime_type}, {len(raw)} bytes]")
             else:
                 parts.append(str(block))
-        return "\n".join(parts) or "(no output)"
+        return ToolResult(
+            content="\n".join(parts) or "(no output)",
+            attachments=attachments,
+            metadata={"mcp_images": image_metadata} if image_metadata else {},
+        )
 
     # ── connection internals ───────────────────────────────────────────
 

--- a/tests/agents/chat/test_agent_loop.py
+++ b/tests/agents/chat/test_agent_loop.py
@@ -150,6 +150,22 @@ class _Registry:
         )
 
 
+class _ImageRegistry(_Registry):
+    async def execute(self, name: str, **kwargs):
+        self.executed.append({"name": name, "kwargs": kwargs})
+        return ToolResult(
+            content="[MCP image attached: image/jpeg, 3 bytes]",
+            attachments=[
+                Attachment(
+                    type="image",
+                    base64="QUJD",
+                    filename="mcp-image-1.jpg",
+                    mime_type="image/jpeg",
+                )
+            ],
+        )
+
+
 @pytest.fixture(autouse=True)
 def _fake_llm_config(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
@@ -499,6 +515,68 @@ async def test_tool_round_then_finish(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result.metadata["rounds"] == 2
     # Only the finish round's text is the persisted answer.
     assert result.metadata["response"] == "Found what was needed."
+
+
+@pytest.mark.asyncio
+async def test_codex_tool_image_is_injected_into_the_next_model_round(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _ImageRegistry()
+    client = _ScriptedChatClient(
+        [
+            [
+                _llm_chunk(
+                    tool_calls=[
+                        {
+                            "id": "call-1",
+                            "name": "web_search",
+                            "arguments": json.dumps({"query": "figure"}),
+                        }
+                    ]
+                )
+            ],
+            [_llm_chunk(content="I can see the figure.")],
+        ]
+    )
+    pipeline = AgenticChatPipeline(language="en")
+    pipeline.binding = "openai_codex"
+    pipeline.registry = registry
+    monkeypatch.setattr(pipeline, "_compose_enabled_tools", lambda _context: ["web_search"])
+    monkeypatch.setattr(pipeline, "_build_openai_client", lambda: client)
+
+    await _run(
+        pipeline,
+        UnifiedContext(session_id="s1", user_message="Inspect the figure"),
+    )
+
+    second_round = client.calls[1]["messages"]
+    tool_message = next(message for message in second_round if message.get("role") == "tool")
+    assert isinstance(tool_message["content"], list)
+    image_part = next(part for part in tool_message["content"] if part.get("type") == "image_url")
+    assert image_part["image_url"]["url"] == "data:image/jpeg;base64,QUJD"
+    assert second_round[-1]["role"] == "tool"
+
+
+def test_non_codex_tool_image_does_not_change_tool_message_shape() -> None:
+    pipeline = AgenticChatPipeline(language="en")
+    pipeline.binding = "openai"
+    messages: list[dict[str, Any]] = [
+        {"role": "tool", "tool_call_id": "call-1", "content": "image attached"}
+    ]
+    attachments = {
+        "call-1": [
+            Attachment(
+                type="image",
+                base64="QUJD",
+                filename="mcp-image-1.jpg",
+                mime_type="image/jpeg",
+            )
+        ]
+    }
+
+    pipeline._attach_tool_images(messages, attachments)
+
+    assert messages == [{"role": "tool", "tool_call_id": "call-1", "content": "image attached"}]
 
 
 @pytest.mark.asyncio

--- a/tests/core/agentic/test_tool_dispatch_events.py
+++ b/tests/core/agentic/test_tool_dispatch_events.py
@@ -23,7 +23,7 @@ from typing import Any
 import pytest
 
 from deeptutor.core.agentic.tool_dispatch import dispatch_tool_calls
-from deeptutor.core.context import UnifiedContext
+from deeptutor.core.context import Attachment, UnifiedContext
 from deeptutor.core.stream import StreamEvent, StreamEventType
 from deeptutor.core.stream_bus import StreamBus
 from deeptutor.core.tool_protocol import ToolResult
@@ -51,6 +51,21 @@ class _ProgressRegistry:
         await sink("tool_log", "step 1/2")
         await sink("tool_log", "")  # empty messages stay dropped
         return ToolResult(content="ok", success=True)
+
+
+class _ImageRegistry(_Registry):
+    async def execute(self, name: str, **kwargs: Any) -> ToolResult:
+        return ToolResult(
+            content="[MCP image attached: image/jpeg, 3 bytes]",
+            attachments=[
+                Attachment(
+                    type="image",
+                    base64="QUJD",
+                    filename="mcp-image-1.jpg",
+                    mime_type="image/jpeg",
+                )
+            ],
+        )
 
 
 def _augment(tool_name: str, tool_args: dict[str, Any], _ctx: UnifiedContext) -> dict[str, Any]:
@@ -150,6 +165,34 @@ async def test_tool_call_event_args_exclude_private_kwargs() -> None:
     # The whole event must survive strict JSON serialization — this is what
     # the WS push and the turn-event store both rely on.
     json.dumps(tool_calls[0].to_dict())
+
+
+@pytest.mark.asyncio
+async def test_tool_attachment_stays_bound_to_its_call_id() -> None:
+    bus = StreamBus()
+    events: list[StreamEvent] = []
+
+    async def _consume() -> None:
+        async for event in bus.subscribe():
+            events.append(event)
+
+    consumer = asyncio.create_task(_consume())
+    await asyncio.sleep(0)
+    outcome = await dispatch_tool_calls(
+        tool_calls=[{"id": "c1", "name": "image_tool", "arguments": "{}"}],
+        context=UnifiedContext(session_id="s1", user_message="inspect"),
+        stream=bus,
+        source="chat",
+        stage="responding",
+        iteration_index=0,
+        registry=_ImageRegistry(),
+    )
+    await bus.close()
+    await consumer
+
+    assert outcome.tool_attachments_by_id["c1"][0].base64 == "QUJD"
+    assert outcome.tool_messages[0]["content"] == ("[MCP image attached: image/jpeg, 3 bytes]")
+    assert "QUJD" not in outcome.tool_messages[0]["content"]
 
 
 @pytest.mark.asyncio

--- a/tests/services/llm/test_openai_responses_converters.py
+++ b/tests/services/llm/test_openai_responses_converters.py
@@ -4,7 +4,41 @@ from __future__ import annotations
 
 from deeptutor.services.llm.provider_core.openai_responses import (
     adapt_chat_kwargs_to_responses,
+    convert_messages,
 )
+
+
+def test_tool_image_content_converts_to_function_output_image() -> None:
+    _, items = convert_messages(
+        [
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "content": [
+                    {"type": "text", "text": "image attached"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/jpeg;base64,QUJD"},
+                    },
+                ],
+            }
+        ]
+    )
+
+    assert items == [
+        {
+            "type": "function_call_output",
+            "call_id": "call-1",
+            "output": [
+                {"type": "input_text", "text": "image attached"},
+                {
+                    "type": "input_image",
+                    "image_url": "data:image/jpeg;base64,QUJD",
+                    "detail": "auto",
+                },
+            ],
+        }
+    ]
 
 
 class TestAdaptChatKwargsToResponses:

--- a/tests/services/mcp/test_progress_reporting.py
+++ b/tests/services/mcp/test_progress_reporting.py
@@ -208,6 +208,75 @@ async def test_progress_reaches_the_sink_end_to_end() -> None:
     assert result.content == "done"
 
 
+@pytest.mark.asyncio
+async def test_image_content_is_returned_as_attachment_not_serialized_text() -> None:
+    class _ImageSession(_Session):
+        async def call_tool(self, tool_name, arguments, progress_callback=None):  # type: ignore[no-untyped-def]
+            from mcp import types
+
+            return types.CallToolResult(
+                content=[
+                    types.TextContent(type="text", text="page image"),
+                    types.ImageContent(type="image", data="QUJD", mimeType="image/jpeg"),
+                ]
+            )
+
+    result = await _adapter(MCPConnectionManager(), _ImageSession()).execute()
+
+    assert result.content == "page image\n[MCP image attached: image/jpeg, 3 bytes]"
+    assert "QUJD" not in result.content
+    assert len(result.attachments) == 1
+    assert result.attachments[0].base64 == "QUJD"
+    assert result.attachments[0].mime_type == "image/jpeg"
+    image_meta = result.metadata["mcp_images"][0]
+    assert image_meta["bytes"] == 3
+    assert image_meta["sha256"] == (
+        "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78"
+    )
+    assert "QUJD" not in str(result.metadata)
+
+
+@pytest.mark.asyncio
+async def test_invalid_image_data_is_omitted_without_leaking_payload() -> None:
+    class _InvalidImageSession(_Session):
+        async def call_tool(self, tool_name, arguments, progress_callback=None):  # type: ignore[no-untyped-def]
+            from mcp import types
+
+            return types.CallToolResult(
+                content=[types.ImageContent(type="image", data="not@base64", mimeType="image/jpeg")]
+            )
+
+    result = await _adapter(MCPConnectionManager(), _InvalidImageSession()).execute()
+
+    assert result.content == "[MCP image omitted: invalid base64]"
+    assert "not@base64" not in result.content
+    assert result.attachments == []
+
+
+@pytest.mark.asyncio
+async def test_oversized_image_is_rejected_before_decode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from deeptutor.services.mcp import manager as manager_module
+
+    monkeypatch.setattr(manager_module, "_MAX_IMAGE_BYTES", 2)
+    monkeypatch.setattr(manager_module, "_MAX_IMAGE_BASE64_CHARS", 4)
+
+    class _OversizedImageSession(_Session):
+        async def call_tool(self, tool_name, arguments, progress_callback=None):  # type: ignore[no-untyped-def]
+            from mcp import types
+
+            return types.CallToolResult(
+                content=[types.ImageContent(type="image", data="QUJDRA==", mimeType="image/jpeg")]
+            )
+
+    result = await _adapter(MCPConnectionManager(), _OversizedImageSession()).execute()
+
+    assert result.content == "[MCP image omitted: exceeds 2 byte limit]"
+    assert "QUJDRA==" not in result.content
+    assert result.attachments == []
+
+
 # ── why a connection failed ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- preserve MCP `ImageContent` as structured `ToolResult.attachments` instead of stringifying its Base64 payload into tool text
- carry image attachments through parallel dispatch, bound to the originating `tool_call_id`
- convert Codex Responses tool images to `function_call_output.output[].type = input_image`
- keep non-Codex providers and existing text-only MCP results on their current message shape

## Problem

`MCPConnectionManager._call_once()` currently stringifies every non-`TextContent` block. For an MCP image result that produces a large textual Pydantic representation containing the Base64 payload. The model therefore receives text, not visual input, while traces and context can be polluted with the encoded image.

The failure was reproduced with PageIndex's `get_document_image`: PageIndex returned a valid JPEG `ImageContent`, but DeepTutor did not send an image part to the model. PageIndex is only the reproducer: the affected input is the standard MCP `ImageContent` type, and the implementation contains no PageIndex-, document-, or language-specific handling.

## Scope and relationship to visual RAG

This PR fixes the runtime transport path for images returned directly by any MCP tool. It does not change document parsing, LlamaIndex ingestion, vector indexing, or retrieval behavior.

#837 addresses a separate ingestion-layer contract for preserving parser-referenced visuals in a LlamaIndex knowledge base. Neither PR depends on the other. Delivering a retrieved LlamaIndex image to a final answer turn would be a separate future change and is not implemented here.

## Implementation

- `ToolResult` gains an `attachments` channel, separate from its LLM-visible text body.
- MCP images are Base64-validated, limited to 10 MiB, restricted to JPEG/PNG/GIF/WebP, and represented in text only by a bounded MIME/size marker.
- Audit metadata records MIME, byte count, and SHA-256, never the Base64 payload.
- Dispatch carries attachments by the exact originating tool call ID.
- The chat loop adds image parts only for `openai_codex`; other provider tool messages remain unchanged.
- The Responses converter emits structured `input_text` / `input_image` blocks in `function_call_output.output`.

## Verification

### Automated

- `3806 passed, 9 skipped` in a fresh Python 3.11 venv installed exactly from `requirements/server.txt` and `requirements/partners.txt`
- `ruff check .`
- `ruff format --check .`
- repository pre-commit hooks on all changed files, including detect-secrets, Bandit, and mypy
- `python -m compileall -q deeptutor`
- `git diff --check`

The new tests cover:

- text + image MCP results without Base64 leakage into text/metadata
- invalid Base64 and pre-decode image-size rejection
- attachment ownership by `tool_call_id`
- Codex Responses `function_call_output.input_image` conversion
- next-round image injection and unchanged non-Codex message shape

### Real end-to-end regression

Using a fresh session with the PageIndex `1-20` knowledge base and `openai_codex / gpt-5.6-sol`:

1. the model called `mcp_pageindex_get_document_image`
2. a redacted request observer saw `function_call_output.output[].type = input_image`
3. the model read the three transactions, signed amounts, and icon colors from figure 1.1-5
4. the run completed with zero stream errors
5. the redacted report contained no long Base64 runs or data URL payloads

No PageIndex index or production data was changed for this validation.

## Branch coordination

This targets `dev` per `CONTRIBUTING.md` and depends on the Codex vision capability support already merged there in #821. `deeptutor/services/mcp/manager.py` was also changed independently by #813 on `main`; maintainers may need to reconcile that file when the branches converge. This PR intentionally does not copy #813 into `dev` or alter its transport-error scope.

## Design sync

The mechanism is documented here in the PR because the repository's architecture instruction file is protected in the contributor environment. The contract is: tool text remains textual; binary tool evidence stays structured through dispatch and is converted only at a provider boundary.
