### PR TITLE
fix: isolate Partner sessions and memory per user

### DIFF
--- a/deeptutor/api/routers/plugins_api.py
+++ b/deeptutor/api/routers/plugins_api.py
@@ -300,11 +300,13 @@ async def _execute_capability_stream(
             _ensure_running_partner,
             _partner_chat_stream,
         )
+        from deeptutor.multi_user.partner_access import assert_partner_allowed
 
         if not body.content.strip():
             yield _sse("error", {"detail": "content is required"})
             return
         try:
+            assert_partner_allowed(partner_id)
             await _ensure_running_partner(partner_id)
         except HTTPException as exc:
             yield _sse("error", {"detail": exc.detail, "status_code": exc.status_code})

--- a/deeptutor/partners/bus/events.py
+++ b/deeptutor/partners/bus/events.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
+from deeptutor.multi_user.models import CurrentUser
+
 
 @dataclass
 class InboundMessage:
@@ -17,6 +19,9 @@ class InboundMessage:
     media: list[str] = field(default_factory=list)  # Media URLs
     metadata: dict[str, Any] = field(default_factory=dict)  # Channel-specific data
     session_key_override: str | None = None  # Optional override for thread-scoped sessions
+    # Authenticated human who initiated an in-app turn. Channel messages leave
+    # this unset and retain the legacy Partner-owned data scope.
+    actor: CurrentUser | None = field(default=None, repr=False)
 
     @property
     def session_key(self) -> str:

--- a/deeptutor/partners/channels/base.py
+++ b/deeptutor/partners/channels/base.py
@@ -31,6 +31,7 @@ class BaseChannel(ABC):
     # them from the channel's own config at init time.
     send_progress: bool = True
     send_tool_hints: bool = True
+    partner_id: str = ""
 
     def __init__(self, config: Any, bus: MessageBus):
         """
@@ -43,6 +44,16 @@ class BaseChannel(ABC):
         self.config = config
         self.bus = bus
         self._running = False
+
+    def media_dir(self, channel: str | None = None) -> Path:
+        """Download directory isolated to this channel's owning Partner."""
+        from deeptutor.partners.config.paths import get_media_dir, get_partner_media_dir
+
+        if self.partner_id:
+            return get_partner_media_dir(self.partner_id, channel or self.name)
+        # Plugin/tests may construct a channel outside PartnerManager. Preserve
+        # the legacy location in that standalone case.
+        return get_media_dir(channel or self.name)
 
     async def transcribe_audio(self, file_path: str | Path) -> str:
         """Transcribe an audio file via Groq Whisper. Returns empty string on failure."""

--- a/deeptutor/partners/channels/discord.py
+++ b/deeptutor/partners/channels/discord.py
@@ -15,7 +15,6 @@ import websockets
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_media_dir
 from deeptutor.partners.config.schema import DeliveryOverrides, StreamingSupport
 from deeptutor.partners.helpers import split_message
 
@@ -415,7 +414,7 @@ class DiscordChannel(BaseChannel):
 
         content_parts = [content] if content else []
         media_paths: list[str] = []
-        media_dir = get_media_dir("discord")
+        media_dir = self.media_dir()
 
         for attachment in payload.get("attachments") or []:
             url = attachment.get("url")

--- a/deeptutor/partners/channels/feishu.py
+++ b/deeptutor/partners/channels/feishu.py
@@ -18,7 +18,6 @@ from pydantic import Field
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_media_dir
 from deeptutor.partners.config.schema import DeliveryOverrides, StreamingSupport
 from deeptutor.partners.helpers import split_markdown_table_row
 
