### PR TITLE
feat(rag): add optional cross-encoder reranking (#304)

### DIFF
--- a/deeptutor/api/routers/knowledge.py
+++ b/deeptutor/api/routers/knowledge.py
@@ -1297,6 +1297,8 @@ class LlamaIndexConfigUpdate(BaseModel):
     top_k: int | None = None
     vector_top_k_multiplier: int | None = None
     bm25_top_k_multiplier: int | None = None
+    reranker_model: str | None = None
+    rerank_top_k: int | None = None
     chunk_size: int | None = None
     chunk_overlap: int | None = None
     image_description_concurrency: int | None = None

--- a/deeptutor/services/config/runtime_settings.py
+++ b/deeptutor/services/config/runtime_settings.py
@@ -251,6 +251,8 @@ DEFAULT_IMA_SETTINGS: dict[str, Any] = {
 # * ``top_k`` — default number of chunks a query returns.
 # * ``vector_top_k_multiplier`` / ``bm25_top_k_multiplier`` — how many extra
 #   candidates each child retriever fetches before fusion re-ranks to ``top_k``.
+# * ``reranker_model`` / ``rerank_top_k`` — optional cross-encoder refinement.
+#   An empty model keeps the exact existing embedding-only ranking.
 # * ``chunk_size`` / ``chunk_overlap`` — indexing chunk geometry; changes apply
 #   on the next (re-)index, not retroactively.
 # * ``image_description_concurrency`` / ``image_description_timeout_seconds`` —
@@ -269,6 +271,8 @@ DEFAULT_LLAMAINDEX_SETTINGS: dict[str, Any] = {
     "top_k": 5,
     "vector_top_k_multiplier": 2,
     "bm25_top_k_multiplier": 2,
+    "reranker_model": "",
+    "rerank_top_k": 50,
     "chunk_size": 512,
     "chunk_overlap": 50,
     "image_description_concurrency": 4,
@@ -829,6 +833,8 @@ class RuntimeSettingsService:
             "bm25_top_k_multiplier": _coerce_clamped_int(
                 settings.get("bm25_top_k_multiplier"), 2, 1, 10
             ),
+            "reranker_model": _string(settings.get("reranker_model"))[:200],
+            "rerank_top_k": _coerce_clamped_int(settings.get("rerank_top_k"), 50, 1, 100),
             "chunk_size": chunk_size,
             "chunk_overlap": chunk_overlap,
             "image_description_concurrency": _coerce_clamped_int(

--- a/deeptutor/services/rag/pipelines/llamaindex/config.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/config.py
@@ -32,11 +32,20 @@ class RetrievalConfig:
     vector_top_k_multiplier: int = 2
     bm25_top_k_multiplier: int = 2
     fusion_num_queries: int = 1
+    reranker_model: str = ""
+    rerank_top_k: int = 50
 
     def candidate_top_k(self, top_k: int, multiplier: int) -> int:
         """Return the number of candidates to ask a child retriever for."""
         requested = max(1, int(top_k))
         return max(requested, requested * max(1, int(multiplier)))
+
+    def rerank_candidate_top_k(self, top_k: int) -> int:
+        """Return the first-stage candidate count before optional reranking."""
+        requested = max(1, int(top_k))
+        if not self.reranker_model:
+            return requested
+        return max(requested, min(100, max(1, int(self.rerank_top_k))))
 
 
 def normalize_retrieval_profile(value: str | None) -> str:
@@ -45,6 +54,11 @@ def normalize_retrieval_profile(value: str | None) -> str:
     if profile in SUPPORTED_RETRIEVAL_PROFILES:
         return profile
     return HYBRID_PROFILE
+
+
+def normalize_reranker_model(value: str | None) -> str:
+    """Return a bounded Hugging Face model identifier (empty disables rerank)."""
+    return (value or "").strip()[:200]
 
 
 def retrieval_config_from_env() -> RetrievalConfig:
@@ -85,6 +99,8 @@ def retrieval_config_from_settings() -> RetrievalConfig:
         profile=normalize_retrieval_profile(settings.get("retrieval_profile")),
         vector_top_k_multiplier=int(settings.get("vector_top_k_multiplier", 2) or 2),
         bm25_top_k_multiplier=int(settings.get("bm25_top_k_multiplier", 2) or 2),
+        reranker_model=normalize_reranker_model(settings.get("reranker_model")),
+        rerank_top_k=int(settings.get("rerank_top_k", 50) or 50),
     )
 
 
@@ -129,6 +145,7 @@ __all__ = [
     "default_top_k",
     "image_description_limits",
     "normalize_retrieval_profile",
+    "normalize_reranker_model",
     "retrieval_config_from_env",
     "retrieval_config_from_settings",
 ]

--- a/deeptutor/services/rag/pipelines/llamaindex/rerank.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/rerank.py
@@ -1,0 +1,130 @@
+"""Optional cross-encoder reranking for the LlamaIndex pipeline."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+import logging
+import math
+from threading import Lock
+from typing import Any, Callable
+
+from llama_index.core.schema import MetadataMode, NodeWithScore
+
+logger = logging.getLogger(__name__)
+
+_RERANKER_CACHE: "OrderedDict[str, Any]" = OrderedDict()
+_RERANKER_CACHE_LOCK = Lock()
+_RERANKER_CACHE_MAXSIZE = 2
+
+
+def clear_reranker_cache() -> None:
+    """Drop cached reranker models (used by tests and settings changes)."""
+    with _RERANKER_CACHE_LOCK:
+        _RERANKER_CACHE.clear()
+
+
+def _load_cross_encoder(model_name: str) -> Any:
+    """Load a SentenceTransformers cross-encoder lazily."""
+    from sentence_transformers import CrossEncoder
+
+    return CrossEncoder(model_name)
+
+
+def _cross_encoder(
+    model_name: str,
+    loader: Callable[[str], Any] | None = None,
+) -> Any | None:
+    with _RERANKER_CACHE_LOCK:
+        cached = _RERANKER_CACHE.get(model_name)
+        if cached is not None:
+            _RERANKER_CACHE.move_to_end(model_name)
+            return cached
+
+    try:
+        model = (loader or _load_cross_encoder)(model_name)
+    except ImportError:
+        logger.warning(
+            "Reranker model %r is configured, but sentence-transformers is not installed; "
+            "using embedding retrieval unchanged.",
+            model_name,
+        )
+        return None
+    except Exception as exc:
+        logger.warning(
+            "Failed to load reranker model %r; using embedding retrieval unchanged: %s",
+            model_name,
+            exc,
+        )
+        return None
+
+    with _RERANKER_CACHE_LOCK:
+        _RERANKER_CACHE[model_name] = model
+        _RERANKER_CACHE.move_to_end(model_name)
+        while len(_RERANKER_CACHE) > _RERANKER_CACHE_MAXSIZE:
+            _RERANKER_CACHE.popitem(last=False)
+    return model
+
+
+def _sigmoid(value: float) -> float:
+    """Convert cross-encoder logits to a stable 0..1 source score."""
+    try:
+        if value >= 0:
+            return 1.0 / (1.0 + math.exp(-value))
+        exp_value = math.exp(value)
+        return exp_value / (1.0 + exp_value)
+    except (OverflowError, ValueError):
+        return 1.0 if value > 0 else 0.0
+
+
+def _identity_logits(scores: Any) -> Any:
+    """Request raw cross-encoder logits from SentenceTransformers."""
+    return scores
+
+
+def rerank_nodes(
+    query: str,
+    nodes: list[Any],
+    *,
+    top_k: int,
+    model_name: str,
+    loader: Callable[[str], Any] | None = None,
+) -> list[Any]:
+    """Rerank LlamaIndex results and return at most ``top_k`` nodes.
+
+    Missing optional dependencies and model-load failures are non-fatal: the
+    first-stage ordering is returned so saved knowledge remains searchable.
+    """
+    requested = max(1, int(top_k))
+    if not query or not nodes or not model_name:
+        return nodes[:requested]
+
+    model = _cross_encoder(model_name, loader)
+    if model is None:
+        return nodes[:requested]
+
+    pairs = [(query, result.node.get_content(metadata_mode=MetadataMode.LLM)) for result in nodes]
+    try:
+        raw_scores = model.predict(pairs, activation_fct=_identity_logits)
+        ranked = sorted(
+            (
+                (index, float(score))
+                for index, score in enumerate(raw_scores)
+                if math.isfinite(float(score))
+            ),
+            key=lambda item: item[1],
+            reverse=True,
+        )[:requested]
+    except Exception as exc:
+        logger.warning(
+            "Reranker model %r failed while scoring %d candidates; "
+            "using embedding retrieval unchanged: %s",
+            model_name,
+            len(nodes),
+            exc,
+        )
+        return nodes[:requested]
+
+    return [NodeWithScore(node=nodes[index].node, score=_sigmoid(score)) for index, score in ranked]
+
+
+__all__ = ["clear_reranker_cache", "rerank_nodes"]

--- a/deeptutor/services/rag/pipelines/llamaindex/retrievers.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/retrievers.py
@@ -17,6 +17,7 @@ from .config import (
     RetrievalConfig,
     retrieval_config_from_settings,
 )
+from .rerank import rerank_nodes
 
 logger = logging.getLogger(__name__)
 
@@ -151,9 +152,38 @@ def build_retriever(
     return index.as_retriever(similarity_top_k=top_k)
 
 
+def retrieve_nodes(
+    index: Any,
+    storage_dir: Path,
+    query: str,
+    *,
+    top_k: int = 5,
+) -> list[Any]:
+    """Run first-stage retrieval and the optional cross-encoder reranker."""
+    config = retrieval_config_from_settings()
+    candidate_top_k = config.rerank_candidate_top_k(top_k)
+    retriever = build_retriever(
+        index,
+        storage_dir,
+        top_k=candidate_top_k,
+        config=config,
+    )
+    candidates = retriever.retrieve(query)
+    if not config.reranker_model:
+        return candidates[: max(1, int(top_k))]
+
+    return rerank_nodes(
+        query,
+        candidates,
+        top_k=top_k,
+        model_name=config.reranker_model,
+    )
+
+
 __all__ = [
     "BM25_PERSIST_DIRNAME",
     "build_bm25_retriever",
     "build_retriever",
     "persist_bm25_retriever",
+    "retrieve_nodes",
 ]

--- a/deeptutor/services/rag/pipelines/llamaindex/storage.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/storage.py
@@ -283,8 +283,7 @@ def prune_index_cache() -> int:
 
 def retrieve_nodes(storage_dir: Path, query: str, *, top_k: int = 5) -> list[Any]:
     index = _cached_index(Path(storage_dir))
-    retriever = retrievers.build_retriever(index, Path(storage_dir), top_k=top_k)
-    return retriever.retrieve(query)
+    return retrievers.retrieve_nodes(index, Path(storage_dir), query, top_k=top_k)
 
 
 def delete_kb_dir(kb_dir: Path) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,6 +242,12 @@ graphrag = ["graphrag>=3.0.1,<4.0.0; python_version < '3.14'"]
 # should get the capable one.
 rag-lightrag = ["raganything>=1.2.5,<2.0.0; python_version < '3.14'"]
 
+# Optional cross-encoder reranker for the default LlamaIndex engine. The
+# sentence-transformers/torch stack is heavy and model-dependent, so it stays
+# out of `all`; retrieval lazily falls back to embedding-only ranking when the
+# package or configured model is unavailable.
+rag-rerank = ["sentence-transformers>=3.0.0,<6.0.0; python_version < '3.14'"]
+
 # Dev/test tooling. Mirrors requirements/dev.txt.
 dev = [
     "deeptutor[server]",

--- a/requirements/rag-rerank.txt
+++ b/requirements/rag-rerank.txt
@@ -1,0 +1,3 @@
+# Mirrors pyproject.toml `[project.optional-dependencies].rag-rerank`.
+# Install deliberately: this pulls the sentence-transformers/torch stack.
+sentence-transformers>=3.0.0,<6.0.0; python_version < "3.14"

--- a/tests/api/test_knowledge_router.py
+++ b/tests/api/test_knowledge_router.py
@@ -1927,3 +1927,35 @@ def test_lightrag_config_endpoint_round_trips_the_indexing_knobs(
     assert again["max_concurrent_files"] == 4
     assert again["entity_extract_max_gleaning"] == 2
     assert again["top_k"] == 42
+
+
+def test_llamaindex_config_endpoint_round_trips_reranker_knobs(monkeypatch, tmp_path: Path) -> None:
+    """The reranker form depends on both fields surviving save/reload."""
+    from deeptutor.services.config.runtime_settings import RuntimeSettingsService
+
+    service = RuntimeSettingsService(tmp_path, process_env={})
+    monkeypatch.setattr(
+        "deeptutor.services.config.get_runtime_settings_service",
+        lambda: service,
+    )
+
+    client = TestClient(_build_app())
+    initial = client.get("/api/v1/knowledge/rag-pipelines/llamaindex/config")
+    assert initial.status_code == 200
+    assert initial.json()["reranker_model"] == ""
+    assert initial.json()["rerank_top_k"] == 50
+
+    saved = client.put(
+        "/api/v1/knowledge/rag-pipelines/llamaindex/config",
+        json={
+            "reranker_model": " BAAI/bge-reranker-base ",
+            "rerank_top_k": 25,
+        },
+    )
+    assert saved.status_code == 200
+    assert saved.json()["reranker_model"] == "BAAI/bge-reranker-base"
+    assert saved.json()["rerank_top_k"] == 25
+
+    again = client.get("/api/v1/knowledge/rag-pipelines/llamaindex/config").json()
+    assert again["reranker_model"] == "BAAI/bge-reranker-base"
+    assert again["rerank_top_k"] == 25

--- a/tests/services/config/test_llamaindex_settings.py
+++ b/tests/services/config/test_llamaindex_settings.py
@@ -14,6 +14,8 @@ def test_llamaindex_defaults_when_absent(tmp_path: Path) -> None:
     assert loaded["top_k"] == 5
     assert loaded["vector_top_k_multiplier"] == 2
     assert loaded["bm25_top_k_multiplier"] == 2
+    assert loaded["reranker_model"] == ""
+    assert loaded["rerank_top_k"] == 50
     assert loaded["chunk_size"] == 512
     assert loaded["chunk_overlap"] == 50
     assert loaded["image_description_concurrency"] == 4
@@ -26,6 +28,8 @@ def test_llamaindex_roundtrip(tmp_path: Path) -> None:
         {
             "retrieval_profile": "vector",
             "top_k": 8,
+            "reranker_model": "  BAAI/bge-reranker-base  ",
+            "rerank_top_k": 25,
             "chunk_size": 1024,
             "chunk_overlap": 0,
             "image_description_concurrency": 8,
@@ -36,6 +40,8 @@ def test_llamaindex_roundtrip(tmp_path: Path) -> None:
     loaded = svc.load_llamaindex(include_process_overrides=False)
     assert loaded["retrieval_profile"] == "vector"
     assert loaded["top_k"] == 8
+    assert loaded["reranker_model"] == "BAAI/bge-reranker-base"
+    assert loaded["rerank_top_k"] == 25
     assert loaded["chunk_size"] == 1024
     assert loaded["chunk_overlap"] == 0
     assert loaded["image_description_concurrency"] == 8
@@ -51,6 +57,8 @@ def test_llamaindex_clamps_out_of_range(tmp_path: Path) -> None:
             "retrieval_profile": "nonsense",
             "top_k": 999,
             "bm25_top_k_multiplier": 0,
+            "reranker_model": "x" * 250,
+            "rerank_top_k": 999,
             "chunk_size": 8,
             "chunk_overlap": 99999,
             "image_description_concurrency": 999,
@@ -62,6 +70,8 @@ def test_llamaindex_clamps_out_of_range(tmp_path: Path) -> None:
     assert loaded["retrieval_profile"] == "hybrid"
     assert loaded["top_k"] == 50
     assert loaded["bm25_top_k_multiplier"] == 1
+    assert len(loaded["reranker_model"]) == 200
+    assert loaded["rerank_top_k"] == 100
     assert loaded["chunk_size"] == 64
     # Overlap is clamped below the chunk size so chunking never degenerates.
     assert loaded["chunk_overlap"] == 63
@@ -103,3 +113,22 @@ def test_image_description_limits_use_runtime_settings(monkeypatch) -> None:
     )
 
     assert config.image_description_limits() == (7, 90.0)
+
+
+def test_retrieval_config_uses_reranker_settings(monkeypatch) -> None:
+    from deeptutor.services.rag.pipelines.llamaindex import config
+
+    monkeypatch.setattr(
+        config,
+        "_load_runtime_settings",
+        lambda: {
+            "reranker_model": " BAAI/bge-reranker-base ",
+            "rerank_top_k": 25,
+        },
+    )
+
+    selected = config.retrieval_config_from_settings()
+
+    assert selected.reranker_model == "BAAI/bge-reranker-base"
+    assert selected.rerank_candidate_top_k(5) == 25
+    assert selected.rerank_candidate_top_k(40) == 40

--- a/tests/services/rag/test_llamaindex_rerank.py
+++ b/tests/services/rag/test_llamaindex_rerank.py
@@ -1,0 +1,167 @@
+"""Optional cross-encoder reranking for LlamaIndex retrieval."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from llama_index.core.schema import NodeWithScore, TextNode
+import pytest
+
+from deeptutor.services.rag.pipelines.llamaindex import rerank as rerank_module
+from deeptutor.services.rag.pipelines.llamaindex import retrievers as retriever_module
+from deeptutor.services.rag.pipelines.llamaindex.config import RetrievalConfig
+
+
+@pytest.fixture(autouse=True)
+def _clear_reranker_cache():
+    rerank_module.clear_reranker_cache()
+    yield
+    rerank_module.clear_reranker_cache()
+
+
+def _result(node_id: str, text: str, score: float = 0.5) -> NodeWithScore:
+    return NodeWithScore(node=TextNode(text=text, id_=node_id), score=score)
+
+
+def test_cross_encoder_reranks_candidates_and_normalizes_scores() -> None:
+    class _FakeModel:
+        def predict(
+            self,
+            pairs: list[tuple[str, str]],
+            *,
+            activation_fct: object,
+        ) -> list[float]:
+            assert all(query == "probe" for query, _ in pairs)
+            assert callable(activation_fct)
+            return [-8.0, 8.0]
+
+    candidates = [_result("weak", "weak candidate"), _result("strong", "strong candidate")]
+
+    ranked = rerank_module.rerank_nodes(
+        "probe",
+        candidates,
+        top_k=2,
+        model_name="fake-reranker",
+        loader=lambda _model: _FakeModel(),
+    )
+
+    assert [result.node_id for result in ranked] == ["strong", "weak"]
+    assert ranked[0].score is not None and ranked[0].score > 0.99
+    assert ranked[1].score is not None and ranked[1].score < 0.01
+
+
+def test_reranker_load_failure_returns_first_stage_candidates(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    candidates = [_result("first", "first"), _result("second", "second")]
+
+    def _missing_dependency(_model: str):
+        raise ImportError("sentence-transformers is not installed")
+
+    with caplog.at_level("WARNING"):
+        ranked = rerank_module.rerank_nodes(
+            "probe",
+            candidates,
+            top_k=1,
+            model_name="fake-reranker",
+            loader=_missing_dependency,
+        )
+
+    assert [result.node_id for result in ranked] == ["first"]
+    assert "sentence-transformers is not installed" in caplog.text
+
+
+def test_reranker_scoring_failure_returns_first_stage_candidates(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class _FailingModel:
+        def predict(
+            self,
+            pairs: list[tuple[str, str]],
+            *,
+            activation_fct: object,
+        ) -> list[float]:
+            raise RuntimeError("scoring failed")
+
+    candidates = [_result("first", "first"), _result("second", "second")]
+
+    with caplog.at_level("WARNING"):
+        ranked = rerank_module.rerank_nodes(
+            "probe",
+            candidates,
+            top_k=1,
+            model_name="fake-reranker",
+            loader=lambda _model: _FailingModel(),
+        )
+
+    assert [result.node_id for result in ranked] == ["first"]
+    assert "failed while scoring 2 candidates" in caplog.text
+
+
+def test_retrieve_nodes_expands_candidates_only_when_reranker_is_configured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeRetriever:
+        def retrieve(self, query: str) -> list[NodeWithScore]:
+            captured["query"] = query
+            return [
+                _result("first", "first"),
+                _result("second", "second"),
+                _result("third", "third"),
+            ]
+
+    def _fake_build(_index, _storage_dir, *, top_k: int, config: RetrievalConfig):
+        captured["candidate_top_k"] = top_k
+        captured["config"] = config
+        return _FakeRetriever()
+
+    def _fail_if_called(*args: object, **kwargs: object):
+        raise AssertionError("rerank_nodes must not run without a configured model")
+
+    monkeypatch.setattr(retriever_module, "build_retriever", _fake_build)
+    monkeypatch.setattr(retriever_module, "rerank_nodes", _fail_if_called)
+    monkeypatch.setattr(
+        retriever_module,
+        "retrieval_config_from_settings",
+        lambda: RetrievalConfig(profile="vector"),
+    )
+
+    unchanged = retriever_module.retrieve_nodes(object(), tmp_path, "probe", top_k=2)
+
+    assert captured["candidate_top_k"] == 2
+    assert [result.node_id for result in unchanged] == ["first", "second"]
+
+    rerank_calls: list[dict[str, object]] = []
+
+    def _fake_rerank(query, candidates, *, top_k, model_name):
+        rerank_calls.append(
+            {
+                "query": query,
+                "count": len(candidates),
+                "top_k": top_k,
+                "model_name": model_name,
+            }
+        )
+        return candidates[:top_k]
+
+    monkeypatch.setattr(retriever_module, "rerank_nodes", _fake_rerank)
+    monkeypatch.setattr(
+        retriever_module,
+        "retrieval_config_from_settings",
+        lambda: RetrievalConfig(profile="vector", reranker_model="fake-reranker", rerank_top_k=9),
+    )
+
+    reranked = retriever_module.retrieve_nodes(object(), tmp_path, "probe", top_k=2)
+
+    assert captured["candidate_top_k"] == 9
+    assert rerank_calls == [
+        {
+            "query": "probe",
+            "count": 3,
+            "top_k": 2,
+            "model_name": "fake-reranker",
+        }
+    ]
+    assert [result.node_id for result in reranked] == ["first", "second"]

--- a/web/components/knowledge/EngineDetail.tsx
+++ b/web/components/knowledge/EngineDetail.tsx
@@ -263,6 +263,38 @@ function NumberField({
   );
 }
 
+function TextField({
+  label,
+  hint,
+  value,
+  maxLength,
+  onChange,
+}: {
+  label: string;
+  hint?: string;
+  value: string;
+  maxLength: number;
+  onChange: (next: string) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-[12px] font-medium text-[var(--foreground)]">
+        {label}
+      </span>
+      <input
+        type="text"
+        value={value}
+        maxLength={maxLength}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-1.5 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
+      />
+      {hint && (
+        <span className="text-[11px] text-[var(--muted-foreground)]">{hint}</span>
+      )}
+    </label>
+  );
+}
+
 /* ----------------------------- Mode selector ----------------------------- */
 
 function ModeSelector({
@@ -389,6 +421,8 @@ function LlamaIndexForm({
         top_k: form.top_k,
         vector_top_k_multiplier: form.vector_top_k_multiplier,
         bm25_top_k_multiplier: form.bm25_top_k_multiplier,
+        reranker_model: form.reranker_model,
+        rerank_top_k: form.rerank_top_k,
         chunk_size: form.chunk_size,
         chunk_overlap: form.chunk_overlap,
         image_description_concurrency: form.image_description_concurrency,
@@ -485,6 +519,36 @@ function LlamaIndexForm({
           disabled={!isHybrid}
           onChange={(v) => set({ bm25_top_k_multiplier: v })}
         />
+      </div>
+
+      {/* Reranking */}
+      <div>
+        <div className="mb-2 flex items-baseline justify-between gap-2">
+          <span className="text-[12px] font-medium text-[var(--foreground)]">
+            {t("Reranking")}
+          </span>
+          <span className="text-[11px] text-[var(--muted-foreground)]">
+            {t("Applies on the next query")}
+          </span>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-[2fr_1fr]">
+          <TextField
+            label={t("Reranker model")}
+            hint={t(
+              "Leave empty to disable. Example: BAAI/bge-reranker-base. Requires the optional rag-rerank extra."
+            )}
+            value={form.reranker_model}
+            maxLength={200}
+            onChange={(v) => set({ reranker_model: v })}
+          />
+          <NumberField
+            label={t("Rerank candidates")}
+            value={form.rerank_top_k}
+            min={1}
+            max={100}
+            onChange={(v) => set({ rerank_top_k: v })}
+          />
+        </div>
       </div>
 
       {/* Chunking */}

--- a/web/lib/knowledge-api.ts
+++ b/web/lib/knowledge-api.ts
@@ -58,6 +58,10 @@ export interface LlamaIndexConfig {
   top_k: number;
   vector_top_k_multiplier: number;
   bm25_top_k_multiplier: number;
+  /** Optional Hugging Face cross-encoder model; empty disables reranking. */
+  reranker_model: string;
+  /** First-stage candidates scored by the optional cross-encoder. */
+  rerank_top_k: number;
   /** Chunk geometry — applies to documents indexed after the change. */
   chunk_size: number;
   chunk_overlap: number;

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -3402,5 +3402,10 @@
   "Tutor threads": "Tutor threads",
   "Filter by archive status": "Filter by archive status",
   "Active and archived": "Active and archived",
-  "Loading conversations": "Loading conversations"
+  "Loading conversations": "Loading conversations",
+  "Reranking": "Reranking",
+  "Applies on the next query": "Applies on the next query",
+  "Reranker model": "Reranker model",
+  "Leave empty to disable. Example: BAAI/bge-reranker-base. Requires the optional rag-rerank extra.": "Leave empty to disable. Example: BAAI/bge-reranker-base. Requires the optional rag-rerank extra.",
+  "Rerank candidates": "Rerank candidates"
 }

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -3402,5 +3402,10 @@
   "Tutor threads": "小老师追问",
   "Filter by archive status": "按归档状态筛选",
   "Active and archived": "进行中与已归档",
-  "Loading conversations": "正在加载聊天"
+  "Loading conversations": "正在加载聊天",
+  "Reranking": "重排序",
+  "Applies on the next query": "在下次查询时生效",
+  "Reranker model": "重排序模型",
+  "Leave empty to disable. Example: BAAI/bge-reranker-base. Requires the optional rag-rerank extra.": "留空表示禁用。示例：BAAI/bge-reranker-base。需要可选的 rag-rerank 依赖。",
+  "Rerank candidates": "重排序候选数"
 }


### PR DESCRIPTION
## Summary
- add an opt-in SentenceTransformers cross-encoder reranking stage for the default LlamaIndex pipeline
- retrieve `max(top_k, rerank_top_k)` candidates, rerank them, and return normalized source scores for the final `top_k`
- expose reranker model and candidate settings through runtime settings, the Knowledge API, and the web engine form
- keep the reranker dependency opt-in via `rag-rerank`, and safely fall back to embedding-only ranking when dependencies, model loading, or scoring fail

HNSW support is handled separately in #1044. This PR is the reranking slice of #304, so it intentionally uses `Refs #304`.

## Testing
- PASS: `env PYTHONPATH=. .../pytest tests/services/rag/test_llamaindex_rerank.py tests/services/rag/test_llamaindex_storage_layout.py tests/services/rag/test_llamaindex_pipeline_stall.py tests/services/rag/test_llamaindex_faiss_vector_store.py tests/services/config/test_llamaindex_settings.py tests/api/test_knowledge_router.py -q` (115 passed)
- PASS: `ruff format --check` and `ruff check` on touched Python files
- PASS: `./node_modules/.bin/tsc --noEmit`
- PASS: `npm run test:node` (652 tests)
- PASS: `npm run lint` (0 errors; 56 pre-existing warnings)
- PASS: `npm run i18n:check`
- PASS: `npm run build`
- PASS: `git diff --check`