### PR TITLE
fix(skills): scope ClawHub installs by publisher (#639)

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,7 +829,11 @@ Because DeepTutor speaks the open Agent-Skills format, **[ClawHub](https://clawh
 ```bash
 deeptutor skill search "git release notes" --hub clawhub
 deeptutor skill install clawhub:git-release-notes@1.0.1
+deeptutor skill install clawhub:udiedrichsen/stock-analysis
 ```
+
+When several publishers share the same slug, search shows each publisher and a
+fully scoped install ref (`clawhub:<ownerHandle>/<slug>`).
 
 Add more registries in `settings/skill_hubs.json`: a `type: "clawhub"` entry points at any compatible HTTP API (EduHub and ClawHub both speak it), `type: "command"` wraps whatever fetch CLI a registry ships, and `"default"` chooses the hub used for bare slugs. All of them feed the same import gate.
 

--- a/deeptutor/services/skill/hub.py
+++ b/deeptutor/services/skill/hub.py
@@ -20,6 +20,8 @@ not a format translation:
 
 Providers are addressed as ``<hub>:<slug>[@version]`` (e.g.
 ``eduhub:socratic-tutor@1.2.0``; the hub prefix defaults to ``eduhub``).
+ClawHub skills can also be publisher-scoped as
+``<hub>:<ownerHandle>/<slug>[@version]``.
 Two provider shapes ship in v1:
 
 * :class:`ClawHubProvider` — speaks the ClawHub HTTP API directly (search /
@@ -79,6 +81,7 @@ _BUILTIN_HUBS: dict[str, dict[str, str]] = {
 
 _REF_RE = re.compile(
     r"^(?:(?P<hub>[a-z0-9][a-z0-9-]{0,31}):)?"
+    r"(?:(?P<owner>[A-Za-z0-9][A-Za-z0-9._-]{0,63})/)?"
     r"(?P<slug>[a-z0-9][a-z0-9._-]{0,127})"
     r"(?:@(?P<version>[A-Za-z0-9][A-Za-z0-9._-]{0,63}))?$"
 )
@@ -104,6 +107,7 @@ class HubSkillRef:
 
     hub: str
     slug: str
+    owner_handle: str = ""
     display_name: str = ""
     summary: str = ""
     version: str = ""
@@ -158,15 +162,41 @@ class SkillHubProvider(Protocol):
 
 
 def parse_hub_ref(ref: str) -> tuple[str, str, str | None]:
-    """Split ``<hub>:<slug>[@version]`` into its parts; hub defaults."""
+    """Split ``<hub>:[<owner>/]<slug>[@version]`` into its parts; hub defaults.
+
+    The returned slug remains publisher-scoped when an owner was supplied. Use
+    :func:`split_owner_slug` at an API boundary that needs the two fields.
+    """
     match = _REF_RE.match((ref or "").strip())
     if match is None:
-        raise HubError(f"Invalid skill reference `{ref}`. Expected <hub>:<slug>[@version].")
+        raise HubError(
+            f"Invalid skill reference `{ref}`. Expected <hub>:[<owner>/]<slug>[@version]."
+        )
     return (
         match.group("hub") or default_hub(),
-        match.group("slug"),
+        f"{match.group('owner')}/{match.group('slug')}"
+        if match.group("owner")
+        else match.group("slug"),
         match.group("version"),
     )
+
+
+def split_owner_slug(slug: str) -> tuple[str, str]:
+    """Split a publisher-scoped slug into ``(ownerHandle, slug)``."""
+    owner, separator, skill_slug = (slug or "").strip().partition("/")
+    if not separator:
+        return "", owner
+    return owner, skill_slug
+
+
+def _owner_handle_from_row(row: dict[str, Any]) -> str:
+    """Read ClawHub's publisher handle from its current and nested shapes."""
+    handle = str(row.get("ownerHandle") or "").strip()
+    for key in ("owner", "publisher"):
+        owner = row.get(key)
+        if isinstance(owner, dict):
+            handle = handle or str(owner.get("handle") or "").strip()
+    return handle
 
 
 # ── safe archive extraction (directory-preserving) ──────────────────────
@@ -310,6 +340,7 @@ class ClawHubProvider:
                 HubSkillRef(
                     hub=self.name,
                     slug=slug,
+                    owner_handle=_owner_handle_from_row(row),
                     display_name=str(row.get("displayName") or row.get("name") or slug),
                     summary=str(row.get("summary") or row.get("description") or ""),
                     version=str(row.get("version") or ""),
@@ -318,9 +349,13 @@ class ClawHubProvider:
         return refs
 
     def verify(self, slug: str, *, version: str | None = None) -> HubVerdict:
+        owner_handle, skill_slug = split_owner_slug(slug)
         try:
             response = self._get(
-                f"/skills/{slug}/verify", version=version, tag=None if version else "latest"
+                f"/skills/{skill_slug}/verify",
+                version=version,
+                tag=None if version else "latest",
+                ownerHandle=owner_handle or None,
             )
             payload = response.json()
         except (HubError, ValueError) as exc:
@@ -333,8 +368,13 @@ class ClawHubProvider:
         return HubVerdict(status="suspicious", detail=decision or "hub flagged this package")
 
     def fetch(self, slug: str, *, version: str | None = None) -> FetchedSkill:
+        owner_handle, skill_slug = split_owner_slug(slug)
         response = self._get(
-            "/download", slug=slug, version=version, tag=None if version else "latest"
+            "/download",
+            slug=skill_slug,
+            version=version,
+            tag=None if version else "latest",
+            ownerHandle=owner_handle or None,
         )
         tmp = Path(tempfile.mkdtemp(prefix="deeptutor-skill-"))
         try:
@@ -348,15 +388,21 @@ class ClawHubProvider:
             raise
         resolved_version = version or self._latest_version(slug)
         return FetchedSkill(
-            ref=HubSkillRef(hub=self.name, slug=slug, version=resolved_version),
+            ref=HubSkillRef(
+                hub=self.name,
+                slug=skill_slug,
+                owner_handle=owner_handle,
+                version=resolved_version,
+            ),
             root=root,
             cleanup_dir=tmp,
         )
 
     def _latest_version(self, slug: str) -> str:
         """Resolve the version actually served by an untagged download."""
+        owner_handle, skill_slug = split_owner_slug(slug)
         try:
-            payload = self._get(f"/skills/{slug}").json()
+            payload = self._get(f"/skills/{skill_slug}", ownerHandle=owner_handle or None).json()
         except (HubError, ValueError):
             return ""
         if not isinstance(payload, dict):
@@ -376,8 +422,10 @@ class ClawHubProvider:
             return None
         stats = row.get("stats") if isinstance(row.get("stats"), dict) else {}
         owner = row.get("owner") if isinstance(row.get("owner"), dict) else {}
+        owner_handle = _owner_handle_from_row(row)
         return {
             "slug": slug,
+            "owner_handle": owner_handle,
             "name": str(row.get("displayName") or row.get("name") or slug),
             "summary": str(row.get("summary") or row.get("description") or ""),
             "version": str(row.get("version") or ""),
@@ -424,14 +472,19 @@ class ClawHubProvider:
 
     def detail(self, slug: str) -> dict[str, Any]:
         """Full metadata + SKILL.md body for one hub skill (browser detail view)."""
+        owner_handle, skill_slug = split_owner_slug(slug)
         try:
-            payload = self._get(f"/skills/{slug}").json()
+            payload = self._get(f"/skills/{skill_slug}", ownerHandle=owner_handle or None).json()
         except ValueError as exc:
             raise HubError(f"{self.name}: skill detail returned invalid JSON") from exc
         if not isinstance(payload, dict):
             raise HubError(f"{self.name}: unrecognised skill detail shape")
         skill = payload.get("skill") if isinstance(payload.get("skill"), dict) else payload
-        listing = self._listing_from_row(skill) or {"slug": slug, "name": slug}
+        listing = self._listing_from_row(skill) or {
+            "slug": skill_slug,
+            "name": skill_slug,
+        }
+        listing.setdefault("owner_handle", owner_handle)
         # Owner sometimes lives at the envelope top level, not inside ``skill``.
         if not listing.get("owner") and isinstance(payload.get("owner"), dict):
             owner = payload["owner"]
@@ -687,6 +740,7 @@ def install_from_hub(
     """
     hub, slug, version = parse_hub_ref(ref)
     resolved = provider or get_hub_provider(hub)
+    owner_handle, skill_slug = split_owner_slug(slug)
 
     verdict = resolved.verify(slug, version=version)
     if verdict.status == "suspicious" and not allow_unverified:
@@ -697,6 +751,15 @@ def install_from_hub(
         )
 
     fetched = resolved.fetch(slug, version=version)
+    origin = {
+        "hub": hub,
+        "slug": skill_slug,
+        "version": fetched.ref.version or version or "",
+        "verdict": verdict.status,
+        "installed_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    if owner_handle:
+        origin["owner_handle"] = owner_handle
     try:
         result = service.install_tree(
             fetched.root,
@@ -706,13 +769,7 @@ def install_from_hub(
             # Stamp the source hub as a tag so imported skills are visibly
             # grouped (e.g. an ``eduhub`` tag) in the user's Skills list.
             extra_tags=[hub],
-            origin={
-                "hub": hub,
-                "slug": slug,
-                "version": fetched.ref.version or version or "",
-                "verdict": verdict.status,
-                "installed_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-            },
+            origin=origin,
         )
     finally:
         fetched.cleanup()

--- a/deeptutor_cli/skill.py
+++ b/deeptutor_cli/skill.py
@@ -93,21 +93,37 @@ def register(app: typer.Typer) -> None:
             console.print("[dim]No skills matched.[/]")
             return
         table = Table(title=f"{target}: {query}")
-        table.add_column("Ref", style="bold")
+        table.add_column("Ref", style="bold", overflow="fold")
+        table.add_column("Publisher")
         table.add_column("Version")
         table.add_column("Summary")
         for ref in refs:
+            install_ref = (
+                f"{ref.hub}:{ref.owner_handle}/{ref.slug}"
+                if ref.owner_handle
+                else f"{ref.hub}:{ref.slug}"
+            )
             table.add_row(
-                f"{ref.hub}:{ref.slug}",
+                install_ref,
+                ref.owner_handle or "-",
                 ref.version or "-",
                 ref.summary[:100] or ref.display_name,
             )
         console.print(table)
-        console.print("[dim]Install with: deeptutor skill install <ref>[/]")
+        install_refs = [
+            f"{ref.hub}:{ref.owner_handle}/{ref.slug}"
+            if ref.owner_handle
+            else f"{ref.hub}:{ref.slug}"
+            for ref in refs
+        ]
+        console.print("[dim]Install with:[/] " + ", ".join(install_refs))
 
     @app.command("install")
     def skill_install(
-        ref: str = typer.Argument(..., help="Skill ref: <hub>:<slug>[@version]."),
+        ref: str = typer.Argument(
+            ...,
+            help="Skill ref: <hub>:[<owner>/]<slug>[@version].",
+        ),
         name: str | None = typer.Option(
             None, "--name", help="Install under a different local skill name."
         ),

--- a/tests/cli/test_skill_cli.py
+++ b/tests/cli/test_skill_cli.py
@@ -1,0 +1,49 @@
+"""CLI tests for skill hub commands."""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+from typer.testing import CliRunner
+
+from deeptutor.services.skill.hub import HubSkillRef
+from deeptutor_cli.main import app
+
+runner = CliRunner()
+
+
+class FakeProvider:
+    def search(self, query: str, *, limit: int = 10) -> list[HubSkillRef]:
+        assert query == "stock analysis"
+        return [
+            HubSkillRef(
+                hub="clawhub",
+                slug="stock-analysis",
+                owner_handle="acme",
+                display_name="Stock Analysis",
+                summary="Analyze stock filings",
+                version="1.2.0",
+            )
+        ]
+
+
+def test_skill_search_shows_publisher_scoped_install_refs(monkeypatch) -> None:
+    import deeptutor.services.skill.hub as hub
+    import deeptutor_cli.skill as skill_cli
+
+    output = io.StringIO()
+    monkeypatch.setattr(hub, "get_hub_provider", lambda _hub: FakeProvider())
+    monkeypatch.setattr(
+        skill_cli,
+        "console",
+        Console(file=output, width=120, force_terminal=False),
+    )
+
+    result = runner.invoke(app, ["skill", "search", "stock analysis"])
+
+    assert result.exit_code == 0, result.output
+    rendered = output.getvalue()
+    assert "Publisher" in rendered
+    assert "acme" in rendered
+    assert "clawhub:acme/stock-analysis" in rendered

--- a/tests/services/skill/test_skill_hub.py
+++ b/tests/services/skill/test_skill_hub.py
@@ -23,6 +23,7 @@ from deeptutor.services.skill.hub import (
     get_hub_provider,
     install_from_hub,
     parse_hub_ref,
+    split_owner_slug,
 )
 from deeptutor.services.skill.service import (
     SkillExistsError,
@@ -176,6 +177,13 @@ def test_origin_recorded_and_dropped_on_delete(tmp_path: Path, svc: SkillService
 
 def test_parse_hub_ref_forms() -> None:
     assert parse_hub_ref("clawhub:my-skill") == ("clawhub", "my-skill", None)
+    assert parse_hub_ref("clawhub:acme/my-skill@1.2.0") == (
+        "clawhub",
+        "acme/my-skill",
+        "1.2.0",
+    )
+    assert split_owner_slug("acme/my-skill") == ("acme", "my-skill")
+    assert split_owner_slug("my-skill") == ("", "my-skill")
     # No prefix resolves to the built-in default hub (EduHub).
     assert parse_hub_ref("my-skill") == ("eduhub", "my-skill", None)
     assert parse_hub_ref("eduhub:my-skill") == ("eduhub", "my-skill", None)
@@ -214,9 +222,16 @@ def test_extract_skill_zip_preserves_dirs_and_blocks_traversal(tmp_path: Path) -
 # ── ClawHubProvider over MockTransport ───────────────────────────────────
 
 
-def _clawhub_client(zip_payload: bytes, *, ok: bool = True) -> httpx.Client:
+def _clawhub_client(
+    zip_payload: bytes,
+    *,
+    ok: bool = True,
+    requests: list[tuple[str, dict[str, str]]] | None = None,
+) -> httpx.Client:
     def handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
+        if requests is not None:
+            requests.append((path, dict(request.url.params)))
         if path == "/api/v1/search":
             return httpx.Response(
                 200,
@@ -224,6 +239,7 @@ def _clawhub_client(zip_payload: bytes, *, ok: bool = True) -> httpx.Client:
                     "results": [
                         {
                             "slug": "demo",
+                            "ownerHandle": "acme",
                             "displayName": "Demo",
                             "summary": "demo summary",
                             "version": "1.2.0",
@@ -245,20 +261,31 @@ def _clawhub_client(zip_payload: bytes, *, ok: bool = True) -> httpx.Client:
 
 def test_clawhub_search_verify_fetch(tmp_path: Path) -> None:
     payload = _zip_bytes({"demo/SKILL.md": "---\nname: demo\ndescription: d\n---\n\nbody\n"})
-    provider = ClawHubProvider(client=_clawhub_client(payload))
+    calls: list[tuple[str, dict[str, str]]] = []
+    provider = ClawHubProvider(client=_clawhub_client(payload, requests=calls))
 
     refs = provider.search("demo")
-    assert refs[0].slug == "demo" and refs[0].version == "1.2.0"
+    assert refs[0].slug == "demo"
+    assert refs[0].owner_handle == "acme"
+    assert refs[0].version == "1.2.0"
 
-    assert provider.verify("demo").status == "ok"
+    assert provider.verify("acme/demo").status == "ok"
 
-    fetched = provider.fetch("demo")
+    fetched = provider.fetch("acme/demo")
     try:
         assert (fetched.root / "SKILL.md").is_file()  # wrapper dir unwrapped
         assert fetched.ref.version == "1.2.0"  # resolved from skill detail
+        assert fetched.ref.slug == "demo"
+        assert fetched.ref.owner_handle == "acme"
     finally:
         fetched.cleanup()
     assert not fetched.cleanup_dir.exists()
+    assert ("ownerHandle", "acme") in calls[1][1].items()
+    assert calls[2] == (
+        "/api/v1/download",
+        {"slug": "demo", "tag": "latest", "ownerHandle": "acme"},
+    )
+    assert calls[3] == ("/api/v1/skills/demo", {"ownerHandle": "acme"})
 
 
 def test_clawhub_verify_states() -> None:
@@ -370,20 +397,31 @@ class _FakeProvider:
         self._pkg = pkg
         self._verdict = verdict
         self.last_cleanup: Path | None = None
+        self.last_verify: str | None = None
+        self.last_fetch: str | None = None
 
     def search(self, query: str, *, limit: int = 10) -> list[HubSkillRef]:
         return []
 
     def verify(self, slug: str, *, version: str | None = None) -> HubVerdict:
+        self.last_verify = slug
         return self._verdict
 
     def fetch(self, slug: str, *, version: str | None = None) -> FetchedSkill:
+        self.last_fetch = slug
+        owner_handle, skill_slug = split_owner_slug(slug)
         tmp = Path(tempfile.mkdtemp(prefix="fakehub-"))
         root = tmp / "pkg"
         shutil.copytree(self._pkg, root)
         self.last_cleanup = tmp
         return FetchedSkill(
-            ref=HubSkillRef(hub=self.name, slug=slug, summary="registry summary", version="0.9.0"),
+            ref=HubSkillRef(
+                hub=self.name,
+                slug=skill_slug,
+                owner_handle=owner_handle,
+                summary="registry summary",
+                version="0.9.0",
+            ),
             root=root,
             cleanup_dir=tmp,
         )
@@ -401,8 +439,26 @@ def test_install_from_hub_happy_path(tmp_path: Path, svc: SkillService) -> None:
         "0.9.0",
         "ok",
     )
+    assert origin["slug"] == "demo"
+    assert "owner_handle" not in origin
     assert origin["installed_at"]
     assert provider.last_cleanup is not None and not provider.last_cleanup.exists()
+
+
+def test_install_from_hub_records_publisher_scope(tmp_path: Path, svc: SkillService) -> None:
+    pkg = _make_package(tmp_path / "pkg", frontmatter="name: demo\ndescription: d")
+    provider = _FakeProvider(pkg, HubVerdict(status="ok"))
+
+    outcome = install_from_hub("fakehub:acme/demo", service=svc, provider=provider)
+
+    assert provider.last_verify == "acme/demo"
+    assert provider.last_fetch == "acme/demo"
+    assert outcome.ref.slug == "demo"
+    assert outcome.ref.owner_handle == "acme"
+    origin = svc.hub_origin("demo")
+    assert origin is not None
+    assert origin["slug"] == "demo"
+    assert origin["owner_handle"] == "acme"
 
 
 def test_install_from_hub_blocks_suspicious_unless_overridden(


### PR DESCRIPTION
## Summary
- Add publisher-scoped ClawHub refs: `<hub>:<ownerHandle>/<slug>[@version]`
- Send `ownerHandle` with verify, download, and detail requests while keeping bare slug installs compatible
- Record `owner_handle` separately in install provenance so the original slug remains stable
- Show a Publisher column and copy-ready scoped install refs in CLI search results
- Document the scoped syntax and add provider, install-provenance, and CLI regressions

Fixes #639

## Testing
- PASS: `env PYTHONPATH=. /Users/Shared/DeepTutor/.venv/bin/pytest tests/cli/test_skill_cli.py tests/services/skill/test_skill_hub.py -q` — 24 passed
- PASS: `ruff format --check` on changed Python files
- PASS: `ruff check` on changed Python files
- PASS: `git diff --check HEAD^ HEAD`