### PR TITLE
fix(tools): decode unicode escapes in ask_user payloads

### DIFF
--- a/deeptutor/learning/pending.py
+++ b/deeptutor/learning/pending.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from deeptutor.learning.models import PendingQuestion
 
+from deeptutor.utils.text_display import decode_escaped_unicode_for_display
+
 
 OPTION_PREFIX_RE = re.compile(r"^\s*([A-Z])\s*[.:：、)）-]\s*(.+)$", re.IGNORECASE | re.DOTALL)
 
@@ -270,9 +272,16 @@ def public_pending_question(pending: PendingQuestion) -> PublicPendingQuestion:
     )
     return PublicPendingQuestion(
         question_id=pending.question_id,
-        prompt=pending.prompt,
+        prompt=decode_escaped_unicode_for_display(pending.prompt),
         question_type=pending.question_type,
-        options=options,
+        options=tuple(
+            PublicPendingOption(
+                id=option.id,
+                label=decode_escaped_unicode_for_display(option.label),
+                body=decode_escaped_unicode_for_display(option.body),
+            )
+            for option in options
+        ),
     )
 
 

--- a/deeptutor/learning/tests/test_mastery_choices.py
+++ b/deeptutor/learning/tests/test_mastery_choices.py
@@ -255,3 +255,22 @@ async def test_recover_options_from_turn_handles_missing_capability_and_errors()
 
     assert await recover_options_from_turn(_Raising(), "turn_1", "q") == {}
     assert await recover_options_from_turn(_FakeStore([]), "", "q") == {}
+
+
+def test_public_pending_question_decodes_unicode_escapes() -> None:
+    from deeptutor.learning.models import PendingQuestion
+    from deeptutor.learning.pending import public_pending_question
+
+    escaped = "\\u300c\\u6570\\u5236\\u8f6c\\u6362\\u300d"
+    pending = PendingQuestion(
+        question_id="q1",
+        knowledge_point_id="kp1",
+        module_id="m1",
+        prompt=escaped,
+        question_type="choice",
+        expected_answer="A",
+        options=["A: first", "B: second"],
+    )
+    public = public_pending_question(pending)
+    assert public.prompt == "「数制转换」"
+    assert public.to_ask_user_dict()["prompt"] == "「数制转换」"

--- a/deeptutor/tools/ask_user.py
+++ b/deeptutor/tools/ask_user.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from deeptutor.utils.text_display import decode_escaped_unicode_for_display
+
 MAX_QUESTIONS = 4
 MAX_OPTIONS = 8
 MAX_OPTION_CHARS = 120  # option label
@@ -253,8 +255,10 @@ def _coerce_string(value: Any) -> str:
     if value is None:
         return ""
     if isinstance(value, str):
-        return value
-    return str(value)
+        raw = value
+    else:
+        raw = str(value)
+    return decode_escaped_unicode_for_display(raw)
 
 
 __all__ = [

--- a/deeptutor/utils/text_display.py
+++ b/deeptutor/utils/text_display.py
@@ -1,0 +1,31 @@
+"""Helpers for learner-facing text that models sometimes double-encode."""
+
+from __future__ import annotations
+
+import codecs
+import re
+
+# Match dense JSON-style ``\\uXXXX`` runs (3+ escapes), mirroring the web
+# markdown decoder so mastery / ask_user cards do not leak literal escapes (#973).
+_ESCAPED_UNICODE_RUN = re.compile(r"(?:\\u[0-9a-fA-F]{4}){3,}")
+
+
+def decode_escaped_unicode_for_display(text: str) -> str:
+    """Decode dense ``\\uXXXX`` runs when they clearly represent non-ASCII text."""
+    if not text or "\\u" not in text:
+        return text
+
+    def _replace(match: re.Match[str]) -> str:
+        run = match.group(0)
+        try:
+            decoded = codecs.decode(run, "unicode_escape")
+        except (UnicodeDecodeError, ValueError):
+            return run
+        if any(ord(ch) > 0x7F for ch in decoded):
+            return decoded
+        return run
+
+    return _ESCAPED_UNICODE_RUN.sub(_replace, text)
+
+
+__all__ = ["decode_escaped_unicode_for_display"]

--- a/tests/tools/test_ask_user.py
+++ b/tests/tools/test_ask_user.py
@@ -344,3 +344,16 @@ def test_to_dict_legacy_path_also_emits_v3() -> None:
         {"label": "a", "description": None},
         {"label": "b", "description": None},
     ]
+
+
+def test_prompt_decodes_dense_unicode_escapes() -> None:
+    """Regression for #973: model tool args can carry literal \\uXXXX stems."""
+    escaped = "\\u300c\\u6570\\u5236\\u8f6c\\u6362\\u300d"
+    payload, err = build_ask_user_payload(
+        questions=[{"prompt": escaped, "options": ["A", "B"]}],
+        intro=escaped,
+    )
+    assert err is None
+    assert payload is not None
+    assert payload.intro == "「数制转换」"
+    assert payload.questions[0].prompt == "「数制转换」"

--- a/tests/utils/test_text_display.py
+++ b/tests/utils/test_text_display.py
@@ -1,0 +1,20 @@
+"""Tests for learner-facing unicode escape decoding (#973)."""
+
+from __future__ import annotations
+
+from deeptutor.utils.text_display import decode_escaped_unicode_for_display
+
+
+def test_decodes_dense_non_ascii_runs() -> None:
+    escaped = "\\u300c\\u6570\\u5236\\u8f6c\\u6362\\u300d"
+    assert decode_escaped_unicode_for_display(escaped) == "「数制转换」"
+
+
+def test_leaves_short_ascii_runs_alone() -> None:
+    text = "A JSON string can encode A as \\u0041."
+    assert decode_escaped_unicode_for_display(text) == text
+
+
+def test_empty_and_plain_text_passthrough() -> None:
+    assert decode_escaped_unicode_for_display("") == ""
+    assert decode_escaped_unicode_for_display("hello") == "hello"


### PR DESCRIPTION
﻿## Summary
- Add `decode_escaped_unicode_for_display` for dense `\\uXXXX` runs that clearly represent non-ASCII text
- Apply when building generic `ask_user` payloads and when projecting mastery pending questions to learner-facing cards
- Complements the web-side decoder in #1020 — fixes escapes at the tool boundary before they reach clients or persisted card metadata

Related to #973

## Test plan
- [x] `pytest tests/utils/test_text_display.py tests/tools/test_ask_user.py -k unicode deeptutor/learning/tests/test_mastery_choices.py::test_public_pending_question_decodes_unicode_escapes -q`
- [ ] Mastery path card stems show Chinese instead of literal `\u300c...` when the model emits escaped tool args
