### PR TITLE
fix(obsidian): tolerate undecodable bytes and date frontmatter (#914, #915)

### DIFF
--- a/deeptutor/capabilities/obsidian/tools.py
+++ b/deeptutor/capabilities/obsidian/tools.py
@@ -52,7 +52,7 @@ def _no_vault_result() -> ToolResult:
 
 
 def _ok(payload: Any) -> ToolResult:
-    return ToolResult(content=json.dumps(payload, ensure_ascii=False), success=True)
+    return ToolResult(content=json.dumps(payload, ensure_ascii=False, default=str), success=True)
 
 
 def _err(message: str) -> ToolResult:

--- a/deeptutor/capabilities/obsidian/vault.py
+++ b/deeptutor/capabilities/obsidian/vault.py
@@ -132,7 +132,7 @@ def read_note(root: Path, ref: str) -> dict[str, Any]:
     path = resolve_note(root, ref)
     if path is None:
         raise VaultError(f"Note {ref!r} not found in the vault.")
-    text = path.read_text(encoding="utf-8")
+    text = path.read_text(encoding="utf-8", errors="replace")
     frontmatter, body = split_frontmatter(text)
     return {"path": _rel(root, path), "frontmatter": frontmatter, "body": body}
 
@@ -146,7 +146,7 @@ def search_notes(root: Path, query: str, limit: int = 20) -> list[dict[str, str]
     hits: list[dict[str, str]] = []
     for path in _iter_markdown(root):
         try:
-            text = path.read_text(encoding="utf-8")
+            text = path.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
         if needle in path.stem.lower() or needle in text.lower():
@@ -191,7 +191,7 @@ def backlinks(root: Path, ref: str, limit: int = 50) -> list[dict[str, str]]:
         if path == target:
             continue
         try:
-            text = path.read_text(encoding="utf-8")
+            text = path.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
         if any(t.strip().lower() == stem for t in _WIKILINK_RE.findall(text)):
@@ -212,7 +212,7 @@ def collect_tags(root: Path, limit: int = 200) -> list[dict[str, Any]]:
 
     for path in _iter_markdown(root):
         try:
-            text = path.read_text(encoding="utf-8")
+            text = path.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
         frontmatter, body = split_frontmatter(text)

--- a/tests/capabilities/test_obsidian_capability.py
+++ b/tests/capabilities/test_obsidian_capability.py
@@ -52,6 +52,28 @@ def test_vault_search_and_list_skip_internal_dirs(tmp_path: Path) -> None:
     assert all(".obsidian" not in p for p in V.list_notes(tmp_path))
 
 
+def test_vault_search_survives_undecodable_note(tmp_path: Path) -> None:
+    # Issue #915: one undecodable byte must not abort the whole vault search.
+    _seed_vault(tmp_path)
+    (tmp_path / "broken.md").write_bytes(b"hello \xe5\xaa world\n")
+    assert [h["path"] for h in V.search_notes(tmp_path, "light")] == ["notes/Photosynthesis.md"]
+
+
+def test_vault_read_tolerates_undecodable_bytes(tmp_path: Path) -> None:
+    # Issue #915: read_note should degrade (replacement char) instead of raising.
+    (tmp_path / "broken.md").write_bytes(b"# title\nhello \xe5\xaa world\n")
+    note = V.read_note(tmp_path, "broken")
+    assert "\ufffd" in note["body"]
+
+
+def test_vault_scans_survive_undecodable_note(tmp_path: Path) -> None:
+    # Issue #915: backlinks and tag collection iterate the same files.
+    _seed_vault(tmp_path)
+    (tmp_path / "broken.md").write_bytes(b"hello \xe5\xaa world\n")
+    assert [b["path"] for b in V.backlinks(tmp_path, "Photosynthesis")] == ["Index.md"]
+    assert {row["tag"] for row in V.collect_tags(tmp_path)} == {"biology"}
+
+
 def test_vault_links_and_backlinks_follow_wikilinks(tmp_path: Path) -> None:
     _seed_vault(tmp_path)
     assert V.outgoing_links(tmp_path, "Photosynthesis") == ["Chlorophyll"]
@@ -171,6 +193,20 @@ async def test_tools_round_trip_against_vault(tmp_path: Path) -> None:
 async def test_read_missing_note_is_graceful(tmp_path: Path) -> None:
     res = await ObsidianReadTool().execute(note="Nope", _vault_path=str(tmp_path))
     assert res.success is False  # VaultError surfaced as a clean failure
+
+
+@pytest.mark.asyncio
+async def test_read_note_with_date_frontmatter(tmp_path: Path) -> None:
+    # Issue #914: unquoted YAML dates parse to datetime.date, which json.dumps
+    # cannot serialize without default=str — obsidian_read must not crash.
+    (tmp_path / "dated.md").write_text(
+        "---\ntype: item-bank\ncreated: 2026-08-11\n---\n\n# Body\n\ntext\n",
+        encoding="utf-8",
+    )
+    res = await ObsidianReadTool().execute(note="dated.md", _vault_path=str(tmp_path))
+    assert res.success is True
+    payload = json.loads(res.content)
+    assert payload["frontmatter"]["created"] == "2026-08-11"
 
 
 # ---- exclusivity & registry --------------------------------------------------


### PR DESCRIPTION
Fixes #914, Fixes #915

Two small robustness fixes for the Obsidian capability — both reported by @eylon-cnaan with the same root theme: legitimate vault content (a mangled byte, an unquoted date) crashes the whole tool instead of degrading one note.

## #915 — one undecodable byte killed every vault search

`search_notes` guards `path.read_text(encoding="utf-8")` with `except OSError`, but `UnicodeDecodeError` is a `ValueError`, so a single non-UTF-8 byte in one note aborted **every** vault search. `read_note` had no guard at all, so `obsidian_read` failed the same way.

Fix: read with `errors="replace"` in all read-only vault scans (`read_note`, `search_notes`, `backlinks`, `collect_tags` — the latter two had the identical `except OSError` gap), keeping the `OSError` skip guard. A bad file now degrades only itself (searchable text with U+FFFD) instead of taking down the vault. Write paths (`append_note`, `set_property`) are intentionally untouched so nothing can round-trip replacement chars into the note on disk.

## #914 — `obsidian_read` failed on any note with a date in its frontmatter

YAML parses `created: 2026-08-11` into a `datetime.date`, and the shared `_ok` helper's `json.dumps` has no encoder for it — `TypeError` escaped `execute()`, so the model only saw "unknown error". Obsidian's own Templates plugin inserts unquoted dates, so ~16% of the reporter's vault was unreadable.

Fix: one argument — `json.dumps(payload, ensure_ascii=False, default=str)` — serializing date scalars as ISO-8601. This also protects `obsidian_tags`, `obsidian_links`, and `obsidian_backlinks`, which route frontmatter through the same helper.

## Verification

- New regression tests (4): search/read/backlinks/tags survive an undecodable note; `obsidian_read` returns ISO-8601 for a dated frontmatter. All 4 fail on the pre-fix code, all pass with the fix.
- `tests/capabilities/test_obsidian_capability.py` — 21 passed
- `tests/agents/research/test_research_obsidian_tools.py` + `tests/knowledge/test_obsidian_kb.py` — 27 passed
- pre-commit on changed files: ruff, ruff-format, bandit, mypy, detect-secrets — all Passed
- Diff: 3 files, +41/−5; no API or behavior change beyond the two failure modes above.
