### PR TITLE
fix(rag): preserve asymmetric embedding context

### DIFF
--- a/deeptutor/services/rag/pipelines/lightrag/config.py
+++ b/deeptutor/services/rag/pipelines/lightrag/config.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 import importlib.util
+import inspect
 import logging
 import re
 from typing import TYPE_CHECKING, TypeVar
@@ -301,8 +302,8 @@ def build_embedding_func(*, io_bridge: OwnerLoopBridge | None = None):
     async def embedding_func(texts, context=None, **_ignored):
         import numpy as np
 
-        # No context means no role, which is what the pinned LightRAG always
-        # passes — defaulting to "document" would label queries as passages.
+        # No context means no role. Defaulting to "document" would label
+        # queries as passages.
         input_type = {
             "query": "search_query",
             "document": "search_document",
@@ -314,11 +315,14 @@ def build_embedding_func(*, io_bridge: OwnerLoopBridge | None = None):
         vectors = await io_bridge.run(request) if io_bridge is not None else await request()
         return np.asarray(vectors, dtype=np.float32)
 
-    return EmbeddingFunc(
-        embedding_dim=dim,
-        max_token_size=int(getattr(cfg, "max_tokens", 0) or _DEFAULT_MAX_TOKEN_SIZE),
-        func=embedding_func,
-    )
+    embedding_kwargs = {
+        "embedding_dim": dim,
+        "max_token_size": int(getattr(cfg, "max_tokens", 0) or _DEFAULT_MAX_TOKEN_SIZE),
+        "func": embedding_func,
+    }
+    if "supports_asymmetric" in inspect.signature(EmbeddingFunc).parameters:
+        embedding_kwargs["supports_asymmetric"] = True
+    return EmbeddingFunc(**embedding_kwargs)
 
 
 __all__ = [

--- a/tests/services/rag/test_lightrag_pipeline.py
+++ b/tests/services/rag/test_lightrag_pipeline.py
@@ -169,12 +169,41 @@ class _FakeEmbeddingFunc:
         max_token_size=8192,
         send_dimensions=None,
         model_name=None,
+        supports_asymmetric=False,
     ) -> None:
         self.embedding_dim = embedding_dim
         self.func = func
         self.max_token_size = max_token_size
         self.send_dimensions = send_dimensions
         self.model_name = model_name
+        self.supports_asymmetric = supports_asymmetric
+
+    async def __call__(self, *args, **kwargs):
+        if not self.supports_asymmetric:
+            kwargs.pop("context", None)
+        return await self.func(*args, **kwargs)
+
+
+class _LegacyFakeEmbeddingFunc:
+    """Models LightRAG before ``supports_asymmetric`` was introduced."""
+
+    def __init__(
+        self,
+        *,
+        embedding_dim,
+        func,
+        max_token_size=8192,
+        send_dimensions=None,
+        model_name=None,
+    ) -> None:
+        self.embedding_dim = embedding_dim
+        self.func = func
+        self.max_token_size = max_token_size
+        self.send_dimensions = send_dimensions
+        self.model_name = model_name
+
+    async def __call__(self, *args, **kwargs):
+        return await self.func(*args, **kwargs)
 
 
 class _RecordingBridge:
@@ -186,10 +215,10 @@ class _RecordingBridge:
         return await factory()
 
 
-def _install_fake_lightrag(monkeypatch) -> None:
+def _install_fake_lightrag(monkeypatch, embedding_func_cls=_FakeEmbeddingFunc) -> None:
     fake_lightrag = types.ModuleType("lightrag")
     fake_utils = types.ModuleType("lightrag.utils")
-    fake_utils.EmbeddingFunc = _FakeEmbeddingFunc
+    fake_utils.EmbeddingFunc = embedding_func_cls
     monkeypatch.setitem(sys.modules, "lightrag", fake_lightrag)
     monkeypatch.setitem(sys.modules, "lightrag.utils", fake_utils)
 
@@ -201,7 +230,8 @@ def test_fake_embedding_func_matches_the_real_dataclass() -> None:
     lightrag_utils = pytest.importorskip("lightrag.utils")
 
     real_fields = {field.name for field in dataclasses.fields(lightrag_utils.EmbeddingFunc)}
-    stub_fields = set(inspect.signature(_FakeEmbeddingFunc.__init__).parameters.keys() - {"self"})
+    stub = _FakeEmbeddingFunc if "supports_asymmetric" in real_fields else _LegacyFakeEmbeddingFunc
+    stub_fields = set(inspect.signature(stub.__init__).parameters.keys() - {"self"})
     assert stub_fields == real_fields
 
 
@@ -230,9 +260,20 @@ def test_embedding_func_returns_numpy_array(monkeypatch) -> None:
     assert bridge.calls == 1
 
 
-def test_embedding_func_maps_lightrag_query_and_document_context(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("embedding_func_cls", "expected_opt_in"),
+    [
+        (_FakeEmbeddingFunc, True),
+        (_LegacyFakeEmbeddingFunc, None),
+    ],
+)
+def test_embedding_func_maps_lightrag_query_and_document_context(
+    monkeypatch,
+    embedding_func_cls,
+    expected_opt_in,
+) -> None:
     calls: list[tuple[list[str], str | None]] = []
-    _install_fake_lightrag(monkeypatch)
+    _install_fake_lightrag(monkeypatch, embedding_func_cls)
 
     class _Config:
         dim = 3
@@ -247,12 +288,11 @@ def test_embedding_func_maps_lightrag_query_and_document_context(monkeypatch) ->
     monkeypatch.setattr("deeptutor.services.embedding.get_embedding_client", lambda: _Client())
 
     embedding = lr_config.build_embedding_func()
-    asyncio.run(embedding.func(["question"], context="query", _priority=1))
-    asyncio.run(embedding.func(["passage"], context="document"))
-    # The pinned LightRAG passes no context at all; that must mean "no role",
-    # not "document", or every query would be embedded as a passage.
-    asyncio.run(embedding.func(["unlabelled"]))
+    asyncio.run(embedding(["question"], context="query", _priority=1))
+    asyncio.run(embedding(["passage"], context="document"))
+    asyncio.run(embedding(["unlabelled"]))
 
+    assert getattr(embedding, "supports_asymmetric", None) is expected_opt_in
     assert calls == [
         (["question"], "search_query"),
         (["passage"], "search_document"),


### PR DESCRIPTION
## Summary

- opt DeepTutor's context-aware embedding adapter into LightRAG asymmetric context forwarding when that constructor capability is available
- preserve compatibility with older supported LightRAG constructors that already forward `context` without an opt-in field
- exercise query, document, and absent-context behavior through the public embedding wrapper instead of bypassing it

## Why

LightRAG 1.4.16 and later remove `context` before calling an embedding function unless the wrapper explicitly declares asymmetric support. DeepTutor's adapter accepts that context and maps it to provider-specific query and document roles, so the default wrapper behavior silently erased an intended distinction.

The capability check avoids creating a new undeclared minimum dependency: older LightRAG constructors remain valid, while newer versions receive `supports_asymmetric=True`.

## Validation

Primary validation targets exact head `69286c3583ad45fca9a02920ac164709bff3bb7a` on base `87ccedd5497d8ec55591d2658fb250d448ea9e54`.

```bash
python -m pytest tests/services/rag/test_lightrag_pipeline.py
```

Result: `70 passed` with LightRAG 1.5.6.

The focused cases cover both constructor contracts:

- LightRAG 1.4.16+ explicitly opts in and forwards query/document context.
- A v1.4.15-compatible constructor still builds and forwards the same context without the newer keyword.
- Missing context remains unlabelled rather than defaulting to a document role.

```bash
ruff check \
  deeptutor/services/rag/pipelines/lightrag/config.py \
  tests/services/rag/test_lightrag_pipeline.py
ruff format --check \
  deeptutor/services/rag/pipelines/lightrag/config.py \
  tests/services/rag/test_lightrag_pipeline.py
git diff --check 87ccedd5497d8ec55591d2658fb250d448ea9e54..69286c3583ad45fca9a02920ac164709bff3bb7a
```

All checks passed; both changed files were already formatted. No embedding provider or model call is made by these tests.
