### PR TITLE
fix: Install mcp by default so pageindex MCP connects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ pip install -e .           — Source install for development
 Source extras (.[ extra ], defined in pyproject.toml):
 .[cli]            — CLI-only dependency set
 .[server]         — Web/API server dependencies
-.[partners]       — Partner channel SDKs + MCP client  (legacy alias: .[tutorbot])
+.[partners]       — Partner channel SDKs  (legacy alias: .[tutorbot])
 .[matrix]         — Matrix channel for Partners (matrix-nio; needs libolm)
 .[matrix-e2e]     — Matrix with end-to-end encryption (matrix-nio[e2e])
 .[math-animator]  — Manim addon (powers `visualize` Manim renders + `deeptutor run math_animator`)

--- a/deeptutor/services/mcp/manager.py
+++ b/deeptutor/services/mcp/manager.py
@@ -669,9 +669,14 @@ class MCPConnectionManager:
         """Connection task: owns the AsyncExitStack for one server."""
         from contextlib import AsyncExitStack
 
-        from mcp import ClientSession
-
         try:
+            # Imported inside the guarded block on purpose (issue #792): if the
+            # `mcp` package is missing, an import at function scope raises before
+            # anything can fail *ready*, so the task dies with an unretrieved
+            # ModuleNotFoundError while the connect waits out the full timeout.
+            # Inside the block the real cause reaches the caller immediately.
+            from mcp import ClientSession
+
             async with AsyncExitStack() as stack:
                 read, write = await self._open_transport(
                     stack, conn.config, owner=conn.owner, server_name=conn.name

--- a/packaging/deeptutor-cli/pyproject.toml
+++ b/packaging/deeptutor-cli/pyproject.toml
@@ -29,6 +29,10 @@ dependencies = [
     "typer>=0.9.0",
     "rich>=13.0.0",
     "prompt_toolkit>=3.0.36",
+    # MCP client. This distribution ships `deeptutor.services.mcp`, including the
+    # built-in PageIndex MCP server that is injected whenever a PageIndex API key
+    # is configured, so it needs the client too (issue #792).
+    "mcp>=1.26.0,<2.0.0",
     "anthropic>=0.30.0",
     "dashscope>=1.14.0",
     "perplexityai>=0.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,13 @@ dependencies = [
     "rich>=13.0.0",
     "prompt_toolkit>=3.0.36",
     "pyte>=0.8.1",  # in-memory terminal emulator: scrape Claude Code's /model TUI on sync
+    # MCP client. Core rather than a `partners`-only extra (issue #792): the
+    # connection manager and the built-in PageIndex MCP server are injected on
+    # any turn where a PageIndex API key is configured, so a plain
+    # `pip install deeptutor` has to be able to import `mcp` — otherwise the
+    # connection task dies with ModuleNotFoundError and every turn stalls for
+    # the full connect timeout.
+    "mcp>=1.26.0,<2.0.0",
     # Full app dependencies included by default for `pip install deeptutor`.
     "anthropic>=0.30.0",
     "dashscope>=1.14.0",
@@ -134,12 +141,12 @@ server = [
     "psutil>=5.9.0,<8.0.0",
 ]
 
-# Partner channel SDKs + MCP client. Mirrors requirements/partners.txt.
+# Partner channel SDKs. Mirrors requirements/partners.txt.
 # Partners run on the chat agent loop, so there is no engine here — just the
-# IM platform SDKs and the MCP client used for deferred tools.
+# IM platform SDKs. The MCP client used for deferred tools is a core dependency
+# (see `mcp` above), not a partners-only one.
 partners = [
     "deeptutor[server]",
-    "mcp>=1.26.0,<2.0.0",
     "python-telegram-bot[socks]>=22.6,<23.0",
     "wecom-aibot-sdk>=1.0.8,<2.0.0",
     "lark-oapi>=1.5.0,<2.0.0",

--- a/requirements/cli.txt
+++ b/requirements/cli.txt
@@ -63,3 +63,8 @@ ddgs>=9.9.1
 typer>=0.9.0
 rich>=13.0.0
 prompt_toolkit>=3.0.36
+
+# --- MCP client (deferred tools; built-in PageIndex MCP server) ---
+# Core, not partners-only: the connection manager injects the built-in
+# pageindex server whenever a PageIndex API key is configured (issue #792).
+mcp>=1.26.0,<2.0.0

--- a/requirements/partners.txt
+++ b/requirements/partners.txt
@@ -5,15 +5,13 @@
 # Keep in sync with pyproject.toml when adding/updating dependencies.
 #
 # Partners run on the chat agent loop (no separate engine), so this set is
-# the IM channel SDKs plus MCP client support.
+# the IM channel SDKs. The MCP client is a core dependency (see cli.txt),
+# pulled in via server.txt below.
 #
 # Preferred install (from a source clone): pip install -e ".[partners]"
 # Use this file for Docker/CI when pyproject.toml/source code aren't yet available.
 
 -r server.txt
-
-# --- MCP client (deferred tools for chat + partners) ---
-mcp>=1.26.0,<2.0.0
 
 # --- Channel SDKs ---
 python-telegram-bot[socks]>=22.6,<23.0

--- a/tests/services/mcp/test_missing_mcp_dependency.py
+++ b/tests/services/mcp/test_missing_mcp_dependency.py
@@ -1,0 +1,84 @@
+"""A missing ``mcp`` package must fail a connect immediately, not time out.
+
+Regression test for issue #792. ``_run_server`` used to import ``mcp`` at
+function scope, above its own ``try``. With the package absent the connection
+task therefore died before it could ever fail the ``ready`` future, so:
+
+* the caller sat out the whole ``_CONNECT_TIMEOUT_S`` window (15s by default)
+  and then reported ``connect timed out after 15s`` — the one explanation that
+  rules out the real cause; and
+* the ``ModuleNotFoundError`` surfaced only as asyncio's "Task exception was
+  never retrieved" noise, detached from the server it belonged to.
+
+The package is a core dependency now (see ``tests/test_packaging_metadata.py``),
+so this should be unreachable on a supported install — but a broken environment
+should still say what is broken instead of stalling every turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+import time
+
+import pytest
+
+from deeptutor.services.mcp import manager as manager_mod
+from deeptutor.services.mcp.config import MCPServerConfig
+from deeptutor.services.mcp.manager import SHARED_OWNER, MCPConnectionManager
+
+# Short enough that a regression (which waits out the full window) is obvious
+# without making the suite slow.
+_PATCHED_TIMEOUT_S = 3
+
+
+@pytest.fixture
+def _no_mcp_package(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every ``import mcp`` raise, as an install without the extra does."""
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "mcp" or name.startswith("mcp."):
+            raise ModuleNotFoundError("No module named 'mcp'", name="mcp")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def test_missing_mcp_package_reports_real_cause_without_waiting_out_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    _no_mcp_package: None,
+) -> None:
+    """The connect fails fast, names the module, and orphans no task exception."""
+    monkeypatch.setattr(manager_mod, "_CONNECT_TIMEOUT_S", _PATCHED_TIMEOUT_S)
+
+    # The built-in pageindex entry's shape: a remote streamableHttp server. The
+    # transport is never opened, so no network is involved.
+    cfg = MCPServerConfig(
+        type="streamableHttp",
+        url="https://api.pageindex.ai/mcp",
+        headers={"Authorization": "Bearer test-key"},
+    )
+
+    async def scenario() -> tuple[float, manager_mod._ServerConnection]:
+        mgr = MCPConnectionManager()
+        started = time.monotonic()
+        await mgr._connect("pageindex", cfg)
+        elapsed = time.monotonic() - started
+        conn = mgr._connections[(SHARED_OWNER, "pageindex")]
+        assert conn.task is not None
+        await conn.task
+        return elapsed, conn
+
+    elapsed, conn = asyncio.run(scenario())
+
+    # Fast-fail: nowhere near the connect timeout.
+    assert elapsed < _PATCHED_TIMEOUT_S / 2
+    assert conn.status == "error"
+    # The reason names the missing module rather than a timeout.
+    assert "No module named 'mcp'" in conn.error
+    assert "timed out" not in conn.error
+    # The task exception was consumed via the ready future, so asyncio has
+    # nothing left to complain about at GC time.
+    assert conn.task is not None and conn.task.done()
+    assert conn.task.exception() is None

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -23,3 +23,47 @@ def test_typer_dependency_does_not_request_removed_all_extra(metadata_path: Path
 
     typer_requirements = [item for item in dependencies if item.startswith("typer")]
     assert typer_requirements == ["typer>=0.9.0"]
+
+
+@pytest.mark.parametrize(
+    "metadata_path",
+    [
+        REPOSITORY_ROOT / "pyproject.toml",
+        REPOSITORY_ROOT / "packaging" / "deeptutor-cli" / "pyproject.toml",
+    ],
+)
+def test_mcp_client_is_a_core_dependency(metadata_path: Path) -> None:
+    """`mcp` must install by default, not only via an extra (issue #792).
+
+    Both distributions ship ``deeptutor.services.mcp``, and the connection
+    manager overlays the built-in PageIndex MCP server onto the config whenever
+    a PageIndex API key is set. That happens on a plain install, so an
+    extra-gated ``mcp`` leaves the connection task dying with
+    ``ModuleNotFoundError`` on every turn.
+    """
+    with metadata_path.open("rb") as file:
+        dependencies = tomllib.load(file)["project"]["dependencies"]
+
+    mcp_requirements = [item for item in dependencies if item.split(">")[0].strip() == "mcp"]
+    assert mcp_requirements == ["mcp>=1.26.0,<2.0.0"]
+
+
+def test_partners_extra_does_not_redeclare_the_core_mcp_client() -> None:
+    """The `partners` extra is IM channel SDKs only; `mcp` is core now."""
+    with (REPOSITORY_ROOT / "pyproject.toml").open("rb") as file:
+        extras = tomllib.load(file)["project"]["optional-dependencies"]
+
+    assert not [item for item in extras["partners"] if item.split(">")[0].strip() == "mcp"]
+
+
+def test_requirements_mirror_the_core_mcp_client() -> None:
+    """Docker/CI installs read requirements/, which must agree with pyproject."""
+    requirements = REPOSITORY_ROOT / "requirements"
+    cli_text = (requirements / "cli.txt").read_text(encoding="utf-8")
+    partners_text = (requirements / "partners.txt").read_text(encoding="utf-8")
+
+    # cli.txt mirrors the core dependency set, so the client belongs there...
+    assert "mcp>=1.26.0,<2.0.0" in cli_text
+    # ...and partners.txt inherits it transitively rather than redeclaring it.
+    assert "-r server.txt" in partners_text
+    assert "mcp>=" not in partners_text


### PR DESCRIPTION
Fixes #792.

## Root cause

Two defects, both in the same failure. Confirmed by reproducing the exact log lines from the issue.

**1. `mcp` was scoped to the wrong dependency group.**

`pyproject.toml` declared `mcp>=1.26.0,<2.0.0` only under `extra == "partners"`. But the MCP connection manager is **core**, not partner-only: `pageindex_server.with_builtin_servers()` overlays a reserved `pageindex` server entry onto the config whenever a PageIndex API key is configured, and `MCPConnectionManager.ensure_started()` is called at the start of every turn. Nothing about that path involves partners.

So a plain `pip install deeptutor` had no `mcp` package, and configuring a PageIndex key was enough to break every turn.

**2. The `mcp` import sat above its own `try`, which converted a permanent error into a timeout.**

In `MCPConnectionManager._run_server()`:

```python
async def _run_server(self, conn, ready) -> None:
    from contextlib import AsyncExitStack

    from mcp import ClientSession   # <-- outside the try

    try:
        ...
    except Exception as exc:
        if not ready.done():
            ready.set_exception(exc)
```

With `mcp` absent, the `ModuleNotFoundError` was raised *before* the `try`, so the `except` never ran and `ready` was never resolved. `_connect()` then sat in `asyncio.wait_for(ready, timeout=_CONNECT_TIMEOUT_S)` for the full 15s and blamed a timeout — the one explanation that rules out the actual cause. The real error surfaced separately as asyncio's "Task exception was never retrieved", detached from the server it belonged to.

## Reproduction

In a venv without `mcp`, connecting the built-in pageindex entry through the real manager:

```
elapsed   = 15.01s
status    = error
error     = 'connect timed out after 15s'

Task exception was never retrieved
future: <Task finished name='mcp-server-pageindex' ... exception=ModuleNotFoundError("No module named 'mcp'")>
  File "deeptutor/services/mcp/manager.py", line 672, in _run_server
    from mcp import ClientSession
ModuleNotFoundError: No module named 'mcp'
```

Byte-for-byte the report in #792, including the 15s stall and the orphaned task exception.

## Fix

- **`pyproject.toml`** — `mcp>=1.26.0,<2.0.0` moved from the `partners` extra into `[project.dependencies]`. The version specifier is unchanged, so `pip install -e ".[partners]"` resolves exactly as before; it now inherits the client instead of declaring it.
- **`packaging/deeptutor-cli/pyproject.toml`** — same dependency added. This distribution includes `deeptutor*` packages, so it ships `deeptutor.services.mcp` and the built-in PageIndex server too, and had the identical gap.
- **`requirements/cli.txt` / `requirements/partners.txt`** — mirrored the move, per the "requirements files mirror the pyproject groups" convention. `cli.txt` carries the core set; `partners.txt` inherits via `-r server.txt`.
- **`deeptutor/services/mcp/manager.py`** — moved `from mcp import ClientSession` inside `_run_server`'s guarded block so an import failure fails `ready` immediately with the real cause. Defense in depth: with fix 1 this is unreachable on a supported install, but a broken environment should say what is broken instead of stalling every turn.
- **`AGENTS.md`** — the extras table described `.[partners]` as "Partner channel SDKs + MCP client"; corrected.

I went with "make `mcp` a core dependency" (the first option under *Expected behavior*) rather than gating the injection on `mcp` being importable, because the manager is genuinely core — gating it would silently downgrade PageIndex retrieval to a no-op instead of fixing it.

## Verification

**Fix 1 — install metadata.** Built each distribution's metadata and checked `Requires-Dist`. Both now declare it unconditionally, with no `extra ==` marker:

```
deeptutor      → Requires-Dist: mcp<2.0.0,>=1.26.0
deeptutor-cli  → Requires-Dist: mcp<2.0.0,>=1.26.0
```

**Fix 1 — runtime.** Installing the declared constraint resolved `mcp` 1.29.0, after which the pageindex server no longer hits `ModuleNotFoundError` at all: the connect proceeds through the real MCP transport to the endpoint and fails only on the remote's HTTP 503 for the throwaway key. The import path is satisfied.

**Fix 2 — behavior.** Same no-`mcp` scenario as the reproduction above, after the change:

```
elapsed   = 0.02s
status    = error
error     = "ModuleNotFoundError: No module named 'mcp'"
```

15.01s → 0.02s, accurate cause, and no orphaned task exception.

**Tests.** Added negative controls, each verified to fail before the fix and pass after:

- `tests/test_packaging_metadata.py` — `mcp` is a core dependency of both distributions, absent from the `partners` extra, and mirrored correctly in `requirements/`. Reverting the dependency change fails all 4.
- `tests/services/mcp/test_missing_mcp_dependency.py` — with `import mcp` forced to raise, the connect fails fast, names the missing module rather than a timeout, and leaves no unretrieved task exception. Reverting the manager change fails it with `connect timed out after 3s` (patched-down timeout) plus the propagating `ModuleNotFoundError` — precisely the reported symptom.

**Suite.** `tests/services/mcp/`, `tests/test_packaging_metadata.py`, `tests/test_matrix_requirements.py`, `tests/agents/chat/test_pageindex_mcp.py`:

| | passed | failed | skipped |
|---|---|---|---|
| clean `dev` baseline | 182 | 4 | 1 |
| this branch | 187 | 4 | 1 |

Same 4 failures before and after, so none are mine. For transparency they are environment limits on my Windows box, not regressions: `test_oauth.py::test_the_store_file_is_owner_only` asserts POSIX `0600` (Windows reports `0666`), and the 3 `test_pageindex_mcp.py` failures come from optional heavy RAG dependencies missing in my minimal venv. Both sets reproduce identically on unmodified `dev`.

**Gates.** `pre-commit run --files <changed>` passes: ruff, ruff-format, mypy, bandit, detect-secrets, check-toml and the file-hygiene hooks all green. The `prettier` hook could not install in my environment (npm registry returned `E401`); it is scoped to `^web/.*` and matches none of the changed files.

Targeting `dev` per CONTRIBUTING.md.
