### PR TITLE
feat: add EPUB support for knowledge base

### DIFF
--- a/deeptutor/services/parsing/engines/text_only/engine.py
+++ b/deeptutor/services/parsing/engines/text_only/engine.py
@@ -18,7 +18,7 @@ from ...types import ParserError
 
 
 class TextOnlyParser:
-    """Built-in PDF/Office/text-file extraction with no external engine."""
+    """Built-in PDF/Office/EPUB/text-file extraction with no external engine."""
 
     name = "text_only"
     needs_local_models = False

--- a/deeptutor/services/rag/file_routing.py
+++ b/deeptutor/services/rag/file_routing.py
@@ -24,6 +24,7 @@ class DocumentType(Enum):
     DOCX = "docx"
     SPREADSHEET = "spreadsheet"
     PRESENTATION = "presentation"
+    EPUB = "epub"
     IMAGE = "image"
     UNKNOWN = "unknown"
 
@@ -42,14 +43,15 @@ class FileTypeRouter:
     """File type router for the RAG pipeline.
 
     Classifies files before processing to route them to appropriate handlers:
-    - PDF / Office files -> parser-based text extraction
+    - PDF / Office / EPUB files -> parser-based text extraction
     - Text files -> Direct read (fast, simple)
     - Unsupported -> Skip with warning
     """
 
     PDF_EXTENSIONS = {".pdf"}
     OFFICE_EXTENSIONS = {".docx", ".xlsx", ".pptx"}
-    PARSER_EXTENSIONS = PDF_EXTENSIONS | OFFICE_EXTENSIONS
+    EPUB_EXTENSIONS = {".epub"}
+    PARSER_EXTENSIONS = PDF_EXTENSIONS | OFFICE_EXTENSIONS | EPUB_EXTENSIONS
 
     TEXT_EXTENSIONS = {
         # Plain text & docs
@@ -191,6 +193,8 @@ class FileTypeRouter:
             return DocumentType.SPREADSHEET
         elif ext == ".pptx":
             return DocumentType.PRESENTATION
+        elif ext in cls.EPUB_EXTENSIONS:
+            return DocumentType.EPUB
         elif ext in cls.IMAGE_EXTENSIONS:
             return DocumentType.IMAGE
         else:
@@ -229,6 +233,7 @@ class FileTypeRouter:
                 DocumentType.DOCX,
                 DocumentType.SPREADSHEET,
                 DocumentType.PRESENTATION,
+                DocumentType.EPUB,
             ):
                 parser_files.append(path)
             elif doc_type in (DocumentType.TEXT, DocumentType.MARKDOWN):
@@ -297,6 +302,7 @@ class FileTypeRouter:
             DocumentType.DOCX,
             DocumentType.SPREADSHEET,
             DocumentType.PRESENTATION,
+            DocumentType.EPUB,
             DocumentType.IMAGE,
         )
 

--- a/deeptutor/utils/document_extractor.py
+++ b/deeptutor/utils/document_extractor.py
@@ -3,9 +3,11 @@
 Bytes-in, text-out. Used by the chat turn runtime to inline the text of
 user-dropped files into the ``effective_user_message`` sent to the LLM.
 
-Two format families:
+Three format families:
   * **Binary Office** (.pdf / .docx / .xlsx / .pptx) — parsed with pymupdf /
     python-docx / openpyxl / python-pptx.
+  * **EPUB** (.epub) — ZIP of XHTML documents; text is pulled in the OPF
+    spine reading order using only the standard library.
   * **Text-like** (plain text, Markdown, source code, JSON, XML, CSV, …) —
     the extension set is imported from ``FileTypeRouter.TEXT_EXTENSIONS`` so
     the chat composer accepts every format the knowledge-base pipeline
@@ -22,8 +24,10 @@ from collections.abc import Iterable
 import io
 import logging
 from pathlib import Path, PurePosixPath
+import posixpath
 import re
 from typing import Any
+from urllib.parse import unquote
 import zipfile
 
 from defusedxml import ElementTree as DefusedElementTree
@@ -89,6 +93,35 @@ def _current_limits() -> tuple[int, int, int, int]:
 _PDF_MAGIC = b"%PDF-"
 _OOXML_MAGIC = b"PK\x03\x04"
 