@@ -852,7 +851,7 @@ class FeishuChannel(BaseChannel):
             (file_path, content_text) - file_path is None if download failed
         """
         loop = asyncio.get_running_loop()
-        media_dir = get_media_dir("feishu")
+        media_dir = self.media_dir()
 
         data, filename = None, None
 

--- a/deeptutor/partners/channels/manager.py
+++ b/deeptutor/partners/channels/manager.py
@@ -44,10 +44,12 @@ class ChannelManager:
         channels_config: ChannelsConfig,
         bus: MessageBus,
         groq_api_key: str = "",
+        partner_id: str = "",
     ):
         self.channels_config = channels_config
         self.bus = bus
         self._groq_api_key = groq_api_key
+        self._partner_id = str(partner_id or "")
         self.channels: dict[str, BaseChannel] = {}
         self._dispatch_task: asyncio.Task | None = None
         self._origin_reply_fingerprints: dict[tuple[str, str, str], str] = {}
@@ -71,6 +73,7 @@ class ChannelManager:
                 continue
             try:
                 channel = cls(section, self.bus)
+                channel.partner_id = self._partner_id
                 channel.transcription_api_key = self._groq_api_key
                 # Effective delivery flags are per-channel only. Historical
                 # top-level channel config keys are ignored at runtime.

--- a/deeptutor/partners/channels/matrix.py
+++ b/deeptutor/partners/channels/matrix.py
@@ -47,7 +47,7 @@ else:
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_data_dir, get_media_dir
+from deeptutor.partners.config.paths import get_data_dir
 from deeptutor.partners.config.schema import DeliveryOverrides
 from deeptutor.partners.helpers import safe_filename
 
@@ -603,7 +603,7 @@ class MatrixChannel(BaseChannel):
         return False
 
     def _media_dir(self) -> Path:
-        return get_media_dir("matrix")
+        return self.media_dir()
 
     @staticmethod
     def _event_source_content(event: RoomMessage) -> dict[str, Any]:

--- a/deeptutor/partners/channels/mattermost.py
+++ b/deeptutor/partners/channels/mattermost.py
@@ -29,7 +29,6 @@ import websockets
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_media_dir
 from deeptutor.partners.config.schema import DeliveryOverrides
 from deeptutor.partners.helpers import split_message
 
@@ -323,7 +322,7 @@ class MattermostChannel(BaseChannel):
         file_ids = post.get("file_ids") or []
         if not file_ids or not self._http:
             return []
-        media_dir = get_media_dir("mattermost")
+        media_dir = self.media_dir()
         paths: list[str] = []
         for file_id in file_ids:
             local = await self._download_file(str(file_id), media_dir)

--- a/deeptutor/partners/channels/napcat.py
+++ b/deeptutor/partners/channels/napcat.py
@@ -27,7 +27,6 @@ from websockets.asyncio.client import connect as ws_connect
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_media_dir
 from deeptutor.partners.config.schema import DeliveryOverrides
 from deeptutor.partners.helpers import safe_filename
 from deeptutor.partners.network import validate_url_target
@@ -573,7 +572,7 @@ class NapcatChannel(BaseChannel):
             name = f"{int(time.time() * 1000)}.jpg"
         # Resolved lazily (not in __init__) so constructing the channel never
         # touches the partners data tree.
-        path = get_media_dir("napcat") / name
+        path = self.media_dir() / name
         try:
             await asyncio.to_thread(path.write_bytes, data)
         except OSError as e:

--- a/deeptutor/partners/channels/telegram.py
+++ b/deeptutor/partners/channels/telegram.py
@@ -19,7 +19,6 @@ from telegram.request import HTTPXRequest
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_media_dir
 from deeptutor.partners.config.schema import DeliveryOverrides, StreamingSupport
 from deeptutor.partners.helpers import (
     is_markdown_table_separator_row,
@@ -801,7 +800,7 @@ class TelegramChannel(BaseChannel):
                 getattr(media_file, "mime_type", None),
                 getattr(media_file, "file_name", None),
             )
-            media_dir = get_media_dir("telegram")
+            media_dir = self.media_dir()
             unique_id = getattr(media_file, "file_unique_id", media_file.file_id)
             file_path = media_dir / f"{unique_id}{ext}"
             await file.download_to_drive(str(file_path))

--- a/deeptutor/partners/channels/wecom.py
+++ b/deeptutor/partners/channels/wecom.py
@@ -12,7 +12,6 @@ from pydantic import Field
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_media_dir
 from deeptutor.partners.config.schema import DeliveryOverrides
 
 WECOM_AVAILABLE = importlib.util.find_spec("wecom_aibot_sdk") is not None
@@ -331,7 +330,7 @@ class WecomChannel(BaseChannel):
                 logger.warning("Failed to download media from WeCom")
                 return None
 
-            media_dir = get_media_dir("wecom")
+            media_dir = self.media_dir()
             if not filename:
                 filename = fname or f"{media_type}_{hash(file_url) % 100000}"
             filename = os.path.basename(filename)

--- a/deeptutor/partners/channels/weixin.py
+++ b/deeptutor/partners/channels/weixin.py
@@ -31,7 +31,7 @@ from pydantic import Field
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_media_dir, get_runtime_subdir
+from deeptutor.partners.config.paths import get_runtime_subdir
 from deeptutor.partners.config.schema import DeliveryOverrides
 from deeptutor.partners.helpers import safe_filename, split_message
 
@@ -881,7 +881,7 @@ class WeixinChannel(BaseChannel):
             if not data:
                 return None
 
-            media_dir = get_media_dir("weixin")
+            media_dir = self.media_dir()
             ext = _ext_for_type(media_type)
             if not filename:
                 ts = int(time.time())

--- a/deeptutor/partners/channels/zulip.py
+++ b/deeptutor/partners/channels/zulip.py
@@ -19,7 +19,6 @@ import requests
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
 from deeptutor.partners.channels.base import BaseChannel
-from deeptutor.partners.config.paths import get_media_dir
 from deeptutor.partners.config.schema import DeliveryOverrides
 from deeptutor.partners.helpers import split_message
 
@@ -550,7 +549,7 @@ class ZulipChannel(BaseChannel):
         if not upload_links:
             return paths
 
-        media_dir = get_media_dir("zulip")
+        media_dir = self.media_dir()
 
         for name, path_id in upload_links:
             local_path = self._download_upload_path(
@@ -635,7 +634,7 @@ class ZulipChannel(BaseChannel):
         name: str | None = None,
         index: int = 0,
     ) -> str | None:
-        media_dir = media_dir or get_media_dir("zulip")
+        media_dir = media_dir or self.media_dir()
         filename = name or Path(unquote(path_id)).name
         dest = self._attachment_destination(media_dir, filename, path_id, index)
 

--- a/deeptutor/partners/config/paths.py
+++ b/deeptutor/partners/config/paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 from deeptutor.partners.helpers import ensure_dir
 
@@ -51,3 +52,29 @@ def get_partner_sessions_dir(partner_id: str) -> Path:
 def get_partner_media_dir(partner_id: str, channel: str | None = None) -> Path:
     base = ensure_dir(get_partner_dir(partner_id) / "media")
     return ensure_dir(base / channel) if channel else base
+
+
+_ACCOUNT_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+def _account_segment(user_id: str) -> str:
+    """Return a filesystem-safe account id, failing closed on invalid input."""
+    value = str(user_id or "").strip()
+    if not _ACCOUNT_ID_RE.fullmatch(value):
+        raise ValueError("Invalid user id for partner data scope")
+    return value
+
+
+def get_partner_user_dir(partner_id: str, user_id: str) -> Path:
+    """Private relationship state for one user interacting with a partner."""
+    return ensure_dir(get_partner_dir(partner_id) / "users" / _account_segment(user_id))
+
+
+def get_partner_user_workspace(partner_id: str, user_id: str) -> Path:
+    """Per-user partner workspace used for relationship memory."""
+    return ensure_dir(get_partner_user_dir(partner_id, user_id) / "workspace")
+
+
+def get_partner_user_sessions_dir(partner_id: str, user_id: str) -> Path:
+    """Per-user conversation history for an assigned partner."""
+    return ensure_dir(get_partner_user_dir(partner_id, user_id) / "sessions")

--- a/deeptutor/services/memory/snapshot/adapters.py
+++ b/deeptutor/services/memory/snapshot/adapters.py
@@ -303,27 +303,40 @@ def read_partner_entities() -> list[Entity]:
     bridges that store into the memory pipeline so partner conversations
     consolidate into L2/L3 like every other surface.
 
-    Partners are anchored to the admin workspace, so we only surface them
-    when the active scope IS the admin's own memory; a regular user's memory
-    view must not see the admin's partner conversations.
+    Admins see the legacy process-wide Partner sessions. Regular users see only
+    their own per-user sessions for Partners that are still assigned to them;
+    neither side scans another user's relationship-state directory.
     """
+    from deeptutor.multi_user.context import get_current_user
+    from deeptutor.multi_user.partner_access import assigned_partner_ids
     from deeptutor.multi_user.paths import get_admin_path_service
 
+    user = get_current_user()
     admin_root = get_admin_path_service().workspace_root.resolve()
