### PR TITLE
fix(tests): ensure non-admin role for alice fixture in channel links …

### DIFF
--- a/tests/services/partners/test_channel_links.py
+++ b/tests/services/partners/test_channel_links.py
@@ -26,6 +26,7 @@ def alice(partners_root):
     from deeptutor.multi_user import identity
     from deeptutor.services.partners.interaction import actor_for_account
 
+    identity.save_user("admin", "hash", "admin")
     identity.save_user("alice", "hash", "user")
     return actor_for_account(identity.get_user("alice")["id"])
 
@@ -208,7 +209,6 @@ async def test_link_command_binds_the_sender_mid_conversation(partners_root, fak
 
 @pytest.mark.asyncio
 async def test_link_command_refuses_a_group_chat(partners_root, fake_orchestrator):
-
     runner = PartnerRunner("ada", PartnerConfig(name="Ada"), MessageBus())
     code = links.issue_link_code("ada", "u_alice").code
 


### PR DESCRIPTION
## Summary

Fixes a CI test failure in `tests/services/partners/test_channel_links.py` introduced in `v1.5.17`.

### Root Cause
In a clean CI environment where `users.json` is initially empty, `identity.save_user("alice", "hash", "user")` triggers the first-user promotion rule in `deeptutor/multi_user/identity.py`, promoting `alice` to `role="admin"`. 

Because admin accounts fall back to the partner's shared session pool rather than private session storage (`personal_actor_id(actor)` returns `None` for admins), turns for `alice` were written to the shared directory. This caused `assert session_store_for("ada", None).messages("qq:private:90210") == []` in `test_a_linked_sender_gets_their_own_private_history` to fail with an `AssertionError`.

### Solution
Pre-register an `admin` user in the `alice` fixture so that `alice` is guaranteed to receive `role="user"` across all test environments.

## Verification
- `pytest tests/services/partners/test_channel_links.py` (15 passed)
- `ruff check tests/services/partners/test_channel_links.py` (passed)
- `ruff format --check tests/services/partners/test_channel_links.py` (passed)