### PR TITLE
fix: log provider error body on tool-schema rejection fallback

### DIFF
--- a/deeptutor/agents/chat/agent_loop.py
+++ b/deeptutor/agents/chat/agent_loop.py
@@ -902,8 +902,7 @@ class AgentLoop:
                 # gpt-5.6-luna/-terra/-sol 400 on tools, root cause still
                 # unconfirmed for lack of this exact log line).
                 logger.warning(
-                    "provider rejected tool schemas for model=%s; retrying without "
-                    "tools. error=%s",
+                    "provider rejected tool schemas for model=%s; retrying without tools. error=%s",
                     kwargs.get("model"),
                     error_text(exc),
                 )

--- a/deeptutor/agents/chat/agent_loop.py
+++ b/deeptutor/agents/chat/agent_loop.py
@@ -47,6 +47,7 @@ from deeptutor.services.llm import LLMProviderTransportError, clean_thinking_tag
 from deeptutor.services.llm.capabilities import threads_session_id
 from deeptutor.services.llm.multimodal import should_degrade_to_text, strip_image_parts_inplace
 from deeptutor.services.llm.request_compat import (
+    error_text,
     is_image_input_unsupported,
     is_stream_options_unsupported,
     is_tool_schema_unsupported,
@@ -894,6 +895,18 @@ class AgentLoop:
                 retry_kwargs.pop("stream_options", None)
                 return await self.client.chat.completions.create(**retry_kwargs)
             if kwargs.get("tools") and is_tool_schema_unsupported(exc):
+                # Capture the provider's raw rejection body. Without it there is
+                # no way to tell *which* parameter/shape a new model family
+                # objects to — the fallback below silently strips tools and the
+                # model degrades to prose with no visible error (see #708:
+                # gpt-5.6-luna/-terra/-sol 400 on tools, root cause still
+                # unconfirmed for lack of this exact log line).
+                logger.warning(
+                    "provider rejected tool schemas for model=%s; retrying without "
+                    "tools. error=%s",
+                    kwargs.get("model"),
+                    error_text(exc),
+                )
                 await self.stream.progress(
                     self.pipeline._t(
                         "notices.tool_schema_fallback",


### PR DESCRIPTION
## Summary

Diagnostic-only fix toward #708. `AgentLoop._create_response_stream` (`deeptutor/agents/chat/agent_loop.py`) already detects when a provider rejects native tool schemas (`is_tool_schema_unsupported`) and falls back to a tool-less retry — but it discards the provider's raw error body in the process. That's exactly the missing evidence blocking #708: the model silently degrades to prose, the "Provider rejected native tool schemas; retrying without tools" notice fires, and there is no record of *what* was actually rejected.

This logs the body (via the existing `error_text()` helper, already used by `is_tool_schema_unsupported` itself) at WARNING before the fallback, so it lands in `data/user/logs/deeptutor.jsonl`.

## Why

Per the thread on #708, `gpt-5.6-luna`/`-terra`/`-sol` 400 on Chat Completions requests that include `tools`, get silently retried without them, and answer in prose claiming the tools are unavailable. The maintainer has been asking since July 27 for the raw 400 response body to confirm which parameter/shape is rejected, but no client in the thread captured it. This change makes that capture automatic on the next occurrence, for this or any future model-family mismatch.

## Scope

Logging only — no control-flow change. The deeper architectural question (whether the agentic loop should route these models through the Responses API path that `OpenAICompatProvider._should_use_responses_api` already implements for non-agentic calls) is a separate, larger change that needs a tester with access to the affected model family before it can be verified; not attempted here.

## Verification

- `ruff check deeptutor/agents/chat/agent_loop.py` — clean.
- `python3 -c "import ast; ast.parse(...)"` — syntax OK.
- No `pip install -e .[all]` available in this environment to run a live LLM call end-to-end; the change is additive (one `logger.warning` call ahead of existing behavior) and doesn't alter the retry/fallback logic itself.

Fixes: partial diagnostic step for #708