### PR TITLE
fix(web): pin chat to late-mounted quiz cards

### DIFF
--- a/web/components/quiz/QuizViewer.tsx
+++ b/web/components/quiz/QuizViewer.tsx
@@ -758,7 +758,10 @@ export default function QuizViewer({
   const currentBookmarked = bookmarked[questionKey] ?? false;
 
   return (
-    <div className="overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)]">
+    <div
+      data-chat-grow="quiz"
+      className="overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)]"
+    >
       <div className="flex items-center gap-2 border-b border-[var(--border)] px-3 py-2">
         <button
           type="button"

--- a/web/hooks/useChatAutoScroll.ts
+++ b/web/hooks/useChatAutoScroll.ts
@@ -170,11 +170,18 @@ export function useChatAutoScroll({
   // Mermaid …) finish hydrating and grow the content height. The user
   // expects to land at the bottom so they see the full result.
   //
-  // The observer is intentionally short-lived (4s after stream stop):
-  // a longer window would mis-classify post-turn user interactions
-  // (expanding a trace ``<details>``, clicking a citation) as
-  // "streaming-style growth" and rip them back to the bottom.
+  // The window is intentionally short (4s after stream stop): a longer one
+  // would mis-classify post-turn user interactions (expanding a trace
+  // ``<details>``, clicking a citation) as "streaming-style growth" and rip
+  // the user back to the bottom.
+  //
+  // Viewers that tag themselves ``[data-chat-grow]`` are the one exception.
+  // Their first JS chunk can land after the short window (issue #955),
+  // leaving the card below the fold until the user scrolls. A *newly
+  // appearing* tagged node is an unambiguous "this growth is not the user"
+  // signal, so it — and nothing else — extends the window.
   const POST_STREAM_AUTOSCROLL_WINDOW_MS = 4000;
+  const LATE_VIEWER_AUTOSCROLL_WINDOW_MS = 12_000;
   useEffect(() => {
     if (isStreaming) return;
     if (!hasMessages) return;
@@ -184,12 +191,42 @@ export function useChatAutoScroll({
 
     let prevHeight = container.scrollHeight;
     let rafId = 0;
-    const deadline = performance.now() + POST_STREAM_AUTOSCROLL_WINDOW_MS;
+    let stopTimer = 0;
+    const startedAt = performance.now();
+    let deadline = startedAt + POST_STREAM_AUTOSCROLL_WINDOW_MS;
+    let growTargets = container.querySelectorAll("[data-chat-grow]").length;
+
+    const stop = () => {
+      mo.disconnect();
+      container.removeEventListener("load", check, true);
+      if (rafId) cancelAnimationFrame(rafId);
+      if (stopTimer) window.clearTimeout(stopTimer);
+      stopTimer = 0;
+    };
+
+    // Keep the teardown pinned to whatever the current deadline is, so the
+    // common case (no late viewer) still stops observing after 4s.
+    const armStop = () => {
+      if (stopTimer) window.clearTimeout(stopTimer);
+      stopTimer = window.setTimeout(
+        stop,
+        Math.max(0, deadline - performance.now()),
+      );
+    };
 
     const check = () => {
       if (rafId) return;
       rafId = requestAnimationFrame(() => {
         rafId = 0;
+        const tagged = container.querySelectorAll("[data-chat-grow]").length;
+        if (tagged > growTargets) {
+          growTargets = tagged;
+          const extended = startedAt + LATE_VIEWER_AUTOSCROLL_WINDOW_MS;
+          if (extended > deadline) {
+            deadline = extended;
+            armStop();
+          }
+        }
         if (performance.now() > deadline) return;
         const curHeight = container.scrollHeight;
         if (curHeight > prevHeight && shouldAutoScrollRef.current) {
@@ -209,54 +246,9 @@ export function useChatAutoScroll({
     // (Opening a history session is not this path: that effect does not
     // re-run on a session switch, so the page re-pins there itself.)
     container.addEventListener("load", check, true);
-    const stopTimer = window.setTimeout(() => {
-      mo.disconnect();
-      container.removeEventListener("load", check, true);
-      if (rafId) cancelAnimationFrame(rafId);
-    }, POST_STREAM_AUTOSCROLL_WINDOW_MS);
+    armStop();
 
-    return () => {
-      window.clearTimeout(stopTimer);
-      mo.disconnect();
-      container.removeEventListener("load", check, true);
-      if (rafId) cancelAnimationFrame(rafId);
-    };
-  }, [hasMessages, isStreaming, pinToBottom]);
-
-  // QuizViewer is loaded with ``next/dynamic({ssr:false})``. The first JS
-  // chunk can land after the 4s generic post-stream window, leaving the
-  // card below the fold until the user scrolls (issue #955). Watch for
-  // ``[data-chat-grow]`` so expanding a trace ``<details>`` still does not
-  // re-pin after the short window.
-  const LATE_VIEWER_AUTOSCROLL_WINDOW_MS = 12_000;
-  useEffect(() => {
-    if (isStreaming || !hasMessages) return;
-    const container = containerRef.current;
-    if (!container) return;
-
-    const pinGrowTarget = (): boolean => {
-      if (!shouldAutoScrollRef.current) return false;
-      if (!container.querySelector("[data-chat-grow]")) return false;
-      pinToBottom();
-      return true;
-    };
-
-    if (pinGrowTarget()) return;
-
-    const deadline = performance.now() + LATE_VIEWER_AUTOSCROLL_WINDOW_MS;
-    const mo = new MutationObserver(() => {
-      if (performance.now() > deadline) return;
-      if (pinGrowTarget()) mo.disconnect();
-    });
-    mo.observe(container, { childList: true, subtree: true });
-    const stopTimer = window.setTimeout(
-      () => mo.disconnect(),
-      LATE_VIEWER_AUTOSCROLL_WINDOW_MS,
-    );
-    return () => {
-      window.clearTimeout(stopTimer);
-      mo.disconnect();
-    };
+    return stop;
   }, [hasMessages, isStreaming, pinToBottom]);
 
   const handleScroll = useCallback(() => {

--- a/web/hooks/useChatAutoScroll.ts
+++ b/web/hooks/useChatAutoScroll.ts
@@ -223,6 +223,42 @@ export function useChatAutoScroll({
     };
   }, [hasMessages, isStreaming, pinToBottom]);
 
+  // QuizViewer is loaded with ``next/dynamic({ssr:false})``. The first JS
+  // chunk can land after the 4s generic post-stream window, leaving the
+  // card below the fold until the user scrolls (issue #955). Watch for
+  // ``[data-chat-grow]`` so expanding a trace ``<details>`` still does not
+  // re-pin after the short window.
+  const LATE_VIEWER_AUTOSCROLL_WINDOW_MS = 12_000;
+  useEffect(() => {
+    if (isStreaming || !hasMessages) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const pinGrowTarget = (): boolean => {
+      if (!shouldAutoScrollRef.current) return false;
+      if (!container.querySelector("[data-chat-grow]")) return false;
+      pinToBottom();
+      return true;
+    };
+
+    if (pinGrowTarget()) return;
+
+    const deadline = performance.now() + LATE_VIEWER_AUTOSCROLL_WINDOW_MS;
+    const mo = new MutationObserver(() => {
+      if (performance.now() > deadline) return;
+      if (pinGrowTarget()) mo.disconnect();
+    });
+    mo.observe(container, { childList: true, subtree: true });
+    const stopTimer = window.setTimeout(
+      () => mo.disconnect(),
+      LATE_VIEWER_AUTOSCROLL_WINDOW_MS,
+    );
+    return () => {
+      window.clearTimeout(stopTimer);
+      mo.disconnect();
+    };
+  }, [hasMessages, isStreaming, pinToBottom]);
+
   const handleScroll = useCallback(() => {
     const container = containerRef.current;
     if (!container) return;

--- a/web/tests/quiz-autoscroll.test.ts
+++ b/web/tests/quiz-autoscroll.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const quizViewer = readFileSync(
+  path.resolve(process.cwd(), "components/quiz/QuizViewer.tsx"),
+  "utf8",
+);
+const autoScroll = readFileSync(
+  path.resolve(process.cwd(), "hooks/useChatAutoScroll.ts"),
+  "utf8",
+);
+
+test("QuizViewer marks itself as late-growing chat content", () => {
+  assert.match(quizViewer, /data-chat-grow="quiz"/);
+});
+
+test("autoscroll waits for late-mounted capability viewers after the stream", () => {
+  assert.match(autoScroll, /LATE_VIEWER_AUTOSCROLL_WINDOW_MS/);
+  assert.match(autoScroll, /\[data-chat-grow\]/);
+  assert.match(autoScroll, /issue #955/);
+});

--- a/web/tests/quiz-autoscroll.test.ts
+++ b/web/tests/quiz-autoscroll.test.ts
@@ -16,8 +16,18 @@ test("QuizViewer marks itself as late-growing chat content", () => {
   assert.match(quizViewer, /data-chat-grow="quiz"/);
 });
 
-test("autoscroll waits for late-mounted capability viewers after the stream", () => {
-  assert.match(autoScroll, /LATE_VIEWER_AUTOSCROLL_WINDOW_MS/);
+test("the post-stream window extends only for late-mounted viewers", () => {
+  assert.match(autoScroll, /POST_STREAM_AUTOSCROLL_WINDOW_MS = 4000/);
+  assert.match(autoScroll, /LATE_VIEWER_AUTOSCROLL_WINDOW_MS = 12_000/);
+  // The extension must be gated on a newly appearing tagged node, not on one
+  // merely being present — an old quiz card must not keep re-pinning the user.
   assert.match(autoScroll, /\[data-chat-grow\]/);
-  assert.match(autoScroll, /issue #955/);
+  assert.match(autoScroll, /tagged > growTargets/);
+});
+
+test("one post-stream observer owns the pin, not two", () => {
+  // A second parallel observer would race the first and re-pin post-turn user
+  // interactions that the short window deliberately excludes.
+  const observers = autoScroll.match(/new MutationObserver\(/g) ?? [];
+  assert.equal(observers.length, 2, "expected one streaming + one post-stream");
 });


### PR DESCRIPTION
## Summary
- Mastery quiz cards are loaded with `next/dynamic({ssr:false})`. The first chunk can appear after the existing 4s post-stream autoscroll window, so the card sits below the composer until the user scrolls.
- Mark `QuizViewer` with `data-chat-grow=quiz` and keep following that node for 12s after the stream ends.
- Leave the short generic window unchanged so expanding a trace `<details>` still does not yank the viewport.

## Test plan
- [ ] Generate a mastery-path multiple-choice quiz and confirm the card lands in view without manual scrolling
- [ ] Expand a trace `<details>` after a normal chat turn and confirm the viewport does not jump
- [x] Source tests in `web/tests/quiz-autoscroll.test.ts`

Related to #955 (scroll half; duplicate options are #956)