### PR TITLE
fix(book): repair the reader flex height chain so long chapters scroll

### DIFF
--- a/web/app/(workspace)/book/page.tsx
+++ b/web/app/(workspace)/book/page.tsx
@@ -971,7 +971,7 @@ function BookPageInner() {
                   void compilePage(pageId, true);
                 }}
               />
-              <div className="min-h-0 flex-1">
+              <div className="flex min-h-0 flex-1 flex-col">
                 <div className="min-h-0 flex-1 overflow-hidden">
                   <PageReader
                     page={selectedPage}


### PR DESCRIPTION
### Description
The book reader cannot scroll at all since v1.5.15: any chapter content taller than one viewport is clipped, making the end-of-chapter quiz, the page navigation footer, and the new learning-capture panel unreachable.

**Fix.** One line: make the wrapper a flex column (`flex flex-col`) so the inner `min-h-0 flex-1` resolves again and `PageReader` / the capture panel get their intended heights back.

### Module(s) Affected
- [x] `web` (Frontend)

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] My changes do not introduce any new security vulnerabilities.