### PR TITLE
fix(chat): prune deleted knowledge base references from sessions

### DIFF
--- a/web/app/(workspace)/home/[[...sessionId]]/page.tsx
+++ b/web/app/(workspace)/home/[[...sessionId]]/page.tsx
@@ -400,6 +400,11 @@ export default function ChatPage() {
   } = useUnifiedChat();
 
   const [knowledgeBases, setKnowledgeBases] = useState<KnowledgeBase[]>([]);
+  const [knowledgeBasesLoaded, setKnowledgeBasesLoaded] = useState(false);
+  const availableKbNames = useMemo(
+    () => new Set(knowledgeBases.map((kb) => kb.name)),
+    [knowledgeBases],
+  );
   // A connected agent to preselect once it loads, from `?agent=<name>` on the
   // URL (the partner list page links here to drop straight into a chat with a
   // partner). Captured once at first client render — the URL is rewritten to
@@ -1190,7 +1195,9 @@ export default function ChatPage() {
       try {
         const list = await listKnowledgeBases({ force: options?.force });
         setKnowledgeBases(list);
+        setKnowledgeBasesLoaded(true);
       } catch {
+        setKnowledgeBasesLoaded(false);
         setKnowledgeBases([]);
       }
     },
@@ -1210,6 +1217,16 @@ export default function ChatPage() {
   useEffect(() => {
     void refreshKnowledgeBases();
   }, [refreshKnowledgeBases]);
+
+  // A physical KB delete does not cascade into persisted session preferences.
+  // Reconcile only after a successful fetch: an empty result then means every
+  // KB was deleted, while a failed request must keep the existing selection.
+  useEffect(() => {
+    if (!knowledgeBasesLoaded) return;
+    const selected = state.knowledgeBases;
+    const pruned = selected.filter((name) => availableKbNames.has(name));
+    if (pruned.length !== selected.length) setKBs(pruned);
+  }, [availableKbNames, knowledgeBasesLoaded, state.knowledgeBases, setKBs]);
 
   const refreshUserEnabledTools = useCallback(
     async (options?: { force?: boolean }) => {
@@ -1465,8 +1482,11 @@ export default function ChatPage() {
   // Fold all messages once per state.messages change to power the
   // SessionActivityPanel on the right (tools, KBs, space refs, attachments).
   const sessionActivity = useMemo(
-    () => buildSessionActivity(state.messages),
-    [state.messages],
+    () =>
+      buildSessionActivity(state.messages, {
+        availableKbNames: knowledgeBasesLoaded ? availableKbNames : undefined,
+      }),
+    [state.messages, availableKbNames, knowledgeBasesLoaded],
   );
 
   // Context-window readout for the composer chip: the newest turn that was
@@ -2200,6 +2220,9 @@ export default function ChatPage() {
                         onEditMessage={editMessage}
                         onSwitchBranch={switchBranch}
                         onSubmitUserReply={submitUserReply}
+                        availableKbNames={
+                          knowledgeBasesLoaded ? availableKbNames : undefined
+                        }
                       />
                       <div
                         ref={messagesEndRef}

--- a/web/components/chat/home/ChatMessages.tsx
+++ b/web/components/chat/home/ChatMessages.tsx
@@ -983,37 +983,45 @@ const UserMessage = memo(function UserMessage({
           label: name,
         };
       }),
-    ...(snap?.bookReferences ?? []).map((ref): ContextTreeItem => ({
-      key: `book-${ref.book_id}`,
-      icon: BookOpen,
-      kind: t("Book"),
-      label: `${ref.page_ids.length} ${t("chapters")}`,
-    })),
-    ...(snap?.notebookReferences ?? []).map((ref): ContextTreeItem => ({
-      key: `nb-${ref.notebook_id}`,
-      icon: BookOpen,
-      kind: t("Notebook"),
-      label: `${ref.record_ids.length} ${t("records")}`,
-    })),
+    ...(snap?.bookReferences ?? []).map(
+      (ref): ContextTreeItem => ({
+        key: `book-${ref.book_id}`,
+        icon: BookOpen,
+        kind: t("Book"),
+        label: `${ref.page_ids.length} ${t("chapters")}`,
+      }),
+    ),
+    ...(snap?.notebookReferences ?? []).map(
+      (ref): ContextTreeItem => ({
+        key: `nb-${ref.notebook_id}`,
+        icon: BookOpen,
+        kind: t("Notebook"),
+        label: `${ref.record_ids.length} ${t("records")}`,
+      }),
+    ),
     // Imported agent conversations are folded into the same history_references
     // payload but carry the `imported_` id prefix — split them back out so they
     // read as "My Agents" rather than "Chat History" (mirrors the composer).
     ...(snap?.historyReferences ?? [])
       .filter((sid) => !sid.startsWith("imported_"))
-      .map((sid): ContextTreeItem => ({
-        key: `hist-${sid}`,
-        icon: MessageSquare,
-        kind: t("Chat History"),
-        label: "",
-      })),
+      .map(
+        (sid): ContextTreeItem => ({
+          key: `hist-${sid}`,
+          icon: MessageSquare,
+          kind: t("Chat History"),
+          label: "",
+        }),
+      ),
     ...(snap?.historyReferences ?? [])
       .filter((sid) => sid.startsWith("imported_"))
-      .map((sid): ContextTreeItem => ({
-        key: `agent-${sid}`,
-        icon: Bot,
-        kind: t("My Agents"),
-        label: "",
-      })),
+      .map(
+        (sid): ContextTreeItem => ({
+          key: `agent-${sid}`,
+          icon: Bot,
+          kind: t("My Agents"),
+          label: "",
+        }),
+      ),
     ...(snap?.questionNotebookReferences?.length
       ? [
           {
@@ -1034,12 +1042,14 @@ const UserMessage = memo(function UserMessage({
           } satisfies ContextTreeItem,
         ]
       : []),
-    ...(snap?.memoryReferences ?? []).map((file): ContextTreeItem => ({
-      key: `mem-${file}`,
-      icon: Brain,
-      kind: t("Memory"),
-      label: file === "summary" ? t("Summary") : t("Profile"),
-    })),
+    ...(snap?.memoryReferences ?? []).map(
+      (file): ContextTreeItem => ({
+        key: `mem-${file}`,
+        icon: Brain,
+        kind: t("Memory"),
+        label: file === "summary" ? t("Summary") : t("Profile"),
+      }),
+    ),
   ];
 
   return (
@@ -1163,8 +1173,8 @@ export const ChatMessageList = memo(function ChatMessageList({
   selectedBranches,
   onEditMessage,
   onSwitchBranch,
-  onSubmitUserReply,
   availableKbNames,
+  onSubmitUserReply,
 }: {
   messages: ChatMessageItem[];
   isStreaming: boolean;
@@ -1410,7 +1420,8 @@ export const ChatMessageList = memo(function ChatMessageList({
           const resultEv = msg.events?.find((e) => e.type === "result");
           if (!resultEv) return null;
           const meta = resultEv.metadata?.metadata as
-            Record<string, unknown> | undefined;
+            | Record<string, unknown>
+            | undefined;
           const cs = meta?.cost_summary as
             | {
                 total_cost_usd?: number;

--- a/web/components/chat/home/ChatMessages.tsx
+++ b/web/components/chat/home/ChatMessages.tsx
@@ -891,6 +891,7 @@ const UserMessage = memo(function UserMessage({
   editDisabled,
   siblingInfo,
   onSwitchBranch,
+  availableKbNames,
 }: {
   msg: ChatMessageItem;
   index: number;
@@ -900,6 +901,8 @@ const UserMessage = memo(function UserMessage({
   editDisabled?: boolean;
   siblingInfo?: SiblingInfo;
   onSwitchBranch?: (parentMessageId: number | null, childId: number) => void;
+  /** Names of KBs confirmed to exist. Omitted when the KB list is unavailable. */
+  availableKbNames?: Set<string>;
 }) {
   const { t } = useTranslation();
   const [editing, setEditing] = useState(false);
@@ -956,64 +959,61 @@ const UserMessage = memo(function UserMessage({
         onClick: onPreviewAttachment ? () => onPreviewAttachment(a) : undefined,
       };
     }),
-    ...(snap?.knowledgeBases ?? []).map((name): ContextTreeItem => {
-      const agentKind = agentKinds[name];
-      if (agentKind) {
+    ...(snap?.knowledgeBases ?? [])
+      .filter(
+        (name) =>
+          !availableKbNames || availableKbNames.has(name) || agentKinds[name],
+      )
+      .map((name): ContextTreeItem => {
+        const agentKind = agentKinds[name];
+        if (agentKind) {
+          return {
+            key: `agent-${name}`,
+            // Brand SVG marks share the lucide call signature (size/strokeWidth/
+            // className); cast bridges the structural-variance gap.
+            icon: (agentGlyph(agentKind) ?? Bot) as unknown as LucideIcon,
+            kind: t("Agent"),
+            label: name,
+          };
+        }
         return {
-          key: `agent-${name}`,
-          // Brand SVG marks share the lucide call signature (size/strokeWidth/
-          // className); cast bridges the structural-variance gap.
-          icon: (agentGlyph(agentKind) ?? Bot) as unknown as LucideIcon,
-          kind: t("Agent"),
+          key: `kb-${name}`,
+          icon: Database,
+          kind: t("Knowledge"),
           label: name,
         };
-      }
-      return {
-        key: `kb-${name}`,
-        icon: Database,
-        kind: t("Knowledge"),
-        label: name,
-      };
-    }),
-    ...(snap?.bookReferences ?? []).map(
-      (ref): ContextTreeItem => ({
-        key: `book-${ref.book_id}`,
-        icon: BookOpen,
-        kind: t("Book"),
-        label: `${ref.page_ids.length} ${t("chapters")}`,
       }),
-    ),
-    ...(snap?.notebookReferences ?? []).map(
-      (ref): ContextTreeItem => ({
-        key: `nb-${ref.notebook_id}`,
-        icon: BookOpen,
-        kind: t("Notebook"),
-        label: `${ref.record_ids.length} ${t("records")}`,
-      }),
-    ),
+    ...(snap?.bookReferences ?? []).map((ref): ContextTreeItem => ({
+      key: `book-${ref.book_id}`,
+      icon: BookOpen,
+      kind: t("Book"),
+      label: `${ref.page_ids.length} ${t("chapters")}`,
+    })),
+    ...(snap?.notebookReferences ?? []).map((ref): ContextTreeItem => ({
+      key: `nb-${ref.notebook_id}`,
+      icon: BookOpen,
+      kind: t("Notebook"),
+      label: `${ref.record_ids.length} ${t("records")}`,
+    })),
     // Imported agent conversations are folded into the same history_references
     // payload but carry the `imported_` id prefix — split them back out so they
     // read as "My Agents" rather than "Chat History" (mirrors the composer).
     ...(snap?.historyReferences ?? [])
       .filter((sid) => !sid.startsWith("imported_"))
-      .map(
-        (sid): ContextTreeItem => ({
-          key: `hist-${sid}`,
-          icon: MessageSquare,
-          kind: t("Chat History"),
-          label: "",
-        }),
-      ),
+      .map((sid): ContextTreeItem => ({
+        key: `hist-${sid}`,
+        icon: MessageSquare,
+        kind: t("Chat History"),
+        label: "",
+      })),
     ...(snap?.historyReferences ?? [])
       .filter((sid) => sid.startsWith("imported_"))
-      .map(
-        (sid): ContextTreeItem => ({
-          key: `agent-${sid}`,
-          icon: Bot,
-          kind: t("My Agents"),
-          label: "",
-        }),
-      ),
+      .map((sid): ContextTreeItem => ({
+        key: `agent-${sid}`,
+        icon: Bot,
+        kind: t("My Agents"),
+        label: "",
+      })),
     ...(snap?.questionNotebookReferences?.length
       ? [
           {
@@ -1034,14 +1034,12 @@ const UserMessage = memo(function UserMessage({
           } satisfies ContextTreeItem,
         ]
       : []),
-    ...(snap?.memoryReferences ?? []).map(
-      (file): ContextTreeItem => ({
-        key: `mem-${file}`,
-        icon: Brain,
-        kind: t("Memory"),
-        label: file === "summary" ? t("Summary") : t("Profile"),
-      }),
-    ),
+    ...(snap?.memoryReferences ?? []).map((file): ContextTreeItem => ({
+      key: `mem-${file}`,
+      icon: Brain,
+      kind: t("Memory"),
+      label: file === "summary" ? t("Summary") : t("Profile"),
+    })),
   ];
 
   return (
@@ -1166,6 +1164,7 @@ export const ChatMessageList = memo(function ChatMessageList({
   onEditMessage,
   onSwitchBranch,
   onSubmitUserReply,
+  availableKbNames,
 }: {
   messages: ChatMessageItem[];
   isStreaming: boolean;
@@ -1201,6 +1200,8 @@ export const ChatMessageList = memo(function ChatMessageList({
           answers?: Array<{ questionId: string; text: string }>;
         },
   ) => void;
+  /** Names of KBs confirmed to exist. Omitted when the KB list is unavailable. */
+  availableKbNames?: Set<string>;
 }) {
   const { t } = useTranslation();
   // Visible path: when no branching has happened the result is identical
@@ -1381,6 +1382,7 @@ export const ChatMessageList = memo(function ChatMessageList({
               editDisabled={isStreaming}
               siblingInfo={sib}
               onSwitchBranch={onSwitchBranch}
+              availableKbNames={availableKbNames}
             />
           );
         }
@@ -1408,8 +1410,7 @@ export const ChatMessageList = memo(function ChatMessageList({
           const resultEv = msg.events?.find((e) => e.type === "result");
           if (!resultEv) return null;
           const meta = resultEv.metadata?.metadata as
-            | Record<string, unknown>
-            | undefined;
+            Record<string, unknown> | undefined;
           const cs = meta?.cost_summary as
             | {
                 total_cost_usd?: number;

--- a/web/lib/session-activity.ts
+++ b/web/lib/session-activity.ts
@@ -70,7 +70,11 @@ export interface SessionActivity {
   isEmpty: boolean;
 }
 
-export function buildSessionActivity(messages: MessageItem[]): SessionActivity {
+export function buildSessionActivity(
+  messages: MessageItem[],
+  options?: { availableKbNames?: Set<string> },
+): SessionActivity {
+  const availableKbNames = options?.availableKbNames;
   const toolCounts = new Map<string, number>();
   const kbs = new Set<string>();
   const historySessionIds = new Set<string>();
@@ -106,7 +110,9 @@ export function buildSessionActivity(messages: MessageItem[]): SessionActivity {
 
     const snap: MessageRequestSnapshot | undefined = msg.requestSnapshot;
     if (snap) {
-      snap.knowledgeBases?.forEach((k) => kbs.add(k));
+      snap.knowledgeBases?.forEach((k) => {
+        if (!availableKbNames || availableKbNames.has(k)) kbs.add(k);
+      });
       snap.historyReferences?.forEach((s) => historySessionIds.add(s));
       snap.bookReferences?.forEach((b) => {
         bookIds.add(b.book_id);

--- a/web/tests/session-activity.test.ts
+++ b/web/tests/session-activity.test.ts
@@ -164,6 +164,41 @@ test("dedupes knowledge bases across turns", () => {
   assert.deepEqual(activity.knowledgeBases, ["KB"]);
 });
 
+test("hides deleted knowledge bases when an available set is given", () => {
+  const activity = buildSessionActivity(
+    messages({
+      role: "user",
+      requestSnapshot: snapshot({ knowledgeBases: ["gone", "alive"] }),
+    }),
+    { availableKbNames: new Set(["alive"]) },
+  );
+
+  assert.deepEqual(activity.knowledgeBases, ["alive"]);
+});
+
+test("hides every stale knowledge base when the confirmed set is empty", () => {
+  const activity = buildSessionActivity(
+    messages({
+      role: "user",
+      requestSnapshot: snapshot({ knowledgeBases: ["last-deleted-kb"] }),
+    }),
+    { availableKbNames: new Set() },
+  );
+
+  assert.deepEqual(activity.knowledgeBases, []);
+});
+
+test("keeps knowledge bases when availability could not be loaded", () => {
+  const activity = buildSessionActivity(
+    messages({
+      role: "user",
+      requestSnapshot: snapshot({ knowledgeBases: ["unconfirmed"] }),
+    }),
+  );
+
+  assert.deepEqual(activity.knowledgeBases, ["unconfirmed"]);
+});
+
 /* ------------------------------------------------------------------ */
 /*  artifactDiskPath                                                   */
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
复现步骤：
1、在KB中，删除了某个KB，
2、回到Chat界面，在Chat输入框的KB选择下拉框，仍然可以可以选择已被删掉的stale KB，不同步将造成困扰，
3、Fix方案如下：

## Summary

- prune deleted knowledge bases from persisted chat selections after a successful KB refresh
- hide stale KB references from message context trees and the session activity panel
- distinguish a confirmed empty KB list from a failed request, while preserving connected-agent references

## Testing

- `npm run test:node` — 578 passed
- `npx eslint .` — 0 errors
- repository Prettier and pre-commit hooks passed
