### PR TITLE
fix(codex): fail closed on TLS verification errors

### DIFF
--- a/deeptutor/services/llm/provider_core/openai_codex_provider.py
+++ b/deeptutor/services/llm/provider_core/openai_codex_provider.py
@@ -99,19 +99,6 @@ class OpenAICodexProvider(LLMProvider):
                                 "Codex login expired and could not be renewed. Sign in again.",
                             ) from None
                     raise
-                except Exception as exc:
-                    if "CERTIFICATE_VERIFY_FAILED" not in str(exc):
-                        raise
-                    logger.warning(
-                        "SSL verification failed for Codex API; retrying with verify=False"
-                    )
-                    content, tool_calls, finish_reason = await _request_codex(
-                        CODEX_RESPONSES_URL,
-                        headers,
-                        body,
-                        verify=False,
-                        on_content_delta=on_content_delta,
-                    )
                 return LLMResponse(
                     content=content,
                     tool_calls=tool_calls,

--- a/tests/services/llm/test_codex_disable_ssl_verify.py
+++ b/tests/services/llm/test_codex_disable_ssl_verify.py
@@ -1,9 +1,7 @@
 """DISABLE_SSL_VERIFY coverage for the OpenAI Codex Responses provider.
 
-The codex provider was previously hardcoded to ``verify=True`` on the first
-attempt, with an auto-retry on ``CERTIFICATE_VERIFY_FAILED``. The flag now
-short-circuits the first attempt while preserving the retry-on-cert-failure
-fallback.
+The flag controls the initial request. A certificate verification failure must
+never trigger an automatic retry with verification disabled.
 """
 
 from __future__ import annotations
@@ -11,9 +9,11 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from typing import Any
 
+import httpx
 import pytest
 
 from deeptutor.services.llm import openai_http_client
+from deeptutor.services.llm.exceptions import LLMProviderTransportError
 from deeptutor.services.llm.provider_core import openai_codex_provider
 
 
@@ -98,25 +98,21 @@ async def test_codex_first_attempt_verify_false_when_flag_set(
 
 
 @pytest.mark.asyncio
-async def test_codex_retry_on_cert_failure_still_works(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The CERTIFICATE_VERIFY_FAILED retry fallback is preserved."""
+async def test_codex_certificate_failure_never_retries_without_verification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     _stub_token_loader(monkeypatch)
     captured: list[dict[str, Any]] = []
-    call_count = {"n": 0}
 
     async def fake_request(*args: Any, **kwargs: Any) -> tuple[str, list[Any], str]:
         captured.append(kwargs)
-        call_count["n"] += 1
-        if call_count["n"] == 1:
-            raise RuntimeError("[SSL: CERTIFICATE_VERIFY_FAILED] cert chain")
-        return ("recovered", [], "stop")
+        raise httpx.ConnectError("[SSL: CERTIFICATE_VERIFY_FAILED] cert chain")
 
     monkeypatch.setattr(openai_codex_provider, "_request_codex", fake_request)
 
     provider = openai_codex_provider.OpenAICodexProvider()
-    result = await provider.chat(messages=[{"role": "user", "content": "hi"}])
+    with pytest.raises(LLMProviderTransportError):
+        await provider.chat(messages=[{"role": "user", "content": "hi"}])
 
-    assert result.content == "recovered"
-    assert len(captured) == 2
+    assert len(captured) == 1
     assert captured[0]["verify"] is True
-    assert captured[1]["verify"] is False


### PR DESCRIPTION
## Summary

- remove the automatic retry that changed a failed Codex HTTPS request from certificate verification enabled to `verify=False`
- preserve the existing `DISABLE_SSL_VERIFY` setting for the initial request
- keep certificate failures on the existing sanitized transport-error path

## Why

An unexpected certificate-verification failure must not silently downgrade the connection security policy. Users who intentionally need verification disabled can still opt in before the request through the existing setting; otherwise the request now fails closed after one attempt.

## Validation

Primary validation targets exact head `19e90e7529efdaa8e3104d7e8ef72033172c22ab` on base `87ccedd5497d8ec55591d2658fb250d448ea9e54`.

```bash
python -m pytest \
  tests/services/llm/test_codex_disable_ssl_verify.py \
  tests/services/llm/test_openai_codex_oauth_provider.py
```

Result: `11 passed`.

```bash
python -m pytest tests/services/llm
```

Result: `232 passed`.

```bash
ruff check \
  deeptutor/services/llm/provider_core/openai_codex_provider.py \
  tests/services/llm/test_codex_disable_ssl_verify.py
ruff format --check \
  deeptutor/services/llm/provider_core/openai_codex_provider.py \
  tests/services/llm/test_codex_disable_ssl_verify.py
git diff --check 87ccedd5497d8ec55591d2658fb250d448ea9e54..19e90e7529efdaa8e3104d7e8ef72033172c22ab
```

All checks passed; both changed files were already formatted.

The tests use a simulated `httpx.ConnectError`; no real Codex request, credential, or TLS endpoint is used.

