### PR TITLE
fix: schedule qualitative mastery reviews

### DIFF
--- a/deeptutor/capabilities/mastery/tools.py
+++ b/deeptutor/capabilities/mastery/tools.py
@@ -532,6 +532,8 @@ class MasteryAssessTool(BaseTool):
         path_id = _resolve_path_id(kwargs)
         if not path_id:
             return _no_path_result()
+        from deeptutor.learning.scheduler import SpacedRepetitionScheduler
+
         kp_id = str(kwargs.get("knowledge_point_id") or "").strip()
         if not kp_id:
             return ToolResult(content="mastery_assess needs a knowledge_point_id.", success=False)
@@ -554,7 +556,13 @@ class MasteryAssessTool(BaseTool):
                 ),
                 success=False,
             )
-        service.record_qualitative(progress, kp_id, passed=passed, evidence=feedback)
+        service.record_qualitative(
+            progress,
+            kp_id,
+            passed=passed,
+            evidence=feedback,
+            scheduler=SpacedRepetitionScheduler(),
+        )
         payload = {
             "knowledge_point_id": kp_id,
             "passed": passed,

--- a/deeptutor/learning/service.py
+++ b/deeptutor/learning/service.py
@@ -230,17 +230,30 @@ class LearningService:
         *,
         passed: bool,
         evidence: str = "",
+        scheduler: SpacedRepetitionScheduler | None = None,
     ) -> None:
         """Record the qualitative (CONCEPT / DESIGN) gate outcome.
 
         The boolean is the gate of record; ``mastery_levels`` is nudged only so
         the map's colour matches the gate (full on pass, capped on fail).
+
+        A first pass starts spaced repetition at the type's first configured
+        interval. Later assessments advance or shorten that existing schedule.
+        An initial failure is not reviewable mastery, so it creates no state.
         """
         progress.qualitative_mastery[kp_id] = bool(passed)
         current = progress.mastery_levels.get(kp_id, 0.0)
         progress.mastery_levels[kp_id] = max(current, 1.0) if passed else min(current, 0.4)
         if evidence:
             progress.feynman_explanations[kp_id] = evidence
+        kp_type = progress.knowledge_types.get(kp_id)
+        if kp_type is not None and scheduler is not None:
+            state = progress.repetition_states.get(kp_id)
+            if state is not None and state.next_review_at <= time.time():
+                scheduler.schedule_next(state, kp_type, passed)
+            elif state is None and passed:
+                progress.repetition_states[kp_id] = scheduler.get_initial_state(kp_type)
+            progress.review_queue = scheduler.build_review_queue(progress)
         progress.updated_at = time.time()
         self.save(progress)
 

--- a/deeptutor/learning/tests/test_guided_mastery_updates.py
+++ b/deeptutor/learning/tests/test_guided_mastery_updates.py
@@ -280,3 +280,68 @@ def test_record_qualitative_pass_and_fail_drive_display_mastery(tmp_path):
     service.record_qualitative(progress, "kp1", passed=False)
     assert progress.qualitative_mastery["kp1"] is False
     assert progress.mastery_levels["kp1"] <= 0.4
+
+
+@pytest.mark.parametrize(
+    ("knowledge_type", "first_interval_days"),
+    [
+        (KnowledgeType.CONCEPT, 3),
+        (KnowledgeType.DESIGN, 14),
+    ],
+)
+def test_record_qualitative_starts_at_first_review_interval(
+    tmp_path, monkeypatch, knowledge_type, first_interval_days
+):
+    store = LearningStore(root=tmp_path)
+    service = LearningService(store)
+    scheduler = SpacedRepetitionScheduler()
+    progress = _make_progress()
+    progress.knowledge_types["kp1"] = knowledge_type
+    now = 1_700_000_000.0
+    monkeypatch.setattr("deeptutor.learning.scheduler.time.time", lambda: now)
+
+    service.record_qualitative(progress, "kp1", passed=True, scheduler=scheduler)
+
+    state = progress.repetition_states["kp1"]
+    assert state.interval_index == 0
+    assert state.next_review_at == now + first_interval_days * 86400
+    assert [task.knowledge_point_id for task in progress.review_queue] == ["kp1"]
+    assert progress.review_queue[0].due_at == state.next_review_at
+
+
+def test_record_qualitative_updates_existing_review_state(tmp_path, monkeypatch):
+    store = LearningStore(root=tmp_path)
+    service = LearningService(store)
+    scheduler = SpacedRepetitionScheduler()
+    progress = _make_progress()
+    now = [1_700_000_000.0]
+    monkeypatch.setattr("deeptutor.learning.scheduler.time.time", lambda: now[0])
+
+    service.record_qualitative(progress, "kp1", passed=True, scheduler=scheduler)
+    first_due = progress.repetition_states["kp1"].next_review_at
+    service.record_qualitative(progress, "kp1", passed=True, scheduler=scheduler)
+    assert progress.repetition_states["kp1"].interval_index == 0
+    assert progress.repetition_states["kp1"].next_review_at == first_due
+
+    now[0] = first_due
+    service.record_qualitative(progress, "kp1", passed=True, scheduler=scheduler)
+    assert progress.repetition_states["kp1"].interval_index == 1
+    second_due = now[0] + 7 * 86400
+    assert progress.repetition_states["kp1"].next_review_at == second_due
+
+    now[0] = second_due
+    service.record_qualitative(progress, "kp1", passed=False, scheduler=scheduler)
+    assert progress.repetition_states["kp1"].interval_index == 0
+    assert progress.repetition_states["kp1"].next_review_at == now[0] + 3 * 86400
+
+
+def test_record_qualitative_initial_failure_does_not_schedule_review(tmp_path):
+    store = LearningStore(root=tmp_path)
+    service = LearningService(store)
+    scheduler = SpacedRepetitionScheduler()
+    progress = _make_progress()
+
+    service.record_qualitative(progress, "kp1", passed=False, scheduler=scheduler)
+
+    assert progress.repetition_states == {}
+    assert progress.review_queue == []

--- a/deeptutor/learning/tests/test_mastery_tools.py
+++ b/deeptutor/learning/tests/test_mastery_tools.py
@@ -565,6 +565,10 @@ async def test_assess_passes_concept(path_id):
     )
     assert result["mastered"] is True
     assert result["next"]["action"] == "complete"
+    progress = LearningStore().load(path_id)
+    assert progress is not None
+    assert progress.repetition_states[concept_kp].interval_index == 0
+    assert [task.knowledge_point_id for task in progress.review_queue] == [mem_kp, concept_kp]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add concept/design qualitative passes to spaced repetition at their first configured interval
- advance or shorten existing qualitative review schedules only when the review is due
- keep initial failures unscheduled and make repeated early assessments idempotent

## Validation
- `python -m pytest -q tests deeptutor/learning/tests` (4037 passed, 7 skipped)
- `python -m ruff check .`
- `python -m ruff format --check .`

Closes #840