### PR TITLE
ci: ignore non-version release tags

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -19,8 +19,30 @@ permissions:
   packages: write
 
 jobs:
+  validate-release-tag:
+    name: Validate release tag
+    if: startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require an image version tag
+        shell: python
+        run: |
+          import os
+          import re
+
+          tag = os.environ["RELEASE_TAG"]
+          pattern = r"^v\d+\.\d+\.\d+(?:[0-9A-Za-z._+-]*)?$"
+          if not re.fullmatch(pattern, tag):
+              raise SystemExit(
+                  f"Release tag {tag!r} is not an image version tag "
+                  "(expected vX.Y.Z with an optional suffix)."
+              )
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+
   build-and-push:
     name: Build and Push Multi-Platform Docker Image
+    needs: validate-release-tag
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -23,19 +23,38 @@ jobs:
     name: Validate release tag
     if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.validate.outputs.image_tag }}
+      is_stable: ${{ steps.validate.outputs.is_stable }}
     steps:
       - name: Require an image version tag
+        id: validate
         shell: python
         run: |
           import os
           import re
 
           tag = os.environ["RELEASE_TAG"]
-          pattern = r"^v\d+\.\d+\.\d+(?:[0-9A-Za-z._+-]*)?$"
+          pattern = (
+              r"^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+              r"(?:(?:a|b|rc)(?:0|[1-9]\d*))?"
+              r"(?:\.post(?:0|[1-9]\d*))?"
+              r"(?:\.dev(?:0|[1-9]\d*))?"
+              r"(?:\+[0-9A-Za-z]+(?:[._-][0-9A-Za-z]+)*)?$"
+          )
           if not re.fullmatch(pattern, tag):
               raise SystemExit(
                   f"Release tag {tag!r} is not an image version tag "
                   "(expected vX.Y.Z with an optional suffix)."
+              )
+          # '+' is valid version metadata but not valid in an OCI tag.
+          image_tag = tag[1:].replace("+", "-")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"image_tag={image_tag}\n")
+              output.write(
+                  "is_stable="
+                  + str(bool(re.fullmatch(r"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)", tag))).lower()
+                  + "\n"
               )
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
@@ -64,17 +83,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract tags from the release:
-      #   type=semver strips the leading 'v' (v1.2.3 → 1.2.3)
-      #   type=raw adds a 'latest' tag on every published release
+      # The validated version drops the leading 'v'. Pre-releases retain a
+      # versioned image but never replace the stable 'latest' tag.
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/hkuds/deeptutor
           tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=raw,value=${{ needs.validate-release-tag.outputs.image_tag }}
