### PR TITLE
fix(security): redact model catalog secrets

### DIFF
--- a/deeptutor/api/routers/settings.py
+++ b/deeptutor/api/routers/settings.py
@@ -28,9 +28,12 @@ from deeptutor.services.codex_auth import (
     reconcile_codex_catalog_update,
 )
 from deeptutor.services.config import (
+    CATALOG_SECRET_MASK,
     get_config_test_runner,
     get_model_catalog_service,
     get_runtime_settings_service,
+    redact_catalog_secrets,
+    restore_catalog_secrets,
 )
 from deeptutor.services.config.origins import normalize_origins
 from deeptutor.services.config.runtime_settings import (
@@ -185,6 +188,7 @@ class FetchModelsPayload(BaseModel):
     binding: str = ""
     base_url: str = ""
     api_key: Optional[str] = None
+    profile_id: Optional[str] = None
 
 
 class NetworkSettingsUpdate(BaseModel):
@@ -597,7 +601,7 @@ async def get_settings():
         return {"ui": load_ui_settings()}
     return {
         "ui": load_ui_settings(),
-        "catalog": get_model_catalog_service().load(),
+        "catalog": redact_catalog_secrets(get_model_catalog_service().load()),
         "providers": _provider_choices(),
     }
 
@@ -693,7 +697,7 @@ async def update_openai_codex_reasoning_effort(
 @router.get("/catalog")
 async def get_catalog():
     _require_settings_admin()
-    return {"catalog": get_model_catalog_service().load()}
+    return {"catalog": redact_catalog_secrets(get_model_catalog_service().load())}
 
 
 @router.get("/network")
@@ -1178,10 +1182,12 @@ async def get_llm_options():
 async def update_catalog(payload: CatalogPayload):
     _require_settings_admin()
     service = get_model_catalog_service()
-    proposed = reconcile_codex_catalog_update(service.load(), payload.catalog)
+    current = service.load()
+    restored = restore_catalog_secrets(payload.catalog, current)
+    proposed = reconcile_codex_catalog_update(current, restored)
     catalog = service.save(proposed)
     _invalidate_runtime_caches()
-    return {"catalog": catalog}
+    return {"catalog": redact_catalog_secrets(catalog)}
 
 
 @router.post("/apply")
@@ -1190,13 +1196,18 @@ async def apply_catalog(payload: CatalogPayload | None = None):
     service = get_model_catalog_service()
     current = service.load()
     catalog = (
-        reconcile_codex_catalog_update(current, payload.catalog) if payload is not None else current
+        reconcile_codex_catalog_update(
+            current,
+            restore_catalog_secrets(payload.catalog, current),
+        )
+        if payload is not None
+        else current
     )
     applied = service.apply(catalog)
     _invalidate_runtime_caches()
     return {
         "message": "Catalog applied to runtime settings.",
-        "catalog": service.load(),
+        "catalog": redact_catalog_secrets(service.load()),
         "runtime": applied,
     }
 
@@ -1220,8 +1231,21 @@ async def fetch_models_from_provider(payload: FetchModelsPayload):
             detail="base_url is required for this provider.",
         )
 
+    api_key = payload.api_key
+    if api_key == CATALOG_SECRET_MASK and payload.profile_id:
+        llm_service = get_model_catalog_service().load().get("services", {}).get("llm", {})
+        profile = next(
+            (
+                item
+                for item in llm_service.get("profiles", [])
+                if item.get("id") == payload.profile_id
+            ),
+            None,
+        )
+        api_key = profile.get("api_key") if profile else None
+
     try:
-        model_ids = await fetch_llm_models(binding, base_url, payload.api_key)
+        model_ids = await fetch_llm_models(binding, base_url, api_key)
     except Exception as exc:  # noqa: BLE001 — surface any provider error as 502
         logger.exception("Failed to fetch models from %s", base_url)
         raise HTTPException(
@@ -1371,7 +1395,11 @@ async def update_enabled_tools(update: EnabledToolsUpdate):
 @router.post("/tests/{service}/start")
 async def start_service_test(service: str, payload: CatalogPayload | None = None):
     _require_settings_admin()
-    run = get_config_test_runner().start(service, payload.catalog if payload else None)
+    catalog = None
+    if payload is not None:
+        current = get_model_catalog_service().load()
+        catalog = restore_catalog_secrets(payload.catalog, current)
+    run = get_config_test_runner().start(service, catalog)
     return {"run_id": run.id}
 
 
@@ -1432,8 +1460,14 @@ class TourCompletePayload(BaseModel):
 @router.post("/tour/complete")
 async def complete_tour(payload: TourCompletePayload | None = None):
     _require_settings_admin()
-    catalog = payload.catalog if payload and payload.catalog else get_model_catalog_service().load()
-    applied = get_model_catalog_service().apply(catalog)
+    service = get_model_catalog_service()
+    current = service.load()
+    catalog = (
+        restore_catalog_secrets(payload.catalog, current)
+        if payload and payload.catalog
+        else current
+    )
+    applied = service.apply(catalog)
     _invalidate_runtime_caches()
     now = int(time.time())
     launch_at = now + 3

--- a/deeptutor/services/config/__init__.py
+++ b/deeptutor/services/config/__init__.py
@@ -18,7 +18,13 @@ from .loader import (
     parse_language,
     resolve_config_path,
 )
-from .model_catalog import ModelCatalogService, get_model_catalog_service
+from .model_catalog import (
+    CATALOG_SECRET_MASK,
+    ModelCatalogService,
+    get_model_catalog_service,
+    redact_catalog_secrets,
+    restore_catalog_secrets,
+)
 from .runtime_settings import (
     HTTP_KEEP_ALIVE_TIMEOUT,
     ChatAttachmentLimits,
@@ -77,6 +83,9 @@ __all__ = [
     "get_kb_config_service",
     "ModelCatalogService",
     "get_model_catalog_service",
+    "CATALOG_SECRET_MASK",
+    "redact_catalog_secrets",
+    "restore_catalog_secrets",
     "ConfigTestRunner",
     "TestRun",
     "get_config_test_runner",

--- a/deeptutor/services/config/model_catalog.py
+++ b/deeptutor/services/config/model_catalog.py
@@ -19,6 +19,94 @@ from .embedding_endpoint import normalize_embedding_endpoint_for_display
 # current user's PathService on every call.
 CATALOG_PATH = get_path_service().get_settings_file("model_catalog")
 
+# A fixed placeholder is returned to settings clients instead of provider
+# credentials. It is also accepted on write as "keep the stored value", so a
+# load/edit/save round trip never sends a real secret to the browser.
+CATALOG_SECRET_MASK = "***"
+_SECRET_FIELD_HINTS = ("api_key", "apikey", "token", "secret", "password")
+
+
+def _is_secret_field(name: str) -> bool:
+    normalized = name.lower()
+    return any(hint in normalized for hint in _SECRET_FIELD_HINTS)
+
+
+def _redact_secret_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return CATALOG_SECRET_MASK if value else value
+    if isinstance(value, dict):
+        return {key: _redact_secret_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_secret_value(item) for item in value]
+    return value
+
+
+def _redact_profile(profile: dict[str, Any]) -> None:
+    for key, value in list(profile.items()):
+        # Header values are credentials often enough that none of them should
+        # cross the API boundary. This also covers JSON-string header maps.
+        if key == "extra_headers" or _is_secret_field(key):
+            profile[key] = _redact_secret_value(value)
+
+
+def redact_catalog_secrets(catalog: dict[str, Any]) -> dict[str, Any]:
+    """Return an API-safe catalog without mutating stored configuration."""
+
+    redacted = deepcopy(catalog)
+    for service in redacted.get("services", {}).values():
+        if not isinstance(service, dict):
+            continue
+        for profile in service.get("profiles", []):
+            if isinstance(profile, dict):
+                _redact_profile(profile)
+    return redacted
+
+
+def _restore_secret_value(proposed: Any, current: Any) -> Any:
+    if proposed == CATALOG_SECRET_MASK:
+        return deepcopy(current)
+    if isinstance(proposed, dict) and isinstance(current, dict):
+        return {
+            key: _restore_secret_value(value, current.get(key)) for key, value in proposed.items()
+        }
+    if isinstance(proposed, list) and isinstance(current, list):
+        return [
+            _restore_secret_value(value, current[index] if index < len(current) else None)
+            for index, value in enumerate(proposed)
+        ]
+    return proposed
+
+
+def _restore_profile_secrets(proposed: dict[str, Any], current: dict[str, Any]) -> None:
+    for key, value in list(proposed.items()):
+        if key == "extra_headers" or _is_secret_field(key):
+            proposed[key] = _restore_secret_value(value, current.get(key))
+
+
+def restore_catalog_secrets(
+    proposed_catalog: dict[str, Any], current_catalog: dict[str, Any]
+) -> dict[str, Any]:
+    """Replace secret placeholders with stored values from the same profile."""
+
+    restored = deepcopy(proposed_catalog)
+    current_services = current_catalog.get("services", {})
+    for service_name, proposed_service in restored.get("services", {}).items():
+        if not isinstance(proposed_service, dict):
+            continue
+        current_service = current_services.get(service_name, {})
+        current_profiles = {
+            profile.get("id"): profile
+            for profile in current_service.get("profiles", [])
+            if isinstance(profile, dict) and profile.get("id")
+        }
+        for profile in proposed_service.get("profiles", []):
+            if not isinstance(profile, dict):
+                continue
+            current_profile = current_profiles.get(profile.get("id"))
+            if current_profile is not None:
+                _restore_profile_secrets(profile, current_profile)
+    return restored
+
 
 def _service_shell() -> dict[str, Any]:
     return {
@@ -249,4 +337,11 @@ def get_model_catalog_service() -> ModelCatalogService:
     return ModelCatalogService.get_instance(get_path_service().get_settings_file("model_catalog"))
 
 
-__all__ = ["CATALOG_PATH", "ModelCatalogService", "get_model_catalog_service"]
+__all__ = [
+    "CATALOG_PATH",
+    "CATALOG_SECRET_MASK",
+    "ModelCatalogService",
+    "get_model_catalog_service",
+    "redact_catalog_secrets",
+    "restore_catalog_secrets",
+]

--- a/deeptutor/services/config/test_runner.py
+++ b/deeptutor/services/config/test_runner.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 
 from .context_window_detection import detect_context_window
 from .embedding_endpoint import redact_embedding_endpoint_for_display
-from .model_catalog import get_model_catalog_service
+from .model_catalog import get_model_catalog_service, redact_catalog_secrets
 from .provider_runtime import (
     resolve_embedding_runtime_config,
     resolve_llm_runtime_config,
@@ -160,7 +160,7 @@ class ConfigTestRunner:
         model["dimension"] = str(actual_dimension)
         saved = service.save(catalog)
         reset_embedding_client()
-        return saved
+        return redact_catalog_secrets(saved)
 
     @staticmethod
     def _capabilities_from_adapter(adapter: Any, model_name: str) -> dict[str, Any]:

--- a/tests/api/test_settings_router.py
+++ b/tests/api/test_settings_router.py
@@ -604,6 +604,31 @@ async def test_get_llm_options_returns_redacted_catalog(monkeypatch: pytest.Monk
     assert "base_url" not in response["options"][0]
 
 
+@pytest.mark.asyncio
+async def test_get_settings_never_returns_catalog_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
+    catalog = _build_catalog(
+        llm_model="gpt-4o-mini",
+        llm_base_url="https://llm.example/v1",
+        llm_api_key="secret-key",
+        embedding_model="text-embedding-3-small",
+        embedding_base_url="https://emb.example/v1/embeddings",
+        embedding_api_key="emb-key",
+    )
+    catalog["services"]["llm"]["profiles"][0]["extra_headers"] = {"Authorization": "Bearer secret"}
+    service = _FakeCatalogService(catalog)
+    monkeypatch.setattr(settings_router, "get_model_catalog_service", lambda: service)
+
+    response = await settings_router.get_settings()
+
+    llm_profile = response["catalog"]["services"]["llm"]["profiles"][0]
+    embedding_profile = response["catalog"]["services"]["embedding"]["profiles"][0]
+    assert llm_profile["api_key"] == settings_router.CATALOG_SECRET_MASK
+    assert llm_profile["extra_headers"]["Authorization"] == settings_router.CATALOG_SECRET_MASK
+    assert embedding_profile["api_key"] == settings_router.CATALOG_SECRET_MASK
+    assert "secret-key" not in json.dumps(response)
+    assert "emb-key" not in json.dumps(response)
+
+
 @pytest.fixture(autouse=True)
 def _reset_runtime_state() -> None:
     llm_config_module.clear_llm_config_cache()
@@ -648,7 +673,8 @@ async def test_update_catalog_invalidates_runtime_caches(monkeypatch: pytest.Mon
     new_llm_client = llm_client_module.get_llm_client()
     new_embedding_client = embedding_client_module.get_embedding_client()
 
-    assert response == {"catalog": updated_catalog}
+    assert response == {"catalog": settings_router.redact_catalog_secrets(updated_catalog)}
+    assert service.load() == updated_catalog
     assert old_llm_config.model == "gpt-old"
     assert new_llm_config.model == "gpt-new"
     assert new_llm_config.base_url == "https://new-llm.example/v1"
@@ -693,13 +719,40 @@ async def test_apply_catalog_invalidates_runtime_caches(monkeypatch: pytest.Monk
     new_llm_client = llm_client_module.get_llm_client()
     new_embedding_client = embedding_client_module.get_embedding_client()
 
-    assert response["catalog"] == applied_catalog
+    assert response["catalog"] == settings_router.redact_catalog_secrets(applied_catalog)
+    assert service.load() == applied_catalog
     assert response["runtime"]["catalog_path"]
     assert new_llm_config.model == "gpt-after-apply"
     assert new_llm_client is not old_llm_client
     assert new_llm_client.config.base_url == "https://after-apply-llm.example/v1"
     assert new_embedding_client is not old_embedding_client
     assert new_embedding_client.config.model == "text-embedding-after-apply"
+
+
+@pytest.mark.asyncio
+async def test_update_catalog_restores_masked_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
+    current = _build_catalog(
+        llm_model="gpt-4o-mini",
+        llm_base_url="https://llm.example/v1",
+        llm_api_key="stored-llm-key",
+        embedding_model="text-embedding-3-small",
+        embedding_base_url="https://emb.example/v1/embeddings",
+        embedding_api_key="stored-embedding-key",
+    )
+    service = _FakeCatalogService(current)
+    monkeypatch.setattr(settings_router, "get_model_catalog_service", lambda: service)
+    monkeypatch.setattr(settings_router, "_invalidate_runtime_caches", lambda: None)
+    draft = settings_router.redact_catalog_secrets(current)
+    draft["services"]["llm"]["profiles"][0]["name"] = "Renamed"
+
+    response = await settings_router.update_catalog(settings_router.CatalogPayload(catalog=draft))
+
+    saved = service.load()
+    assert saved["services"]["llm"]["profiles"][0]["api_key"] == "stored-llm-key"
+    assert saved["services"]["embedding"]["profiles"][0]["api_key"] == ("stored-embedding-key")
+    assert response["catalog"]["services"]["llm"]["profiles"][0]["api_key"] == (
+        settings_router.CATALOG_SECRET_MASK
+    )
 
 
 @pytest.mark.asyncio
@@ -982,6 +1035,45 @@ async def test_fetch_models_returns_picker_options(monkeypatch: pytest.MonkeyPat
             {"id": "gpt-4o-mini", "name": "gpt-4o-mini"},
         ]
     }
+
+
+@pytest.mark.asyncio
+async def test_fetch_models_resolves_masked_key_server_side(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import deeptutor.services.llm.factory as factory_module
+
+    catalog = _build_catalog(
+        llm_model="gpt-4o-mini",
+        llm_base_url="https://llm.example/v1",
+        llm_api_key="stored-secret",
+        embedding_model="text-embedding-3-small",
+        embedding_base_url="https://emb.example/v1/embeddings",
+        embedding_api_key="emb-key",
+    )
+    service = _FakeCatalogService(catalog)
+    monkeypatch.setattr(settings_router, "get_model_catalog_service", lambda: service)
+
+    async def _fake_fetch(binding: str, base_url: str, api_key: str | None = None):
+        assert (binding, base_url, api_key) == (
+            "openai",
+            "https://llm.example/v1",
+            "stored-secret",
+        )
+        return ["gpt-4o-mini"]
+
+    monkeypatch.setattr(factory_module, "fetch_models", _fake_fetch)
+
+    response = await settings_router.fetch_models_from_provider(
+        settings_router.FetchModelsPayload(
+            binding="openai",
+            base_url="https://llm.example/v1",
+            api_key=settings_router.CATALOG_SECRET_MASK,
+            profile_id="llm-profile-default",
+        )
+    )
+
+    assert response == {"models": [{"id": "gpt-4o-mini", "name": "gpt-4o-mini"}]}
 
 
 @pytest.mark.asyncio
@@ -1290,6 +1382,46 @@ def test_get_ui_settings_is_public_without_auth(monkeypatch: pytest.MonkeyPatch,
     payload = response.json()
     assert payload["language"] == "zh"
     assert payload["theme"] == "dark"
+
+
+def test_auth_disabled_settings_endpoint_does_not_expose_provider_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #857: local-admin mode is not a secret-viewing mode."""
+    from fastapi import Depends, FastAPI
+    from fastapi.testclient import TestClient
+
+    from deeptutor.api.routers import auth as auth_router
+
+    catalog = _build_catalog(
+        llm_model="gpt-4o-mini",
+        llm_base_url="https://llm.example/v1",
+        llm_api_key="secret-key",
+        embedding_model="text-embedding-3-small",
+        embedding_base_url="https://emb.example/v1/embeddings",
+        embedding_api_key="emb-key",
+    )
+    monkeypatch.setattr(auth_router, "AUTH_ENABLED", False)
+    monkeypatch.setattr(
+        settings_router,
+        "get_model_catalog_service",
+        lambda: _FakeCatalogService(catalog),
+    )
+
+    app = FastAPI()
+    app.include_router(
+        settings_router.router,
+        prefix="/api/v1/settings",
+        dependencies=[Depends(auth_router.require_auth)],
+    )
+
+    response = TestClient(app).get("/api/v1/settings")
+
+    assert response.status_code == 200
+    serialized = response.text
+    assert "secret-key" not in serialized
+    assert "emb-key" not in serialized
+    assert settings_router.CATALOG_SECRET_MASK in serialized
 
 
 def test_public_ui_read_omits_deployment_configuration(

--- a/tests/services/config/test_model_catalog_secrets.py
+++ b/tests/services/config/test_model_catalog_secrets.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from deeptutor.services.config.model_catalog import (
+    CATALOG_SECRET_MASK,
+    redact_catalog_secrets,
+    restore_catalog_secrets,
+)
+
+
+def _catalog() -> dict:
+    return {
+        "version": 1,
+        "services": {
+            "llm": {
+                "profiles": [
+                    {
+                        "id": "profile-a",
+                        "name": "A",
+                        "api_key": "sk-secret-a",
+                        "extra_headers": {
+                            "Authorization": "Bearer secret",
+                            "X-Tenant": "tenant-secret",
+                        },
+                    },
+                    {
+                        "id": "profile-b",
+                        "name": "B",
+                        "api_key": "sk-secret-b",
+                        "extra_headers": '{"Authorization":"Bearer secret"}',
+                    },
+                ]
+            }
+        },
+    }
+
+
+def test_redact_catalog_secrets_masks_credentials_without_mutating_source() -> None:
+    catalog = _catalog()
+
+    redacted = redact_catalog_secrets(catalog)
+
+    first, second = redacted["services"]["llm"]["profiles"]
+    assert first["api_key"] == CATALOG_SECRET_MASK
+    assert first["extra_headers"] == {
+        "Authorization": CATALOG_SECRET_MASK,
+        "X-Tenant": CATALOG_SECRET_MASK,
+    }
+    assert second["extra_headers"] == CATALOG_SECRET_MASK
+    assert catalog["services"]["llm"]["profiles"][0]["api_key"] == "sk-secret-a"
+
+
+def test_restore_catalog_secrets_matches_profiles_by_id_after_reorder() -> None:
+    current = _catalog()
+    proposed = redact_catalog_secrets(current)
+    proposed["services"]["llm"]["profiles"].reverse()
+    proposed["services"]["llm"]["profiles"][0]["name"] = "Renamed B"
+    proposed["services"]["llm"]["profiles"][1]["api_key"] = "sk-replaced-a"
+
+    restored = restore_catalog_secrets(proposed, current)
+
+    first, second = restored["services"]["llm"]["profiles"]
+    assert first["id"] == "profile-b"
+    assert first["api_key"] == "sk-secret-b"
+    assert first["extra_headers"] == '{"Authorization":"Bearer secret"}'
+    assert first["name"] == "Renamed B"
+    assert second["api_key"] == "sk-replaced-a"
+    assert second["extra_headers"]["Authorization"] == "Bearer secret"
+
+
+def test_restore_catalog_secrets_keeps_explicit_clear() -> None:
+    current = _catalog()
+    proposed = redact_catalog_secrets(current)
+    proposed["services"]["llm"]["profiles"][0]["api_key"] = ""
+
+    restored = restore_catalog_secrets(proposed, current)
+
+    assert restored["services"]["llm"]["profiles"][0]["api_key"] == ""

--- a/web/components/settings/ServiceConfigEditor.tsx
+++ b/web/components/settings/ServiceConfigEditor.tsx
@@ -195,6 +195,7 @@ export function ServiceConfigEditor({ service }: { service: ServiceName }) {
           binding,
           base_url: baseUrl,
           api_key: apiKey || null,
+          profile_id: profileId,
         }),
       });
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- redact provider API keys and extra headers in every catalog-bearing settings response
- restore masked secrets server-side for save, apply, diagnostics, tour completion, and model discovery
- cover auth-disabled access and safe load/edit/save round trips

## Verification
- `pytest -q tests/services/config/test_model_catalog_secrets.py tests/api/test_settings_router.py tests/services/config/test_test_runner_dim_autofill.py` (68 passed)
- `ruff check ...`
- `npx tsc --noEmit`

Fixes #857