### PR TITLE
feat(search): add Serply provider with web, news and scholar modes

### DIFF
--- a/deeptutor/services/config/provider_runtime.py
+++ b/deeptutor/services/config/provider_runtime.py
@@ -87,6 +87,7 @@ SEARCH_PROVIDERS: dict[str, SearchProviderSpec] = {
         supports_answer=True,
     ),
     "serper": SearchProviderSpec(label="Serper", requires_api_key=True, soft_fallback=False),
+    "serply": SearchProviderSpec(label="Serply", requires_api_key=True, soft_fallback=False),
     "firecrawl": SearchProviderSpec(label="Firecrawl", requires_api_key=True, soft_fallback=False),
     # China-hosted engines. Doubao is the one that writes its own answer: Ark
     # exposes web search only as a tool on a Doubao model, never standalone.

--- a/deeptutor/services/search/consolidation.py
+++ b/deeptutor/services/search/consolidation.py
@@ -147,6 +147,7 @@ class AnswerConsolidator:
         "serper": "serper",
         "jina": "jina",
         "serper_scholar": "serper_scholar",
+        "serply_scholar": "serper_scholar",
     }
 
     def __init__(

--- a/deeptutor/services/search/providers/__init__.py
+++ b/deeptutor/services/search/providers/__init__.py
@@ -181,6 +181,7 @@ def _register_builtin_providers() -> None:
         qianfan,
         searxng,
         serper,
+        serply,
         tavily,
         zhipu,
     )
@@ -197,6 +198,7 @@ def _register_builtin_providers() -> None:
         qianfan,
         searxng,
         serper,
+        serply,
         tavily,
         zhipu,
     )

--- a/deeptutor/services/search/providers/serply.py
+++ b/deeptutor/services/search/providers/serply.py
@@ -2,7 +2,7 @@
 
 API: https://serply.io
 Docs: https://serply.io/docs
-Endpoints: https://api.serply.io/v1/{search,news,scholar}/
+Endpoints: https://api.serply.io/v1/{search,news,scholar}/q=<encoded query>
 
 Serply serves live Google SERP rows plus the Google News and Google Scholar
 verticals behind one key, so a study session can go from "what is X" to
@@ -17,6 +17,7 @@ from datetime import datetime
 import html
 import re
 from typing import Any
+from urllib.parse import urlencode
 
 import requests
 
@@ -24,11 +25,11 @@ from ..base import BaseSearchProvider
 from ..types import Citation, SearchResult, WebSearchResponse
 from . import register_provider
 