-    if get_path_service().workspace_root.resolve() != admin_root:
+    # Read-only adapters are also called directly in maintenance/tests where no
+    # CurrentUser ContextVar is installed. Preserve the older path-scope guard
+    # instead of treating a non-admin workspace as the implicit local admin.
+    if user.is_admin and get_path_service().workspace_root.resolve() != admin_root:
         return []
     partners_root = admin_root / "partners"
     if not partners_root.exists():
         return []
 
+    allowed = None if user.is_admin else assigned_partner_ids(user.id)
     out: list[Entity] = []
     for partner_dir in sorted(partners_root.iterdir()):
         if not partner_dir.is_dir():
             continue
-        sessions_dir = partner_dir / "sessions"
+        partner_id = partner_dir.name
+        if allowed is not None and partner_id not in allowed:
+            continue
+        sessions_dir = (
+            partner_dir / "sessions"
+            if user.is_admin
+            else partner_dir / "users" / user.id / "sessions"
+        )
         if not sessions_dir.is_dir():
             continue
-        partner_id = partner_dir.name
         partner_name = _partner_display_name(partner_dir, partner_id)
         for sess_file in sorted(sessions_dir.glob("*.jsonl")):
             entity = _partner_session_entity(sess_file, partner_id, partner_name)

--- a/deeptutor/services/partners/interaction.py
+++ b/deeptutor/services/partners/interaction.py
@@ -1,0 +1,105 @@
+"""Request-local ownership for a human's interaction with a Partner.
+
+Partner configuration and knowledge assets are shared, admin-managed resources.
+Conversation history and learned preferences are relationship state, however,
+and must follow the authenticated human rather than the process-wide Partner.
+This module keeps that distinction in one place and exposes it to Partner-only
+tools through a ContextVar that is safe across concurrent async turns.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from typing import Iterator
+
+from deeptutor.multi_user.models import CurrentUser
+from deeptutor.multi_user.paths import (
+    ensure_scope_workspace,
+    get_admin_path_service,
+    get_path_service_for_scope,
+)
+from deeptutor.partners.config.paths import get_partner_user_workspace
+from deeptutor.services.path_service import PathService
+
+from .scope import is_partner_user_id
+from .sessions import PartnerSessionStore
+
+
+def personal_actor_id(actor: CurrentUser | None) -> str | None:
+    """Account id requiring private Partner state, or ``None`` for legacy scope."""
+    if actor is None or actor.is_admin or is_partner_user_id(actor.id):
+        return None
+    return actor.id
+
+
+@dataclass(frozen=True, slots=True)
+class PartnerTurnContext:
+    partner_id: str
+    actor: CurrentUser | None
+    store: PartnerSessionStore
+    own_memory: PathService
+    shared_memory: PathService
+
+    @property
+    def actor_id(self) -> str | None:
+        return personal_actor_id(self.actor)
+
+
+_current_turn: ContextVar[PartnerTurnContext | None] = ContextVar(
+    "deeptutor_partner_turn", default=None
+)
+
+
+def build_partner_turn_context(
+    partner_id: str,
+    actor: CurrentUser | None,
+    store: PartnerSessionStore,
+    *,
+    legacy_own_memory: PathService,
+) -> PartnerTurnContext:
+    actor_id = personal_actor_id(actor)
+    if actor_id is None:
+        return PartnerTurnContext(
+            partner_id=partner_id,
+            actor=actor,
+            store=store,
+            own_memory=legacy_own_memory,
+            shared_memory=get_admin_path_service(),
+        )
+
+    assert actor is not None
+    ensure_scope_workspace(actor.scope)
+    private_workspace = get_partner_user_workspace(partner_id, actor_id)
+    private_memory = private_workspace / "memory"
+    private_memory.mkdir(parents=True, exist_ok=True)
+    return PartnerTurnContext(
+        partner_id=partner_id,
+        actor=actor,
+        store=store,
+        own_memory=PathService(workspace_root=private_workspace),
+        shared_memory=get_path_service_for_scope(actor.scope),
+    )
+
+
+def get_partner_turn_context() -> PartnerTurnContext | None:
+    return _current_turn.get()
+
+
+@contextmanager
+def partner_turn_context(context: PartnerTurnContext) -> Iterator[None]:
+    token: Token[PartnerTurnContext | None] = _current_turn.set(context)
+    try:
+        yield
+    finally:
+        _current_turn.reset(token)
+
+
+__all__ = [
+    "PartnerTurnContext",
+    "build_partner_turn_context",
+    "get_partner_turn_context",
+    "partner_turn_context",
+    "personal_actor_id",
+]

--- a/deeptutor/services/partners/manager.py
+++ b/deeptutor/services/partners/manager.py
@@ -615,7 +615,7 @@ class PartnerManager:
         from deeptutor.partners.config.schema import ChannelsConfig
 
         channels_config = ChannelsConfig(**config.channels)
-        manager = ChannelManager(channels_config, bus)
+        manager = ChannelManager(channels_config, bus, partner_id=partner_id)
         if not manager.channels:
             logger.info("No channels matched config for partner '%s'", partner_id)
             return None
@@ -812,6 +812,7 @@ class PartnerManager:
         if not instance or not instance.running or not instance.runner:
             raise RuntimeError(f"Partner '{partner_id}' is not running")
 
+        from deeptutor.multi_user.context import get_current_user_or_none
         from deeptutor.partners.bus.events import InboundMessage
 
         resolved_key = (
@@ -826,6 +827,7 @@ class PartnerManager:
             content=content,
             media=media or [],
             session_key_override=resolved_key,
+            actor=get_current_user_or_none(),
         )
         return await instance.runner.process_message(msg, on_event=on_event)
 

--- a/deeptutor/services/partners/runtime.py
+++ b/deeptutor/services/partners/runtime.py
@@ -32,11 +32,17 @@ import uuid
 
 from deeptutor.core.context import Attachment, UnifiedContext
 from deeptutor.core.stream import StreamEvent, StreamEventType
-from deeptutor.multi_user.paths import user_context
+from deeptutor.multi_user.paths import get_current_path_service, user_context
 from deeptutor.partners.bus.events import InboundMessage, OutboundMessage
 from deeptutor.partners.bus.queue import MessageBus
+from deeptutor.partners.config.paths import get_partner_user_sessions_dir
 from deeptutor.partners.helpers import detect_image_mime
 from deeptutor.services.partners.commands import PartnerCommandHandler
+from deeptutor.services.partners.interaction import (
+    build_partner_turn_context,
+    partner_turn_context,
+    personal_actor_id,
+)
 from deeptutor.services.partners.scope import partner_user
 from deeptutor.services.partners.sessions import PartnerSessionStore
 from deeptutor.services.partners.workspace import ensure_partner_workspace, read_soul
@@ -86,6 +92,7 @@ class PartnerRunner:
         self.store = store
         self.save_config = save_config
         self._session_locks: dict[str, asyncio.Lock] = {}
+        self._personal_stores: dict[str, PartnerSessionStore] = {}
         self._tasks: set[asyncio.Task] = set()
 
     # ── inbound loop ──────────────────────────────────────────────
@@ -127,11 +134,22 @@ class PartnerRunner:
 
     # ── one turn ──────────────────────────────────────────────────
 
-    def _lock_for(self, session_key: str) -> asyncio.Lock:
-        lock = self._session_locks.get(session_key)
+    def _store_for(self, msg: InboundMessage) -> PartnerSessionStore:
+        actor_id = personal_actor_id(msg.actor)
+        if actor_id is None:
+            return self.store
+        store = self._personal_stores.get(actor_id)
+        if store is None:
+            store = PartnerSessionStore(get_partner_user_sessions_dir(self.partner_id, actor_id))
+            self._personal_stores[actor_id] = store
+        return store
+
+    def _lock_for(self, session_key: str, *, actor_id: str | None) -> asyncio.Lock:
+        lock_key = f"{actor_id or 'legacy'}:{session_key}"
+        lock = self._session_locks.get(lock_key)
         if lock is None:
             lock = asyncio.Lock()
-            self._session_locks[session_key] = lock
+            self._session_locks[lock_key] = lock
         return lock
 
     async def process_message(
@@ -148,20 +166,24 @@ class PartnerRunner:
         when the reply was already delivered live via stream deltas).
         """
         session_key = msg.session_key
