### PR TITLE
fix(assessment): redirect plain-text mastery quizzes to cards (#941)

### DIFF
--- a/deeptutor/agents/chat/agent_loop.py
+++ b/deeptutor/agents/chat/agent_loop.py
@@ -286,6 +286,7 @@ class AgentLoop:
         exploration_budget = max(1, self.pipeline.effective_max_rounds(self.context))
         settlement_started = False
         nudged_empty_finish = False
+        finish_redirect_used = False
         continued_answer_parts: list[str] = []
         while True:
             settling = state.exploration_rounds >= exploration_budget
@@ -407,6 +408,15 @@ class AgentLoop:
                             ),
                         ),
                     )
+                    continue
+                finish_redirect = self.pipeline._capability_finish_instruction(
+                    self.context, final_text
+                )
+                if finish_redirect and not finish_redirect_used:
+                    finish_redirect_used = True
+                    if result.text:
+                        messages.append({"role": "assistant", "content": result.text})
+                    self._append_loop_instruction(messages, finish_redirect)
                     continue
                 # Finish: the text streamed live this round IS the answer.
                 return await self._finalize_finish(

--- a/deeptutor/agents/chat/agent_loop.py
+++ b/deeptutor/agents/chat/agent_loop.py
@@ -163,6 +163,8 @@ class LLMCallResult:
     visible_text: str = ""
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
     finish_reason: str = ""
+    deferred_chunk_metadata: dict[str, Any] | None = None
+    deferred_completion_metadata: dict[str, Any] | None = None
 
 
 @dataclass(slots=True)
@@ -311,6 +313,7 @@ class AgentLoop:
                     trace_role="response" if settling else "explore",
                     max_tokens=self.pipeline.loop_max_tokens,
                     tool_schemas=self.tool_schemas,
+                    defer_visible_output=self.pipeline._has_capability_finish_guard(self.context),
                 )
             except Exception as exc:
                 # A mid-loop LLM failure (timeout / transient network) must not
@@ -347,6 +350,7 @@ class AgentLoop:
                     # and ask for a continuation. The ordinary exploration /
                     # settlement counters still apply, so repeated truncation
                     # has the same hard upper bound as repeated tool calls.
