### PR TITLE
fix(chat): decode dense non-ASCII unicode escapes for display

### DIFF
--- a/web/lib/markdown-display.ts
+++ b/web/lib/markdown-display.ts
@@ -1,6 +1,7 @@
 "use client";
 
-const ZERO_WIDTH_REGEX = /[\u200B-\u200D\uFEFF]/g;
+const INVISIBLE_CONTROL_REGEX =
+  /[\u200B-\u200F\u202A-\u202E\u2060\u2066-\u2069\uFEFF]/g;
 const EMPTY_DETAILS_REGEX =
   /<details(?:\s[^>]*)?>\s*(<summary(?:\s[^>]*)?>\s*(?:&nbsp;|\s|<br\s*\/?>)*\s*<\/summary>\s*)?<\/details>/gi;
 const EMPTY_SUMMARY_REGEX =
@@ -16,7 +17,7 @@ const EMPTY_HTML_BLOCK_REGEX =
 const HTML_TABLE_REGEX = /<table(?:\s[^>]*)?>[\s\S]*?<\/table>/gi;
 
 function stripInvisibleCharacters(value: string): string {
-  return value.replace(ZERO_WIDTH_REGEX, "");
+  return value.replace(INVISIBLE_CONTROL_REGEX, "");
 }
 
 // Tags that the renderer (rehype-raw + react-markdown) is allowed to render