-        async with self._lock_for(session_key):
+        store = self._store_for(msg)
+        async with self._lock_for(session_key, actor_id=personal_actor_id(msg.actor)):
             command = PartnerCommandHandler(
                 partner_id=self.partner_id,
                 config=self.config,
-                store=self.store,
+                store=store,
                 save_config=self.save_config,
             ).dispatch(msg)
             if command is not None:
                 return command.content
 
             final, turn_events = await self._run_turn(
-                msg, on_event=on_event, delivery_meta=delivery_meta
+                msg,
+                store=store,
+                on_event=on_event,
+                delivery_meta=delivery_meta,
             )
-            self.store.append(
+            store.append(
                 session_key,
                 "user",
                 msg.content,
@@ -170,7 +192,7 @@ class PartnerRunner:
                 attachments=list((msg.metadata or {}).get("_attachment_records") or []),
             )
             if final:
-                self.store.append(
+                store.append(
                     session_key,
                     "assistant",
                     final,
@@ -183,6 +205,7 @@ class PartnerRunner:
         self,
         msg: InboundMessage,
         *,
+        store: PartnerSessionStore,
         on_event: EventCallback | None = None,
         delivery_meta: dict[str, Any] | None = None,
     ) -> tuple[str, list[dict[str, Any]]]:
@@ -191,7 +214,11 @@ class PartnerRunner:
         backup = getattr(self.config, "backup_llm_selection", None) or None
 
         final_text, errors, events = await self._execute_turn(
-            msg, selection=primary, on_event=on_event, delivery_meta=delivery_meta
+            msg,
+            store=store,
+            selection=primary,
+            on_event=on_event,
+            delivery_meta=delivery_meta,
         )
         if not final_text and errors and backup and backup != primary:
             logger.warning(
@@ -202,7 +229,11 @@ class PartnerRunner:
             if delivery_meta is not None:
                 delivery_meta.pop("_streamed", None)
             final_text, errors, events = await self._execute_turn(
-                msg, selection=backup, on_event=on_event, delivery_meta=delivery_meta
+                msg,
+                store=store,
+                selection=backup,
+                on_event=on_event,
+                delivery_meta=delivery_meta,
             )
 
         if not final_text and errors:
@@ -213,6 +244,7 @@ class PartnerRunner:
         self,
         msg: InboundMessage,
         *,
+        store: PartnerSessionStore,
         selection: dict[str, str] | None,
         on_event: EventCallback | None = None,
         delivery_meta: dict[str, Any] | None = None,
@@ -267,7 +299,7 @@ class PartnerRunner:
         # rides the same async context into the orchestrator task.
         llm_token = None
         try:
-            context = self._build_context(msg)
+            context = self._build_context(msg, store=store)
             turn_id = str(context.metadata.get("turn_id") or "")
             send_progress = self._channel_delivery_flag(msg.channel, "send_progress", default=True)
             send_tool_hints = self._channel_delivery_flag(
@@ -279,70 +311,78 @@ class PartnerRunner:
             wants_stream = is_im and send_progress and bool(msg.metadata.get("_wants_stream"))
 
             _config, llm_token = activate_llm_selection(selection)
-            # Everything — rag / skills / notebooks AND memory — resolves to the
-            # partner's own synthetic workspace. The partner-only memory tools
-            # (partner_read / partner_memorize / partner_search, force-mounted by
-            # the pipeline) own the split-memory model: partner_read folds in the
-            # owner's shared L3 on top of the partner's own, partner_memorize
-            # writes only the partner's own. Chat's read_memory / write_memory
-            # are suppressed on partner turns, so no admin memory override is
-            # needed here (and the partner can never write the owner's memory).
+            # RAG / skills / notebooks resolve to the Partner's shared synthetic
+            # workspace. Partner-only memory tools additionally read the turn
+            # context below: assigned users get a private relationship-memory
+            # directory and their own L3 as read-only shared context; admin and
+            # IM turns retain the legacy Partner/admin paths. Product-chat
+            # read_memory / write_memory remain suppressed on Partner turns.
             with user_context(partner_user(self.partner_id, name=self.config.name)):
-                orchestrator = ChatOrchestrator()
-                async for event in orchestrator.handle(context):
-                    if on_event is not None:
-                        await on_event(event)
-                    meta = event.metadata or {}
+                turn_context = build_partner_turn_context(
+                    self.partner_id,
+                    msg.actor,
+                    store,
+                    legacy_own_memory=get_current_path_service(),
+                )
+                with partner_turn_context(turn_context):
+                    orchestrator = ChatOrchestrator()
+                    event_stream = orchestrator.handle(context)
+                    async for event in event_stream:
+                        if on_event is not None:
+                            await on_event(event)
+                        meta = event.metadata or {}
 
-                    # Capture the trace for rehydration — mirror product chat's
-                    # persisted ``assistant_events`` (everything but done/session).
-                    if event.type not in (StreamEventType.DONE, StreamEventType.SESSION):
-                        turn_events.append(event.to_dict())
+                        # Capture the trace for rehydration — mirror product chat's
+                        # persisted ``assistant_events`` (everything but done/session).
+                        if event.type not in (StreamEventType.DONE, StreamEventType.SESSION):
+                            turn_events.append(event.to_dict())
 
-                    if event.type == StreamEventType.CONTENT:
-                        call_id = str(meta.get("call_id") or "")
-                        round_buffers.setdefault(call_id, []).append(event.content or "")
-                        if meta.get("call_kind") == "llm_final_response":
-                            terminator_text += event.content or ""
-                        if wants_stream and event.content:
-                            streamed_rounds[call_id] = (
-                                streamed_rounds.get(call_id, "") + event.content
-                            )
-                            await self._publish_stream_delta(msg, turn_id, call_id, event.content)
-
-                    elif event.type == StreamEventType.TOOL_CALL:
-                        if is_im and send_tool_hints and event.content:
-                            hint = _format_tool_hint(event.content, meta.get("args"))
-                            await self._publish_hint(msg, hint, tool_hint=True)
-
-                    elif event.type == StreamEventType.PROGRESS:
-                        if (
-                            meta.get("trace_kind") == "call_status"
-                            and meta.get("call_state") == "complete"
-                            and meta.get("call_role") == "narration"
-                        ):
+                        if event.type == StreamEventType.CONTENT:
                             call_id = str(meta.get("call_id") or "")
-                            raw_text = "".join(round_buffers.pop(call_id, []))
-                            text = raw_text.strip()
-                            if meta.get("answer_visible") is True:
-                                if raw_text:
-                                    answer_visible_parts.append(raw_text)
+                            round_buffers.setdefault(call_id, []).append(event.content or "")
+                            if meta.get("call_kind") == "llm_final_response":
+                                terminator_text += event.content or ""
+                            if wants_stream and event.content:
+                                streamed_rounds[call_id] = (
+                                    streamed_rounds.get(call_id, "") + event.content
+                                )
+                                await self._publish_stream_delta(
+                                    msg, turn_id, call_id, event.content
+                                )
+
+                        elif event.type == StreamEventType.TOOL_CALL:
+                            if is_im and send_tool_hints and event.content:
+                                hint = _format_tool_hint(event.content, meta.get("args"))
+                                await self._publish_hint(msg, hint, tool_hint=True)
+
+                        elif event.type == StreamEventType.PROGRESS:
+                            if (
+                                meta.get("trace_kind") == "call_status"
+                                and meta.get("call_state") == "complete"
+                                and meta.get("call_role") == "narration"
+                            ):
+                                call_id = str(meta.get("call_id") or "")
+                                raw_text = "".join(round_buffers.pop(call_id, []))
+                                text = raw_text.strip()
+                                if meta.get("answer_visible") is True:
+                                    if raw_text:
+                                        answer_visible_parts.append(raw_text)
+                                    if call_id in streamed_rounds:
+                                        ended_rounds.add(call_id)
+                                        await self._publish_stream_end(msg, turn_id, call_id)
+                                    continue
                                 if call_id in streamed_rounds:
+                                    # Already streamed live — freeze the segment.
                                     ended_rounds.add(call_id)
                                     await self._publish_stream_end(msg, turn_id, call_id)
-                                continue
-                            if call_id in streamed_rounds:
-                                # Already streamed live — freeze the segment.
-                                ended_rounds.add(call_id)
-                                await self._publish_stream_end(msg, turn_id, call_id)
-                            elif is_im and send_progress and text:
-                                await self._publish_hint(msg, text, tool_hint=False)
+                                elif is_im and send_progress and text:
+                                    await self._publish_hint(msg, text, tool_hint=False)
 
-                    elif event.type == StreamEventType.RESULT and event.source == "chat":
-                        final_text = str(meta.get("response") or "")
+                        elif event.type == StreamEventType.RESULT and event.source == "chat":
+                            final_text = str(meta.get("response") or "")
 
-                    elif event.type == StreamEventType.ERROR and event.content:
-                        errors.append(event.content)
+                        elif event.type == StreamEventType.ERROR and event.content:
+                            errors.append(event.content)
         except Exception as exc:
             logger.exception("Partner %s turn crashed", self.partner_id)
             errors.append(f"{type(exc).__name__}: {exc}")
@@ -388,13 +428,19 @@ class PartnerRunner:
 
     # ── context assembly ──────────────────────────────────────────
 
-    def _build_context(self, msg: InboundMessage) -> UnifiedContext:
+    def _build_context(
+        self,
+        msg: InboundMessage,
+        *,
+        store: PartnerSessionStore,
+    ) -> UnifiedContext:
         session_key = msg.session_key
         turn_id = f"partner-{self.partner_id}-{uuid.uuid4().hex[:12]}"
-        history = self.store.conversation_history(session_key)
+        history = store.conversation_history(session_key)
         attachments, attachment_records = self._attachments_from_media(msg.media)
         source_manifest, source_index = self._source_manifest_from_records(
             session_key,
+            store=store,
             fresh_records=attachment_records,
         )
         msg.metadata["_attachment_records"] = attachment_records
@@ -642,6 +688,7 @@ class PartnerRunner:
         self,
         session_key: str,
         *,
+        store: PartnerSessionStore,
         fresh_records: list[dict[str, Any]],
     ) -> tuple[str, dict[str, str]]:
         try:
@@ -656,7 +703,7 @@ class PartnerRunner:
 
         inv = SourceInventory()
         turn_ordinal = 1
-        historical_messages = self.store.messages(session_key, limit=200)
+        historical_messages = store.messages(session_key, limit=200)
         for message in historical_messages:
             if message.get("role") == "user":
                 turn_ordinal += 1

--- a/deeptutor/services/subagent/partner.py
+++ b/deeptutor/services/subagent/partner.py
@@ -82,6 +82,16 @@ class PartnerBackend(SubagentBackend):
         if not pid:
             return ConsultResult(success=False, error="No partner is bound to this connection.")
 
+        # Re-check on every consult: a connection may outlive the grant that
+        # created it, and stale metadata must never remain an authorization path.
+        from deeptutor.multi_user.partner_access import assert_partner_allowed
+
+        try:
+            assert_partner_allowed(pid)
+        except Exception as exc:
+            detail = getattr(exc, "detail", None) or str(exc)
+            return ConsultResult(success=False, error=str(detail))
+
         from deeptutor.services.partners import get_partner_manager
 
         manager = get_partner_manager()

--- a/deeptutor/tools/partner_memory.py
+++ b/deeptutor/tools/partner_memory.py
@@ -2,12 +2,11 @@
 
 A partner has a *split* memory model that the product chat does not:
 
-* its OWN long-term memory lives in the partner's synthetic workspace
-  (``data/partners/<id>/workspace/memory``) and is the only thing
-  ``partner_memorize`` ever writes to — a partner can never mutate the
-  owner's memory;
-* the OWNER's shared memory (the admin L3) is read-only context the
-  partner inherits, so ``partner_read`` returns *both* layers concatenated.
+* relationship memory for an assigned user lives below
+  ``data/partners/<id>/users/<uid>/workspace/memory``; admin and IM turns keep
+  the legacy Partner workspace for backward compatibility;
+* the authenticated human's L3 is read-only context. Admin and IM turns retain
+  the legacy admin L3. ``partner_read`` returns both layers concatenated.
 
 These three tools replace the product chat's ``read_memory`` / ``write_memory``
 for partners (which are suppressed on partner turns) and add a keyword search
@@ -102,15 +101,16 @@ class PartnerReadTool(BaseTool):
         )
 
     async def execute(self, **kwargs: Any) -> ToolResult:
-        from deeptutor.multi_user.paths import (
-            get_admin_path_service,
-            get_current_path_service,
-        )
+        from deeptutor.multi_user.paths import get_admin_path_service, get_current_path_service
         from deeptutor.services.memory import memory_path_service_override
+        from deeptutor.services.partners.interaction import get_partner_turn_context
 
-        with memory_path_service_override(get_admin_path_service()):
+        turn = get_partner_turn_context()
+        shared_service = turn.shared_memory if turn else get_admin_path_service()
+        own_service = turn.own_memory if turn else get_current_path_service()
+        with memory_path_service_override(shared_service):
             shared = _concat_l3()
-        with memory_path_service_override(get_current_path_service()):
+        with memory_path_service_override(own_service):
             own = _concat_l3()
 
         sections = [
@@ -171,6 +171,7 @@ class PartnerMemorizeTool(BaseTool):
         from deeptutor.multi_user.paths import get_current_path_service
         from deeptutor.services.memory import get_memory_store, memory_path_service_override
         from deeptutor.services.memory.trace import TraceEvent
+        from deeptutor.services.partners.interaction import get_partner_turn_context
 
         op = str(kwargs.get("op") or "").strip().lower()
         text = str(kwargs.get("text") or "").strip()
@@ -187,9 +188,11 @@ class PartnerMemorizeTool(BaseTool):
             )
 
         store = get_memory_store()
+        turn = get_partner_turn_context()
+        own_service = turn.own_memory if turn else get_current_path_service()
         # Trace + preference both land in the partner's own memory scope, so the
         # footnote ref resolves inside the same tree it's stored in.
-        with memory_path_service_override(get_current_path_service()):
+        with memory_path_service_override(own_service):
             event = TraceEvent.new(
                 "partner",
                 "preference_stated",
@@ -246,6 +249,7 @@ class PartnerSearchTool(BaseTool):
 
     async def execute(self, **kwargs: Any) -> ToolResult:
         from deeptutor.partners.config.paths import get_partner_sessions_dir
+        from deeptutor.services.partners.interaction import get_partner_turn_context
         from deeptutor.services.partners.sessions import PartnerSessionStore
 
         query = str(kwargs.get("query") or "").strip()
@@ -264,7 +268,12 @@ class PartnerSearchTool(BaseTool):
                 success=False,
             )
 
-        store = PartnerSessionStore(get_partner_sessions_dir(partner_id))
+        turn = get_partner_turn_context()
+        store = (
+            turn.store
+            if turn is not None and turn.partner_id == partner_id
+            else PartnerSessionStore(get_partner_sessions_dir(partner_id))
+        )
         needle = query.lower()
         # (timestamp, formatted_line) — collected across all sessions, then
         # sorted most-recent-first and truncated to ``limit``.

--- a/tests/services/memory/test_snapshot_adapters.py
+++ b/tests/services/memory/test_snapshot_adapters.py
@@ -125,6 +125,36 @@ def test_non_admin_scope_sees_no_partners(tmp_path: Path, monkeypatch: pytest.Mo
     assert adapters.read_partner_entities() == []
 
 
+def test_non_admin_sees_only_assigned_private_partner_sessions(
+    partner_tree: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from deeptutor.multi_user.models import CurrentUser, UserScope
+    from deeptutor.multi_user.paths import user_context
+
+    pdir = partner_tree / "partners" / "bot1"
+    pdir.mkdir(parents=True)
+    _write_session(pdir / "sessions", "admin", [("user", "admin secret")])
+    _write_session(pdir / "users" / "u1" / "sessions", "mine", [("user", "my chat")])
+    _write_session(pdir / "users" / "u2" / "sessions", "theirs", [("user", "their chat")])
+
+    import deeptutor.multi_user.partner_access as partner_access
+
+    monkeypatch.setattr(
+        partner_access,
+        "load_grant",
+        lambda uid: {"partners": [{"partner_id": "bot1"}]} if uid == "u1" else {},
+    )
+    root = (partner_tree / "users" / "u1").resolve()
+    user = CurrentUser("u1", "alice", "user", UserScope("user", "u1", root))
+    with user_context(user):
+        entities = adapters.read_partner_entities()
+
+    assert [entity.id for entity in entities] == ["bot1:mine"]
+    assert "my chat" in entities[0].content
+    assert "admin secret" not in entities[0].content
+    assert "their chat" not in entities[0].content
+
+
 def test_fingerprint_changes_when_conversation_grows(partner_tree: Path) -> None:
     pdir = partner_tree / "partners" / "bot1"
     pdir.mkdir(parents=True)

--- a/tests/services/partners/test_channel_manager.py
+++ b/tests/services/partners/test_channel_manager.py
@@ -34,6 +34,28 @@ class _DummyChannel:
         self.send_tool_hints = True
 
 
+def test_channel_media_is_scoped_to_owning_partner(partners_root):
+    from deeptutor.partners.bus.queue import MessageBus
+    from deeptutor.partners.channels.base import BaseChannel
+
+    class _MediaChannel(BaseChannel):
+        name = "telegram"
+
+        async def start(self):
+            pass
+
+        async def stop(self):
+            pass
+
+        async def send(self, msg):
+            pass
+
+    channel = _MediaChannel({}, MessageBus())
+    channel.partner_id = "ada"
+
+    assert channel.media_dir() == partners_root / "ada" / "media" / "telegram"
+
+
 async def _dispatch_one(
     msg: OutboundMessage,
     *,

--- a/tests/services/partners/test_partner_memory_tools.py
+++ b/tests/services/partners/test_partner_memory_tools.py
@@ -91,6 +91,66 @@ def test_read_own_does_not_leak_into_owner(partners_root: Path) -> None:
     assert "secret partner note" in own_part
 
 
+def test_assigned_users_get_private_relationship_memory(partners_root: Path) -> None:
+    from deeptutor.multi_user.models import CurrentUser
+    from deeptutor.multi_user.paths import get_current_path_service, scope_for_user
+    from deeptutor.partners.config.paths import (
+        get_partner_user_sessions_dir,
+        get_partner_user_workspace,
+    )
+    from deeptutor.services.partners.interaction import (
+        build_partner_turn_context,
+        partner_turn_context,
+    )
+
+    def actor(user_id: str) -> CurrentUser:
+        return CurrentUser(user_id, user_id, "user", scope_for_user(user_id, is_admin=False))
+
+    async def write_for(user: CurrentUser, text: str) -> None:
+        store = PartnerSessionStore(get_partner_user_sessions_dir(PID, user.id))
+        with user_context(partner_user(PID, name="Alice")):
+            turn = build_partner_turn_context(
+                PID,
+                user,
+                store,
+                legacy_own_memory=get_current_path_service(),
+            )
+            with partner_turn_context(turn):
+                result = await PartnerMemorizeTool().execute(op="add", text=text)
+                assert result.success
+
+    _run(write_for(actor("u_alice"), "alice-only preference"))
+    _run(write_for(actor("u_bob"), "bob-only preference"))
+
+    alice_memory = get_partner_user_workspace(PID, "u_alice") / "memory"
+    bob_memory = get_partner_user_workspace(PID, "u_bob") / "memory"
+    assert "alice-only preference" in (alice_memory / "L3" / "preferences.md").read_text()
+    assert "bob-only preference" not in (alice_memory / "L3" / "preferences.md").read_text()
+    assert "bob-only preference" in (bob_memory / "L3" / "preferences.md").read_text()
+    assert not (get_partner_workspace(PID) / "memory" / "L3" / "preferences.md").exists()
+
+    alice_store = PartnerSessionStore(get_partner_user_sessions_dir(PID, "u_alice"))
+    bob_store = PartnerSessionStore(get_partner_user_sessions_dir(PID, "u_bob"))
+    alice_store.append("same-key", "user", "alice private calculus topic")
+    bob_store.append("same-key", "user", "bob private geometry topic")
+
+    async def search_for(user: CurrentUser, store: PartnerSessionStore, query: str):
+        with user_context(partner_user(PID, name="Alice")):
+            turn = build_partner_turn_context(
+                PID,
+                user,
+                store,
+                legacy_own_memory=get_current_path_service(),
+            )
+            with partner_turn_context(turn):
+                return await PartnerSearchTool().execute(query=query)
+
+    bob_search = _run(search_for(actor("u_bob"), bob_store, "alice private"))
+    assert bob_search.metadata["count"] == 0
+    alice_search = _run(search_for(actor("u_alice"), alice_store, "alice private"))
+    assert alice_search.metadata["count"] == 1
+
+
 def test_search_matches_history(partners_root: Path) -> None:
     store = PartnerSessionStore(get_partner_sessions_dir(PID))
     store.append("s1", "user", "Can you explain calculus limits to me?")

--- a/tests/services/partners/test_partner_runtime.py
+++ b/tests/services/partners/test_partner_runtime.py
@@ -583,6 +583,47 @@ class TestBuiltinToolsAndMemory:
         assert memory_root() == before
 
     @pytest.mark.asyncio
+    async def test_authenticated_users_get_isolated_session_history(
+        self, partners_root, fake_orchestrator
+    ):
+        from deeptutor.multi_user.models import CurrentUser
+        from deeptutor.multi_user.paths import scope_for_user
+        from deeptutor.partners.config.paths import get_partner_user_sessions_dir
+
+        alice = CurrentUser("u_alice", "alice", "user", scope_for_user("u_alice", is_admin=False))
+        bob = CurrentUser("u_bob", "bob", "user", scope_for_user("u_bob", is_admin=False))
+        fake_orchestrator.script = _finish("ok")
+        runner = _runner(partners_root)
+
+        first = _msg("alice one")
+        first.actor = alice
+        second = _msg("bob one")
+        second.actor = bob
+        third = _msg("alice two")
+        third.actor = alice
+
+        await runner.process_message(first)
+        await runner.process_message(second)
+        await runner.process_message(third)
+
+        assert fake_orchestrator.seen_contexts[0].conversation_history == []
+        assert fake_orchestrator.seen_contexts[1].conversation_history == []
+        assert fake_orchestrator.seen_contexts[2].conversation_history == [
+            {"role": "user", "content": "alice one"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        alice_store = PartnerSessionStore(get_partner_user_sessions_dir("ada", alice.id))
+        bob_store = PartnerSessionStore(get_partner_user_sessions_dir("ada", bob.id))
+        assert [m["content"] for m in alice_store.messages("telegram:42")] == [
+            "alice one",
+            "ok",
+            "alice two",
+            "ok",
+        ]
+        assert [m["content"] for m in bob_store.messages("telegram:42")] == ["bob one", "ok"]
+        assert runner.store.list_sessions() == []
+
+    @pytest.mark.asyncio
     async def test_turn_trace_persisted_for_rehydration(self, partners_root, fake_orchestrator):
         fake_orchestrator.script = _narration_round("c1", "let me check") + _finish("4.")
         runner = _runner(partners_root)
@@ -695,6 +736,32 @@ class TestLiveTurn:
             assert mgr.subscribe_web_turn("ada", "web-x") is None
             # The completed turn persisted to the session store.
             assert mgr.session_store("ada").messages("web-x")[-1]["content"] == "done!"
+        finally:
+            await mgr.stop_partner("ada")
+
+    @pytest.mark.asyncio
+    async def test_manager_captures_authenticated_actor_for_private_history(
+        self, partners_root, fake_orchestrator
+    ):
+        from deeptutor.multi_user.models import CurrentUser
+        from deeptutor.multi_user.paths import scope_for_user, user_context
+        from deeptutor.partners.config.paths import get_partner_user_sessions_dir
+        from deeptutor.services.partners.manager import PartnerManager
+
+        fake_orchestrator.script = _finish("private reply")
+        mgr = PartnerManager()
+        mgr.save_config("ada", PartnerConfig(name="Ada"), auto_start=True)
+        await mgr.start_partner("ada")
+        actor = CurrentUser("u_alice", "alice", "user", scope_for_user("u_alice", is_admin=False))
+        try:
+            with user_context(actor):
+                assert await mgr.send_message("ada", "private question") == "private reply"
+            private = PartnerSessionStore(get_partner_user_sessions_dir("ada", actor.id))
+            assert [item["content"] for item in private.merged_messages()] == [
+                "private question",
+                "private reply",
+            ]
+            assert mgr.session_store("ada").list_sessions() == []
         finally:
             await mgr.stop_partner("ada")
 

--- a/tests/services/partners/test_zulip_channel.py
+++ b/tests/services/partners/test_zulip_channel.py
@@ -315,10 +315,7 @@ class TestDownloadAttachments:
                 "_extract_upload_links",
                 return_value=[("img.png", "/user_uploads/2/ce/abc/img.png")],
             ),
-            patch(
-                "deeptutor.partners.channels.zulip.get_media_dir",
-                return_value=tmp_path,
-            ),
+            patch.object(ch, "media_dir", return_value=tmp_path),
             patch("deeptutor.partners.channels.zulip.requests.get") as mock_get,
         ):
             mock_resp = MagicMock()
@@ -352,10 +349,7 @@ class TestDownloadAttachments:
                 "_extract_upload_links",
                 return_value=[("img.png", "/user_uploads/2/ce/abc/img.png")],
             ),
-            patch(
-                "deeptutor.partners.channels.zulip.get_media_dir",
-                return_value=tmp_path,
-            ),
+            patch.object(ch, "media_dir", return_value=tmp_path),
         ):
             from pathlib import Path as RealPath
 
@@ -860,10 +854,7 @@ class TestResolveMediaPath:
         ch = _make_channel()
         path_id = "/user_uploads/2/ce/abc123/photo.png"
 
-        with patch(
-            "deeptutor.partners.channels.zulip.get_media_dir",
-            return_value=tmp_path,
-        ):
+        with patch.object(ch, "media_dir", return_value=tmp_path):
             dest = ZulipChannel._attachment_destination(tmp_path, "photo.png", path_id, 0)
             dest.write_bytes(b"cached-data")
 
@@ -876,10 +867,7 @@ class TestResolveMediaPath:
         path_id = "/user_uploads/2/ce/abc123/photo.png"
 
         with (
-            patch(
-                "deeptutor.partners.channels.zulip.get_media_dir",
-                return_value=tmp_path,
-            ),
+            patch.object(ch, "media_dir", return_value=tmp_path),
             patch("deeptutor.partners.channels.zulip.requests.get") as mock_get,
         ):
             mock_resp = MagicMock()
@@ -897,10 +885,7 @@ class TestResolveMediaPath:
         url = "https://example.zulipchat.com/user_uploads/2/ce/abc/photo.png"
 
         with (
-            patch(
-                "deeptutor.partners.channels.zulip.get_media_dir",
-                return_value=tmp_path,
-            ),
+            patch.object(ch, "media_dir", return_value=tmp_path),
             patch("deeptutor.partners.channels.zulip.requests.get") as mock_get,
         ):
             mock_resp = MagicMock()
@@ -916,10 +901,7 @@ class TestResolveMediaPath:
         url = "https://example.zulipchat.com/user_uploads/2/ce/abc/photo.png"
 
         with (
-            patch(
-                "deeptutor.partners.channels.zulip.get_media_dir",
-                return_value=tmp_path,
-            ),
+            patch.object(ch, "media_dir", return_value=tmp_path),
             patch("deeptutor.partners.channels.zulip.requests.get") as mock_get,
         ):
             mock_resp = MagicMock()

--- a/tests/services/test_subagent_backends.py
+++ b/tests/services/test_subagent_backends.py
@@ -839,6 +839,35 @@ async def test_partner_consult_unknown_partner(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_partner_consult_rechecks_revoked_grant(monkeypatch, tmp_path) -> None:
+    from deeptutor.multi_user.models import CurrentUser, UserScope
+    import deeptutor.multi_user.partner_access as partner_access
+    from deeptutor.multi_user.paths import user_context
+    from deeptutor.services.subagent.partner import PartnerBackend
+
+    manager = _FakePartnerManager()
+    _patch_manager(monkeypatch, manager)
+    monkeypatch.setattr(partner_access, "load_grant", lambda uid: {"partners": []})
+    user = CurrentUser(
+        "u_alice",
+        "alice",
+        "user",
+        UserScope("user", "u_alice", (tmp_path / "u_alice").resolve()),
+    )
+
+    async def on_event(ev):
+        pass
+
+    with user_context(user):
+        result = await PartnerBackend().consult("q", on_event=on_event, partner_id="paul")
+
+    assert result.success is False
+    assert "not assigned" in result.error
+    assert manager.started == []
+    assert manager.sent == []
+
+
+@pytest.mark.asyncio
 async def test_partner_consult_empty_reply_is_unsuccessful(monkeypatch) -> None:
     from deeptutor.services.subagent.partner import PartnerBackend
 


### PR DESCRIPTION
## Summary
- isolate assigned users’ Partner session history and learned relationship memory while preserving legacy admin/IM data
- surface only the current user’s assigned Partner conversations in Memory and re-check grants on every consult
- route channel downloads to per-Partner media directories instead of the shared global directory

## Compatibility
- existing admin and IM Partner history/memory remains at the legacy paths and is not migrated or deleted
- Partner Soul, knowledge bases, skills, and configuration remain shared admin-managed assets

## Verification
- `ruff check .`
- `ruff format --check .`
- `pytest -q tests deeptutor/learning/tests` (4028 passed, 7 skipped)

Fixes #621