+                    await self._release_deferred_output(result)
                     await self.stream.progress(
                         self.pipeline._t(
                             "notices.output_truncated",
@@ -412,12 +416,28 @@ class AgentLoop:
                 finish_redirect = self.pipeline._capability_finish_instruction(
                     self.context, final_text
                 )
-                if finish_redirect and not finish_redirect_used:
-                    finish_redirect_used = True
-                    if result.text:
-                        messages.append({"role": "assistant", "content": result.text})
-                    self._append_loop_instruction(messages, finish_redirect)
-                    continue
+                if finish_redirect:
+                    await self._discard_deferred_output(result)
+                    if not finish_redirect_used:
+                        finish_redirect_used = True
+                        if result.text:
+                            messages.append({"role": "assistant", "content": result.text})
+                        self._append_loop_instruction(messages, finish_redirect)
+                        continue
+                    await self.stream.progress(
+                        self.pipeline._t(
+                            "notices.capability_finish_rejected",
+                            default=(
+                                "The model did not complete the required interactive step. "
+                                "Please retry the turn."
+                            ),
+                        ),
+                        source="chat",
+                        stage=LOOP_STAGE,
+                        metadata={"trace_kind": "warning"},
+                    )
+                    return LoopOutcome(final_text="", completed=False)
+                await self._release_deferred_output(result)
                 # Finish: the text streamed live this round IS the answer.
                 return await self._finalize_finish(
                     final_text,
@@ -425,6 +445,7 @@ class AgentLoop:
                     continued_answer_parts=continued_answer_parts,
                 )
 
+            await self._release_deferred_output(result)
             messages.append(assistant_message_with_tool_calls(result.text, result.tool_calls))
             dispatch = await self.pipeline._dispatch_tool_calls(
                 tool_calls=result.tool_calls,
@@ -597,6 +618,42 @@ class AgentLoop:
             await self.pipeline._emit_protocol_fallback_final_response(self.stream, final_text)
         return LoopOutcome(final_text=final_text, completed=True)
 
+    async def _release_deferred_output(self, result: LLMCallResult) -> None:
+        """Publish a buffered capability round only after its protocol accepts it."""
+        if result.deferred_chunk_metadata is not None and result.visible_text:
+            await self.stream.content(
+                result.visible_text,
+                source="chat",
+                stage=LOOP_STAGE,
+                metadata=result.deferred_chunk_metadata,
+            )
+        if result.deferred_completion_metadata is not None:
+            await self.stream.progress(
+                "",
+                source="chat",
+                stage=LOOP_STAGE,
+                metadata=result.deferred_completion_metadata,
+            )
+        result.deferred_chunk_metadata = None
+        result.deferred_completion_metadata = None
+
+    async def _discard_deferred_output(self, result: LLMCallResult) -> None:
+        """Close a rejected round's trace without publishing its buffered prose."""
+        metadata = result.deferred_completion_metadata
+        if metadata is not None:
+            metadata = dict(metadata)
+            metadata["call_role"] = "narration"
+            metadata.pop("answer_visible", None)
+            metadata["finish_rejected"] = True
+            await self.stream.progress(
+                "",
+                source="chat",
+                stage=LOOP_STAGE,
+                metadata=metadata,
+            )
+        result.deferred_chunk_metadata = None
+        result.deferred_completion_metadata = None
+
     # ---- LLM call ----------------------------------------------------------
 
     async def _call_llm(
@@ -608,6 +665,7 @@ class AgentLoop:
         trace_role: str,
         max_tokens: int,
         tool_schemas: list[dict[str, Any]] | None = None,
+        defer_visible_output: bool = False,
     ) -> LLMCallResult:
         await self.pipeline._guard_context_window(messages, self.stream)
         stage = LOOP_STAGE
@@ -686,9 +744,10 @@ class AgentLoop:
                         visible_text_parts.append(segment)
                         if segment.strip():
                             answer_content_emitted = True
-                        await self.stream.content(
-                            segment, source="chat", stage=stage, metadata=chunk_meta
-                        )
+                        if not defer_visible_output:
+                            await self.stream.content(
+                                segment, source="chat", stage=stage, metadata=chunk_meta
+                            )
                     else:
                         await self.stream.thinking(
                             segment, source="chat", stage=stage, metadata=chunk_meta
@@ -850,20 +909,23 @@ class AgentLoop:
             # answer content, not an internal tool preamble.
             completion_metadata["answer_visible"] = True
 
-        await self.stream.progress(
-            "",
-            source="chat",
-            stage=stage,
-            metadata=merge_trace_metadata(
-                trace_meta,
-                completion_metadata,
-            ),
-        )
+        completion_event_metadata = merge_trace_metadata(trace_meta, completion_metadata)
+        if not defer_visible_output:
+            await self.stream.progress(
+                "",
+                source="chat",
+                stage=stage,
+                metadata=completion_event_metadata,
+            )
         return LLMCallResult(
             text=text,
             visible_text="".join(visible_text_parts),
             tool_calls=tool_calls,
             finish_reason=finish_reason,
+            deferred_chunk_metadata=chunk_meta if defer_visible_output else None,
+            deferred_completion_metadata=(
+                completion_event_metadata if defer_visible_output else None
+            ),
         )
 
     async def _create_response_stream(

--- a/deeptutor/agents/chat/agentic_pipeline.py
+++ b/deeptutor/agents/chat/agentic_pipeline.py
@@ -727,6 +727,13 @@ class AgenticChatPipeline:
                 return content
         return ""
 
+    def _has_capability_finish_guard(self, context: UnifiedContext) -> bool:
+        """Whether a capability may need to inspect a tool-less finish first."""
+        return any(
+            callable(getattr(cap, "finish_instruction", None))
+            for cap in self._active_loop_capabilities(context)
+        )
+
     async def _capability_pre_loop_briefings(
         self,
         context: UnifiedContext,

--- a/deeptutor/agents/chat/agentic_pipeline.py
+++ b/deeptutor/agents/chat/agentic_pipeline.py
@@ -702,6 +702,31 @@ class AgenticChatPipeline:
         ]
         return "\n\n".join(seed for seed in seeds if seed)
 
+    def _capability_finish_instruction(self, context: UnifiedContext, final_text: str) -> str:
+        """Let an active capability reject a narrow tool-less finish once.
+
+        This is a protocol guard, not a content generator: capabilities return
+        a short instruction only when their own state proves that required tool
+        work remains. A guard failure must not sink the learner's answer.
+        """
+        for cap in self._active_loop_capabilities(context):
+            hook = getattr(cap, "finish_instruction", None)
+            if not callable(hook):
+                continue
+            try:
+                instruction = hook(context, final_text)
+            except Exception:
+                logger.warning(
+                    "finish guard failed for capability %s",
+                    getattr(cap, "name", "?"),
+                    exc_info=True,
+                )
+                continue
+            content = str(instruction or "").strip()
+            if content:
+                return content
+        return ""
+
     async def _capability_pre_loop_briefings(
         self,
         context: UnifiedContext,

--- a/deeptutor/capabilities/mastery/loop.py
+++ b/deeptutor/capabilities/mastery/loop.py
@@ -206,14 +206,10 @@ class MasteryLoopCapability:
         """Redirect a quantitative assessment away from a plain-text finish."""
         if not self.is_active(context):
             return None
-        if context.metadata.get("_mastery_plain_quiz_guard_used"):
-            return None
-
         needs_card = bool(context.metadata.get("_mastery_quiz_needs_card"))
         if not needs_card and not _looks_like_plain_choice_quiz(final_text):
             return None
 
-        context.metadata["_mastery_plain_quiz_guard_used"] = True
         return (
             "The previous reply tried to finish a mastery assessment as plain text. "
             "Do not repeat the question in prose. First ensure the question and its "

--- a/deeptutor/capabilities/mastery/loop.py
+++ b/deeptutor/capabilities/mastery/loop.py
@@ -40,6 +40,14 @@ _RECOMMENDATION_SUFFIX = re.compile(
     r"[\s　]*[（(]\s*(?:推荐|建议|recommended|recommend)\s*[)）][\s　]*$",
     re.IGNORECASE,
 )
+_PLAIN_CHOICE_OPTION_RE = re.compile(
+    r"^(?:[-*+]\s*)?(?:\*\*)?([A-D])(?:\*\*)?\s*[.、):：-]\s*(\S.*)$",
+    re.IGNORECASE,
+)
+_PLAIN_QUIZ_PROMPT_RE = re.compile(
+    r"\b(?:which|choose|select|answer)\b|选择|选哪个|请选择|请回答|答案",
+    re.IGNORECASE,
+)
 
 
 def _without_recommendation(text: Any) -> Any:
@@ -78,6 +86,26 @@ def _strip_answer_hints(kwargs: dict[str, Any]) -> dict[str, Any]:
             }
         )
     return {**kwargs, "questions": cleaned_questions}
+
+
+def _looks_like_plain_choice_quiz(text: str) -> bool:
+    """Recognise a rendered A-D option list with high precision.
+
+    The model may discuss labelled options while teaching. Requiring both an
+    assessment prompt and at least three distinct labelled answer bodies keeps
+    ordinary prose, headings, and option-like vocabulary examples out of this
+    protocol guard.
+    """
+    labels: set[str] = set()
+    prompt_lines: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        match = _PLAIN_CHOICE_OPTION_RE.match(line)
+        if match:
+            labels.add(match.group(1).upper())
+        else:
+            prompt_lines.append(line)
+    return len(labels) >= 3 and any(_PLAIN_QUIZ_PROMPT_RE.search(line) for line in prompt_lines)
 
 
 def _bind_pending_ask_user_args(kwargs: dict[str, Any], path_id: str) -> dict[str, Any]:
@@ -152,11 +180,16 @@ class MasteryLoopCapability:
             return kwargs
         path_id = str(context.metadata.get("mastery_path_id") or "").strip()
         if tool_name == "ask_user":
+            context.metadata["_mastery_quiz_needs_card"] = False
             # Strip hints last, so a card rebound from persisted state is
             # cleaned too — the persisted options were model-authored as well.
             return _strip_answer_hints(_bind_pending_ask_user_args(kwargs, path_id))
         if tool_name in MASTERY_TOOL_NAMES:
             updated = dict(kwargs)
+            if tool_name == "mastery_quiz":
+                context.metadata["_mastery_quiz_needs_card"] = True
+            elif tool_name == "mastery_grade":
+                context.metadata["_mastery_quiz_needs_card"] = False
             updated["_mastery_path_id"] = path_id
             updated["_session_id"] = str(context.session_id or "").strip()
             updated["_turn_id"] = str(context.metadata.get("turn_id") or "").strip()
@@ -168,6 +201,26 @@ class MasteryLoopCapability:
                 updated["_bind_active_path"] = _path_binder(context)
             return updated
         return kwargs
+
+    def finish_instruction(self, context: UnifiedContext, final_text: str) -> str | None:
+        """Redirect a quantitative assessment away from a plain-text finish."""
+        if not self.is_active(context):
+            return None
+        if context.metadata.get("_mastery_plain_quiz_guard_used"):
+            return None
+
+        needs_card = bool(context.metadata.get("_mastery_quiz_needs_card"))
+        if not needs_card and not _looks_like_plain_choice_quiz(final_text):
+            return None
+
+        context.metadata["_mastery_plain_quiz_guard_used"] = True
+        return (
+            "The previous reply tried to finish a mastery assessment as plain text. "
+            "Do not repeat the question in prose. First ensure the question and its "
+            "answer are registered with mastery_quiz (retry it if the previous call "
+            "failed), then present the persisted question with ask_user and stop for "
+            "the learner's answer."
+        )
 
     def pre_loop_seed(self, context: UnifiedContext) -> str:
         _ = context

--- a/deeptutor/capabilities/protocol.py
+++ b/deeptutor/capabilities/protocol.py
@@ -84,6 +84,12 @@ class LoopCapability(Protocol):
     a ``getattr`` default, like ``pre_loop``). The dispatcher runs them before
     the round's other calls and re-binds those calls afterwards, so a switch
     and a write issued in the same round cannot land on different targets.
+
+    A capability MAY also define ``finish_instruction(context, final_text)``.
+    It is called after a tool-less LLM round and may return a short protocol
+    instruction when that round must not finalize the turn. The answer loop
+    gives the model one additional round with tools still mounted; capability
+    implementations are responsible for keeping the check narrow and bounded.
     """
 
     name: str

--- a/tests/agents/chat/test_agent_loop.py
+++ b/tests/agents/chat/test_agent_loop.py
@@ -606,7 +606,8 @@ async def test_mastery_tool_round_keeps_teaching_markdown_visible(
     assert markers[0]["call_role"] == "narration"
     assert markers[0]["answer_visible"] is True
     joined_content = "".join(_contents(events))
-    assert joined_content.startswith(explanation + "Choose the answer when you are ready.")
+    assert joined_content.startswith(explanation)
+    assert "Choose the answer when you are ready." not in joined_content
     assert "Which sum?" in joined_content
     assert client.call_count == 3
     assert [row["name"] for row in registry.executed] == ["mastery_quiz", "ask_user"]
@@ -697,6 +698,46 @@ async def test_mastery_plain_choice_finish_gets_one_protocol_redirect(
     assert "mastery_quiz" in redirect["content"]
     assert "ask_user" in redirect["content"]
     assert _result(events).metadata["completed"] is False
+    assert plain_quiz not in "".join(_contents(events))
+
+
+@pytest.mark.asyncio
+async def test_repeated_plain_choice_failure_is_never_published_as_a_finish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One retry is bounded, but its second invalid quiz still cannot finish."""
+    plain_quiz = "Which value is correct?\n\nA. one\nB. two\nC. three\nD. four"
+    client = _ScriptedChatClient(
+        [[_llm_chunk(content=plain_quiz)], [_llm_chunk(content=plain_quiz)]]
+    )
+    pipeline = AgenticChatPipeline(language="en")
+    pipeline.registry = _Registry()
+    monkeypatch.setattr(pipeline, "_compose_enabled_tools", lambda _context: ["ask_user"])
+    monkeypatch.setattr(pipeline, "_build_openai_client", lambda: client)
+
+    events = await _run(
+        pipeline,
+        UnifiedContext(
+            session_id="s1",
+            user_message="Continue",
+            enabled_tools=["ask_user"],
+            metadata={"mastery_mode": True, "mastery_path_id": ""},
+        ),
+    )
+
+    assert client.call_count == 2
+    assert plain_quiz not in "".join(_contents(events))
+    rejected_calls = [
+        event.metadata
+        for event in events
+        if event.type == StreamEventType.PROGRESS and event.metadata.get("finish_rejected") is True
+    ]
+    assert len(rejected_calls) == 2
+    assert all(metadata["call_state"] == "complete" for metadata in rejected_calls)
+    assert all(metadata["call_role"] == "narration" for metadata in rejected_calls)
+    result = _result(events)
+    assert result.metadata["completed"] is False
+    assert result.metadata["response"] == ""
 
 
 @pytest.mark.asyncio

--- a/tests/agents/chat/test_agent_loop.py
+++ b/tests/agents/chat/test_agent_loop.py
@@ -529,6 +529,16 @@ async def test_mastery_tool_round_keeps_teaching_markdown_visible(
             )
             return schemas
 
+        async def execute(self, name: str, **kwargs):
+            if name == "ask_user":
+                self.executed.append({"name": name, "kwargs": kwargs})
+                return ToolResult(
+                    content="Asked the learner.",
+                    success=True,
+                    pause_for_user={"questions": kwargs["questions"]},
+                )
+            return await super().execute(name, **kwargs)
+
     explanation = (
         "### Binary addition\n\n"
         "| Carry | Sum |\n"
@@ -552,6 +562,19 @@ async def test_mastery_tool_round_keeps_teaching_markdown_visible(
                 ),
             ],
             [_llm_chunk(content="Choose the answer when you are ready.")],
+            [
+                _llm_chunk(
+                    tool_calls=[
+                        {
+                            "id": "ask-1",
+                            "name": "ask_user",
+                            "arguments": json.dumps(
+                                {"questions": [{"id": "q1", "prompt": "Which sum?"}]}
+                            ),
+                        }
+                    ]
+                )
+            ],
         ]
     )
     pipeline = AgenticChatPipeline(language="en")
@@ -559,7 +582,7 @@ async def test_mastery_tool_round_keeps_teaching_markdown_visible(
     monkeypatch.setattr(
         pipeline,
         "_compose_enabled_tools",
-        lambda _context: ["mastery_quiz"],
+        lambda _context: ["mastery_quiz", "ask_user"],
     )
     monkeypatch.setattr(pipeline, "_build_openai_client", lambda: client)
 
@@ -569,7 +592,7 @@ async def test_mastery_tool_round_keeps_teaching_markdown_visible(
             session_id="s1",
             user_message="Teach me binary addition",
             enabled_tools=["mastery_quiz"],
-            metadata={"mastery_mode": True, "mastery_path_id": "path-1"},
+            metadata={"mastery_mode": True, "mastery_path_id": ""},
         ),
     )
 
@@ -582,7 +605,130 @@ async def test_mastery_tool_round_keeps_teaching_markdown_visible(
     ]
     assert markers[0]["call_role"] == "narration"
     assert markers[0]["answer_visible"] is True
-    assert "".join(_contents(events)) == explanation + "Choose the answer when you are ready."
+    joined_content = "".join(_contents(events))
+    assert joined_content.startswith(explanation + "Choose the answer when you are ready.")
+    assert "Which sum?" in joined_content
+    assert client.call_count == 3
+    assert [row["name"] for row in registry.executed] == ["mastery_quiz", "ask_user"]
+    redirect = client.calls[2]["messages"][-1]
+    assert redirect["role"] == "user"
+    assert "mastery_quiz" in redirect["content"]
+    assert "ask_user" in redirect["content"]
+    result = _result(events)
+    assert result.metadata["completed"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "plain_quiz",
+    [
+        (
+            "Which expression builds a dictionary?\n\n"
+            "- A. `{w: words.count(w) for w in words}`\n"
+            "- B. `[w: words.count(w) for w in words]`\n"
+            "- C. `{w for w in words}`\n"
+            "- D. `(w: words.count(w) for w in words)`"
+        ),
+        (
+            "请选择正确的字典推导式：\n\n"
+            "- A. `{w: words.count(w) for w in words}`\n"
+            "- B. `[w: words.count(w) for w in words]`\n"
+            "- C. `{w for w in words}`\n"
+            "- D. `(w: words.count(w) for w in words)`"
+        ),
+    ],
+)
+async def test_mastery_plain_choice_finish_gets_one_protocol_redirect(
+    plain_quiz: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A prose A-D quiz cannot bypass the registered-card assessment flow."""
+
+    class _MasteryCardRegistry(_Registry):
+        async def execute(self, name: str, **kwargs):
+            if name == "ask_user":
+                self.executed.append({"name": name, "kwargs": kwargs})
+                return ToolResult(
+                    content="Asked the learner.",
+                    success=True,
+                    pause_for_user={"questions": kwargs["questions"]},
+                )
+            return await super().execute(name, **kwargs)
+
+    registry = _MasteryCardRegistry()
+    client = _ScriptedChatClient(
+        [
+            [_llm_chunk(content=plain_quiz)],
+            [
+                _llm_chunk(
+                    tool_calls=[
+                        {
+                            "id": "ask-1",
+                            "name": "ask_user",
+                            "arguments": json.dumps(
+                                {"questions": [{"id": "q1", "prompt": "Which expression?"}]}
+                            ),
+                        }
+                    ]
+                )
+            ],
+        ]
+    )
+    pipeline = AgenticChatPipeline(language="en")
+    pipeline.registry = registry
+    monkeypatch.setattr(pipeline, "_compose_enabled_tools", lambda _context: ["ask_user"])
+    monkeypatch.setattr(pipeline, "_build_openai_client", lambda: client)
+
+    events = await _run(
+        pipeline,
+        UnifiedContext(
+            session_id="s1",
+            user_message="Continue",
+            enabled_tools=["ask_user"],
+            metadata={"mastery_mode": True, "mastery_path_id": ""},
+        ),
+    )
+
+    assert client.call_count == 2
+    assert [row["name"] for row in registry.executed] == ["ask_user"]
+    redirect = client.calls[1]["messages"][-1]
+    assert redirect["role"] == "user"
+    assert "plain text" in redirect["content"]
+    assert "mastery_quiz" in redirect["content"]
+    assert "ask_user" in redirect["content"]
+    assert _result(events).metadata["completed"] is False
+
+
+@pytest.mark.asyncio
+async def test_mastery_labelled_teaching_examples_stay_direct(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A labelled teaching list is not itself an assessment prompt."""
+    registry = _Registry()
+    teaching = (
+        "Here are container spellings to remember:\n\n"
+        "- A. lists use brackets.\n"
+        "- B. dictionaries answer key lookups with braces and a colon.\n"
+        "- C. sets use braces without a colon."
+    )
+    client = _ScriptedChatClient([[_llm_chunk(content=teaching)]])
+    pipeline = AgenticChatPipeline(language="en")
+    pipeline.registry = registry
+    monkeypatch.setattr(pipeline, "_compose_enabled_tools", lambda _context: [])
+    monkeypatch.setattr(pipeline, "_build_openai_client", lambda: client)
+
+    events = await _run(
+        pipeline,
+        UnifiedContext(
+            session_id="s1",
+            user_message="Teach me Python containers",
+            metadata={"mastery_mode": True, "mastery_path_id": ""},
+        ),
+    )
+
+    assert client.call_count == 1
+    assert "".join(_contents(events)) == teaching
+    assert _result(events).metadata["completed"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Description

Mastery path could end a turn by rendering a multiple-choice question as plain text. That question never entered the persisted assessment flow, so the learner could answer in chat without a real quiz card, question-bank entry, or mastery update.

This adds a narrow capability finish guard:

- Active loop capabilities can optionally return one protocol instruction when a tool-less final response must not finish the turn.
- Mastery marks a turn as needing a card after `mastery_quiz`, and clears that state when `ask_user` or `mastery_grade` is bound.
- If the model tries to finish without the required card, the next round retains tools and instructs it to register or retry `mastery_quiz`, then present the persisted question through `ask_user`.
- A high-precision plain-choice detector catches rendered A-D quizzes in English and Chinese even when the model skipped `mastery_quiz`; assessment wording is checked outside option bodies so labelled teaching examples remain normal prose.
- The redirect is used once, and guard failures do not suppress the learner's answer.

### Related Issues

- Fixes #941

### Module(s) Affected

- [x] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `capabilities`

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] My changes do not require documentation updates.
- [x] My changes do not introduce any new security vulnerabilities.

### Validation

- `PASS` `python -m pytest tests/agents/chat/test_agent_loop.py -q` — 40 passed.
- `PASS` focused Ruff check on all five touched Python files.
- `PASS` focused Ruff format check on all five touched Python files.
- `PASS` `git diff --check`.
- Regression coverage includes English and Chinese plain-choice quizzes, reuse of an already-registered quiz, and labelled teaching examples that must finish normally.
- Full `pre-commit run --all-files` is not clean on the current base: its Prettier hook rewrites 35 unrelated web files. Those generated formatting changes are intentionally excluded from this PR. The repository hygiene, Python, secret, Bandit, and Mypy hooks passed before the Prettier hook result.
