### PR TITLE
fix(usage): record token usage emitted as plain dicts by native adapters

### DIFF
--- a/deeptutor/core/agentic/usage.py
+++ b/deeptutor/core/agentic/usage.py
@@ -31,9 +31,17 @@ class UsageTracker:
 
     def add_from_response(self, response_or_usage: Any) -> None:
         usage = getattr(response_or_usage, "usage", None) or response_or_usage
-        prompt = int(getattr(usage, "prompt_tokens", 0) or 0)
-        completion = int(getattr(usage, "completion_tokens", 0) or 0)
-        total = int(getattr(usage, "total_tokens", prompt + completion) or 0)
+        if hasattr(usage, "model_dump"):
+            usage = usage.model_dump()
+        elif not isinstance(usage, dict):
+            usage = {
+                key: getattr(usage, key, None)
+                for key in ("prompt_tokens", "completion_tokens", "total_tokens")
+                if hasattr(usage, key)
+            }
+        prompt = int(usage.get("prompt_tokens") or 0)
+        completion = int(usage.get("completion_tokens") or 0)
+        total = int(usage.get("total_tokens") or prompt + completion)
         if prompt or completion or total:
             self.prompt_tokens += prompt
             self.completion_tokens += completion

--- a/tests/core/test_record_streamed_usage.py
+++ b/tests/core/test_record_streamed_usage.py
@@ -62,6 +62,36 @@ def test_accounting_errors_never_propagate() -> None:
     assert tracker.calls == 0
 
 
+def test_records_dict_frame_from_native_adapters() -> None:
+    # Native-adapter providers (anthropic, codex, copilot, codebuddy) emit
+    # usage as a plain dict rather than an object with attributes.
+    tracker = UsageTracker()
+    record_streamed_usage(
+        tracker,
+        {"prompt_tokens": 1200, "completion_tokens": 400, "total_tokens": 1600},
+        input_chars=9999,
+        output_chars=9999,
+    )
+
+    assert tracker.calls == 1
+    assert tracker.prompt_tokens == 1200
+    assert tracker.completion_tokens == 400
+    assert tracker.total_tokens == 1600
+
+
+class _PydanticLikeUsage:
+    def model_dump(self) -> dict[str, int]:
+        return {"prompt_tokens": 5, "completion_tokens": 6, "total_tokens": 11}
+
+
+def test_records_model_dump_frame() -> None:
+    tracker = UsageTracker()
+    tracker.add_from_response(_PydanticLikeUsage())
+
+    assert tracker.calls == 1
+    assert tracker.total_tokens == 11
+
+
 def test_message_content_chars_handles_all_shapes() -> None:
     assert message_content_chars({"content": "hello"}) == 5
     assert message_content_chars({"content": None}) == 0


### PR DESCRIPTION
### Description

`UsageTracker.add_from_response` reads usage via attribute access, but the native-adapter providers (`anthropic`, `openai_codex`, `github_copilot`, `codebuddy`) emit `usage` as a **plain dict** (e.g. `anthropic_provider.py` builds `{"prompt_tokens": ..., "completion_tokens": ..., "total_tokens": ...}`). `getattr()` on a dict returns the default for every key, so:

1. every streamed call on these bindings records `0` tokens and `calls` stays `0`;
2. `UsageTracker.summary()` returns `None`;
3. `emit_capability_result` omits `cost_summary` from the turn's `result` event;
4. the web UI gates `CostFooter` on `total_calls`, so **no cost/token statistics are ever displayed** for users on these bindings.

The char-based estimate fallback in `record_streamed_usage` does not compensate, because it only triggers when the usage frame is `None` — and these providers do send a (non-empty) frame.

**Fix:** normalize `usage` to a dict before reading (`model_dump()` when available, dict comprehension over the known keys otherwise) — the same pattern already used by the embedding adapters (`services/embedding/adapters/openai_sdk.py`, `dashscope_native.py`). Object-shaped usage (plain `AsyncOpenAI` bindings) keeps working exactly as before.

Verified with an A/B test against the original code: dict frame `{"prompt_tokens": 1200, "completion_tokens": 400, "total_tokens": 1600}` → original records `calls=0, summary()=None`; patched records `calls=1, total_tokens=1600`.

### Module(s) Affected

- [x] `core`

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues. *(scoped to the two changed files via `pre-commit run --files` — all hooks pass)*
- [x] I have added relevant tests for my changes.
- [x] My changes do not introduce any new security vulnerabilities.