+_EPUB_CONTENT_EXTENSIONS: frozenset[str] = frozenset({".xhtml", ".html", ".htm"})
+_EPUB_BLOCK_TAGS: frozenset[str] = frozenset(
+    {
+        "p",
+        "div",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "li",
+        "blockquote",
+        "tr",
+        "table",
+        "section",
+        "article",
+        "header",
+        "footer",
+        "aside",
+        "figure",
+        "figcaption",
+        "dd",
+        "dt",
+        "dl",
+        "hr",
+    }
+)
+
 
 class DocumentExtractionError(Exception):
     """Base class for extraction failures. ``str(exc)`` is user-friendly."""
@@ -146,6 +179,12 @@ def _check_magic(ext: str, data: bytes, filename: str) -> None:
                 f"{filename} does not look like a valid Office file (bad header)",
                 filename=filename,
             )
+    elif ext == ".epub":
+        if not data.startswith(_OOXML_MAGIC):
+            raise CorruptDocumentError(
+                f"{filename} does not look like a valid EPUB (bad header)",
+                filename=filename,
+            )
 
 
 def extract_text_from_bytes(
@@ -187,6 +226,8 @@ def extract_text_from_bytes(
         text = _extract_xlsx(data, filename)
     elif ext == ".pptx":
         text = _extract_pptx(data, filename)
+    elif ext == ".epub":
+        text = _extract_epub(data, filename)
     elif ext in TEXT_LIKE_EXTENSIONS:
         text = _extract_text_like(data, filename)
     else:  # pragma: no cover - guarded above
@@ -400,6 +441,129 @@ def _extract_text_like(data: bytes, filename: str) -> str:
         raise CorruptDocumentError(
             f"{filename}: failed to decode text ({exc})", filename=filename
         ) from exc
+
+
+def _epub_parse_member(zf: zipfile.ZipFile, member: str, filename: str) -> Any | None:
+    """Parse one XML/XHTML member, returning ``None`` when unreadable.
+
+    Real-world EPUBs occasionally ship sloppy XHTML (undeclared entities,
+    stray tags); a single bad chapter must not sink the whole book, so parse
+    failures are logged and skipped instead of raising.
+    """
+    try:
+        return _parse_xml_member(zf, member, filename)
+    except CorruptDocumentError as exc:
+        logger.warning("EPUB %s: skipping unparseable member %s (%s)", filename, member, exc)
+        return None
+
+
+def _epub_render_text(element: Any, parts: list[str]) -> None:
+    """Append the text of one XHTML element and its subtree to ``parts``.
+
+    Element text is emitted before its children and each child's tail after
+    it, preserving the document's word spacing. Block-level tags contribute a
+    paragraph break; ``script``/``style`` subtrees are dropped entirely.
+    """
+    tag = _local_name(element.tag) if isinstance(element.tag, str) else ""
+    if tag in {"script", "style"}:
+        return
+    if element.text:
+        parts.append(element.text)
+    if tag == "br":
+        parts.append("\n")
+    for child in element:
+        _epub_render_text(child, parts)
+        if child.tail:
+            parts.append(child.tail)
+    if tag in _EPUB_BLOCK_TAGS:
+        parts.append("\n\n")
+
+
+def _epub_xhtml_text(root: Any) -> str:
+    """Render one XHTML document as plain text with paragraph breaks.
+
+    Keeps the source whitespace of text nodes (XHTML carries its own word
+    spacing) and collapses each line afterwards, so ``<b>world</b>.`` stays
+    ``world.`` instead of gaining a stray space.
+    """
+    parts: list[str] = []
+    _epub_render_text(root, parts)
+    raw = "".join(parts)
+    lines = [re.sub(r"\s+", " ", line).strip() for line in raw.split("\n")]
+    return "\n".join(line for line in lines if line)
+
+
+def _epub_html_members(names: list[str]) -> list[str]:
+    """Archive members that look like XHTML content, in archive order."""
+    return [name for name in names if _ext(name) in _EPUB_CONTENT_EXTENSIONS]
+
+
+def _epub_content_files(zf: zipfile.ZipFile, filename: str) -> list[str]:
+    """Resolve the XHTML content documents of an EPUB in reading order.
+
+    Follows the standard chain ``META-INF/container.xml`` -> OPF package
+    document -> spine ``itemref`` order. Falls back to every HTML/XHTML
+    member in archive order when package metadata is missing or unusable.
+    """
+    names = zf.namelist()
+    name_set = set(names)
+
+    container_root = _epub_parse_member(zf, "META-INF/container.xml", filename)
+    if container_root is None:
+        return _epub_html_members(names)
+
+    opf_path = ""
+    for node in container_root.iter():
+        if _local_name(node.tag) == "rootfile":
+            opf_path = node.get("full-path") or ""
+            break
+    if not opf_path or opf_path not in name_set:
+        return _epub_html_members(names)
+
+    opf_root = _epub_parse_member(zf, opf_path, filename)
+    if opf_root is None:
+        return _epub_html_members(names)
+
+    manifest: dict[str, str] = {}
+    spine_ids: list[str] = []
+    for node in opf_root.iter():
+        name = _local_name(node.tag)
+        if name == "item":
+            item_id = node.get("id")
+            href = node.get("href")
+            if item_id and href:
+                manifest[item_id] = href
+        elif name == "itemref":
+            idref = node.get("idref")
+            if idref:
+                spine_ids.append(idref)
+
+    opf_dir = posixpath.dirname(opf_path)
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for idref in spine_ids:
+        href = manifest.get(idref)
+        if not href:
+            continue
+        member = posixpath.normpath(posixpath.join(opf_dir, unquote(href.split("#", 1)[0])))
+        if member in name_set and member not in seen:
+            ordered.append(member)
+            seen.add(member)
+    return ordered or _epub_html_members(names)
+
+
+def _extract_epub(data: bytes, filename: str) -> str:
+    """Extract the reading text of an EPUB with only the standard library."""
+    with _open_ooxml(data, filename) as zf:
+        chapters: list[str] = []
+        for member in _epub_content_files(zf, filename):
+            root = _epub_parse_member(zf, member, filename)
+            if root is None:
+                continue
+            text = _epub_xhtml_text(root)
+            if text:
+                chapters.append(text)
+    return "\n\n".join(chapters)
 
 
 def _open_ooxml(data: bytes, filename: str) -> zipfile.ZipFile:

--- a/deeptutor/utils/document_validator.py
+++ b/deeptutor/utils/document_validator.py
@@ -33,6 +33,7 @@ class DocumentValidator:
         ".xls",
         ".pptx",
         ".ppt",
+        ".epub",
     }
 
     # MIME type mapping for additional validation
@@ -52,6 +53,8 @@ class DocumentValidator:
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         "application/vnd.ms-powerpoint",
         "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/epub+zip",
+        "application/epub",
     }
 
     @staticmethod

