### PR TITLE
fix(whisper): show plugin-required empty state

### DIFF
--- a/web/app/(workspace)/whisper/page.tsx
+++ b/web/app/(workspace)/whisper/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Ear, Loader2 } from "lucide-react";
+import { apiFetch, apiUrl } from "@/lib/api";
 import WhisperComposer from "@/components/whisper/WhisperComposer";
 import WhisperMessageList from "@/components/whisper/WhisperMessageList";
 import WhisperRoomChip from "@/components/whisper/WhisperRoomChip";
@@ -19,6 +20,11 @@ import {
   type WhisperMessage,
   type WhisperSeat,
 } from "@/lib/whisper-transcript";
+import {
+  WHISPER_CAPABILITY_BY_SEAT,
+  hasWhisperCapabilities,
+  type WhisperPluginStatus,
+} from "@/lib/whisper-availability";
 
 function newMessageId(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
@@ -48,6 +54,8 @@ export default function WhisperPage() {
   const [dtSessionId, setDtSessionId] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
   const [everConnected, setEverConnected] = useState(false);
+  const [pluginStatus, setPluginStatus] =
+    useState<WhisperPluginStatus>("checking");
 
   const clientRef = useRef<UnifiedWSClient | null>(null);
   const seatRef = useRef<WhisperSeat>(seat);
@@ -135,7 +143,25 @@ export default function WhisperPage() {
     }
   }, []);
 