@@ -668,8 +669,8 @@ function decodeEscapedUnicodeRun(escaped: string): string {
 export function normalizeMarkdownForDisplay(content: string): string {
   if (!content) return "";
 
-  const normalized = decodeEscapedUnicodeRuns(
-    stripInvisibleCharacters(String(content)).replace(/\r\n/g, "\n"),
+  const normalized = stripInvisibleCharacters(
+    decodeEscapedUnicodeRuns(String(content).replace(/\r\n/g, "\n")),
   )
     .replace(EMPTY_DETAILS_REGEX, "")
     .replace(EMPTY_SUMMARY_REGEX, "")

--- a/web/lib/markdown-display.ts
+++ b/web/lib/markdown-display.ts
@@ -151,6 +151,7 @@ const MATH_SPAN_REGEX =
 // two delimiters the author meant to pair (see repairStrongEmphasisLine).
 const MALFORMED_STRONG_EMPHASIS_REGEX =
   /(?<!\S)\*\*(?=\S)([^*\n]*?[:：])[ \t]+\*\*(?=\S)/g;
+const ESCAPED_UNICODE_RUN_REGEX = /(?:\\u[0-9a-fA-F]{4}){3,}/g;
 const INDENTED_CODE_LINE_REGEX = /^(?: {4}|\t)/;
 const PROTECTED_SPAN_REGEX = /```[\s\S]*?```|`[^`\n]*`/g;
 const PROTECTED_PLACEHOLDER_REGEX = /\u0000PROTECTED_(\d+)\u0000/g;
@@ -625,11 +626,51 @@ function linkifyCitationsOutsideCode(content: string): string {
   );
 }
 
+function decodeEscapedUnicodeRuns(content: string): string {
+  const fenced = maskProtectedSpans(
+    content,
+    FENCED_CODE_BLOCK_REGEX,
+    "UNICODE_FENCED_CODE",
+  );
+  const math = maskProtectedSpans(
+    fenced.masked,
+    MATH_SPAN_REGEX,
+    "UNICODE_MATH",
+  );
+  const inline = maskProtectedSpans(
+    math.masked,
+    INLINE_CODE_SPAN_REGEX,
+    "UNICODE_INLINE_CODE",
+  );
+  const decoded = inline.masked
+    .split("\n")
+    .map((line) =>
+      INDENTED_CODE_LINE_REGEX.test(line)
+        ? line
+        : line.replace(ESCAPED_UNICODE_RUN_REGEX, decodeEscapedUnicodeRun),
+    )
+    .join("\n");
+  return fenced.restore(math.restore(inline.restore(decoded)));
+}
+
+function decodeEscapedUnicodeRun(escaped: string): string {
+  try {
+    const value = JSON.parse(`"${escaped}"`) as string;
+    const containsNonAscii = Array.from(value).some(
+      (character) => character.charCodeAt(0) > 0x7f,
+    );
+    return containsNonAscii ? value : escaped;
+  } catch {
+    return escaped;
+  }
+}
+
 export function normalizeMarkdownForDisplay(content: string): string {
   if (!content) return "";
 
-  const normalized = stripInvisibleCharacters(String(content))
-    .replace(/\r\n/g, "\n")
+  const normalized = decodeEscapedUnicodeRuns(
+    stripInvisibleCharacters(String(content)).replace(/\r\n/g, "\n"),
+  )
     .replace(EMPTY_DETAILS_REGEX, "")
     .replace(EMPTY_SUMMARY_REGEX, "")
     .replace(EMPTY_PROGRESS_REGEX, "")

--- a/web/tests/markdown-display.test.ts
+++ b/web/tests/markdown-display.test.ts
@@ -85,6 +85,41 @@ test("normalizeMarkdownForDisplay removes empty details blocks", () => {
   assert.equal(normalizeMarkdownForDisplay(input), "Before\n\nAfter");
 });
 
+test("normalizeMarkdownForDisplay decodes dense non-ASCII JSON escapes", () => {
+  const input = "\\u300c\\u6570\\u5236\\u8f6c\\u6362\\u300d";
+  assert.equal(normalizeMarkdownForDisplay(input), "「数制转换」");
+});
+
+test("normalizeMarkdownForDisplay keeps isolated and ASCII unicode escape examples", () => {
+  const inputs = [
+    "A JSON string can encode A as \\u0041.",
+    "Three ASCII escapes: \\u0041\\u0042\\u0043.",
+  ];
+
+  for (const input of inputs) {
+    assert.equal(normalizeMarkdownForDisplay(input), input);
+  }
+});
+
+test("normalizeMarkdownForDisplay keeps unicode escapes inside code verbatim", () => {
+  const input = [
+    "Escaped text: `\\u300c\\u6570\\u5236\\u8f6c\\u6362\\u300d`",
+    "",
+    "```json",
+    '"label": "\\u300c\\u6570\\u5236\\u8f6c\\u6362\\u300d"',
+    "```",
+  ].join("\n");
+
+  assert.equal(normalizeMarkdownForDisplay(input), input);
+});
+
+test("normalizeMarkdownForDisplay keeps unicode escapes in indented code verbatim", () => {
+  const input =
+    'Example:\n\n    "label": "\\u300c\\u6570\\u5236\\u8f6c\\u6362\\u300d"';
+
+  assert.equal(normalizeMarkdownForDisplay(input), input);
+});
+
 test("normalizeMarkdownForDisplay removes raw html control placeholders", () => {
   const input =
     'Before\n\n<progress></progress>\n<input type="text" />\n<textarea> </textarea>\n\nAfter';

--- a/web/tests/markdown-display.test.ts
+++ b/web/tests/markdown-display.test.ts
@@ -90,6 +90,17 @@ test("normalizeMarkdownForDisplay decodes dense non-ASCII JSON escapes", () => {
   assert.equal(normalizeMarkdownForDisplay(input), "「数制转换」");
 });
 
+test("decoded unicode cannot reintroduce invisible or bidi controls", () => {
+  assert.equal(
+    normalizeMarkdownForDisplay("\\u200b\\u4e2d\\u6587"),
+    "中文",
+  );
+  assert.equal(
+    normalizeMarkdownForDisplay("\\u202e\\u0061\\u0062"),
+    "ab",
+  );
+});
+
 test("normalizeMarkdownForDisplay keeps isolated and ASCII unicode escape examples", () => {
   const inputs = [
     "A JSON string can encode A as \\u0041.",


### PR DESCRIPTION
## Summary
- Decode dense `\uXXXX` runs in displayed Markdown when they represent non-ASCII text, which repairs escaped Chinese prose reported in mastery-path summaries.
- Use the standard `JSON.parse` contract instead of adding a dependency.
- Keep isolated examples and ASCII-only escape runs unchanged.
- Preserve escaped examples inside fenced code, indented code, inline code, and math spans.

Closes #973.

## Testing
- `npm run test:node` (590 tests)
- `npx tsc --noEmit`
- `./node_modules/.bin/eslint lib/markdown-display.ts tests/markdown-display.test.ts`
- `npm run i18n:parity`
- `npm run build`