### PR TITLE
fix: isolate invalid Partner channel configs

### DIFF
--- a/deeptutor/api/routers/partners.py
+++ b/deeptutor/api/routers/partners.py
@@ -229,6 +229,25 @@ def _validate_channels_payload(channels: dict) -> None:
             detail=f"{t('api.invalid_channels_config')}: {exc}",
         ) from None
 
+    empty_allow_lists = sorted(
+        name
+        for name, section in channels.items()
+        if isinstance(section, dict)
+        and section.get("enabled") is True
+        and section.get("allow_from", section.get("allowFrom")) == []
+    )
+    if empty_allow_lists:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": (
+                    "Enabled channels require at least one allowed sender: "
+                    + ", ".join(empty_allow_lists)
+                ),
+                "channels": empty_allow_lists,
+            },
+        )
+
 
 # Inline avatars are client-resized to ~128px before upload; this cap is a
 # server-side backstop so config.yaml can't be bloated with raw photos.

--- a/deeptutor/partners/channels/manager.py
+++ b/deeptutor/partners/channels/manager.py
@@ -83,12 +83,16 @@ class ChannelManager:
                 channel.send_tool_hints = self._resolve_bool_override(
                     section, "send_tool_hints", default=True
                 )
+                if getattr(channel.config, "allow_from", None) == []:
+                    _logger().warning(
+                        'Skipping channel "{}": allowFrom is empty (denies all)',
+                        name,
+                    )
+                    continue
                 self.channels[name] = channel
                 _logger().info("{} channel enabled", cls.display_name)
             except Exception as e:
                 _logger().warning("{} channel not available: {}", name, e)
-
-        self._validate_allow_from()
 
     @staticmethod
     def _resolve_bool_override(section: Any, key: str, *, default: bool) -> bool:
@@ -107,14 +111,6 @@ class ChannelManager:
             return value if isinstance(value, bool) else default
         value = getattr(section, key, None)
         return value if isinstance(value, bool) else default
-
-    def _validate_allow_from(self) -> None:
-        for name, ch in self.channels.items():
-            if getattr(ch.config, "allow_from", None) == []:
-                raise SystemExit(
-                    f'Error: "{name}" has empty allowFrom (denies all). '
-                    f'Set ["*"] to allow everyone, or add specific user IDs.'
-                )
 
     async def _start_channel(self, name: str, channel: BaseChannel) -> None:
         try:

--- a/tests/api/test_partners_channel_schema.py
+++ b/tests/api/test_partners_channel_schema.py
@@ -11,6 +11,7 @@ Covers:
 
 from __future__ import annotations
 
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 import pytest
 
@@ -21,6 +22,19 @@ from deeptutor.api.routers._partners_channel_schema import (
     inline_refs,
     resolve_config_model,
 )
+from deeptutor.api.routers.partners import _validate_channels_payload
+
+
+class TestChannelPayloadValidation:
+    def test_rejects_enabled_channel_with_empty_allow_list(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_channels_payload({"weixin": {"enabled": True, "allow_from": [], "token": ""}})
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail["channels"] == ["weixin"]
+
+    def test_allows_disabled_channel_with_empty_allow_list(self) -> None:
+        _validate_channels_payload({"weixin": {"enabled": False, "allow_from": []}})
 
 
 class TestResolveConfigModel:

--- a/tests/services/partners/test_channel_manager.py
+++ b/tests/services/partners/test_channel_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -10,6 +11,27 @@ import pytest
 from deeptutor.partners.bus.events import OutboundMessage
 from deeptutor.partners.channels.manager import ChannelManager
 from deeptutor.partners.config.schema import ChannelsConfig
+
+
+def test_empty_allow_list_skips_only_misconfigured_channel(monkeypatch):
+    class _Channel:
+        display_name = "Test"
+
+        def __init__(self, config, _bus):
+            self.config = SimpleNamespace(allow_from=config["allow_from"])
+
+    monkeypatch.setattr(
+        "deeptutor.partners.channels.registry.discover_all",
+        lambda: {"invalid": _Channel, "valid": _Channel},
+    )
+    config = ChannelsConfig(
+        invalid={"enabled": True, "allow_from": []},
+        valid={"enabled": True, "allow_from": ["user-1"]},
+    )
+
+    manager = ChannelManager(config, _MultiShotBus([]))  # type: ignore[arg-type]
+
+    assert list(manager.channels) == ["valid"]
 
 
 class _OneShotBus:


### PR DESCRIPTION
### Summary

- reject newly saved enabled channels whose `allow_from` list is empty
- skip only a legacy misconfigured channel during runtime initialization
- preserve deny-by-default behavior and continue starting other valid channels and the Partner runtime

### Verification

- `463 passed` across Partner service and API tests
- `ruff check .`
- `ruff format --check .`

Fixes #827