### PR TITLE
Fix missing assistant responses in Course Chat

### DIFF
--- a/web/context/UnifiedChatContext.tsx
+++ b/web/context/UnifiedChatContext.tsx
@@ -31,7 +31,10 @@ import { normalizeMarkdownForDisplay } from "@/lib/markdown-display";
 import { normalizeMessageContent } from "@/lib/message-content";
 import { buildVisiblePath, tipMessageId } from "@/lib/message-branches";
 import { nextOptimisticId, resolvePersistedMessage } from "@/lib/optimistic-id";
-import { reconcileTurnIds } from "@/lib/turn-reconcile";
+import {
+  latestAssistantNeedsHydration,
+  reconcileTurnIds,
+} from "@/lib/turn-reconcile";
 import {
   isNarrationMarker,
   recomputeAnswerContent,
@@ -1186,6 +1189,19 @@ export function UnifiedChatProvider({
               userMessageId: doneMeta?.user_message_id ?? null,
               assistantMessageId,
             });
+            const finishedSession = stateRef.current.sessions[effectiveKey];
+            const sessionId = finishedSession?.sessionId;
+            if (
+              sessionId &&
+              latestAssistantNeedsHydration(finishedSession?.messages ?? [])
+            ) {
+              // The id-only fast path is safe when live content arrived. If
+              // it did not, rehydrate the persisted assistant row instead of
+              // leaving a completed turn visibly blank.
+              loadSessionRef.current?.(sessionId).catch(() => {
+                /* non-fatal — the live state remains usable */
+              });
+            }
           } else {
             // Older backend without ids on ``done`` — fall back to the
             // full session refetch.
@@ -1274,6 +1290,15 @@ export function UnifiedChatProvider({
                 key: record.key,
                 status: "failed",
               });
+              const sessionId = session.sessionId;
+              if (sessionId) {
+                // A close can happen after the backend has persisted the
+                // answer but before the final stream event reaches the UI.
+                // Reload the session so a completed turn is not left blank.
+                loadSessionRef.current?.(sessionId).catch(() => {
+                  /* non-fatal — the failed state remains visible */
+                });
+              }
               // Surface the disconnect to the user. The WS client already
               // logs to console — we add a toast so non-debugging users
               // don't see streaming silently flatline.

--- a/web/lib/turn-reconcile.ts
+++ b/web/lib/turn-reconcile.ts
@@ -17,6 +17,7 @@
 export interface ReconcilableMessage {
   id?: number;
   role: "user" | "assistant" | "system";
+  content?: string;
   parentMessageId?: number | null;
   events?: Array<{ turn_id?: string }>;
 }
@@ -34,6 +35,21 @@ export interface ReconcileResult<T> {
   messages: T[];
   selectedBranches: Record<string, number>;
   changed: boolean;
+}
+
+/**
+ * The completed-turn event carries persisted row ids, but the assistant body
+ * still arrives through the live event stream. If that stream was interrupted
+ * or a client/backend version mismatch filtered the content event, the local
+ * assistant row can be empty even though the server has persisted the answer.
+ */
+export function latestAssistantNeedsHydration(
+  messages: ReconcilableMessage[],
+): boolean {
+  const assistant = [...messages]
+    .reverse()
+    .find((message) => message.role === "assistant");
+  return Boolean(assistant && !(assistant.content ?? "").trim());
 }
 
 function isOptimisticId(id: unknown): id is number {

--- a/web/tests/turn-reconcile.test.ts
+++ b/web/tests/turn-reconcile.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  latestAssistantNeedsHydration,
   reconcileTurnIds,
   type ReconcilableMessage,
 } from "../lib/turn-reconcile";
@@ -169,4 +170,24 @@ test("returns original references when there is nothing to reconcile", () => {
   assert.equal(result.changed, false);
   assert.equal(result.messages, messages);
   assert.equal(result.selectedBranches, branches);
+});
+
+test("detects a completed turn whose local assistant body was missed", () => {
+  assert.equal(
+    latestAssistantNeedsHydration([
+      { id: 50, role: "user", content: "question" },
+      { id: -5001, role: "assistant", content: "" },
+    ]),
+    true,
+  );
+});
+
+test("does not rehydrate a completed turn that already has content", () => {
+  assert.equal(
+    latestAssistantNeedsHydration([
+      { id: 51, role: "user", content: "question" },
+      { id: 52, role: "assistant", content: "answer" },
+    ]),
+    false,
+  );
 });


### PR DESCRIPTION
## What changed

- Rehydrate the persisted session when a completed turn has an empty local assistant body.
- Recover the session after a WebSocket close so a persisted answer is not left blank.
- Add regression coverage for missed and present assistant content.

## Why

The fast completion path reconciled optimistic message IDs but assumed the assistant content event had reached the browser. When that event was missed, the UI showed the user prompt without a visible assistant response even though the backend had persisted the answer.

## Validation

- TypeScript compilation for the node-test project passed.
- Focused turn-reconciliation tests passed: 9/9.
- `git diff --check` passed.

## Scope

This PR contains only the Course Chat runtime fix and its tests. Existing unrelated worktree changes were left unstaged and uncommitted.
