### PR TITLE
fix(llm): disable DeepSeek flash thinking on openai bindings

### DIFF
--- a/deeptutor/agents/chat/agent_loop.py
+++ b/deeptutor/agents/chat/agent_loop.py
@@ -164,6 +164,7 @@ class LLMCallResult:
     visible_text: str = ""
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
     finish_reason: str = ""
+    reasoning_content: str = ""
     deferred_chunk_metadata: dict[str, Any] | None = None
     deferred_completion_metadata: dict[str, Any] | None = None
 
@@ -367,7 +368,11 @@ class AgentLoop:
                     if result.visible_text:
                         continued_answer_parts.append(result.visible_text)
                     if result.text:
-                        messages.append({"role": "assistant", "content": result.text})
+                        self._append_assistant_turn(
+                            messages,
+                            content=result.text,
+                            reasoning_content=result.reasoning_content,
+                        )
                     self._append_loop_instruction(
                         messages,
                         self.pipeline._t(
@@ -400,7 +405,11 @@ class AgentLoop:
                         metadata={"trace_kind": "warning"},
                     )
                     if result.text:
-                        messages.append({"role": "assistant", "content": result.text})
+                        self._append_assistant_turn(
+                            messages,
+                            content=result.text,
+                            reasoning_content=result.reasoning_content,
+                        )
                     self._append_loop_instruction(
                         messages,
                         self.pipeline._t(
@@ -423,7 +432,11 @@ class AgentLoop:
                     if not finish_redirect_used:
                         finish_redirect_used = True
                         if result.text:
-                            messages.append({"role": "assistant", "content": result.text})
+                            self._append_assistant_turn(
+                                messages,
+                                content=result.text,
+                                reasoning_content=result.reasoning_content,
+                            )
                         self._append_loop_instruction(messages, finish_redirect)
                         continue
                     await self.stream.progress(
@@ -448,7 +461,13 @@ class AgentLoop:
                 )
 
             await self._release_deferred_output(result)
-            messages.append(assistant_message_with_tool_calls(result.text, result.tool_calls))
+            messages.append(
+                assistant_message_with_tool_calls(
+                    result.text,
+                    result.tool_calls,
+                    reasoning_content=result.reasoning_content or None,
+                )
+            )
             dispatch = await self.pipeline._dispatch_tool_calls(
                 tool_calls=result.tool_calls,
                 context=self.context,
@@ -516,6 +535,19 @@ class AgentLoop:
             messages[-1]["content"] = f"{prior}\n\n{instruction}" if prior else instruction
             return
         messages.append({"role": "user", "content": instruction})
+
+    @staticmethod
+    def _append_assistant_turn(
+        messages: list[dict[str, Any]],
+        *,
+        content: str,
+        reasoning_content: str = "",
+    ) -> None:
+        """Append an assistant row, replaying thinking-mode reasoning when present."""
+        message: dict[str, Any] = {"role": "assistant", "content": content}
+        if reasoning_content:
+            message["reasoning_content"] = reasoning_content
+        messages.append(message)
 
     def _fold_context_checkpoint(
         self,
@@ -741,6 +773,7 @@ class AgentLoop:
             # once, only after a successful attempt.
             usage_seen: Any = None
             text_parts: list[str] = []
+            reasoning_parts: list[str] = []
             tool_acc = ToolCallAccumulator()
             output_chars = 0
             finish_reason = ""
@@ -794,6 +827,7 @@ class AgentLoop:
                     if reasoning_text:
                         output_chars += len(reasoning_text)
                         output_emitted = True
+                        reasoning_parts.append(reasoning_text)
                         await self.stream.thinking(
                             reasoning_text, source="chat", stage=stage, metadata=chunk_meta
                         )
@@ -978,6 +1012,7 @@ class AgentLoop:
             visible_text="".join(visible_text_parts),
             tool_calls=tool_calls,
             finish_reason=finish_reason,
+            reasoning_content="".join(reasoning_parts),
             deferred_chunk_metadata=chunk_meta if defer_visible_output else None,
             deferred_completion_metadata=(
                 completion_event_metadata if defer_visible_output else None

--- a/deeptutor/core/agentic/messages.py
+++ b/deeptutor/core/agentic/messages.py
@@ -8,9 +8,17 @@ from typing import Any
 def assistant_message_with_tool_calls(
     content: str,
     tool_calls: list[dict[str, Any]],
+    *,
+    reasoning_content: str | None = None,
 ) -> dict[str, Any]:
-    """Build the assistant message that precedes tool result messages."""
-    return {
+    """Build the assistant message that precedes tool result messages.
+
+    ``reasoning_content`` is optional: DeepSeek thinking-mode Chat Completions
+    requires the prior round's reasoning to be echoed on the assistant turn
+    that issued the tool calls (#1058). Responses-API replay is handled
+    separately via ``_responses_output_items``.
+    """
+    message: dict[str, Any] = {
         "role": "assistant",
         "content": content or None,
         "tool_calls": [
@@ -25,6 +33,9 @@ def assistant_message_with_tool_calls(
             for tool_call in tool_calls
         ],
     }
+    if reasoning_content:
+        message["reasoning_content"] = reasoning_content
+    return message
 
 
 __all__ = ["assistant_message_with_tool_calls"]

--- a/deeptutor/services/llm/reasoning_params.py
+++ b/deeptutor/services/llm/reasoning_params.py
@@ -38,8 +38,13 @@ _MINIMAL_NOT_OFF_PATTERNS: dict[str, tuple[str, ...]] = {
 }
 _CUSTOM_MODEL_THINKING_STYLES: tuple[tuple[tuple[str, ...], str], ...] = (
     (("qwen3", "qwen-3", "qwq", "qwen-plus"), "enable_thinking"),
-    (("deepseek-v4-pro", "deepseek-reasoner"), "thinking_type"),
+    (("deepseek-v4-pro", "deepseek-reasoner", "deepseek-r1"), "thinking_type"),
 )
+# Model substrings that default to thinking off — independent of binding name,
+# so ``LLM_BINDING=openai`` pointed at DeepSeek with deepseek-v4-flash still
+# sends ``thinking: disabled`` and avoids the mid-conversation
+# ``reasoning_content must be passed back`` 400 (#1058).
+_THINKING_DISABLED_BY_DEFAULT_MODELS: tuple[str, ...] = ("deepseek-v4-flash",)
 _THINKING_DISABLED_BY_DEFAULT: tuple[tuple[str, str], ...] = (("deepseek", "deepseek-v4-flash"),)
 
 
@@ -56,11 +61,17 @@ def _custom_thinking_style(model_name: str) -> tuple[str, tuple[str, ...]]:
     for patterns, style in _CUSTOM_MODEL_THINKING_STYLES:
         if _matches(model_name, patterns):
             return style, patterns
+    # Flash needs thinking_type so we can send ``disabled`` by default, but it
+    # must NOT inherit the high-effort patterns used by pro/reasoner.
+    if any(pattern in model_name.lower() for pattern in _THINKING_DISABLED_BY_DEFAULT_MODELS):
+        return "thinking_type", ()
     return "", ()
 
 
 def _disable_thinking_by_default(provider_name: str, model_name: str) -> bool:
     normalized = model_name.strip().lower()
+    if any(pattern in normalized for pattern in _THINKING_DISABLED_BY_DEFAULT_MODELS):
+        return True
     return any(
         provider_name == provider and pattern in normalized
         for provider, pattern in _THINKING_DISABLED_BY_DEFAULT
@@ -110,11 +121,15 @@ def build_openai_compatible_reasoning_kwargs(
         thinking_style = _PROVIDER_THINKING_STYLES.get(provider_name, "")
     if not patterns:
         patterns = _PROVIDER_REASONING_PATTERNS.get(provider_name, ())
-    if provider_name == "custom":
+    # Infer style from the model id when the binding has none of its own —
+    # covers ``custom`` endpoints and ``openai`` bindings aimed at DeepSeek /
+    # Qwen gateways (#1058).
+    if not thinking_style:
         custom_style, custom_patterns = _custom_thinking_style(model_name)
         if custom_style:
             thinking_style = custom_style
-            patterns = custom_patterns
+            if not patterns:
+                patterns = custom_patterns
 
     resolved_effort = reasoning_effort
     if resolved_effort is None:

--- a/tests/core/test_agentic_messages.py
+++ b/tests/core/test_agentic_messages.py
@@ -37,3 +37,18 @@ def test_assistant_message_with_tool_calls_preserves_order_and_arguments() -> No
         "name": "read",
         "arguments": '{"id":2}',
     }
+
+
+def test_assistant_message_with_tool_calls_replays_reasoning_content() -> None:
+    message = assistant_message_with_tool_calls(
+        content="",
+        tool_calls=[{"id": "call-1", "name": "search"}],
+        reasoning_content="Need to look this up.",
+    )
+
+    assert message["reasoning_content"] == "Need to look this up."
+    assert "reasoning_content" not in assistant_message_with_tool_calls(
+        content="hi",
+        tool_calls=[{"id": "call-1", "name": "search"}],
+        reasoning_content="",
+    )

--- a/tests/services/llm/test_openai_compat_reasoning_content.py
+++ b/tests/services/llm/test_openai_compat_reasoning_content.py
@@ -98,6 +98,29 @@ def test_services_deepseek_v4_flash_disables_thinking_by_default() -> None:
     assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
 
 
+def test_openai_binding_deepseek_v4_flash_disables_thinking_by_default() -> None:
+    """#1058: openai binding pointed at DeepSeek must still disable flash thinking."""
+    kwargs = _build_services_kwargs(
+        "openai",
+        None,
+        model="deepseek-v4-flash",
+    )
+
+    assert "reasoning_effort" not in kwargs
+    assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
+
+
+def test_openai_binding_deepseek_v4_pro_enables_thinking_by_default() -> None:
+    kwargs = _build_services_kwargs(
+        "openai",
+        None,
+        model="deepseek-v4-pro",
+    )
+
+    assert kwargs["reasoning_effort"] == "high"
+    assert kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
+
+
 def test_services_deepseek_v4_pro_enables_thinking_by_default() -> None:
     kwargs = _build_services_kwargs("deepseek", None)
 


### PR DESCRIPTION
﻿## Summary
- Infer DeepSeek/Qwen thinking controls from the model id when the binding itself has none (covers `LLM_BINDING=openai` pointed at DeepSeek)
- Default `deepseek-v4-flash` to `thinking: disabled` regardless of binding name, matching the native DeepSeek provider
- Replay Chat Completions `reasoning_content` on assistant tool-call turns (and continue/nudge assistant rows) so thinking-mode rounds stay valid

Fixes #1058

Related: #1048 covers Responses-API reasoning replay; this PR covers the Chat Completions / openai-binding gap reported against v1.6.0.

## Test plan
- [x] `pytest tests/services/llm/test_openai_compat_reasoning_content.py tests/core/test_agentic_messages.py tests/services/llm/test_reasoning_params.py -q` (39 passed)
- [x] `pytest tests/agents/chat/test_agent_loop.py -k "tool_round or empty_finish" -q` (5 passed)
- [ ] Multi-turn chat with `openai` binding + `deepseek-v4-flash` no longer 400s on round 2/3
