### PR TITLE
fix(embedding): enable Jina retrieval roles (#1063)

### DIFF
--- a/deeptutor/services/embedding/adapters/jina.py
+++ b/deeptutor/services/embedding/adapters/jina.py
@@ -14,6 +14,11 @@ logger = logging.getLogger(__name__)
 
 
 class JinaEmbeddingAdapter(BaseEmbeddingAdapter):
+    # Jina ignores `input_type` unless explicitly opted in. Enabling it changes
+    # vectors for both documents and queries, so the embedding signature must
+    # distinguish pre-role Jina indexes.
+    SUPPORTS_INPUT_TYPE = True
+
     MODELS_INFO = {
         "jina-embeddings-v3": {
             "default": 1024,

--- a/deeptutor/services/rag/embedding_signature.py
+++ b/deeptutor/services/rag/embedding_signature.py
@@ -12,14 +12,21 @@ logger = logging.getLogger(__name__)
 
 def signature_from_config(config: Any) -> EmbeddingSignature:
     """Build a stable RAG index signature from an embedding config object."""
+    binding = (getattr(config, "binding", "") or "").strip().lower()
+    # Role support is a vector-space change. Jina previously sent no task, so
+    # its role-aware indexes need a different signature. Providers that were
+    # already role-aware before signatures gained this field keep the blank
+    # value to avoid invalidating compatible indexes.
+    role_semantics = "jina-task" if binding == "jina" else ""
     return EmbeddingSignature(
-        binding=(getattr(config, "binding", "") or "").strip().lower(),
+        binding=binding,
         model=(getattr(config, "model", "") or "").strip(),
         dimension=int(getattr(config, "dim", 0) or 0),
         base_url=(
             getattr(config, "effective_url", None) or getattr(config, "base_url", None) or ""
         ).strip(),
         api_version=(getattr(config, "api_version", "") or "").strip(),
+        role_semantics=role_semantics,
     )
 
 

--- a/deeptutor/services/rag/index_versioning.py
+++ b/deeptutor/services/rag/index_versioning.py
@@ -52,10 +52,15 @@ class EmbeddingSignature:
     dimension: int
     base_url: str
     api_version: str
+    role_semantics: str = ""
 
     def hash(self) -> str:
         """Short hex digest used as the stable signature."""
-        canonical = json.dumps(asdict(self), sort_keys=True, ensure_ascii=False)
+        fields = asdict(self)
+        role_semantics = fields.pop("role_semantics")
+        if role_semantics:
+            fields["role_semantics"] = role_semantics
+        canonical = json.dumps(fields, sort_keys=True, ensure_ascii=False)
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
 
 

--- a/tests/services/embedding/test_jina_adapter.py
+++ b/tests/services/embedding/test_jina_adapter.py
@@ -1,0 +1,71 @@
+"""Tests for role-aware Jina embedding requests."""
+
+from __future__ import annotations
+
+import pytest
+
+from deeptutor.services.embedding.adapters.base import EmbeddingRequest
+from deeptutor.services.embedding.adapters.jina import JinaEmbeddingAdapter
+
+
+@pytest.mark.asyncio
+async def test_jina_adapter_maps_retrieval_roles_to_tasks(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _Response:
+        status_code = 200
+        text = ""
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {
+                "data": [{"embedding": [0.1, 0.2]}],
+                "model": "jina-embeddings-v3",
+            }
+
+    class _AsyncClient:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args) -> None:
+            return None
+
+        async def post(self, url: str, *, json: dict[str, object], **_kwargs):
+            captured["url"] = url
+            captured["payload"] = json
+            return _Response()
+
+    monkeypatch.setattr(
+        "deeptutor.services.embedding.adapters.jina.httpx.AsyncClient", _AsyncClient
+    )
+    adapter = JinaEmbeddingAdapter(
+        {
+            "api_key": "test-key",
+            "base_url": "https://api.jina.ai/v1/embeddings",
+            "model": "jina-embeddings-v3",
+            "dimensions": 2,
+        }
+    )
+
+    document_request = EmbeddingRequest(
+        texts=["document text"],
+        model="jina-embeddings-v3",
+        dimensions=2,
+        input_type="search_document",
+    )
+    await adapter.embed(document_request)
+    assert captured["payload"]["task"] == "retrieval.passage"
+
+    query_request = EmbeddingRequest(
+        texts=["query text"],
+        model="jina-embeddings-v3",
+        dimensions=2,
+        input_type="search_query",
+    )
+    await adapter.embed(query_request)
+    assert captured["payload"]["task"] == "retrieval.query"

--- a/tests/services/rag/test_index_versioning.py
+++ b/tests/services/rag/test_index_versioning.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -22,6 +23,55 @@ def _signature(model: str = "embed-a", dim: int = 1024) -> EmbeddingSignature:
         base_url="https://example.test/v1",
         api_version="",
     )
+
+
+def test_legacy_role_naive_signature_hash_is_stable() -> None:
+    fields = {
+        "api_version": "",
+        "base_url": "https://api.openai.com/v1/embeddings",
+        "binding": "openai",
+        "dimension": 1536,
+        "model": "text-embedding-3-small",
+    }
+    signature = EmbeddingSignature(
+        binding=fields["binding"],
+        model=fields["model"],
+        dimension=fields["dimension"],
+        base_url=fields["base_url"],
+        api_version="",
+    )
+    expected_hash = hashlib.sha256(
+        json.dumps(fields, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()[:16]
+
+    assert signature.hash() == expected_hash
+    assert signature.role_semantics == ""
+
+
+def test_jina_role_semantics_changes_signature() -> None:
+    from types import SimpleNamespace
+
+    from deeptutor.services.rag.embedding_signature import signature_from_config
+
+    config = SimpleNamespace(
+        binding="jina",
+        model="jina-embeddings-v3",
+        dim=1024,
+        base_url="https://api.jina.ai/v1/embeddings",
+        effective_url="https://api.jina.ai/v1/embeddings",
+        api_version="",
+    )
+    legacy_signature = EmbeddingSignature(
+        binding="jina",
+        model="jina-embeddings-v3",
+        dimension=1024,
+        base_url="https://api.jina.ai/v1/embeddings",
+        api_version="",
+    )
+    active_signature = signature_from_config(config)
+
+    assert active_signature.role_semantics == "jina-task"
+    assert active_signature.hash() != legacy_signature.hash()
 
 
 def test_resolve_storage_dir_for_write_allocates_flat_version_dirs(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1063

## Problem

`JinaEmbeddingAdapter` already mapped retrieval roles to Jina tasks, but did not opt into `SUPPORTS_INPUT_TYPE`. The embedding client therefore dropped `input_type`, Jina received no `task`, and retrieval queries/index documents were embedded symmetrically instead of using asymmetric retrieval semantics.

## Changes

- Enable retrieval-role forwarding for the Jina embedding adapter.
- Add a `role_semantics` field to embedding signatures and set a Jina-specific value, so indexes built before role forwarding are treated as incompatible instead of silently reused.
- Preserve blank semantics for existing role-naive providers and providers that already used roles before signature versioning.
- Add adapter and RAG index-versioning regression tests.

## Verification

- Focused embedding/RAG tests: 31 passed.
- Relevant broader test selection: 169 passed.
- `ruff format --check` and `ruff check` passed.
- `git diff --check` passed.

## Migration

Existing Jina-backed indexes have a different embedding signature and require a rebuild because role-aware task input changes both query and document vectors.