### PR TITLE
fix(sessions): ensure cleanup of mastery path on session deletion

### DIFF
--- a/deeptutor/api/routers/sessions.py
+++ b/deeptutor/api/routers/sessions.py
@@ -10,6 +10,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field, field_validator
 
+from deeptutor.learning.storage import LearningStore
 from deeptutor.services.session import get_session_store, get_sqlite_session_store
 from deeptutor.services.storage.attachment_store import get_attachment_store
 
@@ -156,6 +157,10 @@ async def delete_session(session_id: str):
     deleted = await store.delete_session(session_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Session not found")
+    try:
+        LearningStore().delete(session_id)
+    except Exception:
+        logger.exception("failed to clean up mastery path for session %s", session_id)
     try:
         await get_attachment_store().delete_session(session_id)
     except Exception:

--- a/tests/multi_user/test_session_cleanup.py
+++ b/tests/multi_user/test_session_cleanup.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import asyncio
+
+
+def test_delete_session_cleans_only_current_user_artifacts(as_user, monkeypatch) -> None:
+    from deeptutor.api.routers import sessions as sessions_router
+    from deeptutor.learning.models import LearningProgress
+    from deeptutor.learning.storage import LearningStore
+    from deeptutor.services.storage.attachment_store import (
+        get_attachment_store,
+        reset_attachment_store,
+    )
+
+    session_id = "shared-session-id"
+    attachment_id = "upload-1"
+
+    class _SessionStore:
+        async def delete_session(self, candidate: str) -> bool:
+            return candidate == session_id
+
+    monkeypatch.setattr(sessions_router, "get_session_store", lambda: _SessionStore())
+    reset_attachment_store()
+
+    async def _seed(uid: str) -> None:
+        with as_user(uid):
+            LearningStore().save(LearningProgress(book_id=session_id))
+            await get_attachment_store().put(
+                session_id=session_id,
+                attachment_id=attachment_id,
+                filename="notes.txt",
+                data=uid.encode(),
+            )
+
+    async def _artifacts_exist(uid: str) -> tuple[bool, bool]:
+        with as_user(uid):
+            learning_exists = LearningStore().exists(session_id)
+            attachment_exists = (
+                get_attachment_store().resolve_path(
+                    session_id=session_id,
+                    attachment_id=attachment_id,
+                    filename="notes.txt",
+                )
+                is not None
+            )
+            return learning_exists, attachment_exists
+
+    async def _exercise() -> None:
+        await _seed("u_alice")
+        await _seed("u_bob")
+
+        with as_user("u_alice"):
+            response = await sessions_router.delete_session(session_id)
+
+        assert response == {"deleted": True, "session_id": session_id}
+        assert await _artifacts_exist("u_alice") == (False, False)
+        assert await _artifacts_exist("u_bob") == (True, True)
+
+    asyncio.run(_exercise())


### PR DESCRIPTION
### Description
Cascade-delete the session's associated Mastery Path when deleting a session (DELETE /api/v1/sessions/{session_id}).

Background & Problem: When a user selects the mastery_path capability inside a chat session and builds a learning path, the path is stored in LearningStore using the session_id as its identifier ({session_id}.json). However, when deleting the chat session, only the session records and attachments were cleaned up, leaving orphan Mastery Path entries lingering in the Learning Space dashboard.

Solution:

In `deeptutor/api/routers/sessions.py`, added a cleanup call LearningStore().delete(session_id) inside delete_session.
Leveraged the idempotent deletion in LearningStore.delete so sessions without an associated Mastery Path are unaffected without incurring redundant read overhead.

### Related Issues


### Module(s) Affected
- [ ] `agents`
- [x] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
- `LearningStore.delete(session_id)` is idempotent and safe under concurrency lock (_cas_lock), gracefully handling cases where no Mastery Path file exists for the session.
