### PR TITLE
fix(partners): coalesce streaming draft updates (#788)

### DIFF
--- a/web/components/partners/PartnerChat.tsx
+++ b/web/components/partners/PartnerChat.tsx
@@ -25,6 +25,7 @@ import {
   resumePartnerSession,
 } from "@/lib/partners-api";
 import { freshPartnerSessionKey } from "@/lib/partner-session";
+import { createPartnerDraftPublisher } from "@/lib/partner-chat-draft";
 import { ReconnectingWebSocket } from "@/lib/reconnecting-websocket";
 import type { ExportableMessage } from "@/lib/chat-export";
 import type { StreamEvent } from "@/lib/unified-ws";
@@ -328,11 +329,10 @@ export default function PartnerChat({
     // Authoritative live-turn accumulator. Lives in the effect scope so
     // connection handlers can mutate it cheaply; renders see snapshots only.
     let live: { events: StreamEvent[]; content: string } | null = null;
-    const publish = () => {
-      setDraft(
-        live ? { events: [...live.events], content: live.content } : null,
-      );
-    };
+    // Local providers can emit many tokens between animation frames. Publish
+    // one immutable snapshot per frame so React never enters an update storm.
+    const { publish, publishNow, cancel: cancelPendingPublish } =
+      createPartnerDraftPublisher(() => live, setDraft);
 
     const handleMessage = (message: MessageEvent) => {
       let data: {
@@ -389,11 +389,11 @@ export default function PartnerChat({
             events: finished?.events.length ? finished.events : undefined,
           },
         ]);
-        publish();
+        publishNow();
       } else if (data.type === "done") {
         setStreaming(false);
         live = null;
-        publish();
+        publishNow();
       } else if (data.type === "stopped") {
         // Server cancelled the turn (/stop or the stop button). Keep any
         // partial answer the user already saw; drop the live draft.
@@ -410,7 +410,7 @@ export default function PartnerChat({
           ]);
         }
         setStreaming(false);
-        publish();
+        publishNow();
       } else if (data.type === "proactive") {
         setMessages((msgs) => [
           ...msgs,
@@ -422,7 +422,7 @@ export default function PartnerChat({
           { role: "assistant", content: data.content ?? "Error", error: true },
         ]);
         live = null;
-        publish();
+        publishNow();
         setStreaming(false);
       }
     };
@@ -464,6 +464,7 @@ export default function PartnerChat({
     connection.start();
 
     return () => {
+      cancelPendingPublish();
       window.removeEventListener("focus", wakeWhenActive);
       window.removeEventListener("online", wakeWhenActive);
       document.removeEventListener("visibilitychange", wakeWhenActive);

--- a/web/lib/partner-chat-draft.ts
+++ b/web/lib/partner-chat-draft.ts
@@ -1,0 +1,54 @@
+import type { StreamEvent } from "@/lib/unified-ws";
+
+export interface PartnerDraftSnapshot {
+  events: StreamEvent[];
+  content: string;
+}
+
+interface FrameScheduler {
+  schedule: (callback: () => void) => number;
+  cancel: (handle: number) => void;
+}
+
+const browserScheduler: FrameScheduler = {
+  schedule: (callback) => requestAnimationFrame(callback),
+  cancel: (handle) => cancelAnimationFrame(handle),
+};
+
+export function createPartnerDraftPublisher(
+  getDraft: () => PartnerDraftSnapshot | null,
+  setDraft: (draft: PartnerDraftSnapshot | null) => void,
+  scheduler: FrameScheduler = browserScheduler,
+) {
+  let frame = 0;
+  let scheduled = false;
+  const emit = () => {
+    const draft = getDraft();
+    setDraft(
+      draft ? { events: [...draft.events], content: draft.content } : null,
+    );
+  };
+  const cancelFrame = () => {
+    if (!scheduled) return;
+    scheduler.cancel(frame);
+    frame = 0;
+    scheduled = false;
+  };
+
+  return {
+    publish() {
+      if (scheduled) return;
+      frame = scheduler.schedule(() => {
+        scheduled = false;
+        frame = 0;
+        emit();
+      });
+      scheduled = true;
+    },
+    publishNow() {
+      cancelFrame();
+      emit();
+    },
+    cancel: cancelFrame,
+  };
+}

--- a/web/tests/partner-chat-draft.test.ts
+++ b/web/tests/partner-chat-draft.test.ts
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { StreamEvent } from "../lib/unified-ws";
+import { createPartnerDraftPublisher } from "../lib/partner-chat-draft";
+
+function createFrameQueue() {
+  const frames: Array<{ callback: () => void; cancelled: boolean }> = [];
+  return {
+    frames,
+    scheduler: {
+      schedule: (callback: () => void) => {
+        const frame = { callback, cancelled: false };
+        frames.push(frame);
+        return frames.length - 1;
+      },
+      cancel: (handle: number) => {
+        frames[handle].cancelled = true;
+      },
+    },
+    flush(index = 0) {
+      const frame = frames[index];
+      assert.ok(frame);
+      assert.equal(frame.cancelled, false);
+      frame.callback();
+    },
+  };
+}
+
+test("partner draft snapshots coalesce bursts into one frame update", () => {
+  const queue = createFrameQueue();
+  const published: Array<{ events: StreamEvent[]; content: string } | null> =
+    [];
+  let live: { events: StreamEvent[]; content: string } | null = {
+    events: [],
+    content: "",
+  };
+  const publisher = createPartnerDraftPublisher(
+    () => live,
+    (draft) => published.push(draft),
+    queue.scheduler,
+  );
+
+  for (const token of ["a", "b", "c"]) {
+    live.events.push({ type: "content", content: token } as StreamEvent);
+    live.content += token;
+    publisher.publish();
+  }
+
+  assert.equal(queue.frames.length, 1);
+  assert.equal(published.length, 0);
+  queue.flush();
+  assert.equal(published.length, 1);
+  assert.equal(published[0]?.content, "abc");
+  assert.equal(published[0]?.events.length, 3);
+});
+
+test("canceling a partner draft frame prevents a stale publish", () => {
+  const queue = createFrameQueue();
+  const published: unknown[] = [];
+  let live: { events: StreamEvent[]; content: string } | null = {
+    events: [],
+    content: "partial",
+  };
+  const publisher = createPartnerDraftPublisher(
+    () => live,
+    (draft) => published.push(draft),
+    queue.scheduler,
+  );
+
+  publisher.publish();
+  publisher.cancel();
+  live = null;
+
+  assert.equal(queue.frames[0].cancelled, true);
+  assert.equal(published.length, 0);
+});
+
+test("terminal partner updates replace a scheduled frame immediately", () => {
+  const queue = createFrameQueue();
+  const published: Array<{ events: StreamEvent[]; content: string } | null> =
+    [];
+  let live: { events: StreamEvent[]; content: string } | null = {
+    events: [],
+    content: "partial",
+  };
+  const publisher = createPartnerDraftPublisher(
+    () => live,
+    (draft) => published.push(draft),
+    queue.scheduler,
+  );
+
+  publisher.publish();
+  live = null;
+  publisher.publishNow();
+
+  assert.equal(queue.frames[0].cancelled, true);
+  assert.deepEqual(published, [null]);
+});


### PR DESCRIPTION
## Summary
- Coalesce high-frequency PartnerChat streaming token updates into one immutable React state snapshot per animation frame
- Publish terminal done, stopped, and error states immediately
- Cancel pending frame publication during effect cleanup to prevent stale updates

Fixes #788

## Testing
- PASS: npm run test:node (655 tests)
- PASS: ./node_modules/.bin/tsc --noEmit
- PASS: npm run lint (0 errors; 56 pre-existing warnings)
- PASS: npm run build
- PASS: git diff --check