--- a/tests/services/rag/test_file_routing.py
+++ b/tests/services/rag/test_file_routing.py
@@ -27,6 +27,8 @@ class TestExtensionClassification:
             ("paper.docx", DocumentType.DOCX),
             ("sheet.xlsx", DocumentType.SPREADSHEET),
             ("deck.pptx", DocumentType.PRESENTATION),
+            ("book.epub", DocumentType.EPUB),
+            ("BOOK.EPUB", DocumentType.EPUB),
             ("photo.png", DocumentType.IMAGE),
         ],
     )
@@ -56,15 +58,17 @@ class TestClassifyFiles:
         xlsx.write_bytes(b"PK\x03\x04")
         pptx = tmp_path / "a.pptx"
         pptx.write_bytes(b"PK\x03\x04")
+        epub = tmp_path / "a.epub"
+        epub.write_bytes(b"PK\x03\x04")
         txt = tmp_path / "a.txt"
         txt.write_text("hi")
         png = tmp_path / "a.png"
         png.write_bytes(b"\x89PNG\r\n")
 
         cls = FileTypeRouter.classify_files(
-            [str(pdf), str(docx), str(xlsx), str(pptx), str(txt), str(png)]
+            [str(pdf), str(docx), str(xlsx), str(pptx), str(epub), str(txt), str(png)]
         )
-        assert cls.parser_files == [str(pdf), str(docx), str(xlsx), str(pptx)]
+        assert cls.parser_files == [str(pdf), str(docx), str(xlsx), str(pptx), str(epub)]
         assert cls.text_files == [str(txt)]
         assert cls.image_files == [str(png)]
         assert cls.unsupported == []
@@ -86,6 +90,7 @@ class TestSupportedExtensionsAndGlobs:
         assert ".pptx" in exts
         assert ".md" in exts
         assert ".txt" in exts
+        assert ".epub" in exts
         assert ".png" in exts
 
     def test_glob_patterns_match_supported_extensions(self) -> None:
@@ -128,6 +133,10 @@ class TestQuickHelpers:
         assert FileTypeRouter.needs_parser("paper.docx") is True
         assert FileTypeRouter.needs_parser("sheet.xlsx") is True
         assert FileTypeRouter.needs_parser("deck.pptx") is True
+
+    def test_needs_parser_for_epub(self) -> None:
+        assert FileTypeRouter.needs_parser("book.epub") is True
+        assert FileTypeRouter.needs_parser("BOOK.EPUB") is True
 
     def test_needs_parser_false_for_text(self) -> None:
         assert FileTypeRouter.needs_parser("notes.md") is False

