### PR TITLE
fix(question): validate topic before generation

### DIFF
--- a/deeptutor/agents/question/capability.py
+++ b/deeptutor/agents/question/capability.py
@@ -42,10 +42,26 @@ class DeepQuestionCapability(BaseCapability):
         llm_config = get_llm_config()
         kb_name = context.knowledge_bases[0] if context.knowledge_bases else None
         turn_id = str(context.metadata.get("turn_id", "") or context.session_id or "deep-question")
-        output_dir = get_path_service().get_task_workspace("deep_question", turn_id)
         i18n = StatusI18n(self.name, context.language, module="question")
 
         overrides = context.config_overrides
+        mode = str(overrides.get("mode", "custom") or "custom").strip().lower()
+        topic = str(overrides.get("topic") or context.user_message or "").strip()
+        # Validate user-fixable input before allocating a workspace or invoking
+        # any provider/parser.  This keeps an empty custom request from
+        # surfacing a low-level filesystem error such as ``Operation not
+        # permitted``.
+        if mode == "custom" and not topic:
+            await stream.error(
+                i18n.t(
+                    "topic_required",
+                    "Please provide a topic before generating questions.",
+                ),
+                source=self.name,
+                metadata={"code": "topic_required", "retryable": True},
+            )
+            return
+        output_dir = get_path_service().get_task_workspace("deep_question", turn_id)
         followup_question_context = context.metadata.get("question_followup_context", {}) or {}
         if isinstance(followup_question_context, dict) and followup_question_context.get(
             "question"

--- a/tests/core/test_capabilities_runtime.py
+++ b/tests/core/test_capabilities_runtime.py
@@ -425,3 +425,36 @@ async def test_visualize_capability_passes_attachments_to_analysis_agent(
     assert captured["analysis"]["attachments"][0].filename == "figure.png"
     result_event = next(event for event in events if event.type == StreamEventType.RESULT)
     assert result_event.metadata["render_type"] == "svg"
+
+
+@pytest.mark.asyncio
+async def test_deep_question_rejects_empty_custom_topic_before_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid input returns a clear error before workspace allocation."""
+
+    monkeypatch.setattr(
+        "deeptutor.services.llm.config.get_llm_config",
+        lambda: SimpleNamespace(api_key="", base_url="", api_version=""),
+    )
+
+    class FailingPathService:
+        def get_task_workspace(self, *_args: Any, **_kwargs: Any) -> str:
+            raise AssertionError("workspace must not be allocated for invalid input")
+
+    monkeypatch.setattr(
+        "deeptutor.services.path_service.get_path_service",
+        lambda: FailingPathService(),
+    )
+
+    context = UnifiedContext(
+        user_message="",
+        config_overrides={"mode": "custom", "topic": ""},
+        language="en",
+    )
+    events = await _collect_events(lambda bus: DeepQuestionCapability().run(context, bus))
+
+    errors = [event for event in events if event.type == StreamEventType.ERROR]
+    assert errors
+    assert "topic" in errors[-1].content.lower()
+    assert errors[-1].metadata["code"] == "topic_required"

--- a/web/app/(workspace)/home/[[...sessionId]]/page.tsx
+++ b/web/app/(workspace)/home/[[...sessionId]]/page.tsx
@@ -491,6 +491,9 @@ export default function ChatPage() {
   const [quizConfig, setQuizConfig] = useState<DeepQuestionFormConfig>({
     ...DEFAULT_QUIZ_CONFIG,
   });
+  const [quizValidationErrors, setQuizValidationErrors] = useState<string[]>(
+    [],
+  );
   const [quizPdf, setQuizPdf] = useState<File | null>(null);
   const [visualizeConfig, setVisualizeConfig] = useState<VisualizeFormConfig>({
     ...DEFAULT_VISUALIZE_CONFIG,
@@ -699,6 +702,7 @@ export default function ChatPage() {
   // CapabilityConfigCard don't churn on every keystroke.
   const handleChangeQuizConfig = useCallback((next: DeepQuestionFormConfig) => {
     setQuizConfig(next);
+    setQuizValidationErrors([]);
     setCapabilityConfigConfirmed(false);
   }, []);
   const handleUploadQuizPdf = useCallback((file: File | null) => {
@@ -1543,7 +1547,8 @@ export default function ChatPage() {
         <CapabilityConfigCard
           capability="deep_question"
           confirmed={capabilityConfigConfirmed}
-          canConfirm
+          canConfirm={quizValidationErrors.length === 0}
+          validationErrors={quizValidationErrors}
           onConfirm={handleConfirmCapabilityConfig}
         >
           <QuizConfigPanel
@@ -1596,6 +1601,7 @@ export default function ChatPage() {
     capabilityConfigConfirmed,
     handleConfirmCapabilityConfig,
     quizConfig,
+    quizValidationErrors,
     quizPdf,
     handleChangeQuizConfig,
     handleUploadQuizPdf,
@@ -1727,6 +1733,34 @@ export default function ChatPage() {
       )
         return;
 
+      const quizPrompt = content.trim().toLowerCase();
+      const isPlaceholderQuizPrompt = new Set([
+        "开始",
+        "开始生成",
+        "生成",
+        "生成题目",
+        "start",
+        "generate",
+      ]).has(quizPrompt);
+      const hasQuizSource = Boolean(content.trim()) && !isPlaceholderQuizPrompt;
+      if (
+        isQuizMode &&
+        quizConfig.mode === "custom" &&
+        !hasQuizSource &&
+        !attachments.length &&
+        !selectedBookReferences.length &&
+        !selectedNotebookRecords.length &&
+        !selectedHistorySessions.length &&
+        !selectedQuestionEntries.length &&
+        !selectedMemoryFiles.length
+      ) {
+        setQuizValidationErrors([
+          t("Please provide a topic, for example: generate questions about limits."),
+        ]);
+        ensureActivityPanelOpen();
+        return;
+      }
+
       let extraAttachments = attachments.map((a) => ({
         type: a.type,
         filename: a.filename,
@@ -1814,6 +1848,7 @@ export default function ChatPage() {
       quizPdf,
       researchConfig,
       researchValidation,
+      ensureActivityPanelOpen,
       selectedAgent,
       selectedHistorySessions.length,
       selectedAgentSessions.length,


### PR DESCRIPTION
## Summary
- validate empty custom Deep Question topics before workspace allocation
- return structured `topic_required` errors instead of low-level filesystem failures
- block generic placeholder prompts in the web composer and show an inline message
- add a regression test proving invalid input does not allocate a workspace

Fixes #1056

## Verification
- `npm run lint` (pass; existing i18n warnings remain)
- `npm run build` (pass)
- backend pytest could not run in the current environment because the active Python environment is missing `loguru`/`pytest`; the added test is included in `tests/core/test_capabilities_runtime.py`.
