### PR TITLE
fix: preserve console exception tracebacks

### DIFF
--- a/deeptutor/logging/formatters.py
+++ b/deeptutor/logging/formatters.py
@@ -46,4 +46,9 @@ class ConsoleFormatter(logging.Formatter):
         context = getattr(record, "log_context", {}) or {}
         stage = f" @{context['stage']}" if context.get("stage") else ""
         task = f" #{context['task_id']}" if context.get("task_id") else ""
-        return f"{record.levelname:<7} {record.name}{stage}{task} - {record.getMessage()}"
+        message = f"{record.levelname:<7} {record.name}{stage}{task} - {record.getMessage()}"
+        if record.exc_info:
+            # Without this the console loses the traceback that exc_info=True
+            # recorded; only the message would print, hiding the real cause.
+            message = f"{message}\n{self.formatException(record.exc_info)}"
+        return message

--- a/tests/logging/test_formatters.py
+++ b/tests/logging/test_formatters.py
@@ -1,0 +1,45 @@
+"""ConsoleFormatter must surface exc_info, not swallow it.
+
+Previously it printed only ``record.getMessage()``, so ``logger.error(...,
+exc_info=True)`` produced a one-line summary on the console with no traceback —
+hiding the real cause of failures (the stale SSL_CERT_FILE crash was diagnosed
+only because the JSONL file handler still wrote the exception).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from deeptutor.logging.formatters import ConsoleFormatter
+
+
+def _make_record(msg: str, exc_info=None) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="deeptutor.test.formatter",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg=msg,
+        args=(),
+        exc_info=exc_info,
+        func="fn",
+    )
+
+
+def test_console_formatter_without_exc_info_has_no_traceback() -> None:
+    out = ConsoleFormatter().format(_make_record("hello"))
+    assert "hello" in out
+    assert "Traceback" not in out
+
+
+def test_console_formatter_appends_traceback() -> None:
+    try:
+        raise ValueError("kaboom")
+    except ValueError:
+        exc_info = sys.exc_info()
+    out = ConsoleFormatter().format(_make_record("boom", exc_info=exc_info))
+    assert "boom" in out
+    assert "Traceback" in out
+    assert "ValueError" in out
+    assert "kaboom" in out


### PR DESCRIPTION
### Description

长程异步任务时，如果处理返回时间较长，界面会一直转圈，无法得知现在进度或者是否异常。

复现步骤：
1.在新增LlamaIndex类型的KB时，如果一次性新增多个PDF文档，点击创建，
2.这时，后台会异步调用MinerU将PDF提取出文本内容，分离图片，分别保存在data目录下的parse_cache，
3.如果涵盖大量图片的话，后台会异步调用配置的"supports_vision”的LLM如Qwen对图片进行解释，
4.这个过程很漫长，而且容易出错，表现为界面一直转圈，console框无输出，进度条也无反应。。。

修改方案：
保留由 ConsoleFormatter 输出到控制台日志中的异常回溯信息。
该格式化器此前仅返回 record.getMessage ()，即便调用方设置 exc_info=True，也会绕过标准异常格式化流程。

本次修改会将格式化后的异常信息追加至控制台消息中，并为携带与不携带异常信息的日志记录补充回归测试覆盖。

本次修改不仅能完善上述新增KB添加文档的异步处理信息回溯问题，进一步地，整个DeepTutor中所有其他的类似长程异步任务的异步处理信息的交互显示，也会得到完善。

### Related Issues

- No linked issue.

### Module(s) Affected

- [x] `logging`
- [x] `tests`

### Validation

- `pytest tests/logging/test_formatters.py -q` — 2 passed
- `ruff check deeptutor/logging/formatters.py tests/logging/test_formatters.py`
- `ruff format --check deeptutor/logging/formatters.py tests/logging/test_formatters.py`
- Repository pre-commit hooks — passed

### Checklist

- [x] I have read and followed the contribution guidelines.
- [x] My code follows the project's coding standards.
- [x] I have run the relevant pre-commit checks.
- [x] I have added relevant tests for my changes.
- [x] My changes do not introduce any new security vulnerabilities.