--- a/tests/utils/test_document_extractor.py
+++ b/tests/utils/test_document_extractor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import io
+import zipfile
 
 from docx import Document as DocxDocument
 from openpyxl import Workbook
@@ -66,6 +67,56 @@ def _make_pptx(slides_text: list[list[str]]) -> bytes:
     return buf.getvalue()
 
 
+_CONTAINER_XML = (
+    '<?xml version="1.0"?>'
+    '<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+    '<rootfiles><rootfile full-path="{opf}" media-type="application/oebps-package+xml"/>'
+    "</rootfiles></container>"
+)
+
+
+def _make_epub(
+    chapters: dict[str, str],
+    spine: list[str] | None = None,
+    *,
+    opf_dir: str = "OEBPS",
+    with_container: bool = True,
+    with_opf: bool = True,
+) -> bytes:
+    """Build a minimal EPUB in memory.
+
+    ``chapters`` maps member names (relative to ``opf_dir``) to XHTML body
+    markup. ``spine`` is an ordered subset of chapter keys controlling the
+    reading order; it defaults to the dict order.
+    """
+    opf_path = f"{opf_dir}/content.opf"
+    manifest = "".join(
+        f'<item id="ch{i}" href="{name}" media-type="application/xhtml+xml"/>'
+        for i, name in enumerate(chapters)
+    )
+    ids = {name: f"ch{i}" for i, name in enumerate(chapters)}
+    spine_ids = spine if spine is not None else list(chapters)
+    spine_xml = "".join(f'<itemref idref="{ids[name]}"/>' for name in spine_ids)
+    opf = (
+        '<?xml version="1.0"?>'
+        '<package xmlns="http://www.idpf.org/2007/opf" version="3.0">'
+        f"<manifest>{manifest}</manifest><spine>{spine_xml}</spine></package>"
+    )
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("mimetype", "application/epub+zip")
+        if with_container:
+            zf.writestr("META-INF/container.xml", _CONTAINER_XML.format(opf=opf_path))
+        if with_opf:
+            zf.writestr(opf_path, opf)
+        for name, body in chapters.items():
+            zf.writestr(
+                f"{opf_dir}/{name}",
+                f'<html xmlns="http://www.w3.org/1999/xhtml"><body>{body}</body></html>',
+            )
+    return buf.getvalue()
+
+
 # ---------------------------------------------------------------------------
 # is_document_extension
 # ---------------------------------------------------------------------------
@@ -77,6 +128,7 @@ class TestIsDocumentExtension:
         assert is_document_extension("foo.DOCX")
         assert is_document_extension("report.xlsx")
         assert is_document_extension("deck.pptx")
+        assert is_document_extension("book.epub")
 
     def test_text_and_code(self) -> None:
         # Any extension in FileTypeRouter.TEXT_EXTENSIONS should be supported.
@@ -171,6 +223,95 @@ class TestExtractPptx:
         assert "--- Slide 1 ---" in text
         assert "Fallback slide" in text
         assert "第二行" in text
