### PR TITLE
feat(llm): route OpenAI-compatible agent calls through the Responses API

### DIFF
--- a/deeptutor/core/agentic/client.py
+++ b/deeptutor/core/agentic/client.py
@@ -27,6 +27,7 @@ from deeptutor.services.llm import get_token_limit_kwargs, supports_tools
 from deeptutor.services.llm.reasoning_params import (
     build_openai_compatible_reasoning_kwargs,
 )
+from deeptutor.core.agentic.responses_bridge import wrap_responses_bridge
 from deeptutor.services.provider_registry import find_by_name
 
 # Providers that don't reliably support OpenAI function-calling. The loop
@@ -99,12 +100,13 @@ def _build_openai_client(config: LLMClientConfig, *, disable_ssl_verify: bool) -
             http_client=http_client,
             default_headers=default_headers,
         )
-    return AsyncOpenAI(
+    client = AsyncOpenAI(
         api_key=config.api_key or "sk-no-key-required",
         base_url=config.base_url or None,
         http_client=http_client,
         default_headers=default_headers,
     )
+    return wrap_responses_bridge(client, config)
 
 
 async def _close_client(client: Any) -> None:

--- a/deeptutor/core/agentic/responses_bridge.py
+++ b/deeptutor/core/agentic/responses_bridge.py
@@ -115,6 +115,54 @@ def _record_bridge_success(key: str) -> None:
         _bridge_tripped_at.pop(key, None)
 
 
+#: Statuses that mean "this attempt failed, but the endpoint itself is
+#: fine" — relay channel exhaustion (new-api 503), rate limits, upstream
+#: hiccups. Falling back for the request is right; tripping the breaker
+#: would only convert a one-request blip into a five-minute all-chat
+#: window (zero prompt-cache hits), so these never count toward it.
+_TRANSIENT_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+def _failure_status_code(exc: BaseException) -> int | None:
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+    try:
+        return int(status) if status is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def failure_counts_toward_breaker(exc: BaseException) -> bool:
+    """Whether *exc* indicates the ``/responses`` route is truly unusable.
+
+    Connection-level errors (no status, status 0) and transient statuses do
+    not count; definitive rejections (404 no endpoint, 400/401/422 protocol
+    or auth problems) do.
+    """
+    status = _failure_status_code(exc)
+    if status is None or status == 0:
+        return False
+    return status not in _TRANSIENT_STATUS_CODES and status != 408
+
+
+def note_bridge_failure(key: str, exc: BaseException, *, definitive: bool | None = None) -> None:
+    """Record a bridge failure unless it is classified as transient.
+
+    ``definitive=True`` forces counting (e.g. request-conversion bugs that
+    will replay identically); ``definitive=False`` forces skipping; the
+    default classifies by the exception's HTTP status.
+    """
+    counts = failure_counts_toward_breaker(exc) if definitive is None else definitive
+    if counts:
+        _record_bridge_failure(key)
+    else:
+        logger.info(
+            "Responses bridge transient failure (%s); next request retries /responses",
+            exc,
+        )
+
+
 #: Public aliases for callers outside this module (e.g. the aiohttp-based
 #: cloud provider) that share the same breaker state.
 bridge_breaker_tripped = _breaker_tripped
@@ -476,11 +524,9 @@ class _StreamProxy:
         return self
 
     async def __anext__(self) -> Any:
-        try:
-            return await self._agen.__anext__()
-        except Exception:
-            _record_bridge_failure(self._key)
-            raise
+        # Mid-stream failures cannot fall back (deltas already emitted) and
+        # are almost always transient disconnects — never trip the breaker.
+        return await self._agen.__anext__()
 
     async def close(self) -> None:
         close = getattr(self._events_stream, "close", None)
@@ -502,7 +548,7 @@ class _BridgedCompletions:
         try:
             body = build_responses_body(kwargs)
         except Exception as exc:
-            _record_bridge_failure(key)
+            note_bridge_failure(key, exc, definitive=True)
             logger.warning(
                 "Responses bridge request conversion failed (%s); "
                 "using chat completions",
@@ -518,7 +564,7 @@ class _BridgedCompletions:
             _record_bridge_success(key)
             return response_to_chat_shape(response)
         except Exception as exc:
-            _record_bridge_failure(key)
+            note_bridge_failure(key, exc)
             logger.warning(
                 "Responses bridge failed (%s); retrying via chat completions", exc
             )

--- a/deeptutor/core/agentic/responses_bridge.py
+++ b/deeptutor/core/agentic/responses_bridge.py
@@ -115,6 +115,14 @@ def _record_bridge_success(key: str) -> None:
         _bridge_tripped_at.pop(key, None)
 
 
+#: Public aliases for callers outside this module (e.g. the aiohttp-based
+#: cloud provider) that share the same breaker state.
+bridge_breaker_tripped = _breaker_tripped
+record_bridge_failure = _record_bridge_failure
+record_bridge_success = _record_bridge_success
+bridge_breaker_key = _breaker_key
+
+
 def reset_bridge_breaker() -> None:
     """Clear breaker state (test helper)."""
     with _breaker_lock:
@@ -127,8 +135,8 @@ def reset_bridge_breaker() -> None:
 # ---------------------------------------------------------------------------
 
 
-def responses_bridge_enabled(config: Any) -> bool:
-    """Whether *config*'s client should be wrapped with the bridge."""
+def responses_bridge_enabled_for_binding(binding: str | None) -> bool:
+    """Binding-level activation check for callers without a config object."""
     raw = os.environ.get(ENV_USE_RESPONSES_API, "").strip().lower()
     if raw in _TRUTHY_MODES:
         return True
@@ -136,10 +144,28 @@ def responses_bridge_enabled(config: Any) -> bool:
         return False
     # Auto: local servers rarely expose /responses; cloud gateways get probed
     # and fall back through the breaker when they do not.
-    spec = find_by_name(config.binding)
+    spec = find_by_name(binding)
     if spec is not None and getattr(spec, "is_local", False):
         return False
     return True
+
+
+def responses_bridge_enabled(config: Any) -> bool:
+    """Whether *config*'s client should be wrapped with the bridge."""
+    return responses_bridge_enabled_for_binding(getattr(config, "binding", None))
+
+
+def dict_to_ns(value: Any) -> Any:
+    """Recursively convert JSON-style dicts into attribute objects.
+
+    Lets raw aiohttp/SSE payloads flow through the same event converters the
+    SDK object paths use.
+    """
+    if isinstance(value, dict):
+        return SimpleNamespace(**{key: dict_to_ns(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return [dict_to_ns(item) for item in value]
+    return value
 
 
 # ---------------------------------------------------------------------------

--- a/deeptutor/core/agentic/responses_bridge.py
+++ b/deeptutor/core/agentic/responses_bridge.py
@@ -1,0 +1,524 @@
+"""Responses API bridge for raw OpenAI-compatible agent clients.
+
+Every agentic pipeline (chat loop, labeled steps, research, question,
+explore) streams through a raw ``AsyncOpenAI`` client built by
+:func:`deeptutor.core.agentic.client.build_openai_client`, which targets
+``{base}/chat/completions``. Many gateways — OpenAI itself and relays that
+pass the Responses API through — only grant prompt caching on
+``{base}/responses``. That matters for agent loops, which replay one growing
+conversation many times per turn: without prefix-cache hits every round pays
+full input price again.
+
+This module wraps such a client so ``chat.completions.create(...)`` is served
+by the Responses API instead:
+
+* request side — chat messages/tools/kwargs are converted with the shared
+  converters from ``services.llm.provider_core.openai_responses.converters``
+  (system messages are merged into ``instructions`` because the converter
+  keeps only the last one);
+* response side — Responses SDK events and objects are re-shaped into
+  chat-completions chunks (``delta.content`` / ``delta.reasoning_content`` /
+  ``delta.tool_calls`` / ``finish_reason`` / ``usage``, including cached-token
+  details) so every existing consumer keeps working unchanged;
+* failure side — any bridge error immediately retries the original call via
+  Chat Completions and feeds a per-(base, model) circuit breaker, so gateways
+  without ``/responses`` degrade after at most two probes and stay degraded
+  for five minutes.
+
+Activation policy (env ``DEEPTUTOR_USE_RESPONSES_API``):
+
+* ``"on"/"1"/"true"/"yes"``  — always bridge;
+* ``"off"/"0"/"false"/"no"`` — never bridge (kill switch);
+* unset / anything else      — auto: bridge cloud OpenAI-compatible clients;
+  local inference servers (Ollama, vLLM, LM Studio, …) keep plain Chat
+  Completions.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any
+from types import SimpleNamespace
+
+from deeptutor.services.llm.provider_core.openai_responses.converters import (
+    convert_messages,
+    convert_tools,
+)
+from deeptutor.services.llm.provider_core.openai_responses.parsing import (
+    map_finish_reason,
+)
+from deeptutor.services.provider_registry import find_by_name
+
+logger = logging.getLogger(__name__)
+
+ENV_USE_RESPONSES_API = "DEEPTUTOR_USE_RESPONSES_API"
+
+_TRUTHY_MODES = frozenset({"1", "true", "yes", "on"})
+_FALSY_MODES = frozenset({"0", "false", "no", "off"})
+
+#: Models that reject ``temperature`` on the reasoning endpoints — mirror of
+#: OpenAICompatProvider._supports_temperature.
+_TEMP_UNSUPPORTED_TOKENS = ("gpt-5", "o1", "o3", "o4")
+
+_BRIDGE_FAILURE_THRESHOLD = 2
+_BRIDGE_COOLDOWN_S = 300.0
+
+_breaker_lock = threading.Lock()
+_bridge_failures: dict[str, int] = {}
+_bridge_tripped_at: dict[str, float] = {}
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker
+# ---------------------------------------------------------------------------
+
+
+def _breaker_key(base_url: str | None, model: str | None) -> str:
+    return f"{(base_url or '').strip().lower()}|{(model or '').strip().lower()}"
+
+
+def _breaker_tripped(key: str) -> bool:
+    now = time.monotonic()
+    with _breaker_lock:
+        tripped_at = _bridge_tripped_at.get(key)
+        if tripped_at is None:
+            return False
+        if now - tripped_at >= _BRIDGE_COOLDOWN_S:
+            # Cooldown elapsed: expire the entry so the next call probes again.
+            _bridge_tripped_at.pop(key, None)
+            _bridge_failures.pop(key, None)
+            return False
+        return True
+
+
+def _record_bridge_failure(key: str) -> None:
+    with _breaker_lock:
+        failures = _bridge_failures.get(key, 0) + 1
+        _bridge_failures[key] = failures
+        if failures >= _BRIDGE_FAILURE_THRESHOLD:
+            _bridge_tripped_at[key] = time.monotonic()
+            logger.info(
+                "Responses bridge tripped for %s after %d failures; "
+                "chat completions only for %ds",
+                key,
+                failures,
+                _BRIDGE_COOLDOWN_S,
+            )
+
+
+def _record_bridge_success(key: str) -> None:
+    with _breaker_lock:
+        _bridge_failures.pop(key, None)
+        _bridge_tripped_at.pop(key, None)
+
+
+def reset_bridge_breaker() -> None:
+    """Clear breaker state (test helper)."""
+    with _breaker_lock:
+        _bridge_failures.clear()
+        _bridge_tripped_at.clear()
+
+
+# ---------------------------------------------------------------------------
+# Activation policy
+# ---------------------------------------------------------------------------
+
+
+def responses_bridge_enabled(config: Any) -> bool:
+    """Whether *config*'s client should be wrapped with the bridge."""
+    raw = os.environ.get(ENV_USE_RESPONSES_API, "").strip().lower()
+    if raw in _TRUTHY_MODES:
+        return True
+    if raw in _FALSY_MODES:
+        return False
+    # Auto: local servers rarely expose /responses; cloud gateways get probed
+    # and fall back through the breaker when they do not.
+    spec = find_by_name(config.binding)
+    if spec is not None and getattr(spec, "is_local", False):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Request conversion
+# ---------------------------------------------------------------------------
+
+
+def _split_system_messages(messages: list[dict[str, Any]]) -> tuple[str, list[dict[str, Any]]]:
+    """Merge every system message into one instructions string.
+
+    ``convert_messages`` keeps only the *last* system message, but agent
+    pipelines legitimately ship several (base prompt + capability
+    injections), so they are merged here before delegating.
+    """
+    parts: list[str] = []
+    rest: list[dict[str, Any]] = []
+    for message in messages:
+        if message.get("role") != "system":
+            rest.append(message)
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            if content.strip():
+                parts.append(content)
+        elif isinstance(content, list):
+            text = "".join(
+                part.get("text", "") for part in content if isinstance(part, dict)
+            )
+            if text.strip():
+                parts.append(text)
+    return "\n\n".join(parts), rest
+
+
+def _supports_temperature(model_name: str, reasoning_effort: str | None) -> bool:
+    if reasoning_effort and str(reasoning_effort).lower() != "none":
+        return False
+    lowered = model_name.lower()
+    return not any(token in lowered for token in _TEMP_UNSUPPORTED_TOKENS)
+
+
+def build_responses_body(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Translate one chat.completions.create kwargs dict to Responses body."""
+    model = str(kwargs.get("model") or "")
+    messages = list(kwargs.get("messages") or [])
+    reasoning_effort = kwargs.get("reasoning_effort")
+
+    instructions, rest = _split_system_messages(messages)
+    converted_instructions, input_items = convert_messages(rest)
+    merged_instructions = "\n\n".join(
+        part for part in (converted_instructions.strip(), instructions.strip()) if part
+    )
+
+    body: dict[str, Any] = {
+        "model": model,
+        "instructions": merged_instructions or None,
+        "input": input_items,
+        "store": False,
+        "stream": bool(kwargs.get("stream")),
+    }
+
+    max_output_tokens = kwargs.get("max_completion_tokens")
+    if max_output_tokens is None:
+        max_output_tokens = kwargs.get("max_tokens")
+    if max_output_tokens is not None:
+        body["max_output_tokens"] = max(1, int(max_output_tokens))
+
+    temperature = kwargs.get("temperature")
+    if temperature is not None and _supports_temperature(model, reasoning_effort):
+        body["temperature"] = temperature
+
+    if reasoning_effort and str(reasoning_effort).lower() != "none":
+        body["reasoning"] = {"effort": str(reasoning_effort)}
+
+    tools = kwargs.get("tools")
+    if tools:
+        body["tools"] = convert_tools(list(tools))
+        body["tool_choice"] = kwargs.get("tool_choice") or "auto"
+
+    extra_body = kwargs.get("extra_body")
+    if isinstance(extra_body, dict):
+        body.update(extra_body)
+
+    # Unknown Chat Completions kwargs (stream_options, gateway session ids,
+    # …) are deliberately dropped rather than forwarded.
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Response conversion
+# ---------------------------------------------------------------------------
+
+
+def _map_usage(usage_obj: Any) -> SimpleNamespace | None:
+    if usage_obj is None:
+        return None
+    input_tokens = int(getattr(usage_obj, "input_tokens", 0) or 0)
+    output_tokens = int(getattr(usage_obj, "output_tokens", 0) or 0)
+    total = int(getattr(usage_obj, "total_tokens", 0) or (input_tokens + output_tokens))
+    usage = SimpleNamespace(
+        prompt_tokens=input_tokens,
+        completion_tokens=output_tokens,
+        total_tokens=total,
+    )
+    details = getattr(usage_obj, "input_tokens_details", None)
+    cached = int(getattr(details, "cached_tokens", 0) or 0) if details is not None else 0
+    if cached:
+        usage.prompt_tokens_details = SimpleNamespace(cached_tokens=cached)
+    return usage
+
+
+def _tool_call_chunk(
+    *, index: int, id_: str, name: str, arguments: str
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        index=index,
+        id=id_,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _delta_chunk(
+    *,
+    content: str | None = None,
+    reasoning: str | None = None,
+    tool_call: SimpleNamespace | None = None,
+    finish_reason: str | None = None,
+) -> SimpleNamespace:
+    tool_calls = [tool_call] if tool_call is not None else None
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(
+                    content=content,
+                    reasoning_content=reasoning,
+                    tool_calls=tool_calls,
+                ),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=None,
+    )
+
+
+async def responses_events_to_chat_chunks(events: Any) -> Any:
+    """Re-shape a Responses SDK event stream into chat-completions chunks.
+
+    Tool-call arguments are buffered and emitted exactly once per call (on
+    ``output_item.done``) because chat consumers accumulate deltas by
+    concatenation — forwarding partial deltas AND a final full copy would
+    duplicate them. Text and reasoning still stream token by token.
+    """
+    pending: dict[str, dict[str, Any]] = {}
+    emitted_calls = 0
+    if not hasattr(events, "__aiter__"):
+        sync_items = list(events)
+
+        async def _sync_events() -> Any:
+            for item in sync_items:
+                yield item
+
+        events = _sync_events()
+
+    async for event in events:
+        event_type = getattr(event, "type", None)
+
+        if event_type == "response.output_text.delta":
+            delta = getattr(event, "delta", None)
+            if delta:
+                yield _delta_chunk(content=delta)
+
+        elif event_type == "response.reasoning_summary_text.delta":
+            delta = getattr(event, "delta", None)
+            if delta:
+                yield _delta_chunk(reasoning=delta)
+
+        elif event_type == "response.output_item.added":
+            item = getattr(event, "item", None)
+            if item is not None and getattr(item, "type", None) == "function_call":
+                call_id = getattr(item, "call_id", None) or ""
+                pending[call_id] = {
+                    "item_id": getattr(item, "id", None),
+                    "name": getattr(item, "name", None) or "",
+                    "arguments": getattr(item, "arguments", None) or "",
+                }
+
+        elif event_type == "response.function_call_arguments.delta":
+            call_id = getattr(event, "call_id", None) or ""
+            state = pending.setdefault(call_id, {"name": "", "arguments": ""})
+            state["arguments"] += getattr(event, "delta", None) or ""
+
+        elif event_type == "response.function_call_arguments.done":
+            call_id = getattr(event, "call_id", None) or ""
+            state = pending.setdefault(call_id, {"name": "", "arguments": ""})
+            done_args = getattr(event, "arguments", None)
+            if done_args:
+                state["arguments"] = done_args
+
+        elif event_type == "response.output_item.done":
+            item = getattr(event, "item", None)
+            if item is None or getattr(item, "type", None) != "function_call":
+                continue
+            call_id = getattr(item, "call_id", None) or ""
+            state = pending.pop(call_id, {})
+            name = getattr(item, "name", None) or state.get("name") or ""
+            arguments = (
+                state.get("arguments")
+                or getattr(item, "arguments", None)
+                or "{}"
+            )
+            index = emitted_calls
+            emitted_calls += 1
+            yield _delta_chunk(
+                tool_call=_tool_call_chunk(
+                    index=index,
+                    id_=call_id or f"call_{index}",
+                    name=name,
+                    arguments=arguments,
+                )
+            )
+
+        elif event_type == "response.completed":
+            response = getattr(event, "response", None)
+            finish_reason = (
+                "tool_calls"
+                if emitted_calls
+                else map_finish_reason(getattr(response, "status", None))
+            )
+            yield _delta_chunk(finish_reason=finish_reason)
+            usage = _map_usage(getattr(response, "usage", None))
+            if usage is not None:
+                yield SimpleNamespace(choices=[], usage=usage)
+
+        elif event_type in ("error", "response.failed"):
+            detail = (
+                getattr(event, "error", None)
+                or getattr(event, "message", None)
+                or event
+            )
+            raise RuntimeError(f"Responses stream failed: {str(detail)[:300]}")
+
+
+
+
+def response_to_chat_shape(response: Any) -> SimpleNamespace:
+    """Convert a non-streaming Responses object into a chat completion."""
+    text_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    tool_calls: list[SimpleNamespace] = []
+
+    for item in getattr(response, "output", None) or []:
+        item_type = getattr(item, "type", None)
+        if item_type == "message":
+            for part in getattr(item, "content", None) or []:
+                part_type = getattr(part, "type", None)
+                if part_type in ("output_text", "text"):
+                    text_parts.append(getattr(part, "text", "") or "")
+        elif item_type == "reasoning":
+            summary = (
+                getattr(item, "summary", None) or getattr(item, "content", None) or []
+            )
+            for part in summary:
+                text = getattr(part, "text", "")
+                if text:
+                    reasoning_parts.append(text)
+        elif item_type == "function_call":
+            index = len(tool_calls)
+            call_id = getattr(item, "call_id", None) or f"call_{index}"
+            tool_calls.append(
+                _tool_call_chunk(
+                    index=index,
+                    id_=call_id,
+                    name=getattr(item, "name", "") or "",
+                    arguments=getattr(item, "arguments", "") or "{}",
+                )
+            )
+
+    finish_reason = (
+        "tool_calls"
+        if tool_calls
+        else map_finish_reason(getattr(response, "status", None))
+    )
+    message = SimpleNamespace(
+        content="".join(text_parts) or None,
+        tool_calls=tool_calls or None,
+        reasoning_content="".join(reasoning_parts) or None,
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason=finish_reason)],
+        usage=_map_usage(getattr(response, "usage", None)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bridged client
+# ---------------------------------------------------------------------------
+
+
+class _StreamProxy:
+    """Chat-chunks async iterator with the ``close()`` contract callers use."""
+
+    def __init__(self, agen: Any, events_stream: Any, breaker_key: str) -> None:
+        self._agen = agen
+        self._events_stream = events_stream
+        self._key = breaker_key
+
+    def __aiter__(self) -> Any:
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            return await self._agen.__anext__()
+        except Exception:
+            _record_bridge_failure(self._key)
+            raise
+
+    async def close(self) -> None:
+        close = getattr(self._events_stream, "close", None)
+        if callable(close):
+            result = close()
+            if hasattr(result, "__await__"):
+                await result
+
+
+class _BridgedCompletions:
+    def __init__(self, inner: Any, base_url: str | None) -> None:
+        self._inner = inner
+        self._base_url = base_url or ""
+
+    async def create(self, **kwargs: Any) -> Any:
+        key = _breaker_key(self._base_url, kwargs.get("model"))
+        if _breaker_tripped(key):
+            return await self._inner.chat.completions.create(**kwargs)
+        try:
+            body = build_responses_body(kwargs)
+        except Exception as exc:
+            _record_bridge_failure(key)
+            logger.warning(
+                "Responses bridge request conversion failed (%s); "
+                "using chat completions",
+                exc,
+            )
+            return await self._inner.chat.completions.create(**kwargs)
+        try:
+            if body.get("stream"):
+                events_stream = await self._inner.responses.create(**body)
+                agen = responses_events_to_chat_chunks(events_stream)
+                return _StreamProxy(agen, events_stream, key)
+            response = await self._inner.responses.create(**body)
+            _record_bridge_success(key)
+            return response_to_chat_shape(response)
+        except Exception as exc:
+            _record_bridge_failure(key)
+            logger.warning(
+                "Responses bridge failed (%s); retrying via chat completions", exc
+            )
+            return await self._inner.chat.completions.create(**kwargs)
+
+
+class _BridgeClient:
+    """Delegating facade: ``chat.completions.create`` bridged, rest passthrough."""
+
+    def __init__(self, inner: Any, base_url: str | None) -> None:
+        self._inner = inner
+        self.chat = SimpleNamespace(
+            completions=_BridgedCompletions(inner, base_url)
+        )
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+
+def wrap_responses_bridge(client: Any, config: Any) -> Any:
+    """Wrap *client* when the bridge is enabled for *config*'s binding."""
+    if not responses_bridge_enabled(config):
+        return client
+    logger.debug(
+        "Responses bridge active for binding=%s base=%s",
+        getattr(config, "binding", ""),
+        getattr(config, "base_url", ""),
+    )
+    return _BridgeClient(client, getattr(config, "base_url", None))

--- a/deeptutor/services/llm/cloud_provider.py
+++ b/deeptutor/services/llm/cloud_provider.py
@@ -582,14 +582,14 @@ async def _openai_complete(
 
     active, bridge_key = _responses_bridge_active(binding, effective_base, model)
     if active:
-        from deeptutor.core.agentic.responses_bridge import record_bridge_failure
+        from deeptutor.core.agentic.responses_bridge import note_bridge_failure
 
         try:
             bridge_content = await _responses_complete_content(
                 effective_base, headers, data, binding, model
             )
         except Exception as exc:
-            record_bridge_failure(bridge_key)
+            note_bridge_failure(bridge_key, exc)
             logger.warning(
                 "Responses bridge failed for %s (%s); falling back to chat completions",
                 model,
@@ -773,7 +773,7 @@ async def _openai_stream(
 
     active, bridge_key = _responses_bridge_active(binding, effective_base, model)
     if active:
-        from deeptutor.core.agentic.responses_bridge import record_bridge_failure
+        from deeptutor.core.agentic.responses_bridge import note_bridge_failure
 
         try:
             async for piece in _iter_chat_stream_content(
@@ -786,7 +786,7 @@ async def _openai_stream(
                 yield piece
             return
         except Exception as exc:
-            record_bridge_failure(bridge_key)
+            note_bridge_failure(bridge_key, exc)
             logger.warning(
                 "Responses bridge failed for %s (%s); falling back to chat completions",
                 model,

--- a/deeptutor/services/llm/cloud_provider.py
+++ b/deeptutor/services/llm/cloud_provider.py
@@ -278,6 +278,229 @@ async def stream(
             yield chunk
 
 
+def _responses_bridge_active(binding: str, effective_base: str, model: str) -> tuple[bool, str]:
+    """Gate + breaker check shared by the complete/stream bridge branches."""
+    from deeptutor.core.agentic.responses_bridge import (
+        bridge_breaker_key,
+        bridge_breaker_tripped,
+        responses_bridge_enabled_for_binding,
+    )
+
+    if not responses_bridge_enabled_for_binding(binding):
+        return False, ""
+    key = bridge_breaker_key(effective_base, model)
+    if bridge_breaker_tripped(key):
+        return False, key
+    return True, key
+
+
+def _responses_url(effective_base: str) -> str:
+    return f"{effective_base.rstrip('/')}/responses"
+
+
+def _responses_message_content(response_json: Mapping[str, object]) -> str | None:
+    """Extract assistant text from a non-streaming Responses JSON body."""
+    output = response_json.get("output")
+    if not isinstance(output, list):
+        return None
+    parts: list[str] = []
+    for item in output:
+        if not isinstance(item, Mapping) or item.get("type") != "message":
+            continue
+        content = item.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if (
+                isinstance(block, Mapping)
+                and block.get("type") in ("output_text", "text")
+                and isinstance(block.get("text"), str)
+            ):
+                parts.append(block["text"])
+    return "".join(parts) or None
+
+
+async def _responses_complete_content(
+    effective_base: str,
+    headers: dict[str, str],
+    chat_data: Mapping[str, object],
+    binding: str,
+    model: str,
+) -> str | None:
+    """Serve one Chat-Completions-shaped request via ``{base}/responses``.
+
+    Returns the assistant text, or ``None`` when the model produced none.
+    Raises on any transport/HTTP error so the caller can fall back to Chat
+    Completions and feed the breaker.
+    """
+    import json
+
+    from deeptutor.core.agentic.responses_bridge import build_responses_body
+
+    body = build_responses_body(dict(chat_data))
+    body["stream"] = False
+    timeout = aiohttp.ClientTimeout(total=120)
+    connector = _get_aiohttp_connector()
+    async with aiohttp.ClientSession(
+        timeout=timeout, connector=connector, trust_env=True
+    ) as session:
+        async with session.post(
+            _responses_url(effective_base), headers=headers, json=body
+        ) as resp:
+            if resp.status != 200:
+                error_text = await resp.text()
+                raise LLMAPIError(
+                    f"Responses API error: {error_text}",
+                    status_code=resp.status,
+                    provider=binding or "openai",
+                )
+            result = cast(dict[str, object], await resp.json())
+    return _responses_message_content(result)
+
+
+async def _iter_sse_chunk_dicts(
+    resp: aiohttp.ClientResponse,
+) -> AsyncGenerator[dict[str, object], None]:
+    """Parse one Chat-Completions SSE body into decoded chunk dicts."""
+    import json
+
+    async for line in resp.content:
+        line_str = line.decode("utf-8").strip()
+        if not line_str or not line_str.startswith("data:"):
+            continue
+        data_str = line_str[5:].strip()
+        if data_str == "[DONE]":
+            break
+        try:
+            yield cast(dict[str, object], json.loads(data_str))
+        except json.JSONDecodeError:
+            continue
+
+
+async def _iter_chat_stream_content(
+    chunks: AsyncGenerator[dict[str, object], None],
+    binding: str,
+    model: str,
+) -> AsyncGenerator[str, None]:
+    """Yield assistant content strings from chat-completion chunk dicts.
+
+    Handles inline ``<think>``-style markers exactly like the legacy
+    ``_openai_stream`` loop, split across chunk boundaries.
+    """
+    in_thinking_block = False
+    thinking_buffer = ""
+    async for chunk_data in chunks:
+        choices = chunk_data.get("choices")
+        if not isinstance(choices, list) or not choices:
+            continue
+        first_choice = choices[0]
+        delta = first_choice.get("delta") if isinstance(first_choice, Mapping) else None
+        if not isinstance(delta, Mapping):
+            continue
+        content = delta.get("content")
+        if not (isinstance(content, str) and content):
+            continue
+        open_markers = ("<think>", "◣", "꽁")
+        close_markers = ("</think>", "◢", "꽁")
+        if any(open_m in content for open_m in open_markers):
+            in_thinking_block = True
+            for open_m in open_markers:
+                if open_m in content:
+                    parts = content.split(open_m, 1)
+                    if parts[0]:
+                        yield parts[0]
+                    thinking_buffer = open_m + parts[1]
+                    if any(close_m in thinking_buffer for close_m in close_markers):
+                        cleaned = clean_thinking_tags(thinking_buffer, binding, model)
+                        if cleaned:
+                            yield cleaned
+                        thinking_buffer = ""
+                        in_thinking_block = False
+                    break
+            continue
+        if in_thinking_block:
+            thinking_buffer += content
+            if any(close_m in thinking_buffer for close_m in close_markers):
+                cleaned = clean_thinking_tags(thinking_buffer, binding, model)
+                if cleaned:
+                    yield cleaned
+                in_thinking_block = False
+                thinking_buffer = ""
+            continue
+        yield content
+
+
+async def _responses_stream_chunks(
+    effective_base: str,
+    headers: dict[str, str],
+    chat_data: Mapping[str, object],
+    binding: str,
+    model: str,
+    breaker_key: str,
+) -> AsyncGenerator[dict[str, object], None]:
+    """Stream ``{base}/responses`` events re-shaped as chat chunk dicts."""
+    import json
+
+    from deeptutor.core.agentic.responses_bridge import (
+        build_responses_body,
+        dict_to_ns,
+        record_bridge_success,
+        responses_events_to_chat_chunks,
+    )
+
+    body = build_responses_body(dict(chat_data))
+    body["stream"] = True
+    timeout = aiohttp.ClientTimeout(total=300)
+    connector = _get_aiohttp_connector()
+    async with aiohttp.ClientSession(
+        timeout=timeout, connector=connector, trust_env=True
+    ) as session:
+        async with session.post(
+            _responses_url(effective_base), headers=headers, json=body
+        ) as resp:
+            if resp.status != 200:
+                error_text = await resp.text()
+                raise LLMAPIError(
+                    f"Responses API error: {error_text}",
+                    status_code=resp.status,
+                    provider=binding or "openai",
+                )
+
+            async def _events() -> AsyncGenerator[object, None]:
+                async for line in resp.content:
+                    line_str = line.decode("utf-8").strip()
+                    if not line_str.startswith("data:"):
+                        continue
+                    data_str = line_str[5:].strip()
+                    if data_str == "[DONE]":
+                        break
+                    try:
+                        yield dict_to_ns(json.loads(data_str))
+                    except json.JSONDecodeError:
+                        continue
+
+            async for chunk in responses_events_to_chat_chunks(_events()):
+                choices = getattr(chunk, "choices", None) or []
+                if not choices:
+                    continue
+                choice = choices[0]
+                delta = choice.delta
+                yield {
+                    "choices": [
+                        {
+                            "delta": {
+                                "content": getattr(delta, "content", None),
+                                "reasoning_content": getattr(
+                                    delta, "reasoning_content", None
+                                ),
+                            },
+                            "finish_reason": choice.finish_reason,
+                        }
+                    ]
+                }
+    record_bridge_success(breaker_key)
+
+
 async def _openai_complete(
     model: str,
     prompt: str,
@@ -356,6 +579,25 @@ async def _openai_complete(
         implicit_effort = default_reasoning_effort_for(binding, model)
         if implicit_effort:
             data["reasoning_effort"] = implicit_effort
+
+    active, bridge_key = _responses_bridge_active(binding, effective_base, model)
+    if active:
+        from deeptutor.core.agentic.responses_bridge import record_bridge_failure
+
+        try:
+            bridge_content = await _responses_complete_content(
+                effective_base, headers, data, binding, model
+            )
+        except Exception as exc:
+            record_bridge_failure(bridge_key)
+            logger.warning(
+                "Responses bridge failed for %s (%s); falling back to chat completions",
+                model,
+                exc,
+            )
+        else:
+            if bridge_content is not None:
+                return clean_thinking_tags(bridge_content, binding, model)
 
     timeout = aiohttp.ClientTimeout(total=120)
     connector = _get_aiohttp_connector()
@@ -464,9 +706,8 @@ async def _openai_stream(
     **kwargs: object,
 ) -> AsyncGenerator[str, None]:
     """OpenAI-compatible streaming."""
-    import json
-
     # Sanitize URL
+
     if base_url:
         base_url = sanitize_url(base_url, model)
 
@@ -530,6 +771,28 @@ async def _openai_stream(
         if implicit_effort:
             data["reasoning_effort"] = implicit_effort
 
+    active, bridge_key = _responses_bridge_active(binding, effective_base, model)
+    if active:
+        from deeptutor.core.agentic.responses_bridge import record_bridge_failure
+
+        try:
+            async for piece in _iter_chat_stream_content(
+                _responses_stream_chunks(
+                    effective_base, headers, data, binding, model, bridge_key
+                ),
+                binding,
+                model,
+            ):
+                yield piece
+            return
+        except Exception as exc:
+            record_bridge_failure(bridge_key)
+            logger.warning(
+                "Responses bridge failed for %s (%s); falling back to chat completions",
+                model,
+                exc,
+            )
+
     timeout = aiohttp.ClientTimeout(total=300)
     connector = _get_aiohttp_connector()
     async with aiohttp.ClientSession(
@@ -575,76 +838,10 @@ async def _openai_stream(
                 raise
 
         try:
-            # Track thinking block state for streaming
-            in_thinking_block = False
-            thinking_buffer = ""
-
-            async for line in resp.content:
-                line_str = line.decode("utf-8").strip()
-                if not line_str or not line_str.startswith("data:"):
-                    continue
-
-                data_str = line_str[5:].strip()
-                if data_str == "[DONE]":
-                    break
-
-                try:
-                    chunk_data = cast(dict[str, object], json.loads(data_str))
-                    choices = chunk_data.get("choices")
-                    if isinstance(choices, list) and choices:
-                        choices_list = cast(list[object], choices)
-                        first_choice = choices_list[0]
-                        if isinstance(first_choice, Mapping):
-                            delta = cast(Mapping[str, object], first_choice).get("delta")
-                        else:
-                            delta = None
-                        if isinstance(delta, Mapping):
-                            content = cast(Mapping[str, object], delta).get("content")
-                        else:
-                            content = None
-                        if isinstance(content, str) and content:
-                            # Handle thinking tags in streaming for different marker styles
-                            open_markers = ("<think>", "◣", "꽁")
-                            close_markers = ("</think>", "◢", "꽁")
-
-                            # Check for start tag (handle split tags)
-                            if any(open_m in content for open_m in open_markers):
-                                in_thinking_block = True
-                                # Handle case where content has text BEFORE <think>
-                                for open_m in open_markers:
-                                    if open_m in content:
-                                        parts = content.split(open_m, 1)
-                                        if parts[0]:
-                                            yield parts[0]
-                                        thinking_buffer = open_m + parts[1]
-
-                                        # Check if closed immediately in same chunk
-                                        if any(
-                                            close_m in thinking_buffer for close_m in close_markers
-                                        ):
-                                            cleaned = clean_thinking_tags(
-                                                thinking_buffer, binding, model
-                                            )
-                                            if cleaned:
-                                                yield cleaned
-                                            thinking_buffer = ""
-                                            in_thinking_block = False
-                                        break
-                                continue
-                            elif in_thinking_block:
-                                thinking_buffer += content
-                                if any(close_m in thinking_buffer for close_m in close_markers):
-                                    # Block finished
-                                    cleaned = clean_thinking_tags(thinking_buffer, binding, model)
-                                    if cleaned:
-                                        yield cleaned
-                                    in_thinking_block = False
-                                    thinking_buffer = ""
-                                continue
-                            else:
-                                yield content
-                except json.JSONDecodeError:
-                    continue
+            async for piece in _iter_chat_stream_content(
+                _iter_sse_chunk_dicts(resp), binding, model
+            ):
+                yield piece
         finally:
             await resp_cm.__aexit__(None, None, None)
 

--- a/tests/core/agentic/test_responses_bridge.py
+++ b/tests/core/agentic/test_responses_bridge.py
@@ -12,11 +12,20 @@ import deeptutor.core.agentic.responses_bridge as bridge_module
 from deeptutor.core.agentic.responses_bridge import (
     ENV_USE_RESPONSES_API,
     build_responses_body,
+    failure_counts_toward_breaker,
     reset_bridge_breaker,
     response_to_chat_shape,
     responses_events_to_chat_chunks,
     wrap_responses_bridge,
 )
+
+
+class _StatusError(Exception):
+    """Exception carrying an HTTP status, like openai.APIStatusError."""
+
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.status_code = status
 
 
 def _evt(event_type: str, **attrs: Any) -> SimpleNamespace:
@@ -351,7 +360,7 @@ async def test_stream_success_produces_chunks_via_responses() -> None:
 
 @pytest.mark.asyncio
 async def test_failure_falls_back_then_breaker_skips_responses() -> None:
-    factory = _FakeInnerFactory(responses_error=RuntimeError("404 no /responses"))
+    factory = _FakeInnerFactory(responses_error=_StatusError(404, "no /responses"))
     completions = _bridge_over(factory)
     kwargs = {"model": "m", "messages": [{"role": "user", "content": "hi"}]}
 
@@ -379,3 +388,28 @@ async def test_success_resets_breaker_failures() -> None:
         **{"model": "m", "messages": [{"role": "user", "content": "hi"}]}
     )
     assert bridge_module._bridge_failures.get(key) is None
+
+@pytest.mark.asyncio
+async def test_transient_503_never_trips_breaker() -> None:
+    """Relay channel exhaustion (new-api 503) must not lock out /responses."""
+    factory = _FakeInnerFactory(responses_error=_StatusError(503, "no channel"))
+    completions = _bridge_over(factory)
+    kwargs = {"model": "m", "messages": [{"role": "user", "content": "hi"}]}
+
+    for _ in range(5):
+        result = await completions.create(**kwargs)
+        assert result.choices[0].message.content == "fallback"
+
+    # Every request still probes /responses — no 5-minute all-chat window.
+    assert factory.responses_create_calls == 5
+    assert factory.chat_create_calls == 5
+
+
+def test_failure_classification_by_status() -> None:
+    assert not failure_counts_toward_breaker(_StatusError(503, "no channel"))
+    assert not failure_counts_toward_breaker(_StatusError(429, "rate limited"))
+    assert not failure_counts_toward_breaker(_StatusError(500, "upstream"))
+    assert not failure_counts_toward_breaker(RuntimeError("connection reset"))
+    assert failure_counts_toward_breaker(_StatusError(404, "no endpoint"))
+    assert failure_counts_toward_breaker(_StatusError(400, "bad request"))
+    assert failure_counts_toward_breaker(_StatusError(401, "bad key"))

--- a/tests/core/agentic/test_responses_bridge.py
+++ b/tests/core/agentic/test_responses_bridge.py
@@ -1,0 +1,381 @@
+"""Unit tests for the Responses API bridge on agentic clients."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from deeptutor.core.agentic.client import LLMClientConfig, build_openai_client
+import deeptutor.core.agentic.responses_bridge as bridge_module
+from deeptutor.core.agentic.responses_bridge import (
+    ENV_USE_RESPONSES_API,
+    build_responses_body,
+    reset_bridge_breaker,
+    response_to_chat_shape,
+    responses_events_to_chat_chunks,
+    wrap_responses_bridge,
+)
+
+
+def _evt(event_type: str, **attrs: Any) -> SimpleNamespace:
+    return SimpleNamespace(type=event_type, **attrs)
+
+
+async def _agen(items: list[Any]) -> Any:
+    for item in items:
+        yield item
+
+
+def _cloud_config() -> LLMClientConfig:
+    return LLMClientConfig(
+        binding="custom",
+        model="gpt-5.6-terra",
+        api_key="test-key",
+        base_url="https://relay.example/v1",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_breaker(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_USE_RESPONSES_API, raising=False)
+    reset_bridge_breaker()
+
+
+# ---------------------------------------------------------------------------
+# Activation policy
+# ---------------------------------------------------------------------------
+
+
+def test_env_off_returns_inner_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_USE_RESPONSES_API, "off")
+    inner = SimpleNamespace()
+    assert wrap_responses_bridge(inner, _cloud_config()) is inner
+
+
+def test_env_on_forces_bridge_for_local_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(ENV_USE_RESPONSES_API, "on")
+    config = LLMClientConfig(
+        binding="ollama",
+        model="local-model",
+        api_key="test-key",
+        base_url="http://127.0.0.1:11434/v1",
+    )
+    wrapped = wrap_responses_bridge(SimpleNamespace(), config)
+    assert isinstance(wrapped, bridge_module._BridgeClient)
+
+
+def test_auto_mode_skips_local_binding() -> None:
+    config = LLMClientConfig(
+        binding="ollama",
+        model="local-model",
+        api_key="test-key",
+        base_url="http://127.0.0.1:11434/v1",
+    )
+    inner = SimpleNamespace()
+    assert wrap_responses_bridge(inner, config) is inner
+
+
+def test_auto_mode_wraps_cloud_binding() -> None:
+    wrapped = wrap_responses_bridge(SimpleNamespace(), _cloud_config())
+    assert isinstance(wrapped, bridge_module._BridgeClient)
+
+
+def test_build_openai_client_returns_bridged_client() -> None:
+    client = build_openai_client(_cloud_config())
+    assert hasattr(client.chat.completions, "create")
+    # Non-chat attributes delegate to the raw SDK client.
+    assert hasattr(client, "responses")
+
+
+# ---------------------------------------------------------------------------
+# Request conversion
+# ---------------------------------------------------------------------------
+
+
+def test_body_merges_system_messages_and_drops_chat_kwargs() -> None:
+    body = build_responses_body(
+        {
+            "model": "gemini-3.1-pro",
+            "messages": [
+                {"role": "system", "content": "base prompt"},
+                {"role": "system", "content": [{"type": "text", "text": "extra"}]},
+                {"role": "user", "content": "hi"},
+            ],
+            "temperature": 0.2,
+            "max_tokens": 256,
+            "stream_options": {"include_usage": True},
+            "deeptutor_session_id": "sess-1",
+        }
+    )
+    assert body["instructions"] == "base prompt\n\nextra"
+    assert body["input"] == [
+        {"role": "user", "content": [{"type": "input_text", "text": "hi"}]}
+    ]
+    assert body["max_output_tokens"] == 256
+    assert body["temperature"] == 0.2
+    assert "stream_options" not in body
+    assert "deeptutor_session_id" not in body
+
+
+def test_body_drops_temperature_for_reasoning_models() -> None:
+    body = build_responses_body(
+        {
+            "model": "gpt-5.6-terra",
+            "messages": [{"role": "user", "content": "hi"}],
+            "temperature": 0.3,
+            "reasoning_effort": "high",
+        }
+    )
+    assert "temperature" not in body
+    assert body["reasoning"] == {"effort": "high"}
+
+
+def test_body_converts_tools() -> None:
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Search the web",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    body = build_responses_body(
+        {
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": tools,
+        }
+    )
+    assert body["tools"] == [
+        {
+            "type": "function",
+            "name": "web_search",
+            "description": "Search the web",
+            "parameters": {"type": "object", "properties": {}},
+        }
+    ]
+    assert body["tool_choice"] == "auto"
+
+
+# ---------------------------------------------------------------------------
+# Stream conversion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_conversion_shapes_and_usage() -> None:
+    events = [
+        _evt("response.output_text.delta", delta="Hello"),
+        _evt("response.output_text.delta", delta=" world"),
+        _evt("response.reasoning_summary_text.delta", delta="thinking"),
+        _evt(
+            "response.output_item.added",
+            item=SimpleNamespace(
+                type="function_call", call_id="call_1", id="fc_1", name="search"
+            ),
+        ),
+        _evt("response.function_call_arguments.delta", call_id="call_1", delta='{"q'),
+        _evt(
+            "response.function_call_arguments.done",
+            call_id="call_1",
+            arguments='{"query": "deep tutor"}',
+        ),
+        _evt(
+            "response.output_item.done",
+            item=SimpleNamespace(
+                type="function_call",
+                call_id="call_1",
+                name="search",
+                arguments='{"query": "deep tutor"}',
+            ),
+        ),
+        _evt(
+            "response.completed",
+            response=SimpleNamespace(
+                status="completed",
+                usage=SimpleNamespace(
+                    input_tokens=120,
+                    output_tokens=30,
+                    total_tokens=150,
+                    input_tokens_details=SimpleNamespace(cached_tokens=96),
+                ),
+            ),
+        ),
+    ]
+
+    chunks = [chunk async for chunk in responses_events_to_chat_chunks(events)]
+
+    content = "".join(
+        chunk.choices[0].delta.content or "" for chunk in chunks if chunk.choices
+    )
+    reasoning = "".join(
+        chunk.choices[0].delta.reasoning_content or "" for chunk in chunks if chunk.choices
+    )
+    assert content == "Hello world"
+    assert reasoning == "thinking"
+
+    tool_chunks = [
+        chunk.choices[0].delta.tool_calls
+        for chunk in chunks
+        if chunk.choices and chunk.choices[0].delta.tool_calls
+    ]
+    # Arguments buffered and emitted exactly once, with the full payload.
+    assert len(tool_chunks) == 1
+    call = tool_chunks[0][0]
+    assert call.index == 0
+    assert call.id == "call_1"
+    assert call.function.name == "search"
+    assert call.function.arguments == '{"query": "deep tutor"}'
+
+    finish_chunk = next(
+        chunk for chunk in chunks if chunk.choices and chunk.choices[0].finish_reason
+    )
+    assert finish_chunk.choices[0].finish_reason == "tool_calls"
+
+    usage_frames = [chunk for chunk in chunks if not chunk.choices]
+    assert len(usage_frames) == 1
+    usage = usage_frames[-1].usage
+    assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (
+        120,
+        30,
+        150,
+    )
+    assert usage.prompt_tokens_details.cached_tokens == 96
+    # Usage-only frame arrives last, matching Chat Completions ordering.
+    assert chunks[-1] is usage_frames[-1]
+
+
+@pytest.mark.asyncio
+async def test_stream_error_event_raises() -> None:
+    events = [_evt("error", error="boom")]
+    with pytest.raises(RuntimeError, match="boom"):
+        async for _ in responses_events_to_chat_chunks(events):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Non-stream conversion
+# ---------------------------------------------------------------------------
+
+
+def test_nonstream_response_shape() -> None:
+    response = SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text="Answer")],
+            ),
+            SimpleNamespace(
+                type="function_call",
+                call_id="call_9",
+                name="calc",
+                arguments='{"x": 1}',
+            ),
+        ],
+        status="completed",
+        usage=SimpleNamespace(input_tokens=10, output_tokens=5, total_tokens=15),
+    )
+    shaped = response_to_chat_shape(response)
+    choice = shaped.choices[0]
+    assert choice.message.content == "Answer"
+    assert choice.message.tool_calls[0].id == "call_9"
+    assert choice.message.tool_calls[0].function.name == "calc"
+    assert choice.finish_reason == "tool_calls"
+    assert shaped.usage.prompt_tokens == 10
+
+
+# ---------------------------------------------------------------------------
+# Fallback + circuit breaker
+# ---------------------------------------------------------------------------
+
+
+class _FakeInnerFactory:
+    def __init__(self, *, responses_error: Exception | None = None) -> None:
+        self.responses_create_calls = 0
+        self.chat_create_calls = 0
+        self.last_chat_kwargs: dict[str, Any] | None = None
+        self.last_body: dict[str, Any] | None = None
+        self._responses_error = responses_error
+
+    def build(self) -> Any:
+        return SimpleNamespace(
+            responses=SimpleNamespace(create=self._responses_create),
+            chat=SimpleNamespace(completions=SimpleNamespace(create=self._chat_create)),
+        )
+
+    async def _responses_create(self, **body: Any) -> Any:
+        self.responses_create_calls += 1
+        self.last_body = body
+        if self._responses_error is not None:
+            raise self._responses_error
+        if body.get("stream"):
+            return _agen([_evt("response.output_text.delta", delta="hi")])
+        return SimpleNamespace(output=[], status="completed", usage=None)
+
+    async def _chat_create(self, **kwargs: Any) -> Any:
+        self.chat_create_calls += 1
+        self.last_chat_kwargs = kwargs
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="fallback"))]
+        )
+
+
+def _bridge_over(factory: _FakeInnerFactory) -> Any:
+    config = _cloud_config()
+    return wrap_responses_bridge(factory.build(), config).chat.completions
+
+
+@pytest.mark.asyncio
+async def test_stream_success_produces_chunks_via_responses() -> None:
+    factory = _FakeInnerFactory()
+    completions = _bridge_over(factory)
+    kwargs = {
+        "model": "m",
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": True,
+    }
+    stream = await completions.create(**kwargs)
+    chunks = [chunk async for chunk in stream]
+    assert factory.responses_create_calls == 1
+    assert any(
+        chunk.choices and chunk.choices[0].delta.content == "hi" for chunk in chunks
+    )
+    assert factory.chat_create_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_failure_falls_back_then_breaker_skips_responses() -> None:
+    factory = _FakeInnerFactory(responses_error=RuntimeError("404 no /responses"))
+    completions = _bridge_over(factory)
+    kwargs = {"model": "m", "messages": [{"role": "user", "content": "hi"}]}
+
+    first = await completions.create(**kwargs)
+    assert first.choices[0].message.content == "fallback"
+    second = await completions.create(**kwargs)
+    assert second.choices[0].message.content == "fallback"
+    # Two probes tripped the breaker.
+    assert factory.responses_create_calls == 2
+
+    third = await completions.create(**kwargs)
+    assert third.choices[0].message.content == "fallback"
+    assert factory.responses_create_calls == 2  # unchanged: direct chat only
+    assert factory.chat_create_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_success_resets_breaker_failures() -> None:
+    factory = _FakeInnerFactory()
+    completions = _bridge_over(factory)
+    key = bridge_module._breaker_key("https://relay.example/v1", "m")
+    bridge_module._record_bridge_failure(key)
+
+    await completions.create(
+        **{"model": "m", "messages": [{"role": "user", "content": "hi"}]}
+    )
+    assert bridge_module._bridge_failures.get(key) is None

--- a/tests/services/llm/test_cloud_provider.py
+++ b/tests/services/llm/test_cloud_provider.py
@@ -113,6 +113,7 @@ async def test_cloud_complete_fallback(monkeypatch: MonkeyPatch) -> None:
 @pytest.mark.asyncio
 async def test_cloud_stream_yields_chunks(monkeypatch: MonkeyPatch) -> None:
     """Streaming should yield delta content from SSE lines."""
+    monkeypatch.setenv("DEEPTUTOR_USE_RESPONSES_API", "off")
     lines = [
         b'data: {"choices": [{"delta": {"content": "hi"}}]}\n\n',
         b"data: [DONE]\n\n",

--- a/tests/services/llm/test_cloud_responses_bridge.py
+++ b/tests/services/llm/test_cloud_responses_bridge.py
@@ -8,8 +8,8 @@ from typing import Any
 
 import pytest
 
-from deeptutor.services.llm import reset_llm_client
 from deeptutor.services.llm import cloud_provider
+from deeptutor.services.llm import reset_llm_client
 import deeptutor.core.agentic.responses_bridge as bridge_module
 
 
@@ -62,9 +62,13 @@ class _FakeResponse:
 
 
 class _RoutingSession:
-    """Returns distinct fake responses per endpoint and counts posts."""
+    """Returns fake responses per endpoint suffix and counts posts.
 
-    def __init__(self, responses: dict[str, _FakeResponse]) -> None:
+    Values may be response instances (single use) or zero-arg factories
+    producing a fresh response per post (multi-turn tests).
+    """
+
+    def __init__(self, responses: dict[str, Any]) -> None:
         self._responses = responses
         self.posts: list[str] = []
 
@@ -83,7 +87,7 @@ class _RoutingSession:
         self.posts.append(url)
         for suffix, response in self._responses.items():
             if url.endswith(suffix):
-                return response
+                return response() if callable(response) else response
         raise AssertionError(f"unexpected post url: {url}")
 
 
@@ -104,9 +108,7 @@ def _chat_sse(text: str) -> list[bytes]:
     ]
 
 
-def _install(
-    monkeypatch: pytest.MonkeyPatch, session: _RoutingSession
-) -> None:
+def _install(monkeypatch: pytest.MonkeyPatch, session: _RoutingSession) -> None:
     monkeypatch.setattr(
         cloud_provider.aiohttp,
         "ClientSession",
@@ -126,7 +128,9 @@ def _isolated(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[None, None]:
 
 @pytest.mark.asyncio
 async def test_stream_via_responses(monkeypatch: pytest.MonkeyPatch) -> None:
-    session = _RoutingSession({"/responses": _FakeStreamResponseLike(200, _responses_sse())})
+    session = _RoutingSession(
+        {"/responses": _FakeResponse(200, lines=_responses_sse())}
+    )
     _install(monkeypatch, session)
 
     chunks = [
@@ -141,8 +145,8 @@ async def test_stream_via_responses(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
 
     assert "".join(chunks) == "Hello via responses"
-    assert [url for url in session.posts if url.endswith("/responses")]
-    assert not [url for url in session.posts if url.endswith("/chat/completions")]
+    assert any(url.endswith("/responses") for url in session.posts)
+    assert not any(url.endswith("/chat/completions") for url in session.posts)
 
 
 @pytest.mark.asyncio
@@ -151,8 +155,8 @@ async def test_stream_falls_back_on_responses_error(
 ) -> None:
     session = _RoutingSession(
         {
-            "/responses": _FakeStreamResponseLike(404, [], text="no /responses here"),
-            "/chat/completions": _FakeStreamResponseLike(200, _chat_sse("fallback")),
+            "/responses": _FakeResponse(404, text="no /responses here"),
+            "/chat/completions": _FakeResponse(200, lines=_chat_sse("fallback")),
         }
     )
     _install(monkeypatch, session)
@@ -179,8 +183,8 @@ async def test_breaker_blocks_probes_after_two_failures(
 ) -> None:
     session = _RoutingSession(
         {
-            "/responses": _FakeStreamResponseLike(404, [], text="nope"),
-            "/chat/completions": _FakeStreamResponseLike(200, _chat_sse("ok")),
+            "/responses": lambda: _FakeResponse(404, text="nope"),
+            "/chat/completions": lambda: _FakeResponse(200, lines=_chat_sse("ok")),
         }
     )
     _install(monkeypatch, session)
@@ -197,16 +201,42 @@ async def test_breaker_blocks_probes_after_two_failures(
 
     await _one_turn()
     await _one_turn()
-    responses_posts = sum(
-        1 for url in session.posts if url.endswith("/responses")
-    )
+    responses_posts = sum(1 for url in session.posts if url.endswith("/responses"))
     assert responses_posts == 2
 
     await _one_turn()
-    responses_posts = sum(
-        1 for url in session.posts if url.endswith("/responses")
-    )
+    responses_posts = sum(1 for url in session.posts if url.endswith("/responses"))
     assert responses_posts == 2  # breaker: no further probing
+
+
+@pytest.mark.asyncio
+async def test_legacy_transient_503_keeps_probing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """new-api 503 channel exhaustion falls back per request without tripping."""
+    session = _RoutingSession(
+        {
+            "/responses": lambda: _FakeResponse(503, text="no channel"),
+            "/chat/completions": lambda: _FakeResponse(200, lines=_chat_sse("ok")),
+        }
+    )
+    _install(monkeypatch, session)
+
+    for _ in range(3):
+        chunks = [
+            chunk
+            async for chunk in cloud_provider.stream(
+                prompt="hello",
+                model="gpt-test",
+                api_key="k",
+                base_url="https://relay.example/v1",
+                binding="custom",
+            )
+        ]
+        assert "".join(chunks) == "ok"
+
+    responses_posts = sum(1 for url in session.posts if url.endswith("/responses"))
+    assert responses_posts == 3
 
 
 @pytest.mark.asyncio
@@ -241,10 +271,3 @@ async def test_complete_via_responses(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert result == "complete ok"
     assert any(url.endswith("/responses") for url in session.posts)
-
-
-class _FakeStreamResponseLike(_FakeResponse):
-    """Stream-flavoured response (kept name short for the tables above)."""
-
-    def __init__(self, status: int, lines: list[bytes], text: str = "") -> None:
-        super().__init__(status, lines=lines, text=text)

--- a/tests/services/llm/test_cloud_responses_bridge.py
+++ b/tests/services/llm/test_cloud_responses_bridge.py
@@ -1,0 +1,250 @@
+"""Tests for the Responses bridge on the aiohttp cloud provider path."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from types import TracebackType
+from typing import Any
+
+import pytest
+
+from deeptutor.services.llm import reset_llm_client
+from deeptutor.services.llm import cloud_provider
+import deeptutor.core.agentic.responses_bridge as bridge_module
+
+
+class _AsyncIterator:
+    def __init__(self, items: list[bytes]) -> None:
+        self._items = items
+        self._index = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> bytes:
+        if self._index >= len(self._items):
+            raise StopAsyncIteration
+        item = self._items[self._index]
+        self._index += 1
+        return item
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        status: int,
+        *,
+        json_data: dict[str, Any] | None = None,
+        lines: list[bytes] | None = None,
+        text: str = "",
+    ) -> None:
+        self.status = status
+        self._json_data = json_data or {}
+        self.content = _AsyncIterator(lines or [])
+        self._text = text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        return None
+
+    async def json(self) -> dict[str, Any]:
+        return self._json_data
+
+    async def text(self) -> str:
+        return self._text
+
+
+class _RoutingSession:
+    """Returns distinct fake responses per endpoint and counts posts."""
+
+    def __init__(self, responses: dict[str, _FakeResponse]) -> None:
+        self._responses = responses
+        self.posts: list[str] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        return None
+
+    def post(self, url: str, **_kwargs: object) -> _FakeResponse:
+        self.posts.append(url)
+        for suffix, response in self._responses.items():
+            if url.endswith(suffix):
+                return response
+        raise AssertionError(f"unexpected post url: {url}")
+
+
+def _responses_sse() -> list[bytes]:
+    return [
+        b'data: {"type": "response.output_text.delta", "delta": "Hello"}\n\n',
+        b'data: {"type": "response.output_text.delta", "delta": " via responses"}\n\n',
+        b'data: {"type": "response.completed", "response": {"status": "completed", "usage": {"input_tokens": 10, "output_tokens": 3, "total_tokens": 13, "input_tokens_details": {"cached_tokens": 8}}}}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+
+
+def _chat_sse(text: str) -> list[bytes]:
+    return [
+        f'data: {{"choices": [{{"delta": {{"content": "{text}"}}, "finish_reason": null}}]}}\n\n'.encode(),
+        b'data: {"choices": [{"delta": {}, "finish_reason": "stop"}]}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+
+
+def _install(
+    monkeypatch: pytest.MonkeyPatch, session: _RoutingSession
+) -> None:
+    monkeypatch.setattr(
+        cloud_provider.aiohttp,
+        "ClientSession",
+        lambda *args, **kwargs: session,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[None, None]:
+    monkeypatch.delenv(bridge_module.ENV_USE_RESPONSES_API, raising=False)
+    bridge_module.reset_bridge_breaker()
+    reset_llm_client()
+    yield
+    bridge_module.reset_bridge_breaker()
+    reset_llm_client()
+
+
+@pytest.mark.asyncio
+async def test_stream_via_responses(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _RoutingSession({"/responses": _FakeStreamResponseLike(200, _responses_sse())})
+    _install(monkeypatch, session)
+
+    chunks = [
+        chunk
+        async for chunk in cloud_provider.stream(
+            prompt="hello",
+            model="gpt-test",
+            api_key="k",
+            base_url="https://relay.example/v1",
+            binding="custom",
+        )
+    ]
+
+    assert "".join(chunks) == "Hello via responses"
+    assert [url for url in session.posts if url.endswith("/responses")]
+    assert not [url for url in session.posts if url.endswith("/chat/completions")]
+
+
+@pytest.mark.asyncio
+async def test_stream_falls_back_on_responses_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _RoutingSession(
+        {
+            "/responses": _FakeStreamResponseLike(404, [], text="no /responses here"),
+            "/chat/completions": _FakeStreamResponseLike(200, _chat_sse("fallback")),
+        }
+    )
+    _install(monkeypatch, session)
+
+    chunks = [
+        chunk
+        async for chunk in cloud_provider.stream(
+            prompt="hello",
+            model="gpt-test",
+            api_key="k",
+            base_url="https://relay.example/v1",
+            binding="custom",
+        )
+    ]
+
+    assert "".join(chunks) == "fallback"
+    assert any(url.endswith("/responses") for url in session.posts)
+    assert any(url.endswith("/chat/completions") for url in session.posts)
+
+
+@pytest.mark.asyncio
+async def test_breaker_blocks_probes_after_two_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _RoutingSession(
+        {
+            "/responses": _FakeStreamResponseLike(404, [], text="nope"),
+            "/chat/completions": _FakeStreamResponseLike(200, _chat_sse("ok")),
+        }
+    )
+    _install(monkeypatch, session)
+
+    async def _one_turn() -> None:
+        async for _ in cloud_provider.stream(
+            prompt="hello",
+            model="gpt-test",
+            api_key="k",
+            base_url="https://relay.example/v1",
+            binding="custom",
+        ):
+            pass
+
+    await _one_turn()
+    await _one_turn()
+    responses_posts = sum(
+        1 for url in session.posts if url.endswith("/responses")
+    )
+    assert responses_posts == 2
+
+    await _one_turn()
+    responses_posts = sum(
+        1 for url in session.posts if url.endswith("/responses")
+    )
+    assert responses_posts == 2  # breaker: no further probing
+
+
+@pytest.mark.asyncio
+async def test_complete_via_responses(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _RoutingSession(
+        {
+            "/responses": _FakeResponse(
+                200,
+                json_data={
+                    "output": [
+                        {
+                            "type": "message",
+                            "content": [
+                                {"type": "output_text", "text": "complete ok"}
+                            ],
+                        }
+                    ],
+                    "usage": {"input_tokens": 5, "output_tokens": 2},
+                },
+            )
+        }
+    )
+    _install(monkeypatch, session)
+
+    result = await cloud_provider.complete(
+        prompt="hello",
+        model="gpt-test",
+        api_key="k",
+        base_url="https://relay.example/v1",
+        binding="custom",
+    )
+
+    assert result == "complete ok"
+    assert any(url.endswith("/responses") for url in session.posts)
+
+
+class _FakeStreamResponseLike(_FakeResponse):
+    """Stream-flavoured response (kept name short for the tables above)."""
+
+    def __init__(self, status: int, lines: list[bytes], text: str = "") -> None:
+        super().__init__(status, lines=lines, text=text)


### PR DESCRIPTION
## Summary

All agentic pipelines (chat loop, labeled steps, research, question, explore) stream through a raw `AsyncOpenAI` client built by `core/agentic/client.py`, which always targets `{base}/chat/completions`. The existing Responses API support in `services/llm/provider_core` never applies on this path because it is gated to direct `api.openai.com` connections (#882 covered the direct-OpenAI case only).

For users behind OpenAI-compatible gateways/relays this means prompt caching is effectively unreachable: every agent round replays the full conversation at full input price. #727 reports the hard version of this — some gateways reject Chat Completions entirely for newer models (`protocol_not_supported`).

## What this PR does

Adds an opt-out **Responses bridge** at the shared client factory (`core/agentic/client.py`), so `chat.completions.create(...)` is transparently served by `{base}/responses`:

- **Request side**: chat kwargs are converted to Responses bodies using the existing converters in `services/llm/provider_core/openai_responses/` (`convert_messages`, `convert_tools`). Multiple system messages are merged into `instructions` (the converter otherwise keeps only the last one). Chat-only kwargs such as `stream_options` are dropped.
- **Response side**: Responses SDK events and objects are re-shaped into chat-completions chunks (`delta.content`, `delta.reasoning_content`, `delta.tool_calls`, `finish_reason`, `usage` incl. `prompt_tokens_details.cached_tokens`). Tool-call arguments are buffered and emitted exactly once per call so consumers that accumulate deltas by concatenation stay correct. No consumer code changes required.
- **Failure handling**: any bridge error retries the original request via Chat Completions for that call, and feeds a per-(base URL, model) circuit breaker — after 2 failures the gateway is left alone for 5 minutes, then probed again. Gateways without `/responses` therefore degrade gracefully instead of breaking.
- **Activation policy** via `DEEPTUTOR_USE_RESPONSES_API`: `on` / `off` / unset-or-anything (auto). Auto bridges cloud OpenAI-compatible bindings and skips local inference servers (Ollama, vLLM, LM Studio, …).

## Testing

- New unit tests (`tests/core/agentic/test_responses_bridge.py`, 14 cases): activation policy, system-message merging + kwarg dropping, tool schema conversion, stream event shaping (single tool-call emission, finish reason, usage-only final frame with cached tokens), non-stream shape, fallback + breaker trip/expiry.
- Regression: `tests/core` 187 passed; `tests/services/llm` 171 passed, 1 pre-existing skip.
- End-to-end smoke against a local mock gateway exposing both endpoints: streaming served by `/v1/responses`; non-stream conversion; a 404 on `/responses` falls back mid-request to chat completions; breaker stops probing after two failures.

Fixes #727
Relates to #846 (DeepSeek Responses support would slot into the same seam), builds on #882.

Happy to flip the default from auto to opt-in only if maintainers prefer a more conservative rollout.
