### PR TITLE
fix: improve Windows cross-platform compatibility across runner, tool…

### DIFF
--- a/deeptutor/partners/channels/weixin.py
+++ b/deeptutor/partners/channels/weixin.py
@@ -208,7 +208,7 @@ class WeixinChannel(BaseChannel):
         if not state_file.exists():
             return False
         try:
-            data = json.loads(state_file.read_text())
+            data = json.loads(state_file.read_text(encoding="utf-8"))
             if not self.config.token:
                 self._token = data.get("token", "")
             self._get_updates_buf = data.get("get_updates_buf", "")

--- a/deeptutor/services/sandbox/runner/server.py
+++ b/deeptutor/services/sandbox/runner/server.py
@@ -63,11 +63,15 @@ from __future__ import annotations
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import os
-import resource
 import subprocess
 import sys
 import traceback
 from typing import Any
+
+try:
+    import resource
+except ImportError:  # pragma: no cover - non-POSIX platforms (e.g. Windows)
+    resource = None  # type: ignore[assignment]
 
 # Port to listen on inside the container; overridable for local testing.
 DEFAULT_PORT = 8900
@@ -128,23 +132,24 @@ def _build_preexec_fn(memory_mb: int, cpu_seconds: int):
 
     def _apply() -> None:
         # Address space (bytes). Cap virtual memory as a secondary guard.
-        if memory_mb > 0:
+        if memory_mb > 0 and resource is not None:
             mem_bytes = memory_mb * 1024 * 1024
             try:
-                resource.setrlimit(resource.RLIMIT_AS, (mem_bytes, mem_bytes))
+                resource.setrlimit(resource.RLIMIT_AS, (mem_bytes, mem_bytes))  # type: ignore[attr-defined]
             except (ValueError, OSError):
                 pass
         # CPU time (seconds). SIGXCPU/SIGKILL the child if it burns this much CPU.
-        if cpu_seconds > 0:
+        if cpu_seconds > 0 and resource is not None:
             try:
-                resource.setrlimit(resource.RLIMIT_CPU, (cpu_seconds, cpu_seconds))
+                resource.setrlimit(resource.RLIMIT_CPU, (cpu_seconds, cpu_seconds))  # type: ignore[attr-defined]
             except (ValueError, OSError):
                 pass
         # Open file descriptors.
-        try:
-            resource.setrlimit(resource.RLIMIT_NOFILE, (_RLIMIT_NOFILE, _RLIMIT_NOFILE))
-        except (ValueError, OSError):
-            pass
+        if resource is not None:
+            try:
+                resource.setrlimit(resource.RLIMIT_NOFILE, (_RLIMIT_NOFILE, _RLIMIT_NOFILE))  # type: ignore[attr-defined]
+            except (ValueError, OSError):
+                pass
 
     return _apply
 

--- a/deeptutor/tools/file_tools.py
+++ b/deeptutor/tools/file_tools.py
@@ -249,7 +249,8 @@ class ListDirTool(_WorkspaceTool):
                 total += 1
                 if len(items) < cap:
                     rel = item.relative_to(dp)
-                    items.append(f"{rel}/" if item.is_dir() else str(rel))
+                    rel_posix = rel.as_posix()
+                    items.append(f"{rel_posix}/" if item.is_dir() else rel_posix)
             if not items and total == 0:
                 return ToolResult(content=f"Directory {path} is empty")
             text = "\n".join(items)

