### PR TITLE
feat(settings): expose custom reasoning effort (#1010)

### DIFF
--- a/web/lib/reasoning-effort.ts
+++ b/web/lib/reasoning-effort.ts
@@ -129,7 +129,14 @@ export function reasoningEffortOptions(
       : options([], current);
   }
 
-  if (BINARY_THINKING_PROVIDERS.has(provider) || provider === "custom") {
+  if (provider === "custom") {
+    // A user-supplied OpenAI-compatible endpoint may route to any upstream
+    // model, so expose the common cross-gateway levels and let Auto handle
+    // providers without an explicit control.
+    return options(["none", "low", "medium", "high"], current);
+  }
+
+  if (BINARY_THINKING_PROVIDERS.has(provider)) {
     const supported =
       provider === "minimax" ||
       includesAny(modelName, [
@@ -152,7 +159,7 @@ export function reasoningEffortOptions(
     }
   }
 
-  if (OPENAI_PROVIDERS.has(provider) || provider === "custom") {
+  if (OPENAI_PROVIDERS.has(provider)) {
     const isGpt5OrCodex = includesAny(modelName, ["gpt-5", "codex"]);
     if (isGpt5OrCodex) {
       return options(["minimal", "low", "medium", "high", "xhigh"], current);

--- a/web/tests/reasoning-effort.test.ts
+++ b/web/tests/reasoning-effort.test.ts
@@ -92,11 +92,42 @@ test("known reasoning families get conservative provider-specific choices", () =
     "high",
   ]);
   assert.deepEqual(values("dashscope", "qwen3-max"), ["", "minimal", "high"]);
-  assert.deepEqual(values("custom", "deepseek-reasoner"), [
+});
+
+test("OpenAI-compatible gateways expose explicit effort levels", () => {
+  assert.deepEqual(values("custom", "idrouter/qd/lite"), [
     "",
-    "minimal",
+    "none",
+    "low",
+    "medium",
     "high",
   ]);
+  assert.deepEqual(values("openai-compatible", "gateway/model"), [
+    "",
+    "none",
+    "low",
+    "medium",
+    "high",
+  ]);
+  assert.deepEqual(values("custom", "gateway/model", "vendor-level"), [
+    "",
+    "none",
+    "low",
+    "medium",
+    "high",
+    "vendor-level",
+  ]);
+});
+
+test("Anthropic-compatible aliases follow the Anthropic model rules", () => {
+  assert.deepEqual(
+    values("anthropic-compatible", "claude-sonnet-4-5"),
+    ["", "none", "low", "medium", "high"],
+  );
+  assert.deepEqual(
+    values("anthropic_compatible", "claude-opus-4-6").includes("adaptive"),
+    false,
+  );
 });
 
 test("unknown models stay hidden unless they already carry an override", () => {


### PR DESCRIPTION
## Summary
- Show `none`, `low`, `medium`, and `high` reasoning-effort choices for canonical `custom` and `openai-compatible` gateway profiles.
- Preserve a catalog value outside those choices so existing hand-edited settings remain visible and can be reset from the UI.
- Keep Anthropic-compatible profiles on the existing Anthropic model rules.

Fixes #1010

## Testing
- [x] `npm run test:node -- reasoning-effort` — 653 passed
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/eslint lib/reasoning-effort.ts tests/reasoning-effort.test.ts`
- [x] `git diff --check`