### PR TITLE
feat(rag): preserve structured parser visuals

### DIFF
--- a/deeptutor/api/routers/knowledge.py
+++ b/deeptutor/api/routers/knowledge.py
@@ -2554,12 +2554,14 @@ async def reindex_knowledge_base(
         kb_dir = kb_base_dir / kb_name
         signature_hash = kb_provider
         if provider_uses_embedding_versions(kb_provider):
-            from deeptutor.services.rag.embedding_signature import signature_from_embedding_config
+            from deeptutor.services.rag.embedding_signature import (
+                llamaindex_signature_from_embedding_config,
+            )
             from deeptutor.services.rag.index_versioning import (
                 find_matching_version,
             )
 
-            signature = signature_from_embedding_config()
+            signature = llamaindex_signature_from_embedding_config()
             if signature is None:
                 raise HTTPException(
                     status_code=409,

--- a/deeptutor/knowledge/manager.py
+++ b/deeptutor/knowledge/manager.py
@@ -139,13 +139,15 @@ def _reconcile_embedding_flags(knowledge_bases: dict, base_dir: Path | None = No
 
     Returns ``True`` when any entry changed.
     """
-    from deeptutor.services.rag.embedding_signature import signature_from_embedding_config
+    from deeptutor.services.rag.embedding_signature import (
+        llamaindex_signature_from_embedding_config,
+    )
     from deeptutor.services.rag.index_versioning import (
         find_matching_version,
     )
 
     fp = _get_embedding_fingerprint()
-    signature = signature_from_embedding_config()
+    signature = llamaindex_signature_from_embedding_config()
     changed = False
 
     if signature is None and not fp:
@@ -472,15 +474,20 @@ class KnowledgeBaseManager:
             # the UI can render version chips without recomputing.
             try:
                 from deeptutor.services.rag.embedding_signature import (
+                    llamaindex_signature_from_embedding_config,
                     signature_from_embedding_config,
                 )
 
-                sig = signature_from_embedding_config()
+                provider = normalize_provider_name(kb_config.get("rag_provider"))
+                sig = (
+                    llamaindex_signature_from_embedding_config()
+                    if provider_uses_embedding_versions(provider)
+                    else signature_from_embedding_config()
+                )
                 if sig is not None:
                     kb_config["embedding_signature"] = sig.hash()
                 kb_dir = self.base_dir / name
                 if kb_dir.is_dir():
-                    provider = normalize_provider_name(kb_config.get("rag_provider"))
                     kb_config["index_versions"] = inspect_kb_versions(kb_dir, provider)
             except Exception:  # pragma: no cover - best-effort metadata
                 pass
@@ -962,12 +969,16 @@ class KnowledgeBaseManager:
     def get_rag_storage_path(self, name: str | None = None) -> Path:
         """Get active index storage path for a knowledge base."""
         kb_dir = self.get_knowledge_base_path(name)
-        from deeptutor.services.rag.embedding_signature import signature_from_embedding_config
+        from deeptutor.services.rag.embedding_signature import (
+            llamaindex_signature_from_embedding_config,
+        )
         from deeptutor.services.rag.index_versioning import (
             resolve_storage_dir_for_read,
         )
 
-        active_storage = resolve_storage_dir_for_read(kb_dir, signature_from_embedding_config())
+        active_storage = resolve_storage_dir_for_read(
+            kb_dir, llamaindex_signature_from_embedding_config()
+        )
         legacy_storage = kb_dir / "rag_storage"
         if active_storage is not None:
             return active_storage
@@ -1289,7 +1300,10 @@ class KnowledgeBaseManager:
                 pass
 
         # Check rag_initialized from provider-owned real output, not metadata alone.
-        from deeptutor.services.rag.embedding_signature import signature_from_embedding_config
+        from deeptutor.services.rag.embedding_signature import (
+            llamaindex_signature_from_embedding_config,
+            signature_from_embedding_config,
+        )
         from deeptutor.services.rag.index_versioning import (
             find_matching_version,
         )
@@ -1299,6 +1313,7 @@ class KnowledgeBaseManager:
 
         active_signature = signature_from_embedding_config()
         if provider_uses_embedding_versions(rag_provider):
+            active_signature = llamaindex_signature_from_embedding_config()
             matched_entry = (
                 find_matching_version(kb_probe_dir, active_signature)
                 if (kb_probe_dir and active_signature)

--- a/deeptutor/services/rag/embedding_signature.py
+++ b/deeptutor/services/rag/embedding_signature.py
@@ -9,6 +9,8 @@ from deeptutor.services.rag.index_versioning import EmbeddingSignature
 
 logger = logging.getLogger(__name__)
 
+LLAMAINDEX_INGESTION_SCHEMA_VERSION = "1"
+
 
 def signature_from_config(config: Any) -> EmbeddingSignature:
     """Build a stable RAG index signature from an embedding config object."""
@@ -35,6 +37,22 @@ def signature_from_embedding_config() -> EmbeddingSignature | None:
     except Exception as exc:
         logger.debug(f"Cannot resolve embedding signature: {exc}")
         return None
+
+
+def llamaindex_signature_from_embedding_config() -> EmbeddingSignature | None:
+    """Return the active embedding identity plus LlamaIndex's node schema."""
+
+    signature = signature_from_embedding_config()
+    if signature is None:
+        return None
+    return EmbeddingSignature(
+        binding=signature.binding,
+        model=signature.model,
+        dimension=signature.dimension,
+        base_url=signature.base_url,
+        api_version=signature.api_version,
+        ingestion_schema_version=LLAMAINDEX_INGESTION_SCHEMA_VERSION,
+    )
 
 
 def embedding_meta_fields() -> dict[str, Any]:

--- a/deeptutor/services/rag/index_versioning.py
+++ b/deeptutor/services/rag/index_versioning.py
@@ -52,10 +52,14 @@ class EmbeddingSignature:
     dimension: int
     base_url: str
     api_version: str
+    ingestion_schema_version: str = ""
 
     def hash(self) -> str:
         """Short hex digest used as the stable signature."""
-        canonical = json.dumps(asdict(self), sort_keys=True, ensure_ascii=False)
+        payload = asdict(self)
+        if not payload["ingestion_schema_version"]:
+            payload.pop("ingestion_schema_version")
+        canonical = json.dumps(payload, sort_keys=True, ensure_ascii=False)
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
 
 
@@ -291,7 +295,7 @@ def resolve_storage_dir_for_read(
             return Path(str(latest_flat["storage_path"]))
 
     root_legacy = legacy_storage_dir(kb_dir)
-    if _is_storage_ready(root_legacy):
+    if _is_storage_ready(root_legacy) and not (signature and signature.ingestion_schema_version):
         return root_legacy
 
     return None

--- a/deeptutor/services/rag/linked_kb.py
+++ b/deeptutor/services/rag/linked_kb.py
@@ -176,9 +176,16 @@ def probe_linked_folder(folder_path: str, provider: str) -> ProbeResult:
 
 def _check_embedding(provider: str, version: dict, result: ProbeResult) -> None:
     """Compare the index's embedding identity against the active config."""
-    from deeptutor.services.rag.embedding_signature import signature_from_embedding_config
+    from deeptutor.services.rag.embedding_signature import (
+        llamaindex_signature_from_embedding_config,
+        signature_from_embedding_config,
+    )
 
-    current = signature_from_embedding_config()
+    current = (
+        llamaindex_signature_from_embedding_config()
+        if provider == DEFAULT_PROVIDER
+        else signature_from_embedding_config()
+    )
     compat = result.embedding
     compat.current_model = current.model if current else None
 

--- a/deeptutor/services/rag/pipelines/llamaindex/document_loader.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/document_loader.py
@@ -19,12 +19,14 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from llama_index.core import Document
-from llama_index.core.schema import ImageNode
+from llama_index.core.schema import ImageNode, TextNode
 
 from deeptutor.services.embedding import get_embedding_client
 from deeptutor.services.llm.client import get_llm_client
 from deeptutor.services.rag.file_routing import FileTypeRouter
 from deeptutor.utils.document_validator import DocumentValidator
+
+from .visual_assets import StructuredVisualAsset, build_structured_visual_assets
 
 IMAGE_DESCRIPTION_SYSTEM_PROMPT = (
     "You describe images for a retrieval-augmented knowledge base. "
@@ -62,14 +64,16 @@ class LlamaIndexDocumentLoader:
     async def load(self, file_paths: Iterable[str]) -> list[Any]:
         documents: list[Any] = []
         image_sources: list[_ImageSource] = []
+        structured_assets: list[StructuredVisualAsset] = []
         classification = FileTypeRouter.classify_files(list(file_paths))
 
         for file_path_str in classification.parser_files:
             file_path = Path(file_path_str)
             self.logger.info(f"Parsing document: {file_path.name}")
-            text, extracted_images = self._parse_document(file_path)
+            text, extracted_images, parsed_assets = self._parse_document(file_path)
             self._append_if_nonempty(documents, file_path, text)
             image_sources.extend(extracted_images)
+            structured_assets.extend(parsed_assets)
 
         for file_path_str in classification.text_files:
             file_path = Path(file_path_str)
@@ -83,13 +87,17 @@ class LlamaIndexDocumentLoader:
 
         if image_sources:
             documents.extend(await self._load_image_nodes(image_sources))
+        if structured_assets:
+            documents.extend(await self._load_structured_visual_nodes(structured_assets))
 
         for file_path_str in classification.unsupported:
             self.logger.warning(f"Skipped unsupported file: {Path(file_path_str).name}")
 
         return documents
 
-    def _parse_document(self, file_path: Path) -> tuple[str, list[_ImageSource]]:
+    def _parse_document(
+        self, file_path: Path
+    ) -> tuple[str, list[_ImageSource], list[StructuredVisualAsset]]:
         """Parse a document through the shared, engine-pluggable parse layer.
 
         Returns ``(text, extracted_images)``. A parse failure (engine
@@ -106,11 +114,14 @@ class LlamaIndexDocumentLoader:
                 f"Skipped {file_path.name}: the active document-parsing engine could "
                 f"not handle it ({exc}). Change the engine in Settings → Document Parsing."
             )
-            return "", []
+            return "", [], []
 
         text = parsed.markdown.strip() or self._text_from_blocks(parsed.blocks)
+        if parsed.blocks:
+            assets = build_structured_visual_assets(parsed, origin=file_path)
+            return text, [], assets
         images = self._collect_asset_images(parsed.asset_dir, origin=file_path)
-        return text, images
+        return text, images, []
 
     @staticmethod
     def _text_from_blocks(blocks: list[dict] | None) -> str:
@@ -234,6 +245,108 @@ class LlamaIndexDocumentLoader:
                 )
             )
             self.logger.info(f"Loaded image: {source.path.name} ({len(embedding)}D vector)")
+        return nodes
+
+    async def _load_structured_visual_nodes(self, assets: list[StructuredVisualAsset]) -> list[Any]:
+        """Build linked text companions and optional pre-embedded image nodes."""
+
+        embedding_client = get_embedding_client()
+        supports_images = embedding_client.supports_multimodal_contents()
+        nodes: list[Any] = []
+
+        for asset in assets:
+            companion_id = f"visual-companion-{asset.asset_id}"
+            component_id = f"visual-component-{asset.asset_id}"
+            component_ids: list[str] = []
+            image_embedding: list[float] | None = None
+            mimetype = mimetypes.guess_type(asset.path.name)[0] or "application/octet-stream"
+
+            if supports_images:
+                try:
+                    payload = self._load_image_payload(asset.path)
+                    embeddings = await embedding_client.embed_contents(
+                        [{"image": payload["data_uri"]}]
+                    )
+                    if embeddings:
+                        image_embedding = embeddings[0]
+                        component_ids.append(component_id)
+                except Exception as exc:
+                    self.logger.warning(
+                        "Skipped image embedding for structured visual asset %s: %s",
+                        asset.asset_id,
+                        exc,
+                    )
+
+            page_number = asset.page_index + 1 if asset.page_index is not None else None
+            bbox = list(asset.bbox) if asset.bbox is not None else None
+            metadata = {
+                "file_name": asset.origin.name,
+                "file_path": str(asset.origin),
+                "content_type": asset.resource_type,
+                "asset_id": asset.asset_id,
+                "block_index": asset.block_index,
+                "page": page_number,
+                "bbox": bbox,
+                "source_hash": asset.source_hash,
+                "parser_signature": asset.parser_signature,
+            }
+            companion_text = "\n".join(
+                part
+                for part in (
+                    f"[Visual asset: {asset.resource_type}] {asset.origin.name}",
+                    f"Caption: {asset.caption}" if asset.caption else "",
+                    f"Content:\n{asset.text}" if asset.text else "",
+                    f"Page: {page_number}" if page_number is not None else "",
+                )
+                if part
+            )
+            try:
+                companion_embeddings = await embedding_client.embed(
+                    [companion_text], input_type="search_document"
+                )
+            except Exception as exc:
+                self.logger.warning(
+                    "Skipped structured visual asset %s because its text companion "
+                    "could not be embedded: %s",
+                    asset.asset_id,
+                    exc,
+                )
+                continue
+            if not companion_embeddings:
+                self.logger.warning(
+                    "Skipped structured visual asset with no companion embedding: %s",
+                    asset.asset_id,
+                )
+                continue
+
+            if image_embedding is not None:
+                nodes.append(
+                    ImageNode(
+                        id_=component_id,
+                        text=companion_text,
+                        image_path=str(asset.path),
+                        image_mimetype=mimetype,
+                        metadata={
+                            **metadata,
+                            "node_role": "visual_component",
+                            "companion_node_id": companion_id,
+                        },
+                        embedding=image_embedding,
+                    )
+                )
+
+            nodes.append(
+                TextNode(
+                    id_=companion_id,
+                    text=companion_text,
+                    metadata={
+                        **metadata,
+                        "node_role": "visual_companion",
+                        "component_node_ids": component_ids,
+                    },
+                    embedding=companion_embeddings[0],
+                )
+            )
         return nodes
 
     async def _describe_image(self, file_path: Path, image_base64: str, mimetype: str) -> str:

--- a/deeptutor/services/rag/pipelines/llamaindex/pipeline.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/pipeline.py
@@ -11,7 +11,9 @@ from typing import Any, Callable, Dict, List, Optional
 
 from deeptutor.runtime.home import get_runtime_data_root
 from deeptutor.services.embedding import get_embedding_config
-from deeptutor.services.rag.embedding_signature import signature_from_embedding_config
+from deeptutor.services.rag.embedding_signature import (
+    llamaindex_signature_from_embedding_config,
+)
 from deeptutor.services.rag.index_versioning import (
     EmbeddingSignature,
     resolve_storage_dir_for_read,
@@ -47,7 +49,7 @@ class LlamaIndexPipeline:
     ):
         self.logger = logging.getLogger(__name__)
         self.kb_base_dir = kb_base_dir or DEFAULT_KB_BASE_DIR
-        self._signature_provider = signature_provider or signature_from_embedding_config
+        self._signature_provider = signature_provider or llamaindex_signature_from_embedding_config
         self.document_loader = document_loader or LlamaIndexDocumentLoader(self.logger)
         self._configure_settings()
 

--- a/deeptutor/services/rag/pipelines/llamaindex/visual_assets.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/visual_assets.py
@@ -1,0 +1,150 @@
+"""Minimal structured visual-asset mapping for LlamaIndex ingestion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from deeptutor.services.parsing.types import ParsedDocument
+from deeptutor.services.rag.file_routing import FileTypeRouter
+
+_VISUAL_BLOCK_TYPES = {"image", "table"}
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StructuredVisualAsset:
+    """One parser-referenced visual resource with basic provenance."""
+
+    asset_id: str
+    path: Path
+    origin: Path
+    resource_type: str
+    block_index: int
+    page_index: int | None
+    bbox: tuple[float, float, float, float] | None
+    caption: str
+    text: str
+    source_hash: str
+    parser_signature: str
+
+
+def _text(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list):
+        return "\n".join(str(item).strip() for item in value if str(item).strip())
+    return ""
+
+
+def _bbox(value: Any) -> tuple[float, float, float, float] | None:
+    if not isinstance(value, (list, tuple)) or len(value) != 4:
+        return None
+    try:
+        return tuple(float(item) for item in value)  # type: ignore[return-value]
+    except (TypeError, ValueError):
+        return None
+
+
+def _resolve_path(img_path: Any, asset_dir: Path) -> Path | None:
+    if not isinstance(img_path, str) or not img_path.strip():
+        return None
+    raw = Path(img_path)
+    if ".." in raw.parts:
+        return None
+    if raw.is_absolute():
+        candidate = raw
+    elif raw.parts and raw.parts[0] == asset_dir.name:
+        candidate = asset_dir.parent / raw
+    else:
+        candidate = asset_dir / raw
+    try:
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(asset_dir.resolve(strict=True))
+    except (OSError, ValueError):
+        return None
+    if not resolved.is_file() or resolved.suffix.lower() not in FileTypeRouter.IMAGE_EXTENSIONS:
+        return None
+    return resolved
+
+
+def _asset_id(
+    parsed: ParsedDocument,
+    *,
+    origin: Path,
+    block_index: int,
+    resource_type: str,
+    relative_path: str,
+) -> str:
+    payload = {
+        "source": parsed.source_hash or str(origin.resolve()),
+        "parser": parsed.parser_signature,
+        "block_index": block_index,
+        "resource_type": resource_type,
+        "path": relative_path,
+    }
+    canonical = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def build_structured_visual_assets(
+    parsed: ParsedDocument, *, origin: Path
+) -> list[StructuredVisualAsset]:
+    """Return safe image/table resources explicitly referenced by parser blocks."""
+
+    if not parsed.blocks or not parsed.asset_dir:
+        return []
+    asset_dir = Path(parsed.asset_dir)
+    if not asset_dir.is_dir():
+        return []
+
+    assets: list[StructuredVisualAsset] = []
+    for block_index, block in enumerate(parsed.blocks):
+        if not isinstance(block, dict):
+            continue
+        resource_type = str(block.get("type") or "").strip().lower()
+        if resource_type not in _VISUAL_BLOCK_TYPES:
+            continue
+        path = _resolve_path(block.get("img_path"), asset_dir)
+        if path is None:
+            logger.warning(
+                "Skipped unsafe or missing structured visual reference at block %s in %s",
+                block_index,
+                origin.name,
+            )
+            continue
+        relative_path = path.relative_to(asset_dir.resolve()).as_posix()
+        page_idx = block.get("page_idx")
+        page_index = page_idx if isinstance(page_idx, int) else None
+        caption = _text(
+            block.get("image_caption") or block.get("table_caption") or block.get("caption")
+        )
+        assets.append(
+            StructuredVisualAsset(
+                asset_id=_asset_id(
+                    parsed,
+                    origin=origin,
+                    block_index=block_index,
+                    resource_type=resource_type,
+                    relative_path=relative_path,
+                ),
+                path=path,
+                origin=origin,
+                resource_type=resource_type,
+                block_index=block_index,
+                page_index=page_index,
+                bbox=_bbox(block.get("bbox")),
+                caption=caption,
+                text=_text(block.get("table_body") or block.get("text") or block.get("content")),
+                source_hash=parsed.source_hash,
+                parser_signature=parsed.parser_signature,
+            )
+        )
+    return assets
+
+
+__all__ = ["StructuredVisualAsset", "build_structured_visual_assets"]

--- a/tests/api/test_knowledge_router.py
+++ b/tests/api/test_knowledge_router.py
@@ -840,7 +840,7 @@ def test_reindex_accepts_default_alias(monkeypatch, tmp_path: Path) -> None:
     embedding_signature = importlib.import_module("deeptutor.services.rag.embedding_signature")
     index_versioning = importlib.import_module("deeptutor.services.rag.index_versioning")
     monkeypatch.setattr(
-        embedding_signature, "signature_from_embedding_config", lambda: _Signature()
+        embedding_signature, "llamaindex_signature_from_embedding_config", lambda: _Signature()
     )
     monkeypatch.setattr(index_versioning, "find_matching_version", lambda *_args, **_kwargs: None)
 
@@ -876,7 +876,7 @@ def test_reindex_error_status_bypasses_existing_match_noop(monkeypatch, tmp_path
     embedding_signature = importlib.import_module("deeptutor.services.rag.embedding_signature")
     index_versioning = importlib.import_module("deeptutor.services.rag.index_versioning")
     monkeypatch.setattr(
-        embedding_signature, "signature_from_embedding_config", lambda: _Signature()
+        embedding_signature, "llamaindex_signature_from_embedding_config", lambda: _Signature()
     )
     monkeypatch.setattr(
         index_versioning,
@@ -916,7 +916,7 @@ def test_retry_error_status_queues_reindex(monkeypatch, tmp_path: Path) -> None:
     embedding_signature = importlib.import_module("deeptutor.services.rag.embedding_signature")
     index_versioning = importlib.import_module("deeptutor.services.rag.index_versioning")
     monkeypatch.setattr(
-        embedding_signature, "signature_from_embedding_config", lambda: _Signature()
+        embedding_signature, "llamaindex_signature_from_embedding_config", lambda: _Signature()
     )
     monkeypatch.setattr(
         index_versioning,
@@ -986,7 +986,7 @@ def test_reindex_bypasses_existing_match_when_vectors_are_invalid(
 
     embedding_signature = importlib.import_module("deeptutor.services.rag.embedding_signature")
     monkeypatch.setattr(
-        embedding_signature, "signature_from_embedding_config", lambda: _Signature()
+        embedding_signature, "llamaindex_signature_from_embedding_config", lambda: _Signature()
     )
 
     async def _noop_reindex_task(*_args, **_kwargs):

--- a/tests/knowledge/test_manager_embedding_flags.py
+++ b/tests/knowledge/test_manager_embedding_flags.py
@@ -30,6 +30,11 @@ def _patch_active_embedding(
         "signature_from_embedding_config",
         lambda: _Signature(sig_hash),
     )
+    monkeypatch.setattr(
+        embedding_signature,
+        "llamaindex_signature_from_embedding_config",
+        lambda: _Signature(sig_hash),
+    )
 
 
 def test_in_progress_empty_version_dir_does_not_mark_new_kb_reindex(
@@ -177,3 +182,116 @@ def test_ready_status_records_last_indexed_only_when_index_changes(
     info = KnowledgeBaseManager(base_dir=str(tmp_path)).get_info("kb")
     assert info["metadata"]["last_indexed_at"] == "2026-05-04T10:00:00"
     assert info["metadata"]["last_indexed_count"] == 2
+
+
+def test_old_llamaindex_schema_marks_ready_kb_for_reindex(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from deeptutor.knowledge import manager as manager_module
+    from deeptutor.services.rag import embedding_signature
+    from deeptutor.services.rag.index_versioning import EmbeddingSignature
+
+    base = EmbeddingSignature(
+        binding="openai",
+        model="embed-active",
+        dimension=4096,
+        base_url="https://example.test/v1",
+        api_version="",
+    )
+    monkeypatch.setattr(
+        manager_module, "_get_embedding_fingerprint", lambda: ("embed-active", 4096)
+    )
+    monkeypatch.setattr(embedding_signature, "signature_from_embedding_config", lambda: base)
+    kb_dir = tmp_path / "kb"
+    version_dir = kb_dir / "version-1"
+    version_dir.mkdir(parents=True)
+    (version_dir / "docstore.json").write_text("{}", encoding="utf-8")
+    (version_dir / "index_store.json").write_text("{}", encoding="utf-8")
+    (version_dir / "meta.json").write_text(
+        json.dumps({"signature": base.hash(), "version": "version-1"}),
+        encoding="utf-8",
+    )
+    (tmp_path / "kb_config.json").write_text(
+        json.dumps(
+            {
+                "knowledge_bases": {
+                    "kb": {
+                        "path": "kb",
+                        "rag_provider": "llamaindex",
+                        "embedding_model": "embed-active",
+                        "embedding_dim": 4096,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    entry = KnowledgeBaseManager(base_dir=str(tmp_path)).config["knowledge_bases"]["kb"]
+
+    assert entry["needs_reindex"] is True
+    assert entry["embedding_mismatch"] is True
+
+
+def test_ready_non_llamaindex_status_keeps_embedding_only_signature(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from deeptutor.knowledge import manager as manager_module
+    from deeptutor.services.rag import embedding_signature
+    from deeptutor.services.rag.index_versioning import EmbeddingSignature
+
+    base = EmbeddingSignature(
+        binding="openai",
+        model="embed-active",
+        dimension=4096,
+        base_url="https://example.test/v1",
+        api_version="",
+    )
+    monkeypatch.setattr(
+        manager_module, "_get_embedding_fingerprint", lambda: ("embed-active", 4096)
+    )
+    monkeypatch.setattr(embedding_signature, "signature_from_embedding_config", lambda: base)
+    manager = KnowledgeBaseManager(base_dir=str(tmp_path))
+    manager.config["knowledge_bases"] = {
+        "graph-kb": {"rag_provider": "graphrag", "path": "graph-kb"}
+    }
+    manager._save_config()
+
+    manager.update_kb_status(name="graph-kb", status="ready")
+
+    entry = KnowledgeBaseManager(base_dir=str(tmp_path)).config["knowledge_bases"]["graph-kb"]
+    assert entry["embedding_signature"] == base.hash()
+
+
+def test_ready_llamaindex_status_records_ingestion_schema_signature(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from deeptutor.knowledge import manager as manager_module
+    from deeptutor.services.rag import embedding_signature
+    from deeptutor.services.rag.index_versioning import EmbeddingSignature
+
+    base = EmbeddingSignature(
+        binding="openai",
+        model="embed-active",
+        dimension=4096,
+        base_url="https://example.test/v1",
+        api_version="",
+    )
+    monkeypatch.setattr(
+        manager_module, "_get_embedding_fingerprint", lambda: ("embed-active", 4096)
+    )
+    monkeypatch.setattr(embedding_signature, "signature_from_embedding_config", lambda: base)
+    manager = KnowledgeBaseManager(base_dir=str(tmp_path))
+    manager.config["knowledge_bases"] = {"kb": {"rag_provider": "llamaindex", "path": "kb"}}
+    manager._save_config()
+
+    manager.update_kb_status(name="kb", status="ready")
+
+    entry = KnowledgeBaseManager(base_dir=str(tmp_path)).config["knowledge_bases"]["kb"]
+    assert entry["embedding_signature"] == (
+        embedding_signature.llamaindex_signature_from_embedding_config().hash()
+    )
+    assert entry["embedding_signature"] != base.hash()

--- a/tests/knowledge/test_manager_get_info_status.py
+++ b/tests/knowledge/test_manager_get_info_status.py
@@ -61,6 +61,11 @@ def _patch_active_embedding(
         "signature_from_embedding_config",
         lambda: _Signature(sig_hash),
     )
+    monkeypatch.setattr(
+        embedding_signature,
+        "llamaindex_signature_from_embedding_config",
+        lambda: _Signature(sig_hash),
+    )
 
 
 def test_processing_with_ready_index_promotes_to_ready(

--- a/tests/services/rag/test_index_versioning.py
+++ b/tests/services/rag/test_index_versioning.py
@@ -130,3 +130,72 @@ def test_list_kb_versions_includes_legacy_nested_and_root_layouts(tmp_path: Path
     layouts = {entry["layout"] for entry in list_kb_versions(kb_dir)}
 
     assert {"nested_legacy", "root_legacy"} <= layouts
+
+
+def test_ingestion_schema_changes_embedding_signature_and_version_metadata(
+    tmp_path: Path,
+) -> None:
+    base = _signature()
+    assert base.hash() == "f758673f49726b31"
+    schema_v1 = EmbeddingSignature(
+        binding=base.binding,
+        model=base.model,
+        dimension=base.dimension,
+        base_url=base.base_url,
+        api_version=base.api_version,
+        ingestion_schema_version="1",
+    )
+    schema_v2 = EmbeddingSignature(
+        binding=base.binding,
+        model=base.model,
+        dimension=base.dimension,
+        base_url=base.base_url,
+        api_version=base.api_version,
+        ingestion_schema_version="2",
+    )
+
+    assert base.hash() != schema_v1.hash()
+    assert schema_v1.hash() != schema_v2.hash()
+
+    kb_dir = tmp_path / "kb"
+    storage_dir = resolve_storage_dir_for_write(kb_dir, schema_v1)
+    (storage_dir / "docstore.json").write_text("{}", encoding="utf-8")
+    write_version_meta(kb_dir, schema_v1, storage_dir=storage_dir)
+
+    metadata = json.loads((storage_dir / "meta.json").read_text(encoding="utf-8"))
+    assert metadata["ingestion_schema_version"] == "1"
+    assert find_matching_version(kb_dir, schema_v2) is None
+
+
+def test_llamaindex_signature_helper_adds_only_ingestion_schema(
+    monkeypatch,
+) -> None:
+    from deeptutor.services.rag import embedding_signature
+
+    base = _signature()
+    monkeypatch.setattr(embedding_signature, "signature_from_embedding_config", lambda: base)
+
+    llamaindex = embedding_signature.llamaindex_signature_from_embedding_config()
+
+    assert base.ingestion_schema_version == ""
+    assert base.hash() == "f758673f49726b31"
+    assert llamaindex.ingestion_schema_version == "1"
+    assert llamaindex.hash() != base.hash()
+
+
+def test_schema_aware_read_does_not_reuse_root_legacy_store(tmp_path: Path) -> None:
+    kb_dir = tmp_path / "kb"
+    legacy = kb_dir / "llamaindex_storage"
+    legacy.mkdir(parents=True)
+    (legacy / "docstore.json").write_text("{}", encoding="utf-8")
+    base = _signature()
+    schema = EmbeddingSignature(
+        binding=base.binding,
+        model=base.model,
+        dimension=base.dimension,
+        base_url=base.base_url,
+        api_version=base.api_version,
+        ingestion_schema_version="1",
+    )
+
+    assert resolve_storage_dir_for_read(kb_dir, schema) is None

--- a/tests/services/rag/test_linked_kb.py
+++ b/tests/services/rag/test_linked_kb.py
@@ -25,6 +25,14 @@ from deeptutor.services.rag.linked_kb import (
 _SIG = EmbeddingSignature(
     binding="openai", model="text-embedding-3-small", dimension=1536, base_url="u", api_version=""
 )
+_LLAMAINDEX_SIG = EmbeddingSignature(
+    binding=_SIG.binding,
+    model=_SIG.model,
+    dimension=_SIG.dimension,
+    base_url=_SIG.base_url,
+    api_version=_SIG.api_version,
+    ingestion_schema_version="1",
+)
 
 
 def _write_llamaindex_index(root: Path, *, signature: str, docs: int = 0) -> None:
@@ -95,9 +103,11 @@ def test_probe_errors_when_no_index(tmp_path: Path) -> None:
 
 
 def test_probe_finds_ready_llamaindex_index(tmp_path: Path, monkeypatch) -> None:
-    _write_llamaindex_index(tmp_path, signature=_SIG.hash(), docs=3)
+    _write_llamaindex_index(tmp_path, signature=_LLAMAINDEX_SIG.hash(), docs=3)
     # Current embedding matches what the index was built with.
-    monkeypatch.setattr(emb_sig, "signature_from_embedding_config", lambda: _SIG)
+    monkeypatch.setattr(
+        emb_sig, "llamaindex_signature_from_embedding_config", lambda: _LLAMAINDEX_SIG
+    )
 
     result = probe_linked_folder(str(tmp_path), "llamaindex")
     assert result.ok
@@ -109,7 +119,9 @@ def test_probe_finds_ready_llamaindex_index(tmp_path: Path, monkeypatch) -> None
 
 def test_probe_warns_on_embedding_mismatch(tmp_path: Path, monkeypatch) -> None:
     _write_llamaindex_index(tmp_path, signature="0000different0000")
-    monkeypatch.setattr(emb_sig, "signature_from_embedding_config", lambda: _SIG)
+    monkeypatch.setattr(
+        emb_sig, "llamaindex_signature_from_embedding_config", lambda: _LLAMAINDEX_SIG
+    )
 
     result = probe_linked_folder(str(tmp_path), "llamaindex")
     # A mismatch is a warning, not a hard block — the user may switch models.
@@ -121,7 +133,7 @@ def test_probe_warns_on_embedding_mismatch(tmp_path: Path, monkeypatch) -> None:
 def test_probe_unverifiable_embedding_is_a_warning(tmp_path: Path, monkeypatch) -> None:
     _write_llamaindex_index(tmp_path, signature=_SIG.hash())
     # No embedding configured → can't verify compatibility.
-    monkeypatch.setattr(emb_sig, "signature_from_embedding_config", lambda: None)
+    monkeypatch.setattr(emb_sig, "llamaindex_signature_from_embedding_config", lambda: None)
 
     result = probe_linked_folder(str(tmp_path), "llamaindex")
     assert result.ok

--- a/tests/services/rag/test_llamaindex_document_loader.py
+++ b/tests/services/rag/test_llamaindex_document_loader.py
@@ -292,3 +292,144 @@ def test_loader_logs_all_missing_multimodal_image_requirements(
     assert "LLM provider/model does not support multimodal image input" in caplog.text
     assert "text-embedding-3-small" in caplog.text
     assert "gpt-3.5-turbo" in caplog.text
+
+
+def test_structured_visual_keeps_text_companion_with_text_only_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("llama_index.core")
+    from llama_index.core.schema import ImageNode, TextNode
+
+    from deeptutor.services.parsing.types import ParsedDocument
+    from deeptutor.services.rag.pipelines.llamaindex import document_loader as loader_module
+
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"stub")
+    asset_dir = tmp_path / "images"
+    asset_dir.mkdir()
+    figure = asset_dir / "figure.png"
+    figure.write_bytes(b"\x89PNG\r\n")
+    (asset_dir / "unreferenced.png").write_bytes(b"\x89PNG\r\n")
+
+    _install_stub_parse_service(
+        monkeypatch,
+        {
+            "paper.pdf": ParsedDocument(
+                markdown="Paper body",
+                blocks=[
+                    {
+                        "type": "image",
+                        "img_path": str(figure),
+                        "page_idx": 3,
+                        "bbox": [10, 20, 30, 40],
+                        "image_caption": ["Figure 2: Number line"],
+                    }
+                ],
+                asset_dir=asset_dir,
+                source_hash="source-hash",
+                parser_signature="parser-v1",
+            )
+        },
+    )
+
+    class _TextOnlyEmbeddingClient:
+        config = type("Config", (), {"binding": "openai", "model": "text-embedding"})()
+
+        def supports_multimodal_contents(self) -> bool:
+            return False
+
+        async def embed(self, texts, **_kwargs):
+            return [[0.7, 0.8] for _ in texts]
+
+    monkeypatch.setattr(loader_module, "get_embedding_client", lambda: _TextOnlyEmbeddingClient())
+
+    documents = asyncio.run(loader_module.LlamaIndexDocumentLoader().load([str(pdf_path)]))
+
+    companions = [
+        node
+        for node in documents
+        if isinstance(node, TextNode) and node.metadata.get("node_role") == "visual_companion"
+    ]
+    assert len(companions) == 1
+    companion = companions[0]
+    assert "Figure 2: Number line" in companion.text
+    assert companion.metadata["file_name"] == "paper.pdf"
+    assert companion.metadata["page"] == 4
+    assert companion.metadata["bbox"] == [10.0, 20.0, 30.0, 40.0]
+    assert companion.metadata["component_node_ids"] == []
+    assert companion.embedding == [0.7, 0.8]
+    assert not any(isinstance(node, ImageNode) for node in documents)
+
+
+def test_structured_visual_links_image_and_companion_for_multimodal_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("llama_index.core")
+    from llama_index.core.schema import ImageNode, TextNode
+
+    from deeptutor.services.parsing.types import ParsedDocument
+    from deeptutor.services.rag.pipelines.llamaindex import document_loader as loader_module
+
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"stub")
+    asset_dir = tmp_path / "images"
+    asset_dir.mkdir()
+    table = asset_dir / "table.png"
+    table.write_bytes(b"\x89PNG\r\n")
+    _install_stub_parse_service(
+        monkeypatch,
+        {
+            "paper.pdf": ParsedDocument(
+                markdown="Paper body",
+                blocks=[
+                    {
+                        "type": "table",
+                        "img_path": str(table),
+                        "table_caption": ["Table 1: Results"],
+                    }
+                ],
+                asset_dir=asset_dir,
+                source_hash="source-hash",
+                parser_signature="parser-v1",
+            )
+        },
+    )
+
+    captured: list[dict[str, str]] = []
+
+    class _MultimodalEmbeddingClient:
+        config = type("Config", (), {"binding": "jina", "model": "multimodal"})()
+
+        def supports_multimodal_contents(self) -> bool:
+            return True
+
+        async def embed_contents(self, contents):
+            captured.extend(contents)
+            return [[0.1, 0.2, 0.3]]
+
+        async def embed(self, texts, **_kwargs):
+            return [[0.4, 0.5, 0.6] for _ in texts]
+
+    monkeypatch.setattr(loader_module, "get_embedding_client", lambda: _MultimodalEmbeddingClient())
+
+    documents = asyncio.run(loader_module.LlamaIndexDocumentLoader().load([str(pdf_path)]))
+
+    component = next(
+        node
+        for node in documents
+        if isinstance(node, ImageNode) and node.metadata.get("node_role") == "visual_component"
+    )
+    companion = next(
+        node
+        for node in documents
+        if isinstance(node, TextNode) and node.metadata.get("node_role") == "visual_companion"
+    )
+    assert component.embedding == [0.1, 0.2, 0.3]
+    assert component.image_path == str(table)
+    assert component.metadata["content_type"] == "table"
+    assert component.metadata["asset_id"] == companion.metadata["asset_id"]
+    assert component.metadata["companion_node_id"] == companion.node_id
+    assert companion.metadata["component_node_ids"] == [component.node_id]
+    assert companion.embedding == [0.4, 0.5, 0.6]
+    assert "Table 1: Results" in companion.text
+    assert captured[0]["image"].startswith("data:image/png;base64,")

--- a/tests/services/rag/test_llamaindex_ingestion.py
+++ b/tests/services/rag/test_llamaindex_ingestion.py
@@ -29,3 +29,25 @@ def test_documents_do_not_bypass_chunking_pipeline(monkeypatch) -> None:
     assert captured["documents"] == [llama_document, plain_node]
     assert captured["show_progress"] is False
     assert nodes == ["chunked:Document", "chunked:TextNode", embedded_node]
+
+
+def test_preembedded_visual_companion_preserves_stable_id(monkeypatch) -> None:
+    from deeptutor.services.rag.pipelines.llamaindex import ingestion
+
+    class FakePipeline:
+        def run(self, *, documents, show_progress):
+            raise AssertionError("pre-embedded companion must bypass transformations")
+
+    monkeypatch.setattr(ingestion, "build_ingestion_pipeline", lambda: FakePipeline())
+    companion = TextNode(
+        id_="visual-companion-stable",
+        text="Caption: Figure 1",
+        metadata={"node_role": "visual_companion", "asset_id": "asset-1"},
+        embedding=[0.1, 0.2],
+    )
+
+    nodes = ingestion.documents_to_nodes([companion], show_progress=False)
+
+    assert nodes == [companion]
+    assert nodes[0].node_id == "visual-companion-stable"
+    assert nodes[0].metadata["asset_id"] == "asset-1"

--- a/tests/services/rag/test_llamaindex_storage_layout.py
+++ b/tests/services/rag/test_llamaindex_storage_layout.py
@@ -214,3 +214,16 @@ def test_retrieval_config_reads_profile_from_env(monkeypatch: pytest.MonkeyPatch
     config = config_module.retrieval_config_from_env()
 
     assert config.profile == config_module.VECTOR_PROFILE
+
+
+def test_pipeline_default_signature_includes_ingestion_schema(monkeypatch) -> None:
+    from deeptutor.services.rag import embedding_signature
+    from deeptutor.services.rag.pipelines.llamaindex.pipeline import LlamaIndexPipeline
+
+    base = _signature()
+    monkeypatch.setattr(embedding_signature, "signature_from_embedding_config", lambda: base)
+    monkeypatch.setattr(LlamaIndexPipeline, "_configure_settings", lambda self: None)
+
+    pipeline = LlamaIndexPipeline()
+
+    assert pipeline._current_signature().ingestion_schema_version == "1"

--- a/tests/services/rag/test_llamaindex_visual_assets.py
+++ b/tests/services/rag/test_llamaindex_visual_assets.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from deeptutor.services.parsing.types import ParsedDocument
+
+
+def test_structured_visual_assets_only_include_safe_referenced_files(
+    tmp_path: Path, caplog
+) -> None:
+    from deeptutor.services.rag.pipelines.llamaindex.visual_assets import (
+        build_structured_visual_assets,
+    )
+
+    asset_dir = tmp_path / "images"
+    asset_dir.mkdir()
+    referenced = asset_dir / "figure.png"
+    referenced.write_bytes(b"image")
+    unreferenced = asset_dir / "unused.png"
+    unreferenced.write_bytes(b"unused")
+    outside = tmp_path / "outside.png"
+    outside.write_bytes(b"outside")
+
+    parsed = ParsedDocument(
+        markdown="Body",
+        asset_dir=asset_dir,
+        source_hash="source-hash",
+        parser_signature="parser-v1",
+        blocks=[
+            {
+                "type": "image",
+                "img_path": str(referenced),
+                "page_idx": 2,
+                "bbox": [10, 20, 30, 40],
+                "image_caption": ["Figure 1"],
+            },
+            {"type": "image", "img_path": str(asset_dir / "missing.png")},
+            {"type": "image", "img_path": str(outside)},
+            {"type": "image", "img_path": "../outside.png"},
+            {"type": "text", "img_path": str(unreferenced), "text": "not visual"},
+        ],
+    )
+
+    assets = build_structured_visual_assets(parsed, origin=tmp_path / "book.pdf")
+
+    assert "Skipped unsafe or missing structured visual reference" in caplog.text
+    assert len(assets) == 1
+    asset = assets[0]
+    assert asset.path == referenced
+    assert asset.resource_type == "image"
+    assert asset.block_index == 0
+    assert asset.page_index == 2
+    assert asset.bbox == (10.0, 20.0, 30.0, 40.0)
+    assert asset.caption == "Figure 1"
+    assert asset.source_hash == "source-hash"
+    assert asset.parser_signature == "parser-v1"
+    assert len(asset.asset_id) == 64
+
+
+def test_structured_table_asset_preserves_parser_text(tmp_path: Path) -> None:
+    from deeptutor.services.rag.pipelines.llamaindex.visual_assets import (
+        build_structured_visual_assets,
+    )
+
+    asset_dir = tmp_path / "images"
+    asset_dir.mkdir()
+    table = asset_dir / "table.png"
+    table.write_bytes(b"image")
+    parsed = ParsedDocument(
+        markdown="Body",
+        asset_dir=asset_dir,
+        source_hash="source-hash",
+        parser_signature="parser-v1",
+        blocks=[
+            {
+                "type": "table",
+                "img_path": str(table),
+                "table_caption": ["Table 1"],
+                "table_body": "Year | Value\n2026 | 42",
+            }
+        ],
+    )
+
+    asset = build_structured_visual_assets(parsed, origin=tmp_path / "book.pdf")[0]
+
+    assert asset.text == "Year | Value\n2026 | 42"


### PR DESCRIPTION
### Description

Preserves parser-referenced visual structure in LlamaIndex ingestion without adding document-specific classification or description heuristics.

- Treats explicit `image` and `table` parser blocks as authoritative when structured blocks are available.
- Resolves only referenced files contained beneath `asset_dir`; missing, unsupported, and out-of-root paths are skipped with warnings.
- Maps each accepted block to one deterministic visual asset carrying source/parser identity, page, bbox, caption, and parser-provided table text.
- Always creates a pre-embedded text companion node so text-only embedding providers retain visual retrieval context.
- Adds a linked `ImageNode` only when the active embedding provider supports image contents.
- Versions the LlamaIndex ingestion schema together with the embedding identity, so incompatible existing indexes are marked for rebuild instead of being mixed incrementally.
- Keeps non-LlamaIndex provider signatures unchanged and preserves the existing fallback for parsers that return no structured blocks.

This intentionally does **not** add decorative-image classification, automatic panel grouping, visual-description prompts, provider-specific adapters, or image-pixel delivery to final answer turns.

### Generality and scope

The implementation is parser-neutral: it consumes the existing `ParsedDocument.blocks` and `asset_dir` contract and does not special-case MinerU, PageIndex, any document, language, figure identifier, or classification threshold. One parser block maps to one visual asset deliberately; broader classification, grouping, and generated-description policies require independent evidence and review.

This PR also does not depend on #830. #830 handles images returned by MCP tools at runtime; this PR handles parser-referenced assets during LlamaIndex ingestion. Delivering retrieved image pixels to a final answer turn remains out of scope for both changes.

### Related Issues

- Closes #835
- Related to #814
- Related to #525
- Supersedes closed prototype #834. That PR is retained only as historical design reference; its classification, grouping, and generated-description heuristics are not proposed for merge.

### Module(s) Affected

- [x] `api`
- [x] `knowledge`
- [x] `services`
- [x] `tests`

### Checklist

- [x] I have read and followed the contribution guidelines.
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues. (Not run; the repository Ruff, format, test, diff, and security gates below passed.)
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary). (The design boundary is recorded in RFC #835; no root `AGENTS.md` change is included.)
- [x] My changes do not introduce any new security vulnerabilities.

### Verification

CI-equivalent Python suite after installing `requirements/server.txt` and `requirements/partners.txt` dependencies:

```text
3897 passed, 9 skipped, 11 warnings
```

Focused final-tree suite:

```text
106 passed, 11 warnings
```

Static gates:

```text
1173 files already formatted
All checks passed!
git diff --check: passed
added-line security scan: no matches
```

### Additional Notes

- Base: `dev`, per `CONTRIBUTING.md`.
- The two commits separate visual-node ingestion from schema/version lifecycle changes for reviewability.
- No user settings, parser cache, credentials, production KB data, or `AGENTS.md` changes are included.
- No production KB was rebuilt and no service was restarted.
- Design sync: RFC #835 defines the minimal contract, non-goals, and open design questions.
- Independent review: not run; deterministic verification and main-agent diff review were completed.