--- a/tests/agents/chat/test_cli_app_wiring.py
+++ b/tests/agents/chat/test_cli_app_wiring.py
@@ -35,7 +35,7 @@ def test_a_cli_app_call_is_given_a_workdir_and_a_writable_mount(
     kwargs = _augment("cli_blender", monkeypatch, tmp_path)
 
     workdir = kwargs["_sandbox_workdir"]
-    assert workdir.endswith("/cli")
+    assert Path(workdir).as_posix().endswith("/cli")
     assert Path(workdir).is_dir(), "the app cannot write into a directory nobody created"
     assert kwargs["_sandbox_user_id"] == "u_ada"
     mount = kwargs["_sandbox_mounts"][0]

--- a/tests/agents/chat/test_prompt_identity.py
+++ b/tests/agents/chat/test_prompt_identity.py
@@ -80,7 +80,7 @@ def test_blank_identity_falls_back_to_product():
 def test_shipped_yaml_carries_partner_templates():
     root = Path(__file__).resolve().parents[3] / "deeptutor/agents/chat/prompts"
     for lang in ("en", "zh"):
-        data = yaml.safe_load((root / lang / "agentic_chat.yaml").read_text())
+        data = yaml.safe_load((root / lang / "agentic_chat.yaml").read_text(encoding="utf-8"))
         assert "{name}" in data["general_partner"]
         assert "{description}" in data["general_partner_description"]
         assert "partner_turn_policy" in data

--- a/tests/capabilities/test_status_i18n_consistency.py
+++ b/tests/capabilities/test_status_i18n_consistency.py
@@ -26,13 +26,13 @@ _CODE = _REPO / "deeptutor" / "agents" / "visualize" / "capability.py"
 
 
 def _status_keys(lang: str) -> set[str]:
-    data = yaml.safe_load((_PROMPTS / lang / "visualize.yaml").read_text()) or {}
+    data = yaml.safe_load((_PROMPTS / lang / "visualize.yaml").read_text(encoding="utf-8")) or {}
     status = data.get("status") if isinstance(data, dict) else None
     return set((status or {}).keys())
 
 
 def _code() -> str:
-    return _CODE.read_text()
+    return _CODE.read_text(encoding="utf-8")
 
 
 def test_en_zh_status_parity() -> None:

--- a/tests/multi_user/test_resource_isolation.py
+++ b/tests/multi_user/test_resource_isolation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 
 def test_book_session_ids_are_scoped_per_user(as_user) -> None:
     from deeptutor.book.storage import BookStorage
@@ -44,5 +46,5 @@ def test_partner_data_is_admin_anchored_not_user_scoped(as_user) -> None:
         attacker_dir = manager._partners_dir
 
     assert victim_dir == attacker_dir
-    assert str(victim_dir).endswith("data/partners")
+    assert Path(victim_dir).as_posix().endswith("data/partners")
     assert "u_victim" not in str(victim_dir)

--- a/tests/services/test_config_loader.py
+++ b/tests/services/test_config_loader.py
@@ -53,4 +53,8 @@ def test_load_config_with_main_uses_explicit_project_root() -> None:
     config = load_config_with_main("main.yaml", PROJECT_ROOT)
 
     assert "system" in config
-    assert config["paths"]["solve_output_dir"].endswith("data/user/workspace/chat/deep_solve")
+    assert (
+        Path(config["paths"]["solve_output_dir"])
+        .as_posix()
+        .endswith("data/user/workspace/chat/deep_solve")
+    )


### PR DESCRIPTION
### Summary
This PR resolves several Windows-specific compatibility issues across the runner server, workspace tools, and test suites, ensuring developers on Windows can run tests, develop locally, and contribute without platform-induced errors.

### Key Changes
- **Runner Server (`server.py`)**: Guard `import resource` with `try...except ImportError` and provide type annotations for non-POSIX platforms (resolving `ModuleNotFoundError: No module named 'resource'` during pytest collection on Windows).
- **Workspace Tools (`file_tools.py`)**: Use `rel.as_posix()` in `ListDirTool` so relative paths are returned with forward slashes consistently across all operating systems.
- **Encoding Consistency**: Specify `encoding="utf-8"` in `weixin.py` state file loading and YAML prompt tests (`test_prompt_identity.py`, `test_status_i18n_consistency.py`) to prevent `UnicodeDecodeError` under default Windows code pages (e.g. GBK/CP936).
- **Test Path Assertions**: Use `Path(...).as_posix()` for path comparisons in `test_cli_app_wiring.py`, `test_config_loader.py`, and `test_resource_isolation.py`.

### Verification
- `pytest tests/tools/test_file_tools.py tests/agents/chat/test_prompt_identity.py tests/agents/chat/test_cli_app_wiring.py tests/capabilities/test_status_i18n_consistency.py tests/services/test_config_loader.py tests/multi_user/test_resource_isolation.py` (25 passed).
- Code formatting and static type checks passed (`ruff check`, `ruff format`, `mypy`).