### PR TITLE
feat: add per-conversation reasoning-effort override (#641)

### DIFF
--- a/deeptutor/services/config/provider_runtime.py
+++ b/deeptutor/services/config/provider_runtime.py
@@ -724,7 +724,11 @@ def resolve_llm_runtime_config(
     """Resolve active LLM config with TutorBot-style provider matching."""
     catalog_service = service or get_model_catalog_service()
     loaded = _with_personal_llm_profiles(_load_catalog(catalog))
-    loaded = apply_llm_selection_to_catalog(loaded, llm_selection)
+    # Parse the payload once: ``apply_llm_selection_to_catalog`` would otherwise
+    # re-parse it, so a malformed selection would be validated (and rejected)
+    # from two places. ``from_payload`` is idempotent on an already-parsed value.
+    selection = LLMSelection.from_payload(llm_selection)
+    loaded = apply_llm_selection_to_catalog(loaded, selection)
 
     profile, model = _active_profile_and_model(loaded, catalog_service, "llm")
     resolved_model = _as_str((model or {}).get("model"))
@@ -740,9 +744,8 @@ def resolve_llm_runtime_config(
     # caller's LLMSelection takes precedence over the profile/model default
     # resolved above. The model/global config value stays the fallback when
     # no override is present, preserving today's behavior.
-    selection_effort = LLMSelection.from_payload(llm_selection)
-    if selection_effort is not None and selection_effort.reasoning_effort:
-        reasoning_effort = selection_effort.reasoning_effort
+    if selection is not None and selection.reasoning_effort:
+        reasoning_effort = selection.reasoning_effort
     active_extra_headers = _to_headers((profile or {}).get("extra_headers"))
     context_window = _coerce_optional_int((model or {}).get("context_window"))
     if context_window is None:

--- a/deeptutor/services/config/provider_runtime.py
+++ b/deeptutor/services/config/provider_runtime.py
@@ -736,6 +736,13 @@ def resolve_llm_runtime_config(
     active_api_base = _as_str((profile or {}).get("base_url"))
     active_api_version = _as_str((profile or {}).get("api_version"))
     reasoning_effort = _as_str((model or {}).get("reasoning_effort")) or None
+    # Per-conversation override (#641): an explicit reasoning_effort on the
+    # caller's LLMSelection takes precedence over the profile/model default
+    # resolved above. The model/global config value stays the fallback when
+    # no override is present, preserving today's behavior.
+    selection_effort = LLMSelection.from_payload(llm_selection)
+    if selection_effort is not None and selection_effort.reasoning_effort:
+        reasoning_effort = selection_effort.reasoning_effort
     active_extra_headers = _to_headers((profile or {}).get("extra_headers"))
     context_window = _coerce_optional_int((model or {}).get("context_window"))
     if context_window is None:

--- a/deeptutor/services/model_selection/__init__.py
+++ b/deeptutor/services/model_selection/__init__.py
@@ -1,5 +1,15 @@
 """Model selection services for request-scoped runtime switching."""
 
-from .llm import LLMSelection, apply_llm_selection_to_catalog, list_llm_options
+from .llm import (
+    VALID_REASONING_EFFORTS,
+    LLMSelection,
+    apply_llm_selection_to_catalog,
+    list_llm_options,
+)
 
-__all__ = ["LLMSelection", "apply_llm_selection_to_catalog", "list_llm_options"]
+__all__ = [
+    "LLMSelection",
+    "VALID_REASONING_EFFORTS",
+    "apply_llm_selection_to_catalog",
+    "list_llm_options",
+]

--- a/deeptutor/services/model_selection/llm.py
+++ b/deeptutor/services/model_selection/llm.py
@@ -8,12 +8,14 @@ from typing import Any
 
 from deeptutor.services.provider_registry import find_by_name
 
-# Reasoning-effort vocabulary already used elsewhere in the codebase (see
-# services/llm/reasoning_params.py and services/subagent/models.py) — kept
-# here as the single source of truth for what a conversation-level override
-# (#641) may request. Not every provider/model supports every value; callers
-# that need a narrower, model-specific list should filter client-side before
-# submitting a selection.
+# What a conversation-level override (#641) is allowed to ask for. This is a
+# request-validation vocabulary, deliberately the union of every level any
+# provider understands — `services/llm/reasoning_params.py` is what maps a
+# level onto a given provider's actual knob, and the per-backend `efforts`
+# lists in `services/subagent/models.py` describe what each subagent CLI
+# accepts. Neither of those is interchangeable with this one. Not every
+# provider/model supports every value, so callers that can offer a narrower,
+# model-specific list should filter before submitting a selection.
 VALID_REASONING_EFFORTS: tuple[str, ...] = (
     "none",
     "minimal",

--- a/deeptutor/services/model_selection/llm.py
+++ b/deeptutor/services/model_selection/llm.py
@@ -8,6 +8,22 @@ from typing import Any
 
 from deeptutor.services.provider_registry import find_by_name
 
+# Reasoning-effort vocabulary already used elsewhere in the codebase (see
+# services/llm/reasoning_params.py and services/subagent/models.py) — kept
+# here as the single source of truth for what a conversation-level override
+# (#641) may request. Not every provider/model supports every value; callers
+# that need a narrower, model-specific list should filter client-side before
+# submitting a selection.
+VALID_REASONING_EFFORTS: tuple[str, ...] = (
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+)
+
 
 @dataclass(frozen=True, slots=True)
 class LLMSelection:
@@ -15,10 +31,17 @@ class LLMSelection:
 
     The selection intentionally carries IDs only. Provider secrets stay in the
     server-side catalog and are resolved only at runtime.
+
+    ``reasoning_effort`` is an optional per-conversation override (#641):
+    when set, it takes precedence over the profile/model's own
+    ``reasoning_effort`` default for calls made with this selection. ``None``
+    means "no override" — the existing profile/global/provider default
+    resolution applies unchanged.
     """
 
     profile_id: str
     model_id: str
+    reasoning_effort: str | None = None
 
     @classmethod
     def from_payload(cls, value: Any) -> "LLMSelection | None":
@@ -35,10 +58,21 @@ class LLMSelection:
             return None
         if not profile_id or not model_id:
             raise ValueError("Invalid LLM selection: profile_id and model_id are required.")
-        return cls(profile_id=profile_id, model_id=model_id)
+
+        reasoning_effort = str(value.get("reasoning_effort") or "").strip().lower() or None
+        if reasoning_effort is not None and reasoning_effort not in VALID_REASONING_EFFORTS:
+            raise ValueError(
+                "Invalid LLM selection: unsupported reasoning_effort "
+                f"{reasoning_effort!r}. Expected one of "
+                f"{', '.join(VALID_REASONING_EFFORTS)}."
+            )
+        return cls(profile_id=profile_id, model_id=model_id, reasoning_effort=reasoning_effort)
 
     def to_dict(self) -> dict[str, str]:
-        return {"profile_id": self.profile_id, "model_id": self.model_id}
+        payload = {"profile_id": self.profile_id, "model_id": self.model_id}
+        if self.reasoning_effort:
+            payload["reasoning_effort"] = self.reasoning_effort
+        return payload
 
 
 def _coerce_int(value: Any) -> int | None:
@@ -135,4 +169,9 @@ def apply_llm_selection_to_catalog(
     raise ValueError("Invalid LLM selection: selected profile/model was not found.")
 
 
-__all__ = ["LLMSelection", "apply_llm_selection_to_catalog", "list_llm_options"]
+__all__ = [
+    "LLMSelection",
+    "VALID_REASONING_EFFORTS",
+    "apply_llm_selection_to_catalog",
+    "list_llm_options",
+]

--- a/deeptutor/services/session/turn_runtime.py
+++ b/deeptutor/services/session/turn_runtime.py
@@ -1896,6 +1896,7 @@ class TurnRuntimeManager:
                     "llm_selection": payload.get("llm_selection") or {},
                     "llm_model": str(getattr(llm_config, "model", "") or ""),
                     "llm_provider": str(getattr(llm_config, "provider_name", "") or ""),
+                    "llm_reasoning_effort": str(getattr(llm_config, "reasoning_effort", "") or ""),
                     # Per-turn full-text payload for read_source. Empty when
                     # the manifest is empty (non-chat capabilities, or chat
                     # turns with no attached sources). Consumed by the chat

--- a/tests/services/config/test_provider_runtime.py
+++ b/tests/services/config/test_provider_runtime.py
@@ -551,6 +551,69 @@ def test_llm_reasoning_effort_resolves_from_catalog() -> None:
     assert resolved.reasoning_effort == "high"
 
 
+def test_llm_selection_reasoning_effort_overrides_catalog_default() -> None:
+    catalog = _build_catalog(
+        llm_profile={
+            "id": "llm-p",
+            "name": "LLM",
+            "binding": "openai",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "sk-test",
+            "api_version": "",
+            "extra_headers": {},
+            "models": [
+                {
+                    "id": "llm-m",
+                    "name": "GPT 4o mini",
+                    "model": "gpt-4o-mini",
+                    "reasoning_effort": "high",
+                }
+            ],
+        }
+    )
+    resolved = resolve_llm_runtime_config(
+        catalog=catalog,
+        llm_selection={"profile_id": "llm-p", "model_id": "llm-m", "reasoning_effort": "low"},
+    )
+    assert resolved.reasoning_effort == "low"
+
+
+def test_llm_selection_without_reasoning_effort_keeps_catalog_default() -> None:
+    catalog = _build_catalog(
+        llm_profile={
+            "id": "llm-p",
+            "name": "LLM",
+            "binding": "openai",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "sk-test",
+            "api_version": "",
+            "extra_headers": {},
+            "models": [
+                {
+                    "id": "llm-m",
+                    "name": "GPT 4o mini",
+                    "model": "gpt-4o-mini",
+                    "reasoning_effort": "high",
+                }
+            ],
+        }
+    )
+    resolved = resolve_llm_runtime_config(
+        catalog=catalog,
+        llm_selection={"profile_id": "llm-p", "model_id": "llm-m"},
+    )
+    assert resolved.reasoning_effort == "high"
+
+
+def test_llm_selection_reasoning_effort_applies_even_without_catalog_default() -> None:
+    catalog = _build_catalog()
+    resolved = resolve_llm_runtime_config(
+        catalog=catalog,
+        llm_selection={"profile_id": "llm-p", "model_id": "llm-m", "reasoning_effort": "xhigh"},
+    )
+    assert resolved.reasoning_effort == "xhigh"
+
+
 def test_search_fallback_to_duckduckgo_without_key() -> None:
     catalog = _build_catalog(
         search_profile={

--- a/tests/services/model_selection/test_llm_selection.py
+++ b/tests/services/model_selection/test_llm_selection.py
@@ -86,3 +86,39 @@ def test_apply_llm_selection_rejects_model_not_in_profile():
         assert "Invalid LLM selection" in str(exc)
     else:
         raise AssertionError("expected invalid selection to fail")
+
+
+def test_llm_selection_from_payload_accepts_valid_reasoning_effort():
+    selection = LLMSelection.from_payload(
+        {"profile_id": "p1", "model_id": "m1", "reasoning_effort": "High"}
+    )
+    assert selection.reasoning_effort == "high"
+
+
+def test_llm_selection_from_payload_rejects_unsupported_reasoning_effort():
+    try:
+        LLMSelection.from_payload(
+            {"profile_id": "p1", "model_id": "m1", "reasoning_effort": "ultra"}
+        )
+    except ValueError as exc:
+        assert "reasoning_effort" in str(exc)
+    else:
+        raise AssertionError("expected invalid reasoning_effort to fail")
+
+
+def test_llm_selection_from_payload_without_reasoning_effort_defaults_to_none():
+    selection = LLMSelection.from_payload({"profile_id": "p1", "model_id": "m1"})
+    assert selection.reasoning_effort is None
+
+
+def test_llm_selection_to_dict_round_trips_reasoning_effort():
+    selection = LLMSelection(profile_id="p1", model_id="m1", reasoning_effort="xhigh")
+    payload = selection.to_dict()
+    assert payload["reasoning_effort"] == "xhigh"
+    restored = LLMSelection.from_payload(payload)
+    assert restored == selection
+
+
+def test_llm_selection_to_dict_omits_reasoning_effort_when_unset():
+    selection = LLMSelection(profile_id="p1", model_id="m1")
+    assert "reasoning_effort" not in selection.to_dict()


### PR DESCRIPTION
Description: Adds an optional per-conversation reasoning_effort override to LLMSelection, the existing model-pin primitive that already flows from a turn's payload (or saved session preferences) through to the real LLM call. When set, it takes precedence over the profile/model's own default; when unset, existing resolution is unchanged. The effective value is also exposed in the turn metadata that already surfaces llm_model/llm_provider (Activity panel data). The chat-composer selector UI itself is a separate frontend change, not included here.

Related Issues: Related to #641

Module(s) Affected: services, api

Additional Notes: 9 new tests added (tests/services/model_selection/test_llm_selection.py, tests/services/config/test_provider_runtime.py); full suite run clean against a fresh dev checkout.