### PR TITLE
feat(subagent): add Antigravity CLI (agy) backend

### DIFF
--- a/deeptutor/services/subagent/__init__.py
+++ b/deeptutor/services/subagent/__init__.py
@@ -1,7 +1,8 @@
 """Subagent driver layer — drive a user's local agent CLI as a subagent.
 
 DeepTutor runs on the same machine as the user's configured agent CLIs — Claude
-Code, Codex, Gemini CLI, Kimi CLI, opencode, MiMo Code — so the backend can
+Code, Codex, Gemini CLI, Antigravity CLI, Kimi CLI, opencode, MiMo Code — so the
+backend can
 drive them directly (spawned in print mode, or via a managed local server for
 the opencode family) and stream back every native event. This package is the
 decoupled core of that: backends that know one CLI each, a shared

--- a/deeptutor/services/subagent/antigravity.py
+++ b/deeptutor/services/subagent/antigravity.py
@@ -1,0 +1,285 @@
+"""Antigravity CLI backend — drive the local ``agy`` CLI in headless print mode.
+
+Google retired Gemini CLI for consumer tiers in favor of Antigravity CLI
+(``agy``). Headless mode shares the ``-p`` / ``--output-format stream-json``
+surface, but the NDJSON vocabulary differs: events use an ``event`` key
+(``init``, ``step_update``, ``result``) instead of Gemini's ``type`` field
+(``message`` / ``tool_use`` / …). Auth still lives under ``~/.gemini``.
+
+Permission asks have no interactive TUI in headless mode; ``auto_approve``
+maps onto ``--dangerously-skip-permissions``. Sessions resume with
+``--conversation <id>`` (not Gemini's ``--resume``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from deeptutor.services.subagent.base import OnEvent, SubagentBackend
+from deeptutor.services.subagent.config import BackendConfig
+from deeptutor.services.subagent.process import probe_version, stream_process_lines
+from deeptutor.services.subagent.types import (
+    EVENT_ERROR,
+    EVENT_LOG,
+    EVENT_TEXT,
+    EVENT_TOOL,
+    EVENT_TOOL_RESULT,
+    ConsultResult,
+    DetectResult,
+    SubagentEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+_MAX_FIELD_CHARS = 4000
+_TOOL_HEADER_CHARS = 160
+
+_TOOL_PRIMARY_ARGS = (
+    "CommandLine",
+    "command",
+    "file_path",
+    "path",
+    "pattern",
+    "query",
+    "url",
+    "prompt",
+    "description",
+)
+
+_EFFORTS = frozenset({"low", "medium", "high"})
+
+
+class AntigravityBackend(SubagentBackend):
+    kind = "antigravity"
+    display_name = "Antigravity CLI"
+    cli_command = "agy"
+
+    async def detect(self) -> DetectResult:
+        ok, text = await probe_version([self.cli_command, "--version"])
+        return DetectResult(
+            kind=self.kind,
+            display_name=self.display_name,
+            available=ok,
+            version=text if ok else "",
+            detail="" if ok else (text or "agy CLI not found on PATH"),
+        )
+
+    def _build_command(
+        self,
+        question: str,
+        *,
+        session_id: str | None,
+        config: BackendConfig,
+    ) -> list[str]:
+        prompt = question
+        # No system-prompt flag — prefix once on the session-creating consult.
+        if config.system_prompt.strip() and not session_id:
+            prompt = f"{config.system_prompt.strip()}\n\n{question}"
+        cmd = [
+            self.cli_command,
+            "-p",
+            prompt,
+            "--output-format",
+            "stream-json",
+        ]
+        # Unattended runs soft-deny shell/mutating tools unless we skip asks.
+        if config.auto_approve is not False:
+            cmd.append("--dangerously-skip-permissions")
+        if session_id:
+            cmd += ["--conversation", session_id]
+        if config.model:
+            cmd += ["--model", config.model]
+        effort = str(config.effort or "").strip().lower()
+        if effort in _EFFORTS:
+            cmd += ["--effort", effort]
+        cmd += list(config.extra_args)
+        return cmd
+
+    async def consult(
+        self,
+        question: str,
+        *,
+        on_event: OnEvent,
+        cwd: str | None = None,
+        session_id: str | None = None,
+        config: BackendConfig | None = None,
+        images: list[str] | None = None,  # noqa: ARG002 — no documented @path attach
+        partner_id: str | None = None,  # noqa: ARG002 — partner-only; ignored here
+    ) -> ConsultResult:
+        config = config or BackendConfig()
+        cmd = self._build_command(question, session_id=session_id, config=config)
+        result = ConsultResult(session_id=session_id)
+        # Accumulate agent_response text_delta fragments into blocks; a tool
+        # step closes the current block so post-tool text starts a new row.
+        stream: dict[str, Any] = {"blocks": [], "open": False}
+
+        async def emit(
+            kind: str, text: str, raw: dict[str, Any], meta: dict[str, Any] | None = None
+        ) -> None:
+            result.event_count += 1
+            await on_event(SubagentEvent(kind=kind, text=text, raw=raw, meta=meta or {}))
+
+        try:
+            async for channel, line in stream_process_lines(cmd, cwd=cwd):
+                if channel == "exit":
+                    if line != "0" and result.success and not result.final_text:
+                        result.success = False
+                        result.error = f"agy exited with code {line}"
+                        await emit(EVENT_ERROR, result.error, {"returncode": line})
+                    continue
+                if channel == "stderr":
+                    if line.strip():
+                        await emit(EVENT_LOG, line, {"stream": "stderr"})
+                    continue
+                event = _parse_json(line)
+                if event is None:
+                    if line.strip():
+                        await emit(EVENT_LOG, line, {"stream": "stdout"})
+                    continue
+                await self._handle_event(event, result, stream, emit)
+        except Exception as exc:  # pragma: no cover - defensive: surface, don't crash the turn
+            logger.warning("antigravity consult failed: %s", exc, exc_info=True)
+            result.success = False
+            result.error = str(exc)
+            await emit(EVENT_ERROR, str(exc), {})
+
+        if not result.final_text:
+            result.final_text = "\n\n".join(b for b in stream["blocks"] if b.strip()).strip()
+        return result
+
+    async def _handle_event(
+        self,
+        event: dict[str, Any],
+        result: ConsultResult,
+        stream: dict[str, Any],
+        emit: Any,
+    ) -> None:
+        etype = str(event.get("event") or "")
+
+        if etype == "init":
+            sid = str(event.get("conversation_id") or "")
+            if sid:
+                result.session_id = sid
+            init = event.get("init") if isinstance(event.get("init"), dict) else {}
+            model = str(init.get("model") or "")
+            await emit(EVENT_LOG, f"Session started{f' · {model}' if model else ''}", event)
+            return
+
+        if etype == "step_update":
+            step = event.get("step_update")
+            if not isinstance(step, dict):
+                return
+            step_type = str(step.get("step_type") or "")
+
+            if step_type == "agent_response":
+                delta = str(step.get("text_delta") or "")
+                if not delta:
+                    return
+                blocks: list[str] = stream["blocks"]
+                if stream["open"] and blocks:
+                    blocks[-1] += delta
+                else:
+                    blocks.append(delta)
+                    stream["open"] = True
+                await emit(
+                    EVENT_TEXT,
+                    blocks[-1].strip(),
+                    event,
+                    {"merge_id": f"txt:{len(blocks) - 1}"},
+                )
+                return
+
+            if step_type == "tool":
+                stream["open"] = False
+                await emit(EVENT_TOOL, _render_tool_use(step), event)
+                # tool_info arrives with both call and result on the DONE step.
+                if str(step.get("state") or "") == "DONE":
+                    await emit(EVENT_TOOL_RESULT, _render_tool_result(step), event)
+                return
+
+            return
+
+        if etype == "result":
+            payload = event.get("result") if isinstance(event.get("result"), dict) else {}
+            sid = str(payload.get("conversation_id") or event.get("conversation_id") or "")
+            if sid:
+                result.session_id = sid
+            status = str(payload.get("status") or "").upper()
+            if status and status != "SUCCESS":
+                result.success = False
+                error = payload.get("error")
+                if isinstance(error, str) and error.strip():
+                    result.error = error.strip()
+                elif isinstance(error, dict) and error.get("message"):
+                    result.error = str(error["message"])
+                elif not result.error:
+                    result.error = f"agy ended with status {status}"
+                if result.error:
+                    await emit(EVENT_ERROR, result.error, event)
+            response = str(payload.get("response") or "").strip()
+            if response and not result.final_text:
+                result.final_text = response
+            return
+
+        await emit(EVENT_LOG, _compact(event), event)
+
+
+def _parse_json(line: str) -> dict[str, Any] | None:
+    line = line.strip()
+    if not line or line[0] not in "{[":
+        return None
+    try:
+        parsed = json.loads(line)
+    except (ValueError, TypeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _render_tool_use(step: dict[str, Any]) -> str:
+    info = step.get("tool_info") if isinstance(step.get("tool_info"), dict) else {}
+    name = str(info.get("name") or step.get("tool_name") or "tool")
+    params = info.get("parameters")
+    if not isinstance(params, dict) or not params:
+        return name
+    for key in _TOOL_PRIMARY_ARGS:
+        value = params.get(key)
+        if isinstance(value, str) and value.strip():
+            return f"{name}({_inline(value)})"
+    return f"{name}({_inline(_compact(params))})"
+
+
+def _render_tool_result(step: dict[str, Any]) -> str:
+    info = step.get("tool_info") if isinstance(step.get("tool_info"), dict) else {}
+    error = info.get("error")
+    if isinstance(error, dict) and error.get("message"):
+        return _truncate(str(error["message"]))
+    if isinstance(error, str) and error.strip():
+        return _truncate(error)
+    return _truncate(str(info.get("output") or "")) or "(no output)"
+
+
+def _inline(text: str) -> str:
+    one_line = " ".join(text.split())
+    if len(one_line) > _TOOL_HEADER_CHARS:
+        return one_line[:_TOOL_HEADER_CHARS].rstrip() + " …"
+    return one_line
+
+
+def _compact(obj: Any) -> str:
+    try:
+        text = json.dumps(obj, ensure_ascii=False)
+    except (TypeError, ValueError):
+        text = str(obj)
+    return _truncate(text)
+
+
+def _truncate(text: str) -> str:
+    text = text.strip()
+    if len(text) > _MAX_FIELD_CHARS:
+        return text[:_MAX_FIELD_CHARS].rstrip() + " …"
+    return text
+
+
+__all__ = ["AntigravityBackend"]

--- a/deeptutor/services/subagent/config.py
+++ b/deeptutor/services/subagent/config.py
@@ -59,9 +59,10 @@ class BackendConfig:
     network_access: bool = False
     # Codex: --ephemeral — don't persist the session under ~/.codex/sessions.
     ephemeral: bool = False
-    # Kimi / opencode / MiMo: answer the CLI's permission asks affirmatively so
-    # a headless run never stalls (kimi --yolo; the opencode family's
-    # permission.asked replies). Same trust model as CC's bypassPermissions.
+    # Kimi / Antigravity / opencode / MiMo: answer the CLI's permission asks
+    # affirmatively so a headless run never stalls (kimi --yolo; agy
+    # --dangerously-skip-permissions; the opencode family's permission.asked
+    # replies). Same trust model as CC's bypassPermissions.
     auto_approve: bool = True
     # Kimi: stream the model's thinking (--thinking / --no-thinking). The
     # opencode family always streams reasoning over its event bus.

--- a/deeptutor/services/subagent/models.py
+++ b/deeptutor/services/subagent/models.py
@@ -13,6 +13,8 @@ page's "sync" button just re-reads it:
   we offer those as suggestions and the UI also allows a free-text model.
 * **Gemini CLI** models are stable aliases (auto / pro / flash / flash-lite)
   plus any concrete name — curated suggestions, free text allowed.
+* **Antigravity CLI** enumerates slugs via ``agy models``; reasoning effort is
+  ``--effort`` (low / medium / high). Sync re-runs the catalog command.
 * **Kimi CLI** has no model-list surface — free text only.
 * **opencode / MiMo Code** enumerate ``provider/model`` slugs via their own
   ``<cli> models`` command (models.dev catalog); syncing re-runs it with
@@ -58,6 +60,9 @@ _GEMINI_MODELS = (
     ("flash", "Gemini Flash"),
     ("flash-lite", "Gemini Flash-Lite"),
 )
+
+# Antigravity CLI: ``--effort`` — low / medium / high.
+_ANTIGRAVITY_EFFORTS = ("low", "medium", "high")
 
 # opencode family: ``--variant`` — provider-relative reasoning effort.
 _OPENCODE_EFFORTS = ("minimal", "high", "max")
@@ -222,6 +227,60 @@ async def _gemini_options() -> BackendOptions:
     )
 
 
+async def _list_agy_models() -> list[ModelOption]:
+    """Parse ``agy models`` — ``<slug><spaces><display name>`` per line."""
+    cmd = resolve_cli_command(["agy", "models"])
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        out, _ = await asyncio.wait_for(process.communicate(), timeout=20.0)
+    except FileNotFoundError:
+        return []
+    except (TimeoutError, asyncio.TimeoutError):
+        return []
+    except Exception:  # pragma: no cover - defensive
+        logger.warning("failed to enumerate agy models", exc_info=True)
+        return []
+    models: list[ModelOption] = []
+    for raw in (out or b"").decode("utf-8", "replace").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 1)
+        slug = parts[0]
+        # Skip decorative headers / column labels.
+        if slug.lower() in {"model", "slug", "name", "models"}:
+            continue
+        display = parts[1].strip() if len(parts) > 1 else slug
+        models.append(
+            ModelOption(
+                slug=slug,
+                display_name=display,
+                efforts=list(_ANTIGRAVITY_EFFORTS),
+            )
+        )
+    return models
+
+
+async def _antigravity_options() -> BackendOptions:
+    ok, version = await _probe("antigravity")
+    models = await _list_agy_models() if ok else []
+    return BackendOptions(
+        kind="antigravity",
+        display_name="Antigravity CLI",
+        available=ok,
+        version=version if ok else "",
+        models=models,
+        efforts=list(_ANTIGRAVITY_EFFORTS),
+        allow_custom_model=True,
+        detail="" if ok else (version or "agy CLI not found on PATH"),
+    )
+
+
 async def _kimi_options() -> BackendOptions:
     ok, version = await _probe("kimi")
     return BackendOptions(
@@ -299,6 +358,7 @@ _PROVIDERS: dict[str, Callable[..., Awaitable[BackendOptions]]] = {
     "claude_code": _claude_options,
     "codex": _codex_options,
     "gemini": _gemini_options,
+    "antigravity": _antigravity_options,
     "kimi": _kimi_options,
     "opencode": _opencode_options,
     "mimo": _mimo_options,
@@ -326,6 +386,8 @@ async def sync_backend_options(kind: str) -> BackendOptions:
         return await _claude_options()
     if kind in ("opencode", "mimo"):
         return await _PROVIDERS[kind](refresh=True)
+    if kind == "antigravity":
+        return await _antigravity_options()
     provider = _PROVIDERS.get(kind, _codex_options)
     return await provider()
 

--- a/deeptutor/services/subagent/registry.py
+++ b/deeptutor/services/subagent/registry.py
@@ -2,16 +2,17 @@
 
 Add a new subagent by writing a :class:`SubagentBackend` and listing it here;
 the capability, API and UI all discover it through these helpers. Local-CLI
-backends (Claude Code, Codex, Gemini CLI, Kimi CLI, opencode, MiMo Code) and
-the in-process partner backend live in the same registry but are told apart by
-``local_cli`` — only CLIs are detected on the machine and offered in the
-connect-CLI modal.
+backends (Claude Code, Codex, Gemini CLI, Antigravity CLI, Kimi CLI, opencode,
+MiMo Code) and the in-process partner backend live in the same registry but are
+told apart by ``local_cli`` — only CLIs are detected on the machine and offered
+in the connect-CLI modal.
 """
 
 from __future__ import annotations
 
 import asyncio
 
+from deeptutor.services.subagent.antigravity import AntigravityBackend
 from deeptutor.services.subagent.base import SubagentBackend
 from deeptutor.services.subagent.claude_code import ClaudeCodeBackend
 from deeptutor.services.subagent.codex import CodexBackend
@@ -27,6 +28,7 @@ _BACKENDS: dict[str, SubagentBackend] = {
         ClaudeCodeBackend(),
         CodexBackend(),
         GeminiBackend(),
+        AntigravityBackend(),
         KimiBackend(),
         OpencodeBackend(),
         MimoBackend(),

--- a/tests/services/test_subagent_backends.py
+++ b/tests/services/test_subagent_backends.py
@@ -683,7 +683,7 @@ async def test_detect_all_excludes_partner_backend() -> None:
 
     kinds = {d.kind for d in await detect_all()}
     assert "partner" not in kinds
-    assert kinds <= {"claude_code", "codex", "gemini", "kimi", "opencode", "mimo"}
+    assert kinds <= {"claude_code", "codex", "gemini", "antigravity", "kimi", "opencode", "mimo"}
 
 
 # ---- partner backend: drive a partner as a subagent --------------------------
@@ -1080,6 +1080,152 @@ async def test_gemini_warning_is_log_and_error_result_fails() -> None:
     assert kinds == ["log", "error"]
     assert result.success is False
     assert "quota" in result.error
+
+
+# ---- Antigravity CLI: command building + event parsing -----------------------
+
+
+def test_antigravity_command_build_fresh_resume_approve_and_effort() -> None:
+    from deeptutor.services.subagent.antigravity import AntigravityBackend
+
+    backend = AntigravityBackend()
+    fresh = backend._build_command(
+        "hi", session_id=None, config=BackendConfig(system_prompt="be brief")
+    )
+    assert fresh[:3] == ["agy", "-p", "be brief\n\nhi"]
+    assert "--output-format" in fresh and "stream-json" in fresh
+    assert "--dangerously-skip-permissions" in fresh
+    assert "--conversation" not in fresh
+
+    resumed = backend._build_command(
+        "again",
+        session_id="c1",
+        config=BackendConfig(
+            system_prompt="be brief",
+            auto_approve=False,
+            model="gemini-3.5-flash-medium",
+            effort="high",
+        ),
+    )
+    assert resumed[1:3] == ["-p", "again"]  # no instruction prefix on resume
+    assert "--dangerously-skip-permissions" not in resumed
+    assert "--conversation" in resumed and "c1" in resumed
+    assert resumed[resumed.index("--model") + 1] == "gemini-3.5-flash-medium"
+    assert resumed[resumed.index("--effort") + 1] == "high"
+
+
+async def _drive_antigravity(events):
+    from deeptutor.services.subagent.antigravity import AntigravityBackend
+
+    backend = AntigravityBackend()
+    result = ConsultResult()
+    stream: dict = {"blocks": [], "open": False}
+    emitted: list[tuple[str, str, dict]] = []
+
+    async def emit(kind, text, raw, meta=None):
+        emitted.append((kind, text, meta or {}))
+
+    for ev in events:
+        await backend._handle_event(ev, result, stream, emit)
+    if not result.final_text:
+        result.final_text = "\n\n".join(b for b in stream["blocks"] if b.strip()).strip()
+    return result, emitted
+
+
+@pytest.mark.asyncio
+async def test_antigravity_text_deltas_and_tools_split_blocks() -> None:
+    events = [
+        {
+            "event": "init",
+            "conversation_id": "a1",
+            "init": {"cwd": "/tmp", "tools": ["run_command"], "model": "flash"},
+        },
+        {
+            "event": "step_update",
+            "step_update": {
+                "conversation_id": "a1",
+                "step_index": 2,
+                "state": "ACTIVE",
+                "step_type": "agent_response",
+                "text_delta": "Let me ",
+            },
+        },
+        {
+            "event": "step_update",
+            "step_update": {
+                "conversation_id": "a1",
+                "step_index": 2,
+                "state": "DONE",
+                "step_type": "agent_response",
+                "text_delta": "check.",
+            },
+        },
+        {
+            "event": "step_update",
+            "step_update": {
+                "conversation_id": "a1",
+                "step_index": 3,
+                "state": "DONE",
+                "step_type": "tool",
+                "tool_name": "run_command",
+                "tool_info": {
+                    "name": "run_command",
+                    "parameters": {"CommandLine": "echo hi"},
+                    "output": "hi\n",
+                },
+            },
+        },
+        {
+            "event": "step_update",
+            "step_update": {
+                "conversation_id": "a1",
+                "step_index": 4,
+                "state": "DONE",
+                "step_type": "agent_response",
+                "text_delta": "Done.",
+            },
+        },
+        {
+            "event": "result",
+            "result": {
+                "conversation_id": "a1",
+                "status": "SUCCESS",
+                "response": "Let me check.\n\nDone.",
+            },
+        },
+    ]
+    result, emitted = await _drive_antigravity(events)
+
+    assert result.session_id == "a1"
+    texts = [(t, m.get("merge_id")) for k, t, m in emitted if k == "text"]
+    assert texts == [
+        ("Let me", "txt:0"),
+        ("Let me check.", "txt:0"),
+        ("Done.", "txt:1"),
+    ]
+    assert ("tool", "run_command(echo hi)") in [(k, t) for k, t, _ in emitted]
+    assert ("tool_result", "hi") in [(k, t) for k, t, _ in emitted]
+    assert result.final_text == "Let me check.\n\nDone."
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_antigravity_error_result_fails() -> None:
+    events = [
+        {
+            "event": "result",
+            "result": {
+                "conversation_id": "a2",
+                "status": "ERROR",
+                "response": "",
+                "error": "authentication required",
+            },
+        },
+    ]
+    result, emitted = await _drive_antigravity(events)
+    assert result.success is False
+    assert "authentication" in result.error
+    assert ("error", "authentication required") in [(k, t) for k, t, _ in emitted]
 
 
 # ---- Kimi CLI: command building + line parsing --------------------------------

--- a/web/app/(utility)/settings/agents/antigravity/page.tsx
+++ b/web/app/(utility)/settings/agents/antigravity/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { SubagentSettingsEditor } from "@/components/settings/SubagentSettingsEditor";
+
+export default function AntigravityAgentSettingsPage() {
+  return <SubagentSettingsEditor kind="antigravity" />;
+}

--- a/web/components/agents/ConnectedAgents.tsx
+++ b/web/components/agents/ConnectedAgents.tsx
@@ -36,6 +36,7 @@ function backendLabel(kind: string, tr: (l: Lang) => string): string {
   if (kind === "claude_code") return "Claude Code";
   if (kind === "codex") return "Codex";
   if (kind === "gemini") return "Gemini CLI";
+  if (kind === "antigravity") return "Antigravity CLI";
   if (kind === "kimi") return "Kimi CLI";
   if (kind === "opencode") return "opencode";
   if (kind === "mimo") return "MiMo Code";
@@ -114,8 +115,8 @@ export default function ConnectedAgents() {
         icon={Plug}
         title={tr({ zh: "连接的智能体", en: "Connected agents" })}
         description={tr({
-          zh: "把本机的 Claude Code、Codex、Gemini CLI、Kimi CLI、opencode、MiMo Code 或你的伙伴接进来，在对话中选中后直接向它提问 —— 它的完整运行过程会实时展示。",
-          en: "Bring in the Claude Code, Codex, Gemini CLI, Kimi CLI, opencode, or MiMo Code on this machine, or one of your partners — select one in chat to consult it directly, with its full run shown live.",
+          zh: "把本机的 Claude Code、Codex、Gemini CLI、Antigravity CLI、Kimi CLI、opencode、MiMo Code 或你的伙伴接进来，在对话中选中后直接向它提问 —— 它的完整运行过程会实时展示。",
+          en: "Bring in the Claude Code, Codex, Gemini CLI, Antigravity CLI, Kimi CLI, opencode, or MiMo Code on this machine, or one of your partners — select one in chat to consult it directly, with its full run shown live.",
         })}
         action={
           canConnect ? (
@@ -139,8 +140,8 @@ export default function ConnectedAgents() {
       ) : !canConnect ? (
         <div className="rounded-xl border border-dashed border-[var(--border)] bg-[var(--card)]/40 px-4 py-5 text-[12.5px] leading-relaxed text-[var(--muted-foreground)]">
           {tr({
-            zh: "未在本机检测到可用的智能体 CLI（Claude Code、Codex、Gemini CLI、Kimi CLI、opencode、MiMo Code），也还没有任何伙伴。安装并登录其中任一 CLI，或在「伙伴」里新建一个，即可连接。",
-            en: "No agent CLI detected on this machine (Claude Code, Codex, Gemini CLI, Kimi CLI, opencode, MiMo Code), and no partners yet. Install and log in to any of them, or create a partner, to connect one.",
+            zh: "未在本机检测到可用的智能体 CLI（Claude Code、Codex、Gemini CLI、Antigravity CLI、Kimi CLI、opencode、MiMo Code），也还没有任何伙伴。安装并登录其中任一 CLI，或在「伙伴」里新建一个，即可连接。",
+            en: "No agent CLI detected on this machine (Claude Code, Codex, Gemini CLI, Antigravity CLI, Kimi CLI, opencode, MiMo Code), and no partners yet. Install and log in to any of them, or create a partner, to connect one.",
           })}
         </div>
       ) : connections.length === 0 ? (

--- a/web/components/agents/agent-icons.tsx
+++ b/web/components/agents/agent-icons.tsx
@@ -105,6 +105,29 @@ export function GeminiGlyph({ size = 16, ...props }: GlyphProps) {
   );
 }
 
+// Antigravity CLI — dark tile with an upward arc (successor to Gemini CLI).
+export function AntigravityGlyph({ size = 16, ...props }: GlyphProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden
+      {...props}
+    >
+      <rect width="24" height="24" rx="5.4" fill="#0B1220" />
+      <path
+        d="M5 16.5c2.8-4.2 5.6-6.3 7-6.3s4.2 2.1 7 6.3"
+        stroke="#7DD3FC"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+      <circle cx="12" cy="8.2" r="1.6" fill="#F8FAFC" />
+    </svg>
+  );
+}
+
 // Kimi (Moonshot AI): dark tile with a white K.
 export function KimiGlyph({ size = 16, ...props }: GlyphProps) {
   return (
@@ -197,6 +220,7 @@ export function agentGlyph(kind: string | undefined): AgentGlyph | null {
   if (kind === "claude_code") return ClaudeGlyph;
   if (kind === "codex") return CodexGlyph;
   if (kind === "gemini") return GeminiGlyph;
+  if (kind === "antigravity") return AntigravityGlyph;
   if (kind === "kimi") return KimiGlyph;
   if (kind === "opencode") return OpencodeGlyph;
   if (kind === "mimo") return MimoGlyph;

--- a/web/components/settings/SubagentSettingsEditor.tsx
+++ b/web/components/settings/SubagentSettingsEditor.tsx
@@ -64,7 +64,7 @@ const DEFAULTS: Required<
  * Which knobs each backend kind actually honors — the editor renders from this
  * table instead of per-kind branches. Mirrors what the Python backend reads:
  * e.g. only Claude Code / Gemini use `permission_mode`, only Codex has its
- * sandbox family, kimi/opencode/mimo take the `auto_approve` reply switch.
+ * sandbox family, kimi/antigravity/opencode/mimo take the `auto_approve` reply switch.
  */
 type KindFeatures = {
   effort: boolean;
@@ -104,6 +104,15 @@ const KIND_FEATURES: Record<string, KindFeatures> = {
     thinking: false,
     forwardImages: true, // @path syntax
   },
+  antigravity: {
+    effort: true, // --effort low|medium|high
+    systemPrompt: true,
+    permissionMode: false,
+    codexSandbox: false,
+    autoApprove: true, // --dangerously-skip-permissions
+    thinking: false,
+    forwardImages: false, // no documented headless image attach
+  },
   kimi: {
     effort: false,
     systemPrompt: true,
@@ -139,6 +148,7 @@ const DISPLAY_NAMES: Record<string, string> = {
   claude_code: "Claude Code",
   codex: "Codex",
   gemini: "Gemini CLI",
+  antigravity: "Antigravity CLI",
   kimi: "Kimi CLI",
   opencode: "opencode",
   mimo: "MiMo Code",
@@ -154,6 +164,10 @@ const SYSTEM_PROMPT_HINT: Record<string, Lang> = {
   gemini: {
     zh: "Gemini CLI 没有系统提示 flag——该指令会前缀在每个新会话的第一条消息上。",
     en: "Gemini CLI has no system-prompt flag — the instruction is prefixed to each new session's first message.",
+  },
+  antigravity: {
+    zh: "Antigravity CLI 没有系统提示 flag——该指令会前缀在每个新会话的第一条消息上。",
+    en: "Antigravity CLI has no system-prompt flag — the instruction is prefixed to each new session's first message.",
   },
   kimi: {
     zh: "Kimi CLI 没有系统提示 flag——该指令会前缀在每个新会话的第一条消息上。",

--- a/web/lib/knowledge-helpers.ts
+++ b/web/lib/knowledge-helpers.ts
@@ -116,7 +116,7 @@ export interface KnowledgeBase {
     vault_path?: string;
     /** SQLite store of a connected MarginNote 4 library (when type === "marginnote4"). */
     db_path?: string;
-    /** Backend of a connected subagent (when type === "subagent"): "claude_code" | "codex" | "gemini" | "kimi" | "opencode" | "mimo" | "partner". */
+    /** Backend of a connected subagent (when type === "subagent"): "claude_code" | "codex" | "gemini" | "antigravity" | "kimi" | "opencode" | "mimo" | "partner". */
     agent_kind?: string;
     /** Bound partner id when agent_kind === "partner". */
     partner_id?: string;

--- a/web/lib/settings-nav.ts
+++ b/web/lib/settings-nav.ts
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 
 import {
+  AntigravityGlyph,
   ClaudeGlyph,
   CodexGlyph,
   GeminiGlyph,
@@ -246,6 +247,18 @@ const AGENT_CHILDREN: SettingsLeaf[] = [
     adminOnly: true,
   },
   {
+    key: "agent-antigravity",
+    href: "/settings/agents/antigravity",
+    label: { zh: "Antigravity CLI", en: "Antigravity CLI" },
+    blurb: {
+      zh: "DeepTutor 调用本机 Antigravity CLI（agy）时的模型、推理强度与运行参数。",
+      en: "Model, reasoning effort, and run params for the local Antigravity CLI (agy).",
+    },
+    icon: AntigravityGlyph as unknown as LucideIcon,
+    tile: "bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+    adminOnly: true,
+  },
+  {
     key: "agent-kimi",
     href: "/settings/agents/kimi",
     label: { zh: "Kimi CLI", en: "Kimi CLI" },
@@ -387,6 +400,7 @@ const STORAGE_PATHS: Record<string, string> = {
   "/settings/agents/claude-code": "data/user/settings/subagent.json",
   "/settings/agents/codex": "data/user/settings/subagent.json",
   "/settings/agents/gemini": "data/user/settings/subagent.json",
+  "/settings/agents/antigravity": "data/user/settings/subagent.json",
   "/settings/agents/kimi": "data/user/settings/subagent.json",
   "/settings/agents/opencode": "data/user/settings/subagent.json",
   "/settings/agents/mimo": "data/user/settings/subagent.json",

--- a/web/lib/subagents-api.ts
+++ b/web/lib/subagents-api.ts
@@ -152,7 +152,7 @@ export interface SubagentBackendConfig {
   approval?: string;
   network_access?: boolean;
   ephemeral?: boolean;
-  /** Kimi / opencode / MiMo: answer permission asks affirmatively. */
+  /** Kimi / Antigravity / opencode / MiMo: answer permission asks affirmatively. */
   auto_approve?: boolean;
   /** Kimi: stream the model's thinking (--thinking / --no-thinking). */
   thinking?: boolean;


### PR DESCRIPTION
## Summary
- Add a first-class `antigravity` subagent backend that detects and drives the local `agy` CLI (Google's Gemini CLI successor), including headless `stream-json` parsing for text deltas and tool steps.
- Wire settings / My Agents UI so Antigravity appears alongside Claude Code, Codex, Gemini, Kimi, opencode, and MiMo — model catalog via `agy models`, `--effort`, and `--dangerously-skip-permissions` for unattended runs.
- Keep the existing Gemini CLI backend for users who still have `gemini` on PATH (enterprise / paid Gemini CLI).

Fixes #828

## Test plan
- [ ] `pytest tests/services/test_subagent_backends.py -k antigravity`
- [ ] With `agy` on PATH and logged in: open My Agents → confirm Antigravity CLI is detected
- [ ] Connect it, consult from chat, confirm streamed text + tool rows appear in Activity
- [ ] Settings → Agents → Antigravity: sync models, toggle auto-approve off, confirm consult soft-denies mutating tools

Made with [Cursor](https://cursor.com)