### PR TITLE
Fix llama.cpp context detection for loaded models

### DIFF
--- a/deeptutor/services/config/context_window_detection.py
+++ b/deeptutor/services/config/context_window_detection.py
@@ -32,6 +32,7 @@ _CONTEXT_WINDOW_KEYS = (
     "max_prompt_tokens",
     "max_model_len",
     "max_sequence_length",
+    "n_ctx",
 )
 
 _KNOWN_CONTEXT_WINDOWS: tuple[tuple[str, int], ...] = (

--- a/tests/services/config/test_context_window_detection.py
+++ b/tests/services/config/test_context_window_detection.py
@@ -99,6 +99,28 @@ def test_extract_context_window_reads_novita_context_size_key() -> None:
     )
 
 
+def test_extract_context_window_reads_llamacpp_n_ctx_meta() -> None:
+    """llama.cpp exposes the effective window as ``meta.n_ctx`` for loaded models."""
+    payload = {
+        "data": [
+            {
+                "id": "Qwen3.8-27B:Q6_K_XL",
+                "status": {
+                    "value": "loaded",
+                    "args": ["--alias", "Qwen3.8-27B:Q6_K_XL", "--ctx-size", "400000"],
+                },
+                "preset": "ctx-size = 400000\n",
+                "meta": {"n_ctx": 200_192, "n_ctx_train": 262_144},
+            },
+        ]
+    }
+
+    assert (
+        detection_module._extract_context_window_from_payload(payload, "Qwen3.8-27B:Q6_K_XL")
+        == 200_192
+    )
+
+
 def test_models_endpoint_probe_honors_disable_ssl_verify(monkeypatch) -> None:
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
<!--
Thank you for contributing to DeepTutor! 🚀
Please ensure your PR is ready for review and follows our contribution guidelines.
For more details, see our [CONTRIBUTING.md](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
-->

### Description
Currently, the context detection for llama.cpp models is broken (note 65,536 reported by the tests is incorrect). 

<img width="551" height="578" alt="image" src="https://github.com/user-attachments/assets/6763b849-0e8e-44ba-97b9-bb84417bb0e2" />

This PR uses llama.cpp’s structured `meta.n_ctx` field when detecting context windows from `/v1/models`.
This fixes loaded llama.cpp models incorrectly falling back to the default context size when the provider reports the effective context window under `n_ctx`.

### Related Issues
- Closes #...
- Related to #...

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
*Add any other context or screenshots about the pull request here.*
