### PR TITLE
fix(partners): serve partner artifacts from output downloads

### DIFF
--- a/deeptutor/api/routers/outputs.py
+++ b/deeptutor/api/routers/outputs.py
@@ -9,8 +9,8 @@ from fastapi.responses import FileResponse
 
 from deeptutor.api.routers.auth import require_auth
 from deeptutor.multi_user.context import get_current_user_or_none
-from deeptutor.multi_user.paths import get_path_service_for_scope
 from deeptutor.multi_user.partner_access import visible_partners
+from deeptutor.multi_user.paths import get_path_service_for_scope
 from deeptutor.services.auth import TokenPayload
 from deeptutor.services.partners.scope import partner_scope
 from deeptutor.services.path_service import PathService

--- a/deeptutor/api/routers/outputs.py
+++ b/deeptutor/api/routers/outputs.py
@@ -10,7 +10,9 @@ from fastapi.responses import FileResponse
 from deeptutor.api.routers.auth import require_auth
 from deeptutor.multi_user.context import get_current_user_or_none
 from deeptutor.multi_user.paths import get_path_service_for_scope
+from deeptutor.multi_user.partner_access import visible_partners
 from deeptutor.services.auth import TokenPayload
+from deeptutor.services.partners.scope import partner_scope
 from deeptutor.services.path_service import PathService
 
 router = APIRouter()
@@ -37,11 +39,45 @@ def _resolve_output(path_service: PathService, relative_path: str) -> Path:
     return output_path
 
 
+def _resolve_partner_output(relative_path: str) -> Path | None:
+    """Resolve *relative_path* against partner scopes the caller may use.
+
+    Partner web chats run inside a synthetic workspace under
+    ``data/partners/<id>/workspace``, so generated files are not beneath the
+    human caller's own ``data/users/<uid>`` tree. The public artifact URL shape
+    is still ``/api/outputs/<relative path>``, which means the download surface
+    has to search the caller's visible partner workspaces when their own
+    workspace misses (#1012).
+
+    The first-party chat flow already scopes the request to one conversation, so
+    the same relative path colliding across multiple partners is vanishingly
+    unlikely. Fail closed anyway: only a unique partner match is served.
+    """
+    matches: list[Path] = []
+    for partner in visible_partners():
+        partner_id = str(partner.get("partner_id") or "").strip()
+        if not partner_id:
+            continue
+        candidate = get_path_service_for_scope(partner_scope(partner_id)).resolve_public_output_path(
+            relative_path
+        )
+        if candidate is not None:
+            matches.append(candidate)
+            if len(matches) > 1:
+                return None
+    return matches[0] if matches else None
+
+
 @router.api_route("/{output_path:path}", methods=["GET", "HEAD"])
 async def read_output(
     output_path: str,
     _auth: TokenPayload | None = Depends(require_auth),
 ) -> FileResponse:
-    """Serve one allowlisted artifact from the authenticated user's workspace."""
-    path = _resolve_output(_request_path_service(), output_path)
+    """Serve one allowlisted artifact from the authenticated user's reach."""
+    try:
+        path = _resolve_output(_request_path_service(), output_path)
+    except HTTPException:
+        path = _resolve_partner_output(output_path)
+        if path is None:
+            raise
     return FileResponse(path)

--- a/tests/api/test_output_files.py
+++ b/tests/api/test_output_files.py
@@ -122,6 +122,30 @@ def test_auth_disabled_reads_local_admin_output(output_app) -> None:
     assert response.content == b"local output"
 
 
+def test_authenticated_user_downloads_visible_partner_output(output_app, monkeypatch) -> None:
+    relative_path = "workspace/chat/chat/session-1/code_runs/chart.png"
+    alice = TokenPayload(username="alice", role="user", user_id="u_alice")
+    client, admin_root, _users_root = output_app({"alice-token": alice})
+
+    from deeptutor.api.routers import outputs
+
+    partner_root = admin_root / "partners" / "math-bot" / "workspace"
+    _write_output(partner_root, relative_path, b"\x89PNG\r\n\x1a\npartner image")
+    monkeypatch.setattr(
+        outputs,
+        "visible_partners",
+        lambda: [{"partner_id": "math-bot", "can_manage": True}],
+    )
+
+    with client:
+        client.cookies.set("dt_token", "alice-token")
+        response = client.get(f"/api/outputs/{relative_path}")
+
+    assert response.status_code == 200
+    assert response.content.startswith(b"\x89PNG\r\n\x1a\n")
+    assert response.headers["content-type"] == "image/png"
+
+
 def test_private_suffix_is_rejected(output_app) -> None:
     relative_path = "workspace/chat/chat/session-1/code_runs/private.json"
     alice = TokenPayload(username="alice", role="user", user_id="u_alice")


### PR DESCRIPTION
## Summary
- make `/api/outputs` fall back to partner synthetic workspaces the caller can access when the caller''s own workspace misses
- fail closed on ambiguous partner matches so the shared download endpoint does not guess between multiple partner files
- add a regression test covering partner-generated image downloads through the existing outputs route

## Test plan
- [x] `pytest tests/api/test_output_files.py -q --tb=short -k "partner_output or own_output or same_output or invalid_auth or auth_disabled or private_suffix or path_traversal"`
- [ ] Full `pytest tests/api/test_output_files.py -q` (blocked on Windows symlink privilege for two existing symlink tests)