-# mode -> (URL path segment, key that holds the result rows)
-_MODES: dict[str, tuple[str, str]] = {
-    "search": ("search", "results"),
-    "news": ("news", "entries"),
-    "scholar": ("scholar", "articles"),
+# mode -> URL path segment
+_MODES: dict[str, str] = {
+    "search": "search",
+    "news": "news",
+    "scholar": "scholar",
 }
 _TAG = re.compile(r"<[^>]+>")
 
@@ -59,14 +60,14 @@ class SerplyProvider(BaseSearchProvider):
                 news feed ignores it server-side, so rows are also cut here.
             timeout: Request timeout in seconds.
             **kwargs: Additional options, including ``base_url``, the API root
-                (``/search/`` etc. is appended) for a self-hosted gateway.
+                (``/search/q=...`` etc. is appended) for a self-hosted gateway.
 
         Returns:
             WebSearchResponse: Standardized search response.
         """
         if mode not in _MODES:
             raise ValueError(f"Serply mode must be one of {sorted(_MODES)}, got {mode!r}.")
-        path, rows_key = _MODES[mode]
+        path = _MODES[mode]
         root = str(kwargs.get("base_url") or self.BASE_URL).rstrip("/")
         num = max(1, min(int(max_results), 100))
         headers = {
@@ -74,14 +75,15 @@ class SerplyProvider(BaseSearchProvider):
             "Accept": "application/json",
             "User-Agent": "deeptutor",
         }
-        request_kwargs: dict[str, Any] = {"headers": headers, "params": {"q": query, "num": num}}
+        request_kwargs: dict[str, Any] = {"headers": headers}
         if self.proxy:
             request_kwargs["proxies"] = {"http": self.proxy, "https": self.proxy}
-        resp = requests.get(f"{root}/{path}/", timeout=timeout, **request_kwargs)
+        encoded_query = urlencode({"q": query, "num": num})
+        resp = requests.get(f"{root}/{path}/{encoded_query}", timeout=timeout, **request_kwargs)
         if resp.status_code != 200:
             raise Exception(f"Serply API error: {resp.status_code} - {resp.text}")
         payload = resp.json()
-        rows = (payload.get(rows_key) or [])[:num]
+        rows = _result_rows(mode, payload)[:num]
 
         citations: list[Citation] = []
         search_results: list[SearchResult] = []
@@ -123,7 +125,10 @@ def _parse_row(mode: str, row: dict[str, Any]) -> SearchResult:
     title = str(row.get("title", ""))
     url = str(row.get("link", ""))
     if mode == "news":
-        source = (row.get("source") or {}).get("title") or "Google News"
+        raw_source = row.get("source")
+        source = (
+            raw_source.get("title") if isinstance(raw_source, dict) else raw_source
+        ) or "Google News"
         return SearchResult(
             title=title,
             url=url,
@@ -157,3 +162,13 @@ def _parse_row(mode: str, row: dict[str, Any]) -> SearchResult:
         snippet=str(row.get("description", "") or ""),
         source=str(display_url or "Serply"),
     )
+
+
+def _result_rows(mode: str, payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Read each vertical's documented response envelope."""
+    if mode == "news":
+        feed = payload.get("feed")
+        rows = feed.get("entries") if isinstance(feed, dict) else None
+    else:
+        rows = payload.get("articles" if mode == "scholar" else "results")
+    return [row for row in rows or [] if isinstance(row, dict)]

--- a/deeptutor/services/search/providers/serply.py
+++ b/deeptutor/services/search/providers/serply.py
@@ -1,0 +1,159 @@
+"""Serply search provider.
+
+API: https://serply.io
+Docs: https://serply.io/docs
+Endpoints: https://api.serply.io/v1/{search,news,scholar}/
+
+Serply serves live Google SERP rows plus the Google News and Google Scholar
+verticals behind one key, so a study session can go from "what is X" to
+"what do the papers say about X" without switching providers. Every mode
+returns plain rows with no model-written answer, so consolidation still
+supplies the answer.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import html
+import re
+from typing import Any
+
+import requests
+
+from ..base import BaseSearchProvider
+from ..types import Citation, SearchResult, WebSearchResponse
+from . import register_provider
+
+# mode -> (URL path segment, key that holds the result rows)
+_MODES: dict[str, tuple[str, str]] = {
+    "search": ("search", "results"),
+    "news": ("news", "entries"),
+    "scholar": ("scholar", "articles"),
+}
+_TAG = re.compile(r"<[^>]+>")
+
+
+@register_provider("serply")
+class SerplyProvider(BaseSearchProvider):
+    """Serply Google SERP / News / Scholar provider."""
+
+    description = "Google SERP, News and Scholar results"
+    BASE_URL = "https://api.serply.io/v1"
+    API_KEY_ENV_VARS = ("SERPLY_API_KEY", "SEARCH_API_KEY")
+
+    def search(
+        self,
+        query: str,
+        mode: str = "search",
+        max_results: int = 5,
+        timeout: int = 30,
+        **kwargs: Any,
+    ) -> WebSearchResponse:
+        """Search Serply.
+
+        Args:
+            query: Search query.
+            mode: ``search`` (Google web), ``news`` (Google News) or ``scholar``
+                (Google Scholar).
+            max_results: Result cap. Serply's own ``num`` accepts 1-100; the
+                news feed ignores it server-side, so rows are also cut here.
+            timeout: Request timeout in seconds.
+            **kwargs: Additional options, including ``base_url``, the API root
+                (``/search/`` etc. is appended) for a self-hosted gateway.
+
+        Returns:
+            WebSearchResponse: Standardized search response.
+        """
+        if mode not in _MODES:
+            raise ValueError(f"Serply mode must be one of {sorted(_MODES)}, got {mode!r}.")
+        path, rows_key = _MODES[mode]
+        root = str(kwargs.get("base_url") or self.BASE_URL).rstrip("/")
+        num = max(1, min(int(max_results), 100))
+        headers = {
+            "X-Api-Key": self.api_key,
+            "Accept": "application/json",
+            "User-Agent": "deeptutor",
+        }
+        request_kwargs: dict[str, Any] = {"headers": headers, "params": {"q": query, "num": num}}
+        if self.proxy:
+            request_kwargs["proxies"] = {"http": self.proxy, "https": self.proxy}
+        resp = requests.get(f"{root}/{path}/", timeout=timeout, **request_kwargs)
+        if resp.status_code != 200:
+            raise Exception(f"Serply API error: {resp.status_code} - {resp.text}")
+        payload = resp.json()
+        rows = (payload.get(rows_key) or [])[:num]
+
+        citations: list[Citation] = []
+        search_results: list[SearchResult] = []
+        for idx, row in enumerate(rows, 1):
+            result = _parse_row(mode, row)
+            search_results.append(result)
+            citations.append(
+                Citation(
+                    id=idx,
+                    reference=f"[{idx}]",
+                    url=result.url,
+                    title=result.title,
+                    snippet=result.snippet,
+                    date=result.date,
+                    source=result.source,
+                )
+            )
+
+        metadata: dict[str, Any] = {"finish_reason": "stop", "mode": mode}
+        if payload.get("related_searches"):
+            metadata["relatedSearches"] = payload["related_searches"]
+        if payload.get("knowledge_graph"):
+            metadata["knowledgeGraph"] = payload["knowledge_graph"]
+
+        return WebSearchResponse(
+            query=query,
+            answer="",
+            provider="serply_scholar" if mode == "scholar" else "serply",
+            timestamp=datetime.now().isoformat(),
+            model=f"serply-{mode}",
+            citations=citations,
+            search_results=search_results,
+            metadata=metadata,
+        )
+
+
+def _parse_row(mode: str, row: dict[str, Any]) -> SearchResult:
+    """Map one Serply row onto ``SearchResult``; each vertical has its own shape."""
+    title = str(row.get("title", ""))
+    url = str(row.get("link", ""))
+    if mode == "news":
+        source = (row.get("source") or {}).get("title") or "Google News"
+        return SearchResult(
+            title=title,
+            url=url,
+            snippet=html.unescape(_TAG.sub("", str(row.get("summary", "") or ""))).strip(),
+            date=str(row.get("published", "") or ""),
+            source=str(source),
+        )
+    if mode == "scholar":
+        # Keyed like Serper's scholar rows so the shared academic template renders them.
+        attributes: dict[str, Any] = {}
+        if (row.get("author") or {}).get("names"):
+            attributes["publicationInfo"] = row["author"]["names"]
+        cited = ((row.get("extras") or {}).get("citations") or {}).get("count")
+        if cited is not None:
+            attributes["citedBy"] = cited
+        if (row.get("doc") or {}).get("link"):
+            attributes["pdfUrl"] = row["doc"]["link"]
+        if row.get("id"):
+            attributes["paperId"] = row["id"]
+        return SearchResult(
+            title=title,
+            url=url,
+            snippet=str(row.get("description", "") or ""),
+            source="Google Scholar",
+            attributes=attributes,
+        )
+    display_url = (row.get("metadata") or {}).get("display_url") or ""
+    return SearchResult(
+        title=title,
+        url=url,
+        snippet=str(row.get("description", "") or ""),
+        source=str(display_url or "Serply"),
+    )

--- a/deeptutor_cli/init_wizard.py
+++ b/deeptutor_cli/init_wizard.py
@@ -170,6 +170,13 @@ SEARCH_PROVIDERS: tuple[SearchProviderSpec, ...] = (
         hint="Google results · paid",
     ),
     SearchProviderSpec(
+        name="serply",
+        label="Serply",
+        requires_api_key=True,
+        env_keys=("SERPLY_API_KEY", "SEARCH_API_KEY"),
+        hint="Google SERP · News & Scholar modes · paid",
+    ),
+    SearchProviderSpec(
         name="perplexity",
         label="Perplexity",
         requires_api_key=True,

--- a/tests/services/search/test_search_providers.py
+++ b/tests/services/search/test_search_providers.py
@@ -374,16 +374,18 @@ _SERPLY_BODIES: dict[str, dict[str, Any]] = {
         "related_searches": [{"query": "transformer paper"}],
     },
     "news": {
-        "entries": [
-            {
-                "title": f"Story {i}",
-                "link": f"https://news.example/{i}",
-                "summary": "<a href='x'>Genuine</a> attention &amp; chatbots",
-                "published": "Mon, 25 Aug 2026 09:00:00 GMT",
-                "source": {"title": "Example Times"},
-            }
-            for i in range(10)
-        ]
+        "feed": {
+            "entries": [
+                {
+                    "title": f"Story {i}",
+                    "link": f"https://news.example/{i}",
+                    "summary": "<a href='x'>Genuine</a> attention &amp; chatbots",
+                    "published": "Mon, 25 Aug 2026 09:00:00 GMT",
+                    "source": "Example Times",
+                }
+                for i in range(10)
+            ]
+        }
     },
     "scholar": {
         "articles": [
@@ -408,7 +410,7 @@ def serply_calls(monkeypatch):
 
     def _get(url: str, **kwargs: Any) -> _FakeResponse:
         captured.append({"method": "GET", "url": url, **kwargs})
-        mode = url.rstrip("/").rsplit("/", 1)[-1]
+        mode = url.rsplit("/", 2)[-2]
         return _FakeResponse(_SERPLY_BODIES[mode])
 
     class _FakeRequests:
@@ -422,11 +424,11 @@ def test_serply_carries_max_results_proxy_and_base_url_root(serply_calls) -> Non
     from deeptutor.services.search.providers.serply import SerplyProvider
 
     provider = SerplyProvider(api_key="k", proxy=PROXY)
-    provider.search("q", max_results=3, base_url="https://gateway.example/v1/")
+    provider.search("attention & focus", max_results=3, base_url="https://gateway.example/v1/")
 
     call = serply_calls[-1]
-    assert call["url"] == "https://gateway.example/v1/search/"
-    assert call["params"] == {"q": "q", "num": 3}
+    assert call["url"] == ("https://gateway.example/v1/search/q=attention+%26+focus&num=3")
+    assert "params" not in call
     assert call["headers"]["X-Api-Key"] == "k"
     assert call["proxies"] == {"http": PROXY, "https": PROXY}
 
@@ -464,7 +466,7 @@ def test_serply_news_trims_client_side_and_strips_html(serply_calls) -> None:
 
     response = SerplyProvider(api_key="k").search("chatbots", mode="news", max_results=4)
 
-    assert serply_calls[-1]["url"].endswith("/news/")
+    assert "/news/q=chatbots&num=4" in serply_calls[-1]["url"]
     assert len(response.search_results) == 4
     assert response.search_results[0].snippet == "Genuine attention & chatbots"
     assert response.search_results[0].source == "Example Times"

--- a/tests/services/search/test_search_providers.py
+++ b/tests/services/search/test_search_providers.py
@@ -354,3 +354,144 @@ def test_bocha_surfaces_an_error_carried_inside_a_200(monkeypatch) -> None:
 
     with pytest.raises(Exception, match="quota exhausted"):
         BochaProvider(api_key="k").search("q")
+
+
+# --------------------------------------------------------------------------
+# Serply: one key, three Google verticals (web / news / scholar). It is a GET
+# API, so the cap lands in `params`, and the news feed ignores `num` server-side.
+# --------------------------------------------------------------------------
+
+_SERPLY_BODIES: dict[str, dict[str, Any]] = {
+    "search": {
+        "results": [
+            {
+                "title": "Attention Is All You Need - arXiv",
+                "link": "https://arxiv.org/abs/1706.03762",
+                "description": "The dominant sequence transduction models...",
+                "metadata": {"display_url": "arxiv.org"},
+            }
+        ],
+        "related_searches": [{"query": "transformer paper"}],
+    },
+    "news": {
+        "entries": [
+            {
+                "title": f"Story {i}",
+                "link": f"https://news.example/{i}",
+                "summary": "<a href='x'>Genuine</a> attention &amp; chatbots",
+                "published": "Mon, 25 Aug 2026 09:00:00 GMT",
+                "source": {"title": "Example Times"},
+            }
+            for i in range(10)
+        ]
+    },
+    "scholar": {
+        "articles": [
+            {
+                "id": "W2626778328",
+                "title": "Attention Is All You Need",
+                "link": "https://doi.org/10.65215/2q58a426",
+                "description": "We propose a new simple network architecture...",
+                "author": {"names": "A Vaswani, N Shazeer - 2017"},
+                "extras": {"citations": {"count": 120000}},
+                "doc": {"link": "https://example.org/attention.pdf", "type": "PDF"},
+            }
+        ]
+    },
+}
+
+
+@pytest.fixture
+def serply_calls(monkeypatch):
+    """Capture Serply GETs and answer each with the fixture body for its mode."""
+    captured: list[dict[str, Any]] = []
+
+    def _get(url: str, **kwargs: Any) -> _FakeResponse:
+        captured.append({"method": "GET", "url": url, **kwargs})
+        mode = url.rstrip("/").rsplit("/", 1)[-1]
+        return _FakeResponse(_SERPLY_BODIES[mode])
+
+    class _FakeRequests:
+        get = staticmethod(_get)
+
+    monkeypatch.setattr("deeptutor.services.search.providers.serply.requests", _FakeRequests)
+    return captured
+
+
+def test_serply_carries_max_results_proxy_and_base_url_root(serply_calls) -> None:
+    from deeptutor.services.search.providers.serply import SerplyProvider
+
+    provider = SerplyProvider(api_key="k", proxy=PROXY)
+    provider.search("q", max_results=3, base_url="https://gateway.example/v1/")
+
+    call = serply_calls[-1]
+    assert call["url"] == "https://gateway.example/v1/search/"
+    assert call["params"] == {"q": "q", "num": 3}
+    assert call["headers"]["X-Api-Key"] == "k"
+    assert call["proxies"] == {"http": PROXY, "https": PROXY}
+
+
+def test_serply_metadata_comes_from_the_spec_table() -> None:
+    from deeptutor.services.config import SEARCH_PROVIDERS
+    from deeptutor.services.search.providers import list_providers
+    from deeptutor.services.search.providers.serply import SerplyProvider
+
+    spec = SEARCH_PROVIDERS["serply"]
+    assert "serply" in list_providers()
+    assert SerplyProvider.display_name == spec.label
+    assert SerplyProvider.requires_api_key is True
+    assert SerplyProvider.supports_answer is False
+    # Paid provider: never quietly turn a billed key into DuckDuckGo.
+    assert spec.soft_fallback is False
+
+
+def test_serply_web_rows_map_onto_search_results(serply_calls) -> None:
+    from deeptutor.services.search.providers.serply import SerplyProvider
+
+    response = SerplyProvider(api_key="k").search("attention is all you need")
+
+    assert response.provider == "serply"
+    assert response.answer == ""
+    (row,) = response.search_results
+    assert row.url == "https://arxiv.org/abs/1706.03762"
+    assert row.source == "arxiv.org"
+    assert response.citations[0].reference == "[1]"
+    assert response.metadata["relatedSearches"] == [{"query": "transformer paper"}]
+
+
+def test_serply_news_trims_client_side_and_strips_html(serply_calls) -> None:
+    from deeptutor.services.search.providers.serply import SerplyProvider
+
+    response = SerplyProvider(api_key="k").search("chatbots", mode="news", max_results=4)
+
+    assert serply_calls[-1]["url"].endswith("/news/")
+    assert len(response.search_results) == 4
+    assert response.search_results[0].snippet == "Genuine attention & chatbots"
+    assert response.search_results[0].source == "Example Times"
+    assert response.search_results[0].date.startswith("Mon, 25 Aug 2026")
+
+
+def test_serply_scholar_rows_render_through_the_academic_template(serply_calls) -> None:
+    from deeptutor.services.search.consolidation import AnswerConsolidator
+    from deeptutor.services.search.providers.serply import SerplyProvider
+
+    response = SerplyProvider(api_key="k").search("attention", mode="scholar")
+
+    assert response.provider == "serply_scholar"
+    (row,) = response.search_results
+    assert row.attributes == {
+        "publicationInfo": "A Vaswani, N Shazeer - 2017",
+        "citedBy": 120000,
+        "pdfUrl": "https://example.org/attention.pdf",
+        "paperId": "W2626778328",
+    }
+    rendered = AnswerConsolidator().consolidate(response).answer
+    assert "Cited by: 120000" in rendered
+    assert "[PDF](https://example.org/attention.pdf)" in rendered
+
+
+def test_serply_rejects_an_unknown_mode() -> None:
+    from deeptutor.services.search.providers.serply import SerplyProvider
+
+    with pytest.raises(ValueError, match="mode"):
+        SerplyProvider(api_key="k").search("q", mode="images")


### PR DESCRIPTION
### Description
Adds [Serply](https://serply.io) as a web-search provider. Serply is a paid Google SERP API that also exposes the Google News and Google Scholar verticals behind the same key, which fits a tutoring app: one provider profile covers "what is X", "what is in the news about X" and "what do the papers say about X".

What the change does:

- `deeptutor/services/search/providers/serply.py` (new): `SerplyProvider`, mirroring the Bocha/Brave shape. `GET https://api.serply.io/v1/{search,news,scholar}/` with `X-Api-Key`, `mode="search" | "news" | "scholar"` (default `search`, same knob Serper uses), `max_results` mapped onto Serply's `num`, `proxy` passed through, and `base_url` accepted as the API root for a self-hosted gateway. The news endpoint ignores `num` server-side (returns the whole feed), so rows are also cut client-side. Scholar rows are keyed like Serper's (`publicationInfo`, `citedBy`, `pdfUrl`, `paperId`) and returned as `provider="serply_scholar"`, so the existing academic template renders them unchanged.
- `provider_runtime.py`: one `SEARCH_PROVIDERS` entry, `soft_fallback=False` like the other paid providers so a billed key never silently turns into DuckDuckGo. The Settings dropdown and web connection-field form pick it up from the table.
- `providers/__init__.py`: registers the module.
- `consolidation.py`: maps `serply_scholar` onto the existing `serper_scholar` template (one line).
- `deeptutor_cli/init_wizard.py`: wizard entry reading `SERPLY_API_KEY` / `SEARCH_API_KEY`.
- `tests/services/search/test_search_providers.py`: six tests with `requests` mocked, covering the shared `max_results` / `proxy` / `base_url` contract, spec-table metadata, per-mode row mapping, the client-side news cap and HTML unescaping, the scholar template rendering, and the unknown-mode error.

Nothing changes for anyone who does not create a Serply search profile; no default moves.

Verification:

```
$ pytest tests/services/search tests/services/config tests/cli -q
2 failed, 299 passed, 1 skipped
```
The two failures are `test_llm_probe_config.py::TestLlmProbeUsesAgentsYaml::*` and fail identically on a clean `dev` checkout; they are unrelated to search.

`ruff check .` and `ruff format --check .` pass with the CI-pinned ruff 0.16.0, and `pre-commit run --files <changed files>` passes.

Live-tested against the API with my own key in all three modes, then rendered through `AnswerConsolidator`:

```
--- search: provider=serply n=3
   [1706.03762] Attention Is All You Need - arXiv | https://arxiv.org/abs/1706.03762 | arxiv.org
   Attention Is All You Need - Wikipedia | https://en.wikipedia.org/wiki/... | en.wikipedia.org
--- news: provider=serply n=3
   Fundamentals of AI: Inside the transformer - Cisco Blogs | Cisco Blogs | Mon, 29 Jun 2026
--- scholar: provider=serply_scholar n=3
   Attention Is All You Need | https://doi.org/10.65215/2q58a426 | {'publicationInfo': 'Ashish Vaswani, Noam Shazeer, ... - 2025', 'citedBy': 6870, 'pdfUrl': 'https://...', 'paperId': 'W2626778328'}
  answer preview: ### Academic Results for "attention is all you need transformer" ...
```

### Related Issues
- Closes: none. No open issue asks for this; happy to open one if you track provider additions that way.
- Related to: the provider-layer rebuild in v1.5.12 (f4f2a73b), whose spec-table design is what made this a one-line registration.

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [x] Other: `deeptutor_cli` (init wizard provider entry)

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary). The module docstring carries the provider docs; README only names providers in release notes, so I left it alone. No vendored logo was added: `ProviderIcon` falls back to the generic mark by design. Glad to add an SVG if you want one.
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
Targets `dev` per CONTRIBUTING.

Serply docs for the three endpoints: https://serply.io/docs

Disclosure: I work with Serply. Happy to adjust scope (for example drop the `news` mode, or rename), change the wizard hint, or drop this entirely if it is not a direction you want for the project.
