### PR TITLE
fix(chat): decode unicode escapes in ask_user card text

### DIFF
--- a/web/components/chat/home/AskUserOptions.tsx
+++ b/web/components/chat/home/AskUserOptions.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { decodeEscapedUnicodeForDisplay } from "@/lib/markdown-display";
 import {
   collectNarrationCallIds,
   shouldAppendEventContent,
@@ -376,6 +377,15 @@ export function leadingTraceEvents(
 }
 
 /**
+ * Decode dense JSON unicode escapes before the card paints learner-facing
+ * copy. Markdown already does this; ask_user prompts are plain text and used
+ * to leak ``\\u300c...`` stems (#973).
+ */
+function displayText(value: string): string {
+  return decodeEscapedUnicodeForDisplay(value);
+}
+
+/**
  * One option: v3 emits ``{label, description}`` objects; v2 payloads
  * stored in older sessions carry plain strings. Both normalise to the
  * object shape.
@@ -383,15 +393,15 @@ export function leadingTraceEvents(
 function normaliseOption(raw: unknown): AskUserOption | null {
   if (raw && typeof raw === "object") {
     const o = raw as Record<string, unknown>;
-    const label = String(o.label ?? "").trim();
+    const label = displayText(String(o.label ?? "").trim());
     if (!label) return null;
     const description =
       typeof o.description === "string" && o.description.trim()
-        ? o.description.trim()
+        ? displayText(o.description.trim())
         : null;
     return { label, description };
   }
-  const label = String(raw ?? "").trim();
+  const label = displayText(String(raw ?? "").trim());
   return label ? { label, description: null } : null;
 }
 
@@ -405,7 +415,7 @@ function normaliseAskUserPayload(raw: unknown): AskUserPayload | null {
     for (const item of obj.questions) {
       if (!item || typeof item !== "object") continue;
       const q = item as Record<string, unknown>;
-      const prompt = String(q.prompt ?? q.question ?? "").trim();
+      const prompt = displayText(String(q.prompt ?? q.question ?? "").trim());
       if (!prompt) continue;
       const optionsRaw = Array.isArray(q.options) ? q.options : [];
       questions.push({
@@ -413,7 +423,7 @@ function normaliseAskUserPayload(raw: unknown): AskUserPayload | null {
         prompt,
         header:
           typeof q.header === "string" && q.header.trim()
-            ? q.header.trim()
+            ? displayText(q.header.trim())
             : null,
         multi_select: Boolean(q.multi_select ?? q.multiSelect),
         options: optionsRaw
@@ -422,7 +432,7 @@ function normaliseAskUserPayload(raw: unknown): AskUserPayload | null {
         allow_free_text: q.allow_free_text === false ? false : true,
         placeholder:
           typeof q.placeholder === "string" && q.placeholder.trim()
-            ? (q.placeholder as string).trim()
+            ? displayText((q.placeholder as string).trim())
             : null,
       });
     }
@@ -430,14 +440,14 @@ function normaliseAskUserPayload(raw: unknown): AskUserPayload | null {
     return {
       intro:
         typeof obj.intro === "string" && obj.intro.trim()
-          ? (obj.intro as string).trim()
+          ? displayText((obj.intro as string).trim())
           : null,
       questions,
     };
   }
 
   // Legacy single-question shape from before the multi-question refactor.
-  const prompt = String(obj.question ?? "").trim();
+  const prompt = displayText(String(obj.question ?? "").trim());
   if (!prompt) return null;
   const optionsRaw = Array.isArray(obj.options) ? obj.options : [];
   return {

--- a/web/lib/markdown-display.ts
+++ b/web/lib/markdown-display.ts
@@ -654,6 +654,18 @@ function decodeEscapedUnicodeRuns(content: string): string {
   return fenced.restore(math.restore(inline.restore(decoded)));
 }
 
+/**
+ * Decode dense ``\\uXXXX`` runs that represent non-ASCII text.
+ *
+ * Shared by Markdown rendering and plain-text surfaces (``ask_user`` card
+ * prompts) so escaped Chinese that leaked through a JSON round-trip is
+ * repaired before it reaches the learner (#973).
+ */
+export function decodeEscapedUnicodeForDisplay(content: string): string {
+  if (!content) return "";
+  return decodeEscapedUnicodeRuns(String(content));
+}
+
 function decodeEscapedUnicodeRun(escaped: string): string {
   try {
     const value = JSON.parse(`"${escaped}"`) as string;

--- a/web/tests/ask-user-segments.test.ts
+++ b/web/tests/ask-user-segments.test.ts
@@ -1,10 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  extractAskUserPayload,
   extractMessageSegments,
   leadingTraceEvents,
 } from "../components/chat/home/AskUserOptions";
 import type { StreamEvent } from "../lib/unified-ws";
+import { decodeEscapedUnicodeForDisplay } from "../lib/markdown-display";
 
 function event(
   type: StreamEvent["type"],
@@ -128,5 +130,47 @@ test("each card gets the rounds that followed it", () => {
   assert.deepEqual(
     segments.map((segment) => segment.kind),
     ["ask_user", "trace", "ask_user", "trace"],
+  );
+});
+
+test("ask_user card prompts decode dense non-ASCII unicode escapes (#973)", () => {
+  const escaped =
+    "\\u300c\\u6570\\u5236\\u8f6c\\u6362\\u300d\\u8fd8\\u6ca1\\u8fc7\\u5173";
+  assert.equal(
+    decodeEscapedUnicodeForDisplay(escaped),
+    "「数制转换」还没过关",
+  );
+
+  const card = extractAskUserPayload([
+    event("tool_result", {
+      tool_call_id: "call-1",
+      tool_metadata: {
+        ask_user: {
+          intro: escaped,
+          questions: [
+            {
+              id: "q1",
+              prompt: escaped,
+              header: "\\u6570\\u5236\\u8f6c\\u6362",
+              options: [
+                {
+                  label: "A",
+                  description: "\\u7ee7\\u7eed\\u7b54\\u9898",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    }),
+  ]);
+
+  assert.ok(card);
+  assert.equal(card.payload.intro, "「数制转换」还没过关");
+  assert.equal(card.payload.questions[0].prompt, "「数制转换」还没过关");
+  assert.equal(card.payload.questions[0].header, "数制转换");
+  assert.equal(
+    card.payload.questions[0].options[0].description,
+    "继续答题",
   );
 });

--- a/web/tests/markdown-display.test.ts
+++ b/web/tests/markdown-display.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  decodeEscapedUnicodeForDisplay,
   escapeUnknownHtmlTagsForDisplay,
   hasVisibleMarkdownContent,
   markdownUrlTransform,
@@ -88,6 +89,7 @@ test("normalizeMarkdownForDisplay removes empty details blocks", () => {
 test("normalizeMarkdownForDisplay decodes dense non-ASCII JSON escapes", () => {
   const input = "\\u300c\\u6570\\u5236\\u8f6c\\u6362\\u300d";
   assert.equal(normalizeMarkdownForDisplay(input), "「数制转换」");
+  assert.equal(decodeEscapedUnicodeForDisplay(input), "「数制转换」");
 });
 
 test("decoded unicode cannot reintroduce invisible or bidi controls", () => {


### PR DESCRIPTION
﻿## Summary
- Export the dense non-ASCII `\\uXXXX` decoder so plain-text surfaces can reuse the Markdown fix from #975
- Decode ask_user card intro / prompt / header / option copy during payload normalisation so mastery stems no longer render escaped Chinese
- Add a regression covering the exact `#973` escape run through `extractAskUserPayload`

## Test plan
- [x] `npm run test:node` (652 pass, including `ask_user card prompts decode dense non-ASCII unicode escapes (#973)`)
