### PR TITLE
fix: use Responses API for OpenAI GPT-5 agentic tools

### DIFF
--- a/deeptutor/core/agentic/client.py
+++ b/deeptutor/core/agentic/client.py
@@ -226,6 +226,20 @@ def _build_codebuddy_adapter(config: LLMClientConfig, spec: Any) -> Any:
     return _ProviderOpenAIAdapter(codebuddy_provider)
 
 
+def _build_direct_openai_adapter(config: LLMClientConfig, spec: Any) -> Any:
+    from deeptutor.services.llm.provider_core import OpenAICompatProvider
+
+    provider = OpenAICompatProvider(
+        api_key=config.api_key,
+        api_base=config.base_url or spec.default_api_base or None,
+        default_model=config.model or "gpt-5",
+        extra_headers=config.extra_headers,
+        spec=spec,
+        provider_name=config.binding,
+    )
+    return _ProviderOpenAIAdapter(provider)
+
+
 _NATIVE_ADAPTER_BUILDERS: dict[str, Callable[[LLMClientConfig, Any], Any]] = {
     "anthropic": _build_anthropic_adapter,
     "openai_codex": _build_codex_adapter,
@@ -235,6 +249,17 @@ _NATIVE_ADAPTER_BUILDERS: dict[str, Callable[[LLMClientConfig, Any], Any]] = {
 
 
 def _build_native_provider_adapter(config: LLMClientConfig, spec: Any) -> Any | None:
+    endpoint = (config.base_url or spec.default_api_base or "").lower()
+    model = (config.model or "").lower()
+    if (
+        spec.name == "openai"
+        and not config.api_version
+        and "api.openai.com" in endpoint
+        and any(token in model for token in ("gpt-5", "o1", "o3", "o4"))
+    ):
+        # Reuse the services provider: it already converts messages, tools,
+        # streaming events and token limits for the Responses API.
+        return _build_direct_openai_adapter(config, spec)
     builder = _NATIVE_ADAPTER_BUILDERS.get(spec.backend)
     return builder(config, spec) if builder else None
 
@@ -297,7 +322,9 @@ class _ProviderOpenAIAdapter:
                             for index, tool_call in enumerate(response.tool_calls or [])
                         ],
                     ),
-                    finish_reason=response.finish_reason or "stop",
+                    finish_reason=(
+                        "tool_calls" if response.tool_calls else response.finish_reason or "stop"
+                    ),
                 )
             ],
             usage=response.usage or None,
@@ -378,7 +405,9 @@ class _ProviderOpenAIStream:
                 await self._queue.put(_openai_stream_chunk(tool_call=tool_call, index=index))
             await self._queue.put(
                 _openai_stream_chunk(
-                    finish_reason=response.finish_reason or "stop",
+                    finish_reason=(
+                        "tool_calls" if response.tool_calls else response.finish_reason or "stop"
+                    ),
                     usage=response.usage or None,
                 )
             )

--- a/tests/core/test_agentic_client_provider_kwargs.py
+++ b/tests/core/test_agentic_client_provider_kwargs.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from deeptutor.core.agentic import client as agentic_client
@@ -198,6 +200,88 @@ def test_build_openai_client_routes_codebuddy_backend_through_adapter(monkeypatc
     assert isinstance(client, _ProviderOpenAIAdapter)
     assert captured["api_key"] == "sk-codebuddy"
     assert captured["default_model"] == "codebuddy/hy3"
+
+
+@pytest.mark.asyncio
+async def test_direct_openai_gpt5_agentic_tools_use_provider_adapter(monkeypatch) -> None:
+    captured: dict = {}
+
+    class FakeResponses:
+        async def create(self, **kwargs):
+            captured["request"] = kwargs
+            item = SimpleNamespace(
+                type="function_call",
+                id="fc_123",
+                call_id="call_123",
+                name="web_search",
+                arguments='{"query":"DeepTutor"}',
+            )
+
+            async def events():
+                yield SimpleNamespace(type="response.output_item.added", item=item)
+                yield SimpleNamespace(type="response.output_item.done", item=item)
+                yield SimpleNamespace(
+                    type="response.completed",
+                    response=SimpleNamespace(status="completed", usage=None),
+                )
+
+            return events()
+
+    class UnexpectedChatCompletions:
+        async def create(self, **_kwargs):
+            raise AssertionError("GPT-5 agentic calls must use the Responses API")
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured["init"] = kwargs
+            self.responses = FakeResponses()
+            self.chat = SimpleNamespace(completions=UnexpectedChatCompletions())
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "deeptutor.services.llm.provider_core.openai_compat_provider.AsyncOpenAI",
+        FakeOpenAI,
+    )
+    await agentic_client.close_agentic_client_pool()
+    client = build_openai_client(
+        LLMClientConfig(
+            binding="openai",
+            model="gpt-5.6-luna",
+            api_key="sk-test",
+            base_url="https://api.openai.com/v1",
+        )
+    )
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    stream = await client.chat.completions.create(
+        model="gpt-5.6-luna",
+        messages=[{"role": "user", "content": "Search"}],
+        tools=tools,
+        tool_choice="auto",
+        max_completion_tokens=512,
+        stream=True,
+    )
+    chunks = [chunk async for chunk in stream]
+
+    assert isinstance(client, _ProviderOpenAIAdapter)
+    assert captured["init"]["base_url"] == "https://api.openai.com/v1"
+    assert captured["request"]["stream"] is True
+    assert captured["request"]["tools"][0]["name"] == "web_search"
+    assert "messages" not in captured["request"]
+    tool_call = chunks[-2].choices[0].delta.tool_calls[0]
+    assert tool_call.function.name == "web_search"
+    assert chunks[-1].choices[0].finish_reason == "tool_calls"
+    await agentic_client.close_agentic_client_pool()
 
 
 def test_anthropic_backend_can_use_native_tool_calling() -> None:


### PR DESCRIPTION
### Summary

- route direct OpenAI GPT-5/o-series agentic calls through the existing provider adapter
- reuse the shared Responses API message, tool, streaming, and token conversion
- preserve the raw Chat Completions path for Azure, custom OpenAI-compatible endpoints, and older OpenAI models
- normalize adapted tool-call finish reasons to the OpenAI-style `tool_calls` contract

### Verification

- issue-specific SDK regression proves `responses.create` receives `web_search` and `chat.completions` is not called
- `4033 passed, 7 skipped`
- `ruff check .`
- `ruff format --check .`

Fixes #708