### PR TITLE
fix(api): return JSON for unhandled exceptions

### DIFF
--- a/deeptutor/api/main.py
+++ b/deeptutor/api/main.py
@@ -2,8 +2,9 @@ from contextlib import asynccontextmanager
 import logging
 import sys
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from deeptutor.logging import configure_logging
 from deeptutor.services.config import (
@@ -241,6 +242,26 @@ app = FastAPI(
     # See: https://github.com/HKUDS/DeepTutor/issues/112
     redirect_slashes=False,
 )
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    """Catch-all so 500s always return JSON, never Starlette's plain-text body."""
+    logger.error(
+        "Unhandled exception on %s %s: %s",
+        request.method,
+        request.url.path,
+        exc,
+        exc_info=True,
+    )
+    return JSONResponse(
+        status_code=500,
+        content={
+            "detail": f"{type(exc).__name__}: {exc}",
+            "type": type(exc).__name__,
+        },
+    )
+
 
 # Access logging is funneled through this one middleware. uvicorn's own
 # per-request access log is disabled on every launch path (run_server.py via

--- a/tests/api/test_main_exception_handler.py
+++ b/tests/api/test_main_exception_handler.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_unhandled_exception_returns_json_error() -> None:
+    from deeptutor.api.main import app
+
+    @app.get("/api/v1/__test_unhandled_exception__")
+    def _raise_unhandled() -> None:
+        raise RuntimeError("intentional test failure")
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/api/v1/__test_unhandled_exception__")
+
+    assert response.status_code == 500
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json() == {
+        "detail": "RuntimeError: intentional test failure",
+        "type": "RuntimeError",
+    }


### PR DESCRIPTION
## Description

- Add a catch-all FastAPI exception handler for unhandled server exceptions.
- Return a consistent JSON error body instead of Starlette's plain-text 500 response.
- Include:
  - `detail`: `<ExceptionType>: <message>`
  - `type`: the exception class name
- Log the request method, path, and exception with a stack trace for diagnosis.
- Add API coverage for the response contract.

## Related Issues

- N/A

## Checklist

- [x] Unhandled exceptions return JSON.
- [x] The exception type and message are exposed consistently.
- [x] Stack traces are logged server-side.
- [x] Focused API test passes.

## Verification

```bash
pytest tests/api/test_main_exception_handler.py
```