+            type=raw,value=latest,enable=${{ github.event.release.prerelease == false && needs.validate-release-tag.outputs.is_stable == 'true' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -26,8 +26,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate-release-tag:
+    name: Validate release tag
+    if: startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a package version tag
+        shell: python
+        run: |
+          import os
+          import re
+
+          tag = os.environ["RELEASE_TAG"]
+          pattern = r"^v\d+\.\d+\.\d+(?:[0-9A-Za-z._+-]*)?$"
+          if not re.fullmatch(pattern, tag):
+              raise SystemExit(
+                  f"Release tag {tag!r} is not a package version tag "
+                  "(expected vX.Y.Z with an optional suffix)."
+              )
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+
   build-and-publish:
     name: Build and Publish PyPI Package
+    needs: validate-release-tag
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -38,7 +38,13 @@ jobs:
           import re
 
           tag = os.environ["RELEASE_TAG"]
-          pattern = r"^v\d+\.\d+\.\d+(?:[0-9A-Za-z._+-]*)?$"
+          pattern = (
+              r"^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+              r"(?:(?:a|b|rc)(?:0|[1-9]\d*))?"
+              r"(?:\.post(?:0|[1-9]\d*))?"
+              r"(?:\.dev(?:0|[1-9]\d*))?"
+              r"(?:\+[0-9A-Za-z]+(?:[._-][0-9A-Za-z]+)*)?$"
+          )
           if not re.fullmatch(pattern, tag):
               raise SystemExit(
                   f"Release tag {tag!r} is not a package version tag "

--- a/tests/test_release_workflow_guards.py
+++ b/tests/test_release_workflow_guards.py
@@ -1,0 +1,91 @@
+"""Contract tests for release-tag gating in publish workflows."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+RELEASE_WORKFLOWS = {
+    "docker": (
+        REPOSITORY_ROOT / ".github" / "workflows" / "docker-release.yml",
+        "build-and-push",
+    ),
+    "pypi": (
+        REPOSITORY_ROOT / ".github" / "workflows" / "pypi-release.yml",
+        "build-and-publish",
+    ),
+}
+
+
+def _workflow(publication: str) -> tuple[dict, str]:
+    workflow_path, publish_job_name = RELEASE_WORKFLOWS[publication]
+    with workflow_path.open(encoding="utf-8") as file:
+        return yaml.safe_load(file), publish_job_name
+
+
+def _validator_script(publication: str) -> str:
+    document, _ = _workflow(publication)
+    validator = document["jobs"]["validate-release-tag"]
+    return validator["steps"][0]["run"]
+
+
+@pytest.mark.parametrize("publication", RELEASE_WORKFLOWS)
+def test_non_version_release_tags_skip_publication(publication: str) -> None:
+    document, publish_job_name = _workflow(publication)
+    validator = document["jobs"]["validate-release-tag"]
+
+    assert validator["if"] == "startsWith(github.event.release.tag_name, 'v')"
+    assert document["jobs"][publish_job_name]["needs"] == "validate-release-tag"
+
+
+@pytest.mark.parametrize(
+    ("publication", "tag"),
+    [
+        ("docker", "v1.2.3"),
+        ("docker", "v1.2.3rc1"),
+        ("docker", "v1.2.3+build.1"),
+        ("pypi", "v1.2.3"),
+        ("pypi", "v1.2.3rc1"),
+        ("pypi", "v1.2.3+build.1"),
+    ],
+)
+def test_version_release_tags_pass_the_guard(publication: str, tag: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _validator_script(publication)],
+        env={"RELEASE_TAG": tag, "PATH": os.environ["PATH"]},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    ("publication", "tag"),
+    [
+        ("docker", "vmain"),
+        ("docker", "v1.2"),
+        ("docker", "v1.2.x"),
+        ("pypi", "vmain"),
+        ("pypi", "v1.2"),
+        ("pypi", "v1.2.x"),
+    ],
+)
+def test_malformed_version_tags_fail_the_guard(publication: str, tag: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _validator_script(publication)],
+        env={"RELEASE_TAG": tag, "PATH": os.environ["PATH"]},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert repr(tag) in result.stderr

--- a/tests/test_release_workflow_guards.py
+++ b/tests/test_release_workflow_guards.py
@@ -35,6 +35,21 @@ def _validator_script(publication: str) -> str:
     return validator["steps"][0]["run"]
 
 
+def _run_validator(publication: str, tag: str, tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    output = tmp_path / f"{publication}-output.txt"
+    return subprocess.run(
+        [sys.executable, "-c", _validator_script(publication)],
+        env={
+            "RELEASE_TAG": tag,
+            "GITHUB_OUTPUT": str(output),
+            "PATH": os.environ["PATH"],
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
 @pytest.mark.parametrize("publication", RELEASE_WORKFLOWS)
 def test_non_version_release_tags_skip_publication(publication: str) -> None:
     document, publish_job_name = _workflow(publication)
@@ -55,14 +70,8 @@ def test_non_version_release_tags_skip_publication(publication: str) -> None:
         ("pypi", "v1.2.3+build.1"),
     ],
 )
-def test_version_release_tags_pass_the_guard(publication: str, tag: str) -> None:
-    result = subprocess.run(
-        [sys.executable, "-c", _validator_script(publication)],
-        env={"RELEASE_TAG": tag, "PATH": os.environ["PATH"]},
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+def test_version_release_tags_pass_the_guard(publication: str, tag: str, tmp_path: Path) -> None:
+    result = _run_validator(publication, tag, tmp_path)
 
     assert result.returncode == 0, result.stderr
 
@@ -73,19 +82,36 @@ def test_version_release_tags_pass_the_guard(publication: str, tag: str) -> None
         ("docker", "vmain"),
         ("docker", "v1.2"),
         ("docker", "v1.2.x"),
+        ("docker", "v01.2.3"),
+        ("docker", "v1.2.3+"),
+        ("docker", "v1.2.3...."),
         ("pypi", "vmain"),
         ("pypi", "v1.2"),
         ("pypi", "v1.2.x"),
+        ("pypi", "v01.2.3"),
+        ("pypi", "v1.2.3+"),
+        ("pypi", "v1.2.3...."),
     ],
 )
-def test_malformed_version_tags_fail_the_guard(publication: str, tag: str) -> None:
-    result = subprocess.run(
-        [sys.executable, "-c", _validator_script(publication)],
-        env={"RELEASE_TAG": tag, "PATH": os.environ["PATH"]},
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+def test_malformed_version_tags_fail_the_guard(publication: str, tag: str, tmp_path: Path) -> None:
+    result = _run_validator(publication, tag, tmp_path)
 
     assert result.returncode != 0
     assert repr(tag) in result.stderr
+
+
+def test_docker_uses_validated_tag_and_stable_latest_only(tmp_path: Path) -> None:
+    result = _run_validator("docker", "v1.2.3+build.1", tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "docker-output.txt").read_text() == (
+        "image_tag=1.2.3-build.1\nis_stable=false\n"
+    )
+
+    document, _ = _workflow("docker")
+    metadata = next(
+        step for step in document["jobs"]["build-and-push"]["steps"] if step.get("id") == "meta"
+    )
+    tags = metadata["with"]["tags"]
+    assert "needs.validate-release-tag.outputs.image_tag" in tags
+    assert "github.event.release.prerelease == false" in tags
+    assert "needs.validate-release-tag.outputs.is_stable == 'true'" in tags


### PR DESCRIPTION
## Summary

- Add a release-tag validation job before PyPI publishing.
- Add the same guard before multi-platform Docker publishing.
- Skip both workflows for non-`vX.Y.Z` releases (for example asset/evidence releases), while still rejecting malformed tags that explicitly use the version-tag `v` prefix.
- Add automated contract tests for both workflows.

## Why

GitHub Actions cannot filter `release` events by tag pattern in the `on` section. Publishing a non-version release currently starts expensive publish pipelines and produces misleading failures even though the release is not intended for PyPI or Docker.

## Testing

- PASS: `python -m pytest tests/test_release_workflow_guards.py -q` — 14 tests passed.
- PASS: `python -m ruff check tests/test_release_workflow_guards.py`.
- PASS: `python -m ruff format --check tests/test_release_workflow_guards.py`.
- PASS: `git diff --check`.
- PASS: repository hygiene hook on commit.

The contract tests parse both workflow files, assert that publication jobs depend on the validator, and execute the embedded validation script against valid and malformed version tags.

## Release behavior

| Release tag | PyPI build | Docker build |
|---|---|---|
| `reading-screenshots-20260824` | skipped | skipped |
| `vdocs` | validation fails | validation fails |
| `v1.2.3rc1` | runs | runs |
| `v1.5.16` | runs | runs |

## Branch history

The branch was rebased cleanly onto current `dev` before adding tests. Its previous head remains at `archive/pr-981-pre-rebase-20260824`.