+
+
+class TestExtractEpub:
+    def test_follows_spine_reading_order(self) -> None:
+        data = _make_epub(
+            {
+                "chap1.xhtml": "<h1>Chapter One</h1><p>Alpha text.</p>",
+                "chap2.xhtml": "<h1>Chapter Two</h1><p>Beta text.</p>",
+            },
+            spine=["chap2.xhtml", "chap1.xhtml"],
+        )
+
+        text = extract_text_from_bytes("book.epub", data)
+
+        assert text.index("Chapter Two") < text.index("Chapter One")
+        assert "Alpha text." in text
+        assert "Beta text." in text
+
+    def test_inline_markup_keeps_word_boundaries(self) -> None:
+        data = _make_epub({"c.xhtml": "<p>Hello <b>world</b>. <i>Nice</i> day.</p>"})
+
+        text = extract_text_from_bytes("book.epub", data)
+
+        assert "Hello world. Nice day." in text
+
+    def test_scripts_and_styles_are_dropped(self) -> None:
+        data = _make_epub(
+            {
+                "c.xhtml": (
+                    "<style>body{color:red}</style><script>var x=1;</script><p>Visible only.</p>"
+                )
+            }
+        )
+
+        text = extract_text_from_bytes("book.epub", data)
+
+        assert "Visible only." in text
+        assert "color:red" not in text
+        assert "var x" not in text
+
+    def test_falls_back_to_archive_order_without_container(self) -> None:
+        data = _make_epub(
+            {"a.xhtml": "<p>First member.</p>", "b.xhtml": "<p>Second member.</p>"},
+            with_container=False,
+        )
+
+        text = extract_text_from_bytes("book.epub", data)
+
+        assert "First member." in text
+        assert "Second member." in text
+
+    def test_falls_back_to_archive_order_without_opf(self) -> None:
+        data = _make_epub({"only.xhtml": "<p>Solo chapter.</p>"}, with_opf=False)
+
+        text = extract_text_from_bytes("book.epub", data)
+
+        assert "Solo chapter." in text
+
+    def test_unparseable_chapter_is_skipped_not_fatal(self) -> None:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("mimetype", "application/epub+zip")
+            zf.writestr("META-INF/container.xml", _CONTAINER_XML.format(opf="OEBPS/content.opf"))
+            zf.writestr(
+                "OEBPS/content.opf",
+                '<?xml version="1.0"?>'
+                '<package xmlns="http://www.idpf.org/2007/opf" version="3.0">'
+                '<manifest><item id="c0" href="bad.xhtml"/>'
+                '<item id="c1" href="good.xhtml"/></manifest>'
+                '<spine><itemref idref="c0"/><itemref idref="c1"/></spine></package>',
+            )
+            zf.writestr("OEBPS/bad.xhtml", "<html><body><p>Broken &nbsp; chapter</p></body></html>")
+            zf.writestr("OEBPS/good.xhtml", "<html><body><p>Readable chapter.</p></body></html>")
+
+        text = extract_text_from_bytes("book.epub", buf.getvalue())
+
+        assert "Readable chapter." in text
+        assert "Broken" not in text
+
+    def test_bad_header_raises_corrupt(self) -> None:
+        with pytest.raises(CorruptDocumentError):
+            extract_text_from_bytes("book.epub", b"not a zip at all")
+
+    def test_zip_without_text_raises_empty(self) -> None:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("mimetype", "application/epub+zip")
+        with pytest.raises(EmptyDocumentError):
+            extract_text_from_bytes("book.epub", buf.getvalue())
 
 
 class TestExtractTextLike:

--- a/tests/utils/test_document_validator.py
+++ b/tests/utils/test_document_validator.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import mimetypes
+
 from deeptutor.services.rag.file_routing import FileTypeRouter
 from deeptutor.utils.document_validator import DocumentValidator
 
@@ -52,3 +54,23 @@ def test_validate_upload_safety_custom_policy_allows_images() -> None:
     )
 
     assert safe_name == "diagram.png"
+
+
+def test_validate_upload_safety_kb_policy_allows_epub() -> None:
+    safe_name = DocumentValidator.validate_upload_safety(
+        "Textbook.EPUB",
+        1024,
+        allowed_extensions=FileTypeRouter.get_supported_extensions(),
+    )
+
+    assert safe_name == "Textbook.epub"
+
+
+def test_validate_upload_safety_default_policy_allows_epub() -> None:
+    safe_name = DocumentValidator.validate_upload_safety("novel.epub", 1024)
+
+    assert safe_name == "novel.epub"
+    assert ".epub" in DocumentValidator.ALLOWED_EXTENSIONS
+    assert "application/epub+zip" in DocumentValidator.ALLOWED_MIME_TYPES
+    guessed, _ = mimetypes.guess_type("novel.epub")
+    assert guessed is None or guessed in DocumentValidator.ALLOWED_MIME_TYPES


### PR DESCRIPTION
### Description
Add EPUB ingestion support for the knowledge base:
- `.epub` is classified as a parser-handled document type in `FileTypeRouter`
  and accepted by `DocumentValidator` (extension + MIME check).
- Text is extracted by following `META-INF/container.xml` -> OPF manifest ->
  spine reading order, stripping XHTML to plain text; falls back to archive
  order when package metadata is missing, and skips unparseable chapters
  instead of failing the whole book.
- Both the KB `text_only` parser and chat attachment extraction pick the new
  format up through `extract_text_from_bytes`.

### Related Issues
- Closes #429

### Module(s) Affected
- [x] `services`
- [x] `utils`
- [x] `tests`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
- Parsing uses the standard-library `zipfile` plus the project's existing
  `defusedxml` parser; no new dependencies are introduced.
- XML parsing of archive members is defensive (XXE-safe via defusedxml), and
  filenames never touch disk.
- Docstrings updated to reflect the new format; the README has no supported-
  format list, so no README change is needed.
