### PR TITLE
fix(llm): stop matching bare 'tool' in schema-fallback detector

### DIFF
--- a/deeptutor/services/llm/request_compat.py
+++ b/deeptutor/services/llm/request_compat.py
@@ -76,12 +76,18 @@ def is_stream_options_unsupported(exc: Exception) -> bool:
 
 
 def is_tool_schema_unsupported(exc: Exception) -> bool:
-    """Whether a provider rejected native tool/function-calling schemas."""
+    """Whether a provider rejected native tool/function-calling schemas.
+
+    Deliberately avoids matching the bare substring ``\"tool\"``. Any 400 that
+    merely mentions tools — or echoes the outbound request body — used to trip
+    the chat loop's silent strip-and-retry path and leave the model answering
+    in prose with no tools (#708). Keep markers tied to schema/parameter
+    rejections; ``logged_error_text`` already captures unknowns for follow-up.
+    """
     text = error_text(exc)
     return any(
         marker in text
         for marker in (
-            "tool",
             "function_declaration",
             "function declaration",
             "function_declarations",
@@ -89,6 +95,18 @@ def is_tool_schema_unsupported(exc: Exception) -> bool:
             "parameters.properties",
             "404_not_found",
             "404 not_found",
+            "unsupported parameter: tools",
+            "unknown parameter: tools",
+            "unknown parameter 'tools'",
+            'unknown parameter "tools"',
+            "unexpected keyword argument 'tools'",
+            "tools is not supported",
+            "tools are not supported",
+            "does not support tools",
+            "does not support function calling",
+            "function calling is not supported",
+            "tool use is not supported",
+            "tool calling is not supported",
         )
     )
 

--- a/deeptutor/services/llm/request_compat.py
+++ b/deeptutor/services/llm/request_compat.py
@@ -85,7 +85,7 @@ def is_tool_schema_unsupported(exc: Exception) -> bool:
     rejections; ``logged_error_text`` already captures unknowns for follow-up.
     """
     text = error_text(exc)
-    return any(
+    rejected_schema = any(
         marker in text
         for marker in (
             "function_declaration",
@@ -93,8 +93,6 @@ def is_tool_schema_unsupported(exc: Exception) -> bool:
             "function_declarations",
             "tool_choice",
             "parameters.properties",
-            "404_not_found",
-            "404 not_found",
             "unsupported parameter: tools",
             "unknown parameter: tools",
             "unknown parameter 'tools'",
@@ -107,6 +105,21 @@ def is_tool_schema_unsupported(exc: Exception) -> bool:
             "function calling is not supported",
             "tool use is not supported",
             "tool calling is not supported",
+        )
+    )
+    if rejected_schema:
+        return True
+    not_found = "404_not_found" in text or "404 not_found" in text
+    return not_found and any(
+        marker in text
+        for marker in (
+            "tool schema",
+            "function schema",
+            "function declaration",
+            "function_declaration",
+            "function calling",
+            "tool calling",
+            "tool_choice",
         )
     )
 

--- a/tests/services/llm/test_request_compat.py
+++ b/tests/services/llm/test_request_compat.py
@@ -28,6 +28,8 @@ def test_error_text_prefers_provider_response_body() -> None:
 def test_request_compatibility_classifiers_match_known_provider_errors() -> None:
     assert is_stream_options_unsupported(ValueError("unknown parameter: stream_options"))
     assert is_tool_schema_unsupported(ValueError("function_declaration is unsupported"))
+    assert is_tool_schema_unsupported(ValueError("unsupported parameter: tools"))
+    assert is_tool_schema_unsupported(ValueError("unknown parameter: tools"))
     assert is_image_input_unsupported(ValueError("content must be a string"))
 
 
@@ -37,6 +39,17 @@ def test_request_compatibility_classifiers_ignore_unrelated_errors() -> None:
     assert not is_stream_options_unsupported(error)
     assert not is_tool_schema_unsupported(error)
     assert not is_image_input_unsupported(error)
+
+
+def test_tool_schema_classifier_ignores_errors_that_only_mention_tool() -> None:
+    """Bare ``tool`` must not strip schemas — that silently disabled tools (#708)."""
+    # A temperature / max_tokens rejection that happens to echo the tools list.
+    echoed = ValueError(
+        "unsupported parameter: temperature. request included tools=[web_search]"
+    )
+    assert not is_tool_schema_unsupported(echoed)
+    assert not is_tool_schema_unsupported(RuntimeError("tool call timed out"))
+    assert not is_tool_schema_unsupported(ValueError("failed while invoking tool web_search"))
 
 
 def test_transient_transport_classifier_walks_wrapped_causes() -> None:

--- a/tests/services/llm/test_request_compat.py
+++ b/tests/services/llm/test_request_compat.py
@@ -30,6 +30,9 @@ def test_request_compatibility_classifiers_match_known_provider_errors() -> None
     assert is_tool_schema_unsupported(ValueError("function_declaration is unsupported"))
     assert is_tool_schema_unsupported(ValueError("unsupported parameter: tools"))
     assert is_tool_schema_unsupported(ValueError("unknown parameter: tools"))
+    assert is_tool_schema_unsupported(
+        ValueError("404_NOT_FOUND: function schema endpoint is unavailable")
+    )
     assert is_image_input_unsupported(ValueError("content must be a string"))
 
 
@@ -44,12 +47,13 @@ def test_request_compatibility_classifiers_ignore_unrelated_errors() -> None:
 def test_tool_schema_classifier_ignores_errors_that_only_mention_tool() -> None:
     """Bare ``tool`` must not strip schemas — that silently disabled tools (#708)."""
     # A temperature / max_tokens rejection that happens to echo the tools list.
-    echoed = ValueError(
-        "unsupported parameter: temperature. request included tools=[web_search]"
-    )
+    echoed = ValueError("unsupported parameter: temperature. request included tools=[web_search]")
     assert not is_tool_schema_unsupported(echoed)
     assert not is_tool_schema_unsupported(RuntimeError("tool call timed out"))
     assert not is_tool_schema_unsupported(ValueError("failed while invoking tool web_search"))
+    assert not is_tool_schema_unsupported(
+        ValueError("404_NOT_FOUND: model endpoint /v1/models/missing was not found")
+    )
 
 
 def test_transient_transport_classifier_walks_wrapped_causes() -> None:


### PR DESCRIPTION
## Summary
- Remove the bare `tool` substring from `is_tool_schema_unsupported` — any provider 400 that merely mentioned tools (or echoed the request) was stripping `tools`/`tool_choice` and retrying without them, so the model answered in prose (#708).
- Keep markers tied to real schema/parameter rejections (`function_declaration`, `tool_choice`, `unsupported parameter: tools`, …). Unknown shapes still surface via the existing `logged_error_text` warning.
- This is the defensive half of #708; routing the agentic loop through the Responses API (see #978) remains the structural fix for gpt-5.6 Chat Completions 400s.

Relates to #708

## Test plan
- [x] `pytest tests/services/llm/test_request_compat.py`
- [ ] With a provider that 400s on an unrelated param while echoing `tools=…` in the body: confirm the turn no longer shows “retrying without tools”
- [ ] With a genuine tools rejection (`unsupported parameter: tools` / `function_declaration`): confirm the fallback still trips