### PR TITLE
fix(web): resolve optimistic ids before deleteTurn

### DIFF
--- a/web/context/UnifiedChatContext.tsx
+++ b/web/context/UnifiedChatContext.tsx
@@ -1999,20 +1999,25 @@ export function UnifiedChatProvider({
       const session = currentState.sessions[key];
       if (!session || !session.sessionId) return;
       if (session.isStreaming) return;
-      let effectiveId = messageId;
-      if (messageId < 0) {
-        const origIdx = session.messages.findIndex((m) => m.id === messageId);
-        if (origIdx === -1) return;
-        try {
-          await loadSession(session.sessionId);
-        } catch {
-          return;
-        }
-        const refreshed = stateRef.current.sessions[key];
-        const realId = refreshed?.messages[origIdx]?.id;
-        if (realId == null || realId < 0) return;
-        effectiveId = realId;
+      // Same optimistic-id race as editMessage (#739): after loadSession
+      // dispatches, stateRef can still hold the negative sentinel until
+      // React commits. Resolve from the returned snapshot instead.
+      let target: MessageItem | undefined;
+      try {
+        target = await resolvePersistedMessage(
+          session.messages,
+          messageId,
+          "user",
+          async () =>
+            session.sessionId
+              ? await loadSession(session.sessionId)
+              : undefined,
+        );
+      } catch {
+        return;
       }
+      if (!target || typeof target.id !== "number" || target.id < 0) return;
+      const effectiveId = target.id;
       try {
         await deleteMessage(session.sessionId, effectiveId);
         dispatch({ type: "DELETE_TURN", key, messageId: effectiveId });

--- a/web/tests/optimistic-id.test.ts
+++ b/web/tests/optimistic-id.test.ts
@@ -42,6 +42,29 @@ test("an optimistic message resolves from the returned refresh snapshot", async 
   assert.equal(optimistic[0].id, -100, "the state ref can still be stale");
 });
 
+// deleteTurn used to re-read stateRef after loadSession (same race as #739's
+// edit path). Both mutations must trust the refresh snapshot's id.
+test("deleteTurn-style resolution keeps working when the state ref is stale", async () => {
+  const staleRef = [
+    { id: -42, role: "user", content: "to delete", parentMessageId: 1 },
+    { id: -43, role: "assistant", content: "reply", parentMessageId: -42 },
+  ];
+  const serverSnapshot = [
+    { id: 201, role: "user", content: "to delete", parentMessageId: 1 },
+    { id: 202, role: "assistant", content: "reply", parentMessageId: 201 },
+  ];
+
+  const target = await resolvePersistedMessage(
+    staleRef,
+    -42,
+    "user",
+    async () => serverSnapshot,
+  );
+
+  assert.equal(target?.id, 201);
+  assert.equal(staleRef[0].id, -42);
+});
+
 // Issue #698: the user row and the assistant placeholder are minted
 // back-to-back (ADD_USER_MSG then STREAM_START). When they shared an id, the
 // remap in reconcileTurnIds collapsed both onto the user's persisted id, so


### PR DESCRIPTION
﻿## Summary
- Route `deleteTurn` through `resolvePersistedMessage`, matching the `editMessage` fix from #753 / #739
- Avoid re-reading `stateRef` immediately after `loadSession`, which can still hold the negative optimistic id until React commits
- Add a regression covering stale-ref resolution for the delete path

Related to #739 (leftover delete-side race after the edit fix landed)

## Test plan
- [x] `npm run test:node -- tests/optimistic-id.test.ts` (652 pass, including `deleteTurn-style resolution keeps working when the state ref is stale`)
- [ ] Send a non-first chat turn, quickly delete it before ids reconcile, confirm the turn is removed on the first attempt
