### PR TITLE
测试：兼容 Codex 推理设置的多行调用

### DIFF
--- a/web/tests/codex-oauth-settings-contract.test.ts
+++ b/web/tests/codex-oauth-settings-contract.test.ts
@@ -85,7 +85,7 @@ test("ordinary users can edit only their owner-scoped Codex reasoning overrides"
   );
   assert.match(
     card,
-    /setCodexReasoningEffort\(model\.model, value \|\| null\)/,
+    /setCodexReasoningEffort\(\s*model\.model,\s*value\s*\|\|\s*null,?\s*\)/,
   );
 });
 


### PR DESCRIPTION
## 变更内容

- 放宽 Codex OAuth reasoning override 源码契约测试中的格式匹配。
- 允许函数调用由 Prettier 排成多行，并允许尾逗号。
- 继续严格校验 `model.model` 与 `value || null` 的参数顺序和语义。

## 原因

生产代码中的 `setCodexReasoningEffort` 调用已被 Prettier 格式化为多行形式，但契约测试只接受无尾逗号的单行文本，导致功能未回归时仍出现假失败。本 PR 只修正测试，不修改 Codex OAuth 生产逻辑。

## 验证

- 修复前：前端 Node 全量测试 412/413，唯一失败为该契约断言
- 修复后：前端 Node 全量测试 413/413
- 目标文件 ESLint：通过
- Prettier、detect-secrets、repository hygiene：通过