+  const checkPluginAvailability = useCallback(async () => {
+    setPluginStatus("checking");
+    try {
+      const response = await apiFetch(apiUrl("/api/v1/plugins/list"));
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const payload = (await response.json()) as unknown;
+      setPluginStatus(hasWhisperCapabilities(payload) ? "available" : "missing");
+    } catch {
+      setPluginStatus("error");
+    }
+  }, []);
+
   useEffect(() => {
+    void checkPluginAvailability();
+  }, [checkPluginAvailability]);
+
+  useEffect(() => {
+    if (pluginStatus !== "available") return;
+
     const client = new UnifiedWSClient(handleEvent, () => {
       setBusy(false);
       setConnected(false);
@@ -165,7 +191,7 @@ export default function WhisperPage() {
       client.disconnect();
       clientRef.current = null;
     };
-  }, [handleEvent]);
+  }, [handleEvent, pluginStatus]);
 
   useEffect(() => {
     if (scrollerRef.current) {
@@ -180,9 +206,10 @@ export default function WhisperPage() {
 
   const traineeNeedsRoom = seat === "trainee" && !roomId;
   const roomLocked = crisisHit || roomClosed;
+  const pluginReady = pluginStatus === "available";
   // Typing stays available during busy / trainee-without-room; only Send locks.
-  const inputDisabled = roomLocked;
-  const sendBlocked = busy || roomLocked || traineeNeedsRoom;
+  const inputDisabled = !pluginReady || roomLocked;
+  const sendBlocked = !pluginReady || busy || roomLocked || traineeNeedsRoom;
 
   function sendWithRetry(payload: StartTurnMessage, attempt = 0) {
     const client = clientRef.current;
@@ -238,8 +265,7 @@ export default function WhisperPage() {
     }, 120_000);
     retryTimersRef.current.add(busyWatchdog);
 
-    const capability =
-      seat === "visitor" ? "whisper_visitor" : "whisper_trainee";
+    const capability = WHISPER_CAPABILITY_BY_SEAT[seat];
     const payload: StartTurnMessage = {
       type: "start_turn",
       content: text,
@@ -323,6 +349,7 @@ export default function WhisperPage() {
                   role="tab"
                   aria-selected={active}
                   onClick={() => switchSeat(value)}
+                  disabled={!pluginReady}
                   className={`rounded-[10px] px-3 py-1.5 text-xs font-medium capitalize transition-colors ${
                     active
                       ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
@@ -334,7 +361,7 @@ export default function WhisperPage() {
               );
             })}
           </div>
-          {!connected && (
+          {pluginReady && !connected && (
             <span className="inline-flex items-center gap-1 text-[11px] text-[var(--muted-foreground)]">
               <Loader2 className="h-3 w-3 animate-spin" />
               {everConnected ? t("Reconnecting…") : t("Connecting…")}
@@ -355,6 +382,45 @@ export default function WhisperPage() {
         </div>
       )}
 
+      {pluginStatus !== "available" && (
+        <div
+          role="status"
+          className="border-b border-[var(--border)] bg-[var(--background)] px-4 py-3 text-xs text-[var(--muted-foreground)]"
+        >
+          <div className="mx-auto flex w-full max-w-3xl flex-wrap items-center justify-between gap-2">
+            <div>
+              <p className="font-medium text-[var(--foreground)]">
+                {pluginStatus === "checking"
+                  ? t("Checking Whisper plugin…")
+                  : pluginStatus === "missing"
+                    ? t("Whisper plugin required")
+                    : t("Unable to check Whisper plugin")}
+              </p>
+              <p className="mt-1 leading-5">
+                {pluginStatus === "checking"
+                  ? t("Waiting for the backend capability registry…")
+                  : pluginStatus === "missing"
+                    ? t(
+                        "Install or enable a plugin that provides whisper_visitor and whisper_trainee, then retry.",
+                      )
+                    : t(
+                        "The capability registry could not be reached. Check the backend connection and retry.",
+                      )}
+              </p>
+            </div>
+            {pluginStatus !== "checking" && (
+              <button
+                type="button"
+                onClick={() => void checkPluginAvailability()}
+                className="rounded-lg border border-[var(--border)] px-2.5 py-1.5 text-[11px] font-medium transition-colors hover:border-[var(--ring)] hover:text-[var(--foreground)]"
+              >
+                {t("Retry plugin check")}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
       {seat === "trainee" && !roomId && (
         <div
           role="status"
@@ -369,7 +435,9 @@ export default function WhisperPage() {
         className="min-h-0 flex-1 overflow-y-auto px-4 py-4"
       >
         <div className="mx-auto w-full max-w-3xl">
-          <WhisperMessageList messages={visibleMessages} seat={seat} />
+          {pluginStatus === "available" ? (
+            <WhisperMessageList messages={visibleMessages} seat={seat} />
+          ) : null}
         </div>
       </div>
 

--- a/web/lib/whisper-availability.ts
+++ b/web/lib/whisper-availability.ts
@@ -1,0 +1,41 @@
+import type { WhisperSeat } from "./whisper-transcript";
+
+export const WHISPER_CAPABILITY_BY_SEAT: Record<WhisperSeat, string> = {
+  visitor: "whisper_visitor",
+  trainee: "whisper_trainee",
+};
+
+export const REQUIRED_WHISPER_CAPABILITIES = Object.values(
+  WHISPER_CAPABILITY_BY_SEAT,
+);
+
+export type WhisperPluginStatus =
+  | "checking"
+  | "available"
+  | "missing"
+  | "error";
+
+export function hasWhisperCapabilities(payload: unknown): boolean {
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    !Array.isArray((payload as { capabilities?: unknown }).capabilities)
+  ) {
+    return false;
+  }
+
+  const names = new Set(
+    (payload as { capabilities: unknown[] }).capabilities
+      .map((capability) =>
+        capability &&
+        typeof capability === "object" &&
+        "name" in capability &&
+        typeof capability.name === "string"
+          ? capability.name
+          : null,
+      )
+      .filter((name): name is string => name !== null),
+  );
+
+  return REQUIRED_WHISPER_CAPABILITIES.every((name) => names.has(name));
+}

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -3301,5 +3301,12 @@
   "main": "main",
   "docs/": "docs/",
   "*.md": "*.md",
-  "Session {{id}}": "Session {{id}}"
+  "Session {{id}}": "Session {{id}}",
+  "Checking Whisper plugin…": "Checking Whisper plugin…",
+  "Whisper plugin required": "Whisper plugin required",
+  "Unable to check Whisper plugin": "Unable to check Whisper plugin",
+  "Waiting for the backend capability registry…": "Waiting for the backend capability registry…",
+  "Install or enable a plugin that provides whisper_visitor and whisper_trainee, then retry.": "Install or enable a plugin that provides whisper_visitor and whisper_trainee, then retry.",
+  "The capability registry could not be reached. Check the backend connection and retry.": "The capability registry could not be reached. Check the backend connection and retry.",
+  "Retry plugin check": "Retry plugin check"
 }

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -3301,5 +3301,12 @@
   "main": "main",
   "docs/": "docs/",
   "*.md": "*.md",
-  "Session {{id}}": "会话 {{id}}"
+  "Session {{id}}": "会话 {{id}}",
+  "Checking Whisper plugin…": "正在检查密语插件…",
+  "Whisper plugin required": "需要密语插件",
+  "Unable to check Whisper plugin": "无法检查密语插件",
+  "Waiting for the backend capability registry…": "正在等待后端能力注册表…",
+  "Install or enable a plugin that provides whisper_visitor and whisper_trainee, then retry.": "请安装或启用同时提供 whisper_visitor 和 whisper_trainee 的插件，然后重试。",
+  "The capability registry could not be reached. Check the backend connection and retry.": "无法访问能力注册表。请检查后端连接后重试。",
+  "Retry plugin check": "重试插件检查"
 }

--- a/web/tests/whisper-availability.test.ts
+++ b/web/tests/whisper-availability.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  REQUIRED_WHISPER_CAPABILITIES,
+  hasWhisperCapabilities,
+} from "../lib/whisper-availability";
+
+test("whisper requires both seat capabilities", () => {
+  assert.deepEqual(REQUIRED_WHISPER_CAPABILITIES, [
+    "whisper_visitor",
+    "whisper_trainee",
+  ]);
+});
+
+test("whisper availability accepts a complete plugin catalog", () => {
+  assert.equal(
+    hasWhisperCapabilities({
+      capabilities: [
+        { name: "chat" },
+        { name: "whisper_visitor" },
+        { name: "whisper_trainee" },
+      ],
+    }),
+    true,
+  );
+});
+
+test("whisper availability rejects partial plugin catalogs", () => {
+  assert.equal(
+    hasWhisperCapabilities({
+      capabilities: [{ name: "chat" }, { name: "whisper_visitor" }],
+    }),
+    false,
+  );
+});
+
+test("whisper availability rejects malformed payloads safely", () => {
+  for (const payload of [null, {}, { capabilities: "whisper_visitor" }]) {
+    assert.equal(hasWhisperCapabilities(payload), false);
+  }
+});


### PR DESCRIPTION
## Summary
- Check the existing `/api/v1/plugins/list` capability catalog before enabling the Whisper workspace.
- Require both plugin-provided capabilities (`whisper_visitor` and `whisper_trainee`); DeepTutor core intentionally does not implement them.
- When either capability is missing, render an actionable plugin-required state, disable seat switching/input/sending, and allow a retry after installing/enabling a plugin.
- Handle registry lookup failures explicitly instead of forwarding `Unknown capability` to the user.
- Preserve the existing two-seat flow when both capabilities are registered.

Closes #963.

## Testing
- PASS (after rebasing on current `dev`): `npm run test:node` — 598 tests passed.
- PASS (after rebasing on current `dev`): `npm run lint` — 0 errors; 56 pre-existing warnings.
- PASS: `npx tsc --noEmit`.
- PASS: focused ESLint on the changed Whisper page/helper/tests.
- PASS: `npm run i18n:parity`.
- PASS: `npm run build`.
- PASS: real browser check against a production frontend with mocked official plugin-list payloads:
  - partial catalog → plugin-required notice shown; textarea and Send disabled; Retry visible
  - complete catalog → original three-step guide shown; textarea editable; Send enabled after entering a draft

The locale conflict introduced by #903 was resolved by preserving both the new GitHub placeholders and the new Whisper strings. The pre-rebase head remains at `archive/pr-976-pre-rebase-20260824`.
