### PR TITLE
fix(mcp): omit image payloads from tool text

### DIFF
--- a/deeptutor/services/mcp/manager.py
+++ b/deeptutor/services/mcp/manager.py
@@ -557,6 +557,8 @@ class MCPConnectionManager:
         for block in result.content:
             if isinstance(block, types.TextContent):
                 parts.append(block.text)
+            elif isinstance(block, types.ImageContent):
+                parts.append("[MCP image omitted]")
             else:
                 parts.append(str(block))
         return "\n".join(parts) or "(no output)"

--- a/tests/services/mcp/test_progress_reporting.py
+++ b/tests/services/mcp/test_progress_reporting.py
@@ -208,6 +208,25 @@ async def test_progress_reaches_the_sink_end_to_end() -> None:
     assert result.content == "done"
 
 
+@pytest.mark.asyncio
+async def test_image_content_is_omitted_without_serializing_base64() -> None:
+    class _ImageSession(_Session):
+        async def call_tool(self, tool_name, arguments, progress_callback=None):  # type: ignore[no-untyped-def]
+            from mcp import types
+
+            return types.CallToolResult(
+                content=[
+                    types.TextContent(type="text", text="page image"),
+                    types.ImageContent(type="image", data="QUJD", mimeType="image/jpeg"),
+                ]
+            )
+
+    result = await _adapter(MCPConnectionManager(), _ImageSession()).execute()
+
+    assert result.content == "page image\n[MCP image omitted]"
+    assert "QUJD" not in result.content
+
+
 # ── why a connection failed ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
### Description

MCP `ImageContent` blocks currently fall through to `str(block)`, which serializes the full Base64 `data` field into LLM-visible tool text. A single image can therefore consume substantial context and appear in tool traces even though DeepTutor does not currently deliver that block as visual input.

This PR handles standard MCP image blocks explicitly and replaces them with a fixed, bounded marker:

```text
[MCP image omitted]
```

Text blocks and all other MCP content types retain their existing behavior.

### Scope

This is intentionally a safe degradation only. It does **not** add an attachment protocol, provider-specific image transport, PageIndex handling, or visual RAG behavior. Multimodal MCP delivery can be designed separately without retaining the current Base64 leakage.

This supersedes the narrowly reusable part of #830; that older PR also implemented a much broader Codex image-transport path.

### Verification

- `180 passed` — `tests/services/mcp`
- `ruff check` on both changed files
- `ruff format --check` on both changed files
- `python -m compileall` on both changed files
- `git diff --check`
- added-line security scan: no matches

### Design sync

`design-sync: not applicable` — this preserves the current unsupported-image behavior while bounding its textual representation; it does not introduce a new runtime boundary or transport contract.
