### PR TITLE
fix(llm): drop temperature for bare Kimi model ids (k3) on the coding endpoint

### DIFF
--- a/deeptutor/core/agentic/client.py
+++ b/deeptutor/core/agentic/client.py
@@ -533,6 +533,20 @@ def build_completion_kwargs(
             reasoning_effort=reasoning_effort,
         )
     )
+    # Apply provider-spec model overrides last, mirroring
+    # OpenAICompatProvider._build_kwargs: a None value drops the parameter —
+    # e.g. Kimi models ("kimi", "k3") reject any explicit temperature.
+    spec = find_by_name(binding)
+    if spec and model:
+        model_lower = model.lower()
+        for pattern, overrides in spec.model_overrides:
+            if pattern in model_lower:
+                for key, value in overrides.items():
+                    if value is None:
+                        kwargs.pop(key, None)
+                    else:
+                        kwargs[key] = value
+                break
     return kwargs
 
 

--- a/deeptutor/core/agentic/client.py
+++ b/deeptutor/core/agentic/client.py
@@ -29,7 +29,7 @@ from deeptutor.services.llm.openai_http_client import sanitize_invalid_ssl_env
 from deeptutor.services.llm.reasoning_params import (
     build_openai_compatible_reasoning_kwargs,
 )
-from deeptutor.services.provider_registry import find_by_name
+from deeptutor.services.provider_registry import find_by_name, model_overrides_for
 
 # Providers that don't reliably support OpenAI function-calling. The loop
 # still runs without tool schemas — the model just produces prose.
@@ -533,20 +533,14 @@ def build_completion_kwargs(
             reasoning_effort=reasoning_effort,
         )
     )
-    # Apply provider-spec model overrides last, mirroring
-    # OpenAICompatProvider._build_kwargs: a None value drops the parameter —
-    # e.g. Kimi models ("kimi", "k3") reject any explicit temperature.
+    # Apply model-intrinsic overrides last, matching OpenAICompatProvider. A
+    # None value drops the parameter instead of serialising JSON null.
     spec = find_by_name(binding)
-    if spec and model:
-        model_lower = model.lower()
-        for pattern, overrides in spec.model_overrides:
-            if pattern in model_lower:
-                for key, value in overrides.items():
-                    if value is None:
-                        kwargs.pop(key, None)
-                    else:
-                        kwargs[key] = value
-                break
+    for key, value in model_overrides_for(model, spec).items():
+        if value is None:
+            kwargs.pop(key, None)
+        else:
+            kwargs[key] = value
     return kwargs
 
 

--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -364,8 +364,13 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         # this model"). Dropping the parameter (value None) lets the API apply
         # the correct fixed value per model and per thinking/non-thinking mode —
         # Moonshot's own recommendation. The tunable moonshot-v1-* series does
-        # not contain "kimi" and keeps the caller's temperature.
-        model_overrides=(("kimi", {"temperature": None}),),
+        # not contain "kimi" and keeps the caller's temperature. The Kimi
+        # coding endpoint (api.kimi.com/coding/v1) addresses these models by
+        # bare ids ("k3", ...) without the "kimi-" prefix, so match those too.
+        model_overrides=(
+            ("kimi", {"temperature": None}),
+            ("k3", {"temperature": None}),
+        ),
     ),
     # MiniMax runs two separate platforms: global (platform.minimax.io /
     # api.minimax.io) and mainland China (platform.minimaxi.com /

--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -44,6 +44,8 @@ class ProviderSpec:
     supports_prompt_caching: bool = False
     supports_stream_options: bool = True
     model_overrides: tuple[tuple[str, dict[str, Any]], ...] = ()
+    # Bare model ids too short or generic for substring-based vendor detection.
+    exact_model_ids: tuple[str, ...] = ()
     is_oauth: bool = False
     is_direct: bool = False
     thinking_style: str = ""
@@ -369,8 +371,9 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         # bare ids ("k3", ...) without the "kimi-" prefix, so match those too.
         model_overrides=(
             ("kimi", {"temperature": None}),
-            ("k3", {"temperature": None}),
+            ("=k3", {"temperature": None}),
         ),
+        exact_model_ids=("k3",),
     ),
     # MiniMax runs two separate platforms: global (platform.minimax.io /
     # api.minimax.io) and mainland China (platform.minimaxi.com /
@@ -536,6 +539,9 @@ def find_by_model(model: str | None) -> ProviderSpec | None:
         if model_prefix and normalized_prefix == spec.name:
             return spec
     for spec in standard_specs:
+        if model_lower in spec.exact_model_ids:
+            return spec
+    for spec in standard_specs:
         if any(
             kw in model_lower or kw.replace("-", "_") in model_normalized for kw in spec.keywords
         ):
@@ -545,7 +551,12 @@ def find_by_model(model: str | None) -> ProviderSpec | None:
 
 def _matching_overrides(spec: ProviderSpec, model_lower: str) -> dict[str, Any]:
     for pattern, overrides in spec.model_overrides:
