### PR TITLE
fix: Keep env-bootstrapped admin usable and unpromoted (#849)

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ data/
 └── system/                  # auth · grants · audit · user-secrets/<owner> (OAuth tokens)
 ```
 
-The **first registered user becomes admin** and owns model catalogs, provider credentials, shared knowledge bases, skills, and per-user grants. Everyone else gets an isolated workspace and a redacted Settings page — admin-assigned models, KBs, and skills show up as scoped, read-only options, never as raw API keys.
+The **first registered user becomes admin** and owns model catalogs, provider credentials, shared knowledge bases, skills, and per-user grants. Everyone else gets an isolated workspace and a redacted Settings page — admin-assigned models, KBs, and skills show up as scoped, read-only options, never as raw API keys. If `auth.json` already carries a `username` + `password_hash`, that account *is* the admin: `/register` stays closed and accounts created from `/admin/users` are always `role=user` until you promote them.
 
 **Enable it:** turn auth on in `data/user/settings/auth.json`, restart `deeptutor start`, register the first admin at `/register`, then add users from `/admin/users` and assign models, KBs, skills, partners, tool/MCP/CLI-app policy, and code-execution access through grants.
 

--- a/deeptutor/multi_user/identity.py
+++ b/deeptutor/multi_user/identity.py
@@ -121,6 +121,44 @@ def _migrate_secret() -> None:
         logger.warning("Failed to migrate legacy auth secret: %s", exc)
 
 
+def _env_bootstrap_admin() -> tuple[str, str]:
+    """Return ``(username, password_hash)`` for the ``auth.json`` bootstrap admin.
+
+    Both halves are required: the shipped default seeds a username with an
+    empty hash, which cannot authenticate and therefore is not an admin. An
+    empty tuple entry means "no bootstrap admin configured".
+
+    :mod:`deeptutor.services.auth` is imported lazily because it imports this
+    module. Its resolved globals — rather than a fresh settings read — are the
+    source of truth on purpose: they are exactly the credentials
+    ``authenticate()`` accepts, so the promotion gate in :func:`save_user` and
+    the login path can never disagree about whether an admin already exists.
+    """
+    try:
+        from deeptutor.services import auth as auth_service
+
+        username = str(getattr(auth_service, "AUTH_USERNAME", "") or "")
+        password_hash = str(getattr(auth_service, "AUTH_PASSWORD_HASH", "") or "")
+    except Exception as exc:  # pragma: no cover - auth settings unavailable
+        logger.warning("Could not resolve the bootstrap admin credentials: %s", exc)
+        return "", ""
+    if not username or not password_hash:
+        return "", ""
+    return username, password_hash
+
+
+def _env_admin_record(password_hash: str) -> dict[str, Any]:
+    """Build the in-memory record representing the bootstrap admin."""
+    return {
+        "id": "env-admin",
+        "hash": password_hash,
+        "role": "admin",
+        "created_at": "",
+        "disabled": False,
+        "avatar": "",
+    }
+
+
 def load_users(  # nosec B107 - empty defaults mean "no env fallback supplied".
     env_username: str = "",
     env_password_hash: str = "",
@@ -152,21 +190,20 @@ def load_users(  # nosec B107 - empty defaults mean "no env fallback supplied".
     if USERS_FILE.exists() and changed:
         _write_users(canonical)
 
-    if canonical:
-        return canonical
+    # The bootstrap admin is merged in whenever it is configured, not only when
+    # the store is empty. Falling back to it only for an empty store locked the
+    # operator who bootstrapped the deployment out of their own instance the
+    # moment the first real account was written (#849). A stored record with the
+    # same username wins, so the account can later be adopted into the store.
+    # The merge is deliberately in-memory only; no write path passes the env
+    # arguments, so the bootstrap hash is never persisted into ``users.json``
+    # where a rotation of ``auth.json`` could no longer supersede it.
+    if env_username and env_password_hash and env_username not in canonical:
+        merged = {env_username: _env_admin_record(env_password_hash)}
+        merged.update(canonical)
+        return merged
 
-    if env_username and env_password_hash:
-        return {
-            env_username: {
-                "id": "env-admin",
-                "hash": env_password_hash,
-                "role": "admin",
-                "created_at": "",
-                "disabled": False,
-            }
-        }
-
-    return {}
+    return canonical
 
 
 def save_user(username: str, hashed_password: str, role: Role = "user") -> dict[str, Any]:
@@ -174,8 +211,17 @@ def save_user(username: str, hashed_password: str, role: Role = "user") -> dict[
     # Read-modify-write must be atomic so concurrent first-time registrations
     # cannot each see an empty store and each promote themselves to admin.
     with _USERS_WRITE_LOCK:
+        # Called without the env arguments on purpose: ``users`` is written back
+        # to disk below, and the bootstrap admin must stay an in-memory overlay.
         users = load_users()
-        effective_role: Role = "admin" if not users else role
+        env_username, _ = _env_bootstrap_admin()
+        # A configured bootstrap admin counts as an existing account, so the
+        # first account an operator creates from /admin/users is not silently
+        # promoted — that endpoint documents role="user" (#849). Re-saving the
+        # bootstrap admin's own username adopts it into the store instead, and
+        # must keep the admin role.
+        account_exists = bool(users) or (bool(env_username) and env_username != username)
+        effective_role: Role = role if account_exists else "admin"
         existing = users.get(username) or {}
         record = {
             "id": str(existing.get("id") or new_user_id()),

--- a/tests/multi_user/conftest.py
+++ b/tests/multi_user/conftest.py
@@ -56,6 +56,15 @@ def mu_isolated_root(tmp_path, monkeypatch) -> Path:
 
     monkeypatch.setattr(grants, "GRANTS_DIR", system_root / "grants")
 
+    # The ``auth.json`` bootstrap admin is process-global state rather than a
+    # path, and it now takes part in the first-user promotion decision (#849).
+    # Clear it so a developer with real credentials configured sees the same
+    # results as CI; tests that need one patch these back explicitly.
+    from deeptutor.services import auth as auth_service
+
+    monkeypatch.setattr(auth_service, "AUTH_USERNAME", "")
+    monkeypatch.setattr(auth_service, "AUTH_PASSWORD_HASH", "")
+
     admin_root.mkdir(parents=True, exist_ok=True)
     return tmp_path
 

--- a/tests/multi_user/test_env_bootstrap_admin.py
+++ b/tests/multi_user/test_env_bootstrap_admin.py
@@ -1,0 +1,265 @@
+"""Regression tests for the env/``auth.json`` bootstrap admin (issue #849).
+
+Two deployment shapes have to behave differently, and the identity store used
+to conflate them:
+
+* **Env-bootstrapped** — ``auth.json`` carries ``username`` +
+  ``password_hash`` and ``users.json`` is empty. An admin already exists, so
+  accounts created from ``/admin/users`` must stay ``role="user"`` and the
+  bootstrap admin must keep working after the store gains its first record.
+* **Genuinely empty** — no bootstrap credentials at all. The first account to
+  register is promoted to admin, which is the documented bootstrap path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# A real bcrypt hash of "bootstrap-pass-1234", generated in-test so no secret
+# literal is committed.
+_BOOTSTRAP_PASSWORD = "bootstrap-pass-1234"  # nosec B105 - test fixture credential
+
+
+@pytest.fixture
+def bootstrap_hash() -> str:
+    from deeptutor.services.auth import hash_password
+
+    return hash_password(_BOOTSTRAP_PASSWORD)
+
+
+@pytest.fixture
+def env_admin(mu_isolated_root, monkeypatch, bootstrap_hash):
+    """Simulate an ``auth.json``-bootstrapped admin with an empty user store."""
+    from deeptutor.services import auth as auth_service
+
+    monkeypatch.setattr(auth_service, "AUTH_USERNAME", "operator")
+    monkeypatch.setattr(auth_service, "AUTH_PASSWORD_HASH", bootstrap_hash)
+    monkeypatch.setattr(auth_service, "AUTH_ENABLED", True)
+    return "operator"
+
+
+# ---------------------------------------------------------------------------
+# Bug A — the first account created by an admin must not be promoted
+# ---------------------------------------------------------------------------
+
+
+def test_first_created_account_is_not_promoted_when_env_admin_exists(env_admin):
+    """``POST /auth/users`` documents role=``user``; honour that."""
+    from deeptutor.multi_user.identity import save_user
+
+    record = save_user("student1", "$2b$12$placeholder", role="user")
+
+    assert record["role"] == "user"
+
+
+def test_admin_can_still_create_an_explicit_admin_when_env_admin_exists(env_admin):
+    """The gate must not clamp an explicitly requested admin role."""
+    from deeptutor.multi_user.identity import save_user
+
+    record = save_user("deputy", "$2b$12$placeholder", role="admin")
+
+    assert record["role"] == "admin"
+
+
+# ---------------------------------------------------------------------------
+# Bug B — the env bootstrap admin must survive the store gaining records
+# ---------------------------------------------------------------------------
+
+
+def test_env_admin_still_resolves_after_first_account_is_created(env_admin, bootstrap_hash):
+    from deeptutor.multi_user.identity import load_users, save_user
+
+    save_user("student1", "$2b$12$placeholder", role="user")
+
+    users = load_users(env_admin, bootstrap_hash)
+
+    assert set(users) == {env_admin, "student1"}
+    assert users[env_admin]["role"] == "admin"
+    assert users[env_admin]["hash"] == bootstrap_hash
+
+
+def test_env_admin_can_log_in_after_first_account_is_created(env_admin):
+    """End-to-end shape of the reported lockout: login returned 401."""
+    from deeptutor.multi_user.identity import save_user
+    from deeptutor.services.auth import authenticate
+
+    save_user("student1", "$2b$12$placeholder", role="user")
+
+    payload = authenticate(env_admin, _BOOTSTRAP_PASSWORD)
+
+    assert payload is not None
+    assert payload.role == "admin"
+
+
+def test_env_admin_is_never_written_into_the_user_store(env_admin):
+    """The bootstrap admin is an in-memory overlay, not a persisted record.
+
+    Persisting it would pin the hash at the time of the first write, so a
+    later rotation of ``auth.json`` would silently keep accepting the old
+    password.
+    """
+    import json
+
+    from deeptutor.multi_user.identity import USERS_FILE, save_user
+
+    save_user("student1", "$2b$12$placeholder", role="user")
+
+    on_disk = json.loads(USERS_FILE.read_text(encoding="utf-8"))
+    assert set(on_disk) == {"student1"}
+
+
+def test_stored_record_wins_over_env_bootstrap_admin(env_admin):
+    """Re-creating the bootstrap username adopts the account into the store."""
+    from deeptutor.multi_user.identity import load_users, save_user
+
+    save_user(env_admin, "$2b$12$adopted", role="admin")
+
+    users = load_users(env_admin, "$2b$12$fromenv")
+
+    assert users[env_admin]["hash"] == "$2b$12$adopted"
+    assert users[env_admin]["role"] == "admin"
+
+
+def test_adopting_the_bootstrap_username_keeps_admin_role(env_admin):
+    """The adoption write must not be demoted to ``user`` by the new gate."""
+    from deeptutor.multi_user.identity import save_user
+
+    record = save_user(env_admin, "$2b$12$adopted", role="user")
+
+    assert record["role"] == "admin"
+
+
+def test_env_admin_appears_exactly_once_in_the_admin_user_list(env_admin, bootstrap_hash):
+    from deeptutor.multi_user.identity import list_user_info, save_user
+
+    save_user("student1", "$2b$12$placeholder", role="user")
+
+    listed = list_user_info(env_admin, bootstrap_hash)
+    usernames = [item["username"] for item in listed]
+
+    assert usernames.count(env_admin) == 1
+    assert set(usernames) == {env_admin, "student1"}
+
+
+def test_is_first_user_is_false_when_only_the_env_admin_exists(env_admin):
+    from deeptutor.services.auth import is_first_user
+
+    assert is_first_user() is False
+
+
+# ---------------------------------------------------------------------------
+# No-env-admin path — the documented bootstrap behaviour is preserved
+# ---------------------------------------------------------------------------
+
+
+def test_first_account_is_promoted_when_no_env_admin_exists(mu_isolated_root):
+    from deeptutor.multi_user.identity import save_user
+
+    record = save_user("alice", "$2b$12$placeholder", role="user")
+
+    assert record["role"] == "admin"
+
+
+def test_second_account_is_not_promoted_when_no_env_admin_exists(mu_isolated_root):
+    from deeptutor.multi_user.identity import save_user
+
+    save_user("alice", "$2b$12$placeholder", role="user")
+    record = save_user("bob", "$2b$12$placeholder", role="user")
+
+    assert record["role"] == "user"
+
+
+def test_partial_env_credentials_do_not_count_as_an_admin(mu_isolated_root, monkeypatch):
+    """A username with no hash cannot log in, so it must not block promotion.
+
+    This is the shipped default (``auth.json`` seeds ``username="admin"`` with
+    an empty hash), so treating it as an existing admin would leave a fresh
+    deployment with no way to create one.
+    """
+    from deeptutor.multi_user.identity import save_user
+    from deeptutor.services import auth as auth_service
+
+    monkeypatch.setattr(auth_service, "AUTH_USERNAME", "admin")
+    monkeypatch.setattr(auth_service, "AUTH_PASSWORD_HASH", "")
+
+    record = save_user("alice", "$2b$12$placeholder", role="user")
+
+    assert record["role"] == "admin"
+
+
+def test_is_first_user_is_true_for_a_genuinely_empty_deployment(mu_isolated_root):
+    from deeptutor.services.auth import is_first_user
+
+    assert is_first_user() is True
+
+
+# ---------------------------------------------------------------------------
+# End-to-end over the real router — the exact sequence reported in #849
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bootstrap_client(env_admin, monkeypatch):
+    """TestClient over the auth router, authenticated as the bootstrap admin."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    import deeptutor.api.routers.auth as auth_router
+    from deeptutor.services.auth import TokenPayload
+
+    tokens = {
+        "operator-token": TokenPayload(username=env_admin, role="admin", user_id="env-admin"),
+    }
+    monkeypatch.setattr(auth_router, "AUTH_ENABLED", True)
+    monkeypatch.setattr(auth_router, "decode_token", lambda token: tokens.get(token))
+
+    app = FastAPI()
+    app.include_router(auth_router.router, prefix="/api/v1/auth")
+    return TestClient(app), {"Authorization": "Bearer operator-token"}
+
+
+def test_admin_create_user_returns_role_user(bootstrap_client):
+    client, headers = bootstrap_client
+
+    response = client.post(
+        "/api/v1/auth/users",
+        json={"username": "student1", "password": "student-pass-1234"},
+        headers=headers,
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["role"] == "user"
+    assert body["is_admin"] is False
+
+
+def test_bootstrap_admin_remains_listed_after_creating_an_account(bootstrap_client, env_admin):
+    client, headers = bootstrap_client
+
+    client.post(
+        "/api/v1/auth/users",
+        json={"username": "student1", "password": "student-pass-1234"},
+        headers=headers,
+    )
+    listed = client.get("/api/v1/auth/users", headers=headers).json()
+
+    by_name = {item["username"]: item for item in listed}
+    assert by_name[env_admin]["role"] == "admin"
+    assert by_name["student1"]["role"] == "user"
+
+
+def test_bootstrap_admin_username_cannot_be_taken_by_a_new_account(bootstrap_client, env_admin):
+    """The bootstrap username is now reserved, so it cannot be clobbered.
+
+    Creating a store record under that name would shadow the overlay and
+    demote the operator, so the endpoint must reject it as already taken.
+    """
+    client, headers = bootstrap_client
+
+    response = client.post(
+        "/api/v1/auth/users",
+        json={"username": env_admin, "password": "attacker-pass-1234"},
+        headers=headers,
+    )
+
+    assert response.status_code == 409


### PR DESCRIPTION
Fixes #849.

Targets `dev` per CONTRIBUTING (`dev` is currently at the same commit as `main`, `23ad80d` / v1.5.12). Happy to retarget to `multi-user` if you'd prefer, though that branch is still at v1.3.8.

## Root cause

Two independent bugs in `deeptutor/multi_user/identity.py` that only bite together, and only when the admin is bootstrapped from `auth.json` (`username` + `password_hash`) instead of `/register`.

**Bug B — `load_users()` dropped the bootstrap admin as soon as the store was non-empty.** The env fallback was reachable only after an early `if canonical: return canonical`, so the fallback was an *empty-store-only* path. `services/auth.authenticate()` resolves credentials through `load_users(AUTH_USERNAME, AUTH_PASSWORD_HASH)`, so the first write to `users.json` made the operator's own login return 401.

**Bug A — `save_user()` decided first-admin promotion from an env-blind view.** It called `load_users()` with no env arguments, so `not users` was true whenever `users.json` was empty regardless of the bootstrap admin, and `effective_role` became `"admin"`. `POST /api/v1/auth/users` documents that new accounts are "always created with role=`user`", and `services.auth.is_first_user()` — which *does* pass the env arguments — disagreed with `save_user()` about whether a first user existed.

Sequence: operator creates one student → the student is promoted to admin → the operator can no longer log in, and the only remaining admin is the student.

## Fix

`load_users()` merges the bootstrap admin whenever it is configured, not only for an empty store. A stored record with the same username still wins, so the account can later be adopted into the store. The merge is deliberately in-memory only — no write path passes the env arguments, so the bootstrap hash is never persisted into `users.json` where a later rotation of `auth.json` could no longer supersede it.

`save_user()` counts a configured bootstrap admin as an existing account, so promotion no longer fires. The one exception is saving that same username, which is an adoption rather than a new account and keeps the admin role.

The genuinely-empty deployment is untouched: with no bootstrap credentials the first `/register` user is still promoted to admin. A username configured with an *empty* hash does not count, which matters because that is the shipped default (`auth.json` seeds `username="admin"` with no hash) — treating it as an admin would leave a fresh install with no way to create one.

One deliberate side effect worth flagging as a positive: because `list_users()` passes the env arguments, the bootstrap username is now present in the `existing` set that `POST /users` and `/register` check, so it returns 409 instead of letting a new store record shadow the overlay and demote the operator. There is a test for this.

Both changes are small and behaviour-preserving for the `/register` bootstrap path. I kept `save_user()`'s public signature unchanged; the bootstrap lookup is an internal helper that reads `services.auth`'s resolved globals via a lazy import (avoiding the module cycle). Reading those globals rather than re-reading the settings file is intentional — they are exactly the credentials `authenticate()` accepts, so the promotion gate and the login path cannot drift apart, which is what caused the original disagreement.

## Verification

New file `tests/multi_user/test_env_bootstrap_admin.py`, 16 tests covering both deployment shapes plus an end-to-end pass over the real router.

Negative control — 6 of the 16 fail on unpatched `identity.py`, including the reported 401:

```
FAILED test_first_created_account_is_not_promoted_when_env_admin_exists   # Bug A
FAILED test_env_admin_still_resolves_after_first_account_is_created       # Bug B
FAILED test_env_admin_can_log_in_after_first_account_is_created           # the 401
FAILED test_env_admin_appears_exactly_once_in_the_admin_user_list
FAILED test_admin_create_user_returns_role_user                           # Bug A over HTTP
FAILED test_bootstrap_admin_remains_listed_after_creating_an_account
6 failed, 10 passed
```

With the fix: `16 passed`.

Coverage of the no-env-admin path, which had to stay unchanged:

- `test_first_account_is_promoted_when_no_env_admin_exists`
- `test_second_account_is_not_promoted_when_no_env_admin_exists`
- `test_partial_env_credentials_do_not_count_as_an_admin` (the shipped `username`-with-empty-hash default)
- `test_is_first_user_is_true_for_a_genuinely_empty_deployment`

Suites run:

- `tests/multi_user` — 130 passed, 1 failed
- `tests/multi_user tests/api tests/services/config` — 598 passed, 11 failed

Every failure above is pre-existing and reproduces identically on a clean `23ad80d` checkout with my two source files stashed (verified both ways). They are Windows-environment artifacts, not regressions: `test_partner_data_is_admin_anchored_not_user_scoped` asserts `str(path).endswith("data/partners")` and gets backslashes; `test_output_files.py` needs symlink privileges; `test_partners_channel_schema.py` and `test_subagents_router.py` need `.[partners]` SDKs I did not install.

Gates: `ruff check` and `ruff format --check` clean on all touched files; `bandit -c pyproject.toml` clean on `identity.py` (exit 0); `mypy --ignore-missing-imports --no-strict-optional` clean on `identity.py`. I could not run the mypy hook across the whole tree — with Python 3.13 the pinned mypy 1.13.0 fails parsing current numpy stubs (`numpy/__init__.pyi: Type statement is only supported in Python 3.12 and greater`), which is unrelated to this change.

## Two extras in the diff

`tests/multi_user/conftest.py` — `mu_isolated_root` now clears `AUTH_USERNAME` / `AUTH_PASSWORD_HASH`. The bootstrap admin is process-global state rather than a path, and it now participates in the promotion decision, so without this a developer with real credentials in `auth.json` would get different results than CI. This is the same hermeticity concern the guards in the root `conftest.py` already handle for paths. Tests that need a bootstrap admin patch them back explicitly.

`README.md` — one sentence noting that a pre-configured `auth.json` admin *is* the admin, so `/register` stays closed and `/admin/users` accounts are `role=user` until promoted. The existing "first registered user becomes admin" line describes only the `/register` path and reads as contradictory for env-bootstrapped deployments. Happy to drop this if you'd rather keep the PR code-only.

## Not addressed

`delete_user()`, `set_role()`, and `set_avatar()` operate on the store only, so they return `False` for the overlay record and the endpoints answer 404 for the bootstrap admin. That 404 is now reachable in a case it wasn't before (a separately-created admin acting on the bootstrap admin), where previously the overlay was only visible while it was the sole account and the self-modification guards returned 400 anyway. It is a confusing message rather than a lockout, and fixing it properly means deciding how a bootstrap admin gets deleted or demoted at all — a design call for you, and out of scope here. Glad to follow up if you want it.