-        if pattern in model_lower:
+        # ``=name`` is an exact bare model id. Most historical patterns are
+        # vendor-family substrings, but a short id such as ``k3`` must not also
+        # match unrelated ids like ``sk3`` or ``k30``.
+        if (pattern.startswith("=") and model_lower == pattern[1:]) or (
+            not pattern.startswith("=") and pattern in model_lower
+        ):
             return dict(overrides)
     return {}
 

--- a/tests/core/test_agentic_client_provider_kwargs.py
+++ b/tests/core/test_agentic_client_provider_kwargs.py
@@ -91,6 +91,30 @@ def test_agentic_kwargs_preserve_legacy_shape_without_binding() -> None:
     assert kwargs == {"temperature": 0.2, "max_tokens": 256}
 
 
+@pytest.mark.parametrize("binding", ["moonshot", "openai", "custom"])
+def test_agentic_kwargs_drop_temperature_for_bare_kimi_k3(binding: str) -> None:
+    kwargs = build_completion_kwargs(
+        temperature=0.2,
+        model="k3",
+        max_tokens=256,
+        binding=binding,
+    )
+
+    assert kwargs == {"max_tokens": 256}
+
+
+@pytest.mark.parametrize("model", ["sk3", "k30", "vendor/k3"])
+def test_short_k3_override_does_not_match_unrelated_models(model: str) -> None:
+    kwargs = build_completion_kwargs(
+        temperature=0.2,
+        model=model,
+        max_tokens=256,
+        binding="moonshot",
+    )
+
+    assert kwargs["temperature"] == pytest.approx(0.2)
+
+
 def test_native_tool_backends_all_have_adapter_builders() -> None:
     # Every tool-gated backend must be adapter-routed, or tool schemas would be
     # attached to a plain AsyncOpenAI client speaking a non-OpenAI wire format.

--- a/tests/services/llm/test_model_overrides.py
+++ b/tests/services/llm/test_model_overrides.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import pytest
 
 from deeptutor.services.llm.provider_core.openai_compat_provider import OpenAICompatProvider
-from deeptutor.services.provider_registry import find_by_name, model_overrides_for
+from deeptutor.services.provider_registry import find_by_model, find_by_name, model_overrides_for
 
 _MOONSHOT_BASE = "https://api.moonshot.cn/v1"
 
@@ -83,3 +83,12 @@ def test_vendor_prefixed_routing_still_finds_the_model() -> None:
     assert model_overrides_for("moonshotai/kimi-k2", find_by_name("openai")) == {
         "temperature": None
     }
+
+
+def test_bare_k3_is_exact_and_does_not_capture_unrelated_short_ids() -> None:
+    moonshot = find_by_name("moonshot")
+    assert model_overrides_for("k3", moonshot) == {"temperature": None}
+    assert model_overrides_for("sk3", moonshot) == {}
+    assert model_overrides_for("k30", moonshot) == {}
+    assert find_by_model("k3") is moonshot
+    assert find_by_model("sk3") is None


### PR DESCRIPTION
## Problem

Using the **Kimi coding endpoint** (`https://api.kimi.com/coding/v1` — the endpoint behind Kimi for Coding subscriptions) with model id `k3`, every chat turn from the agentic pipelines fails with:

```
Error code: 400 - {'error': {'message': 'invalid temperature: only 1 is allowed for this model', 'type': 'invalid_request_error'}}
```

The endpoint addresses models by **bare ids** (`k3`, not `kimi-k3`) — if you configure `Kimi K3` or `kimi-k3` it responds `Your model id does not exist … Please set model id as 'k3'`.

Two gaps cause the failure:

1. **`provider_registry.py`** — the moonshot spec already intends to drop temperature for locked models (comment explicitly lists `k3`), but the only override pattern is the substring `"kimi"`, which bare ids like `k3` never match. So `OpenAICompatProvider._build_kwargs` keeps sending temperature.

2. **`core/agentic/client.py`** — the agentic pipelines (chat / question / research / explorer) stream through a raw `AsyncOpenAI` client, and `build_completion_kwargs()` composes `{"temperature": ...}` unconditionally. It never consulted `spec.model_overrides` at all, so even with fix 1 the chat capability still failed.

## Fix

1. Add `("k3", {"temperature": None})` to the moonshot spec so bare coding-endpoint ids drop the parameter too.
2. Apply `spec.model_overrides` at the end of `build_completion_kwargs()`, mirroring the existing semantics in `OpenAICompatProvider._build_kwargs`: a `None` value drops the parameter, letting the API apply its per-model fixed default (Moonshot's own recommendation). This covers all agentic pipelines in one place.

## Testing

Verified locally against `api.kimi.com/coding/v1` with model id `k3` (v1.5.5):

- before: `deeptutor run chat "hi"` → `400 invalid temperature: only 1 is allowed for this model`
- after: succeeds; payload no longer contains `temperature`; tunable models (e.g. `moonshot-v1-8k`) still send caller temperature unchanged:

```
build_completion_kwargs(temperature=0.2, model='k3', ...)           -> keys: ['max_tokens']
build_completion_kwargs(temperature=0.2, model='moonshot-v1-8k', ...) -> keys: ['max_tokens', 'temperature']
```
