### PR TITLE
fix(llm): persist DeepSeek reasoning across turns (#1058)

### DIFF
--- a/deeptutor/agents/chat/agent_loop.py
+++ b/deeptutor/agents/chat/agent_loop.py
@@ -162,6 +162,8 @@ class AgentLoopState:
 class LLMCallResult:
     text: str
     visible_text: str = ""
+    response_output_items: list[dict[str, Any]] = field(default_factory=list)
+    reasoning_content: str = ""
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
     finish_reason: str = ""
     deferred_chunk_metadata: dict[str, Any] | None = None
@@ -180,6 +182,27 @@ class LoopOutcome:
 
     final_text: str = ""
     completed: bool = False
+    provider_response_state: dict[str, Any] | None = None
+
+
+def _provider_response_state(
+    response_output_items: list[dict[str, Any]],
+    reasoning_content: str,
+) -> dict[str, Any] | None:
+    state: dict[str, Any] = {}
+    if response_output_items:
+        state["responses_output_items"] = response_output_items
+    if reasoning_content:
+        state["reasoning_content"] = reasoning_content
+    return state or None
+
+
+def _assistant_round_message(result: LLMCallResult) -> dict[str, Any]:
+    message: dict[str, Any] = {"role": "assistant", "content": result.text}
+    state = _provider_response_state(result.response_output_items, result.reasoning_content)
+    if state is not None:
+        message["_provider_response_state"] = state
+    return message
 
 
 class AgentLoop:
@@ -238,6 +261,8 @@ class AgentLoop:
                 state=state,
                 checkpoint_boundary=len(messages),
             )
+        if outcome.provider_response_state is not None:
+            self.context.metadata["_provider_response_state"] = outcome.provider_response_state
 
         if state.sources:
             await self.stream.sources(
@@ -367,7 +392,7 @@ class AgentLoop:
                     if result.visible_text:
                         continued_answer_parts.append(result.visible_text)
                     if result.text:
-                        messages.append({"role": "assistant", "content": result.text})
+                        messages.append(_assistant_round_message(result))
                     self._append_loop_instruction(
                         messages,
                         self.pipeline._t(
@@ -400,7 +425,7 @@ class AgentLoop:
                         metadata={"trace_kind": "warning"},
                     )
                     if result.text:
-                        messages.append({"role": "assistant", "content": result.text})
+                        messages.append(_assistant_round_message(result))
                     self._append_loop_instruction(
                         messages,
                         self.pipeline._t(
@@ -423,7 +448,7 @@ class AgentLoop:
                     if not finish_redirect_used:
                         finish_redirect_used = True
                         if result.text:
-                            messages.append({"role": "assistant", "content": result.text})
+                            messages.append(_assistant_round_message(result))
                         self._append_loop_instruction(messages, finish_redirect)
                         continue
                     await self.stream.progress(
@@ -445,10 +470,21 @@ class AgentLoop:
                     final_text,
                     visible_text=result.visible_text,
                     continued_answer_parts=continued_answer_parts,
+                    provider_response_state=_provider_response_state(
+                        result.response_output_items,
+                        result.reasoning_content,
+                    ),
                 )
 
             await self._release_deferred_output(result)
-            messages.append(assistant_message_with_tool_calls(result.text, result.tool_calls))
+            assistant = assistant_message_with_tool_calls(result.text, result.tool_calls)
+            provider_state = _provider_response_state(
+                result.response_output_items,
+                result.reasoning_content,
+            )
+            if provider_state is not None:
+                assistant["_provider_response_state"] = provider_state
+            messages.append(assistant)
             dispatch = await self.pipeline._dispatch_tool_calls(
                 tool_calls=result.tool_calls,
                 context=self.context,
@@ -590,6 +626,10 @@ class AgentLoop:
             result.text,
             visible_text=result.visible_text,
             continued_answer_parts=continued_answer_parts,
+            provider_response_state=_provider_response_state(
+                result.response_output_items,
+                result.reasoning_content,
+            ),
         )
 
     async def _finalize_finish(
@@ -598,6 +638,7 @@ class AgentLoop:
         *,
         visible_text: str | None = None,
         continued_answer_parts: list[str] | None = None,
+        provider_response_state: dict[str, Any] | None = None,
     ) -> LoopOutcome:
         cleaned_text = self._clean(raw_text)
         if continued_answer_parts:
@@ -618,7 +659,11 @@ class AgentLoop:
                 ),
             )
             await self.pipeline._emit_protocol_fallback_final_response(self.stream, final_text)
-        return LoopOutcome(final_text=final_text, completed=True)
+        return LoopOutcome(
+            final_text=final_text,
+            completed=True,
+            provider_response_state=provider_response_state,
+        )
 
     async def _release_deferred_output(self, result: LLMCallResult) -> None:
         """Publish a buffered capability round only after its protocol accepts it."""
@@ -741,6 +786,8 @@ class AgentLoop:
             # once, only after a successful attempt.
             usage_seen: Any = None
             text_parts: list[str] = []
+            reasoning_parts: list[str] = []
+            response_output_items: list[dict[str, Any]] = []
             tool_acc = ToolCallAccumulator()
             output_chars = 0
             finish_reason = ""
@@ -782,6 +829,16 @@ class AgentLoop:
                     choice = choices[0]
                     if getattr(choice, "finish_reason", None):
                         finish_reason = str(choice.finish_reason)
+                    provider_fields = getattr(choice, "provider_specific_fields", None)
+                    if isinstance(provider_fields, dict):
+                        native_items = provider_fields.get("native_output_items")
+                        if isinstance(native_items, list) and any(
+                            isinstance(item, dict) and item.get("type") == "reasoning"
+                            for item in native_items
+                        ):
+                            response_output_items = [
+                                dict(item) for item in native_items if isinstance(item, dict)
+                            ]
                     delta = getattr(choice, "delta", None)
                     if delta is None:
                         continue
@@ -792,6 +849,7 @@ class AgentLoop:
                         None,
                     )
                     if reasoning_text:
+                        reasoning_parts.append(reasoning_text)
                         output_chars += len(reasoning_text)
                         output_emitted = True
                         await self.stream.thinking(
@@ -976,6 +1034,8 @@ class AgentLoop:
         return LLMCallResult(
             text=text,
             visible_text="".join(visible_text_parts),
+            response_output_items=response_output_items,
+            reasoning_content="".join(reasoning_parts),
             tool_calls=tool_calls,
             finish_reason=finish_reason,
             deferred_chunk_metadata=chunk_meta if defer_visible_output else None,

--- a/deeptutor/agents/chat/agentic_pipeline.py
+++ b/deeptutor/agents/chat/agentic_pipeline.py
@@ -407,7 +407,10 @@ class AgenticChatPipeline:
             role = item.get("role")
             content = item.get("content")
             if role in {"user", "assistant"} and isinstance(content, (str, list)):
-                messages.append({"role": role, "content": content})
+                message: dict[str, Any] = {"role": role, "content": content}
+                if role == "assistant" and isinstance(item.get("_provider_response_state"), dict):
+                    message["_provider_response_state"] = item["_provider_response_state"]
+                messages.append(message)
             elif role == "system" and isinstance(content, str) and content.strip():
                 # ContextBuilder emits the compressed-history summary as a
                 # leading system message; deliver it right after the system

--- a/deeptutor/api/routers/sessions.py
+++ b/deeptutor/api/routers/sessions.py
@@ -111,6 +111,17 @@ async def list_sessions(
 MAX_EVENT_PAYLOAD = 1024 * 1024
 _TRUNCATION_NOTICE = "\n\n[... content truncated]"
 _TRUNCATABLE_EVENT_TYPES = ("tool_result", "observation")
+_PRIVATE_MESSAGE_METADATA_KEYS = frozenset({"provider_response_state"})
+
+
+def _redact_private_message_metadata(messages: list[dict[str, Any]]) -> None:
+    """Remove provider-only state before session details cross the API."""
+    for message in messages:
+        metadata = message.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        for key in _PRIVATE_MESSAGE_METADATA_KEYS:
+            metadata.pop(key, None)
 
 
 def _truncate_oversized_events(
@@ -152,6 +163,7 @@ async def get_session(session_id: str):
     session = await store.get_session_with_messages(session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
+    _redact_private_message_metadata(session.get("messages", []))
     _truncate_oversized_events(session.get("messages", []))
     return session
 

--- a/deeptutor/core/agentic/client.py
+++ b/deeptutor/core/agentic/client.py
@@ -472,13 +472,16 @@ class _ProviderOpenAIStream:
                 await self._queue.put(_openai_stream_chunk(content=response.content))
             for index, tool_call in enumerate(response.tool_calls or []):
                 await self._queue.put(_openai_stream_chunk(tool_call=tool_call, index=index))
+            provider_fields = dict(response.provider_specific_fields or {})
+            if response.reasoning_content:
+                provider_fields["reasoning_content"] = response.reasoning_content
             await self._queue.put(
                 _openai_stream_chunk(
                     finish_reason=(
                         "tool_calls" if response.tool_calls else response.finish_reason or "stop"
                     ),
                     usage=response.usage or None,
-                    provider_specific_fields=response.provider_specific_fields,
+                    provider_specific_fields=provider_fields,
                 )
             )
         except Exception as exc:

--- a/deeptutor/services/llm/provider_core/openai_compat_provider.py
+++ b/deeptutor/services/llm/provider_core/openai_compat_provider.py
@@ -48,9 +48,13 @@ _ALLOWED_MSG_KEYS = frozenset(
         "name",
         "reasoning_content",
         "extra_content",
+        "_provider_response_state",
+        "_responses_output_items",
     }
 )
 _ALNUM = string.ascii_letters + string.digits
+
+_INTERNAL_RESPONSE_STATE_KEYS = frozenset({"_provider_response_state", "_responses_output_items"})
 
 _DEFAULT_OPENROUTER_HEADERS = {
     "HTTP-Referer": "https://github.com/HKUDS/DeepTutor",
@@ -82,6 +86,16 @@ def _coerce_dict(value: Any) -> dict[str, Any] | None:
         if isinstance(dumped, dict) and dumped:
             return dumped
     return None
+
+
+def _provider_state_output_items(message: dict[str, Any]) -> list[dict[str, Any]]:
+    state = message.get("_provider_response_state")
+    items = state.get("responses_output_items") if isinstance(state, dict) else None
+    if not isinstance(items, list):
+        items = message.get("_responses_output_items")
+    if not isinstance(items, list):
+        return []
+    return [dict(item) for item in items if isinstance(item, dict)]
 
 
 def _uses_openrouter(spec: "ProviderSpec | None", api_base: str | None) -> bool:
@@ -262,8 +276,42 @@ class OpenAICompatProvider(LLMProvider):
             return tool_call_id
         return hashlib.sha256(tool_call_id.encode()).hexdigest()[:9]
 
-    def _sanitize_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        sanitized = LLMProvider._sanitize_request_messages(messages, _ALLOWED_MSG_KEYS)
+    def _sanitize_messages(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        responses_api: bool = False,
+        model: str | None = None,
+    ) -> list[dict[str, Any]]:
+        prepared: list[dict[str, Any]] = []
+        for message in messages:
+            if not isinstance(message, dict):
+                prepared.append(message)
+                continue
+            clean = {
+                key: value
+                for key, value in message.items()
+                if key not in _INTERNAL_RESPONSE_STATE_KEYS
+            }
+            if responses_api:
+                output_items = _provider_state_output_items(message)
+                if output_items:
+                    clean["_provider_response_state"] = {"responses_output_items": output_items}
+            else:
+                state = message.get("_provider_response_state")
+                reasoning_content = (
+                    state.get("reasoning_content") if isinstance(state, dict) else None
+                )
+                if (
+                    isinstance(reasoning_content, str)
+                    and reasoning_content
+                    and model
+                    and "deepseek" in model.lower()
+                ):
+                    clean["reasoning_content"] = reasoning_content
+            prepared.append(clean)
+
+        sanitized = LLMProvider._sanitize_request_messages(prepared, _ALLOWED_MSG_KEYS)
         id_map: dict[str, str] = {}
 
         def map_id(value: Any) -> Any:
@@ -322,7 +370,9 @@ class OpenAICompatProvider(LLMProvider):
 
         kwargs: dict[str, Any] = {
             "model": model_name,
-            "messages": self._sanitize_messages(self._sanitize_empty_content(messages)),
+            "messages": self._sanitize_messages(
+                self._sanitize_empty_content(messages), model=model_name
+            ),
         }
 
         if self._supports_temperature(model_name, reasoning_effort):
@@ -487,7 +537,9 @@ class OpenAICompatProvider(LLMProvider):
             model_name = model_name.split("/")[-1]
 
         instructions, input_items = convert_messages(
-            self._sanitize_messages(self._sanitize_empty_content(messages))
+            self._sanitize_messages(
+                self._sanitize_empty_content(messages), responses_api=True, model=model_name
+            )
         )
         body: dict[str, Any] = {
             "model": model_name,

--- a/deeptutor/services/llm/provider_core/openai_responses/converters.py
+++ b/deeptutor/services/llm/provider_core/openai_responses/converters.py
@@ -27,6 +27,13 @@ def convert_messages(messages: list[dict[str, Any]]) -> tuple[str, list[dict[str
             continue
 
         if role == "assistant":
+            state = msg.get("_provider_response_state")
+            state_items = state.get("responses_output_items") if isinstance(state, dict) else None
+            if not isinstance(state_items, list):
+                state_items = msg.get("_responses_output_items")
+            if isinstance(state_items, list) and state_items:
+                input_items.extend(dict(item) for item in state_items if isinstance(item, dict))
+                continue
             if isinstance(content, str) and content:
                 input_items.append(
                     {

--- a/deeptutor/services/session/context_builder.py
+++ b/deeptutor/services/session/context_builder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 from typing import Any, Awaitable, Callable
 
 from deeptutor.agents.base_agent import BaseAgent
@@ -60,7 +61,7 @@ def trim_incomplete_tail(text: str) -> str:
     return text.rstrip()
 
 
-def expand_message_context(message: dict[str, Any]) -> list[dict[str, str]]:
+def expand_message_context(message: dict[str, Any]) -> list[dict[str, Any]]:
     """Expand one stored row into its true assistant/user chronology."""
     role = str(message.get("role", "user"))
     content = str(message.get("content", "") or "")
@@ -112,6 +113,18 @@ def build_history_text(history: list[dict[str, Any]]) -> str:
         else:
             lines.append(f"User: {content}")
     return "\n\n".join(lines)
+
+
+def _provider_response_state_tokens(message: dict[str, Any]) -> int:
+    metadata = message.get("metadata")
+    state = metadata.get("provider_response_state") if isinstance(metadata, dict) else None
+    if not isinstance(state, dict):
+        return 0
+    try:
+        serialized = json.dumps(state, ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError):
+        serialized = str(state)
+    return count_tokens(serialized)
 
 
 @dataclass
@@ -194,9 +207,22 @@ class ContextBuilder:
         if cleaned_summary:
             history.append({"role": "system", "content": cleaned_summary})
         for item in messages:
+            expanded_start = len(history)
             for expanded in expand_message_context(item):
                 if expanded["role"] in {"user", "assistant"}:
                     history.append(expanded)
+            if item.get("role") != "assistant":
+                continue
+            metadata = item.get("metadata")
+            provider_state = (
+                metadata.get("provider_response_state") if isinstance(metadata, dict) else None
+            )
+            if not isinstance(provider_state, dict):
+                continue
+            for expanded in reversed(history[expanded_start:]):
+                if expanded.get("role") == "assistant" and expanded.get("content"):
+                    expanded["_provider_response_state"] = provider_state
+                    break
         return history
 
     async def _append_event(
@@ -220,6 +246,7 @@ class ContextBuilder:
             content = str(item.get("content", "") or "")
             clarification = extract_ask_user_clarifications(item)
             tokens = count_tokens(f"{content}\n{clarification}" if clarification else content)
+            tokens += _provider_response_state_tokens(item)
             if selected and total + tokens > recent_budget:
                 break
             selected.insert(0, item)

--- a/deeptutor/services/session/pocketbase_store.py
+++ b/deeptutor/services/session/pocketbase_store.py
@@ -443,6 +443,7 @@ class PocketBaseSessionStore:
                 "role": m["role"],
                 "content": m["content"] or "",
                 "events": filter_ask_user_events(m.get("events")),
+                "metadata": m.get("metadata") or {},
             }
             for m in messages
             if m["role"] in ("user", "assistant", "system")

--- a/deeptutor/services/session/sqlite_store.py
+++ b/deeptutor/services/session/sqlite_store.py
@@ -1347,7 +1347,7 @@ class SQLiteSessionStore:
             if leaf_message_id is None:
                 rows = conn.execute(
                     """
-                    SELECT id, role, content, events_json
+                    SELECT id, role, content, events_json, metadata_json
                     FROM messages
                     WHERE session_id = ?
                       AND role IN ('user', 'assistant', 'system')
@@ -1361,6 +1361,7 @@ class SQLiteSessionStore:
                         "role": row["role"],
                         "content": row["content"] or "",
                         "events": select_ask_user_events(row["events_json"]),
+                        "metadata": _json_loads(row["metadata_json"], {}),
                     }
                     for row in rows
                 ]
@@ -1372,7 +1373,7 @@ class SQLiteSessionStore:
             while current is not None and safety > 0:
                 row = conn.execute(
                     """
-                    SELECT id, role, content, events_json, parent_message_id
+                    SELECT id, role, content, events_json, metadata_json, parent_message_id
                     FROM messages
                     WHERE id = ? AND session_id = ?
                       AND role IN ('user', 'assistant', 'system')
@@ -1387,6 +1388,7 @@ class SQLiteSessionStore:
                         "role": row["role"],
                         "content": row["content"] or "",
                         "events": select_ask_user_events(row["events_json"]),
+                        "metadata": _json_loads(row["metadata_json"], {}),
                     }
                 )
                 parent = row["parent_message_id"]

--- a/deeptutor/services/session/turn_runtime.py
+++ b/deeptutor/services/session/turn_runtime.py
@@ -1653,6 +1653,7 @@ class TurnRuntimeManager:
         attachment_records = []
         assistant_events: list[dict[str, Any]] = []
         assistant_content = ""
+        provider_response_state: dict[str, Any] | None = None
         # Per-round content segments + narration call_ids: a chat-loop round's
         # text is captured live but a round that resolves as narration is
         # dropped from the persisted answer (mirrors the frontend bubble).
@@ -2210,6 +2211,15 @@ class TurnRuntimeManager:
                         seen_artifact_urls.add(attachment["url"])
                         generated_attachments.append(attachment)
 
+            provider_response_state = context.metadata.pop("_provider_response_state", None)
+            if not isinstance(provider_response_state, dict):
+                provider_response_state = None
+            assistant_provider_metadata = (
+                {"provider_response_state": provider_response_state}
+                if provider_response_state is not None
+                else None
+            )
+
             # A mastery turn may have changed which path it is on
             # (``mastery_switch`` / ``mastery_leave``). The conversation's
             # stored preference already followed it; tell the open client too,
@@ -2246,6 +2256,7 @@ class TurnRuntimeManager:
                     events=assistant_events,
                     attachments=generated_attachments or None,
                     parent_message_id=new_user_message_id,
+                    metadata=assistant_provider_metadata,
                 )
             elif branch_parent_explicit:
                 assistant_message_id = await self.store.add_message(
@@ -2256,6 +2267,7 @@ class TurnRuntimeManager:
                     events=assistant_events,
                     attachments=generated_attachments or None,
                     parent_message_id=branch_parent_id,
+                    metadata=assistant_provider_metadata,
                 )
             else:
                 assistant_message_id = await self.store.add_message(
@@ -2265,6 +2277,7 @@ class TurnRuntimeManager:
                     capability=capability_name,
                     events=assistant_events,
                     attachments=generated_attachments or None,
+                    metadata=assistant_provider_metadata,
                 )
             turn_status, turn_error = _resolve_turn_outcome(
                 assistant_events,
@@ -2365,6 +2378,11 @@ class TurnRuntimeManager:
                             capability=capability_name,
                             events=assistant_events,
                             attachments=generated_attachments or None,
+                            metadata=(
+                                {"provider_response_state": provider_response_state}
+                                if provider_response_state is not None
+                                else None
+                            ),
                         )
                     )
             with contextlib.suppress(Exception):

--- a/tests/agents/chat/test_agent_loop.py
+++ b/tests/agents/chat/test_agent_loop.py
@@ -38,8 +38,12 @@ def _llm_chunk(
     tool_calls: list[dict[str, Any]] | None = None,
     usage: Any = None,
     finish_reason: str | None = None,
+    reasoning_content: str | None = None,
+    provider_specific_fields: dict[str, Any] | None = None,
 ) -> SimpleNamespace:
     delta_fields: dict[str, Any] = {"content": content}
+    if reasoning_content is not None:
+        delta_fields["reasoning_content"] = reasoning_content
     if tool_calls is not None:
         delta_fields["tool_calls"] = [
             SimpleNamespace(
@@ -59,6 +63,7 @@ def _llm_chunk(
             SimpleNamespace(
                 delta=SimpleNamespace(**delta_fields),
                 finish_reason=finish_reason,
+                provider_specific_fields=provider_specific_fields,
             )
         ],
         usage=usage,
@@ -447,6 +452,37 @@ async def test_finish_first_round_no_tools(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 @pytest.mark.asyncio
+async def test_finish_round_persists_provider_response_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _Registry()
+    native_items = [{"type": "reasoning", "id": "rs_1", "summary": []}]
+    client = _ScriptedChatClient(
+        [
+            [
+                _llm_chunk(
+                    content="A direct answer.",
+                    reasoning_content="private reasoning",
+                    provider_specific_fields={"native_output_items": native_items},
+                )
+            ]
+        ]
+    )
+    pipeline = AgenticChatPipeline(language="en")
+    pipeline.registry = registry
+    monkeypatch.setattr(pipeline, "_compose_enabled_tools", lambda _context: [])
+    monkeypatch.setattr(pipeline, "_build_openai_client", lambda: client)
+    context = UnifiedContext(session_id="s1", user_message="Hello")
+
+    await _run(pipeline, context)
+
+    assert context.metadata["_provider_response_state"] == {
+        "responses_output_items": native_items,
+        "reasoning_content": "private reasoning",
+    }
+
+
+@pytest.mark.asyncio
 async def test_tool_round_then_finish(monkeypatch: pytest.MonkeyPatch) -> None:
     """A tool round (narration text + a tool call) is followed by a tool-less
     finish round whose text is the answer — two LLM calls, no respond pass."""
@@ -455,7 +491,7 @@ async def test_tool_round_then_finish(monkeypatch: pytest.MonkeyPatch) -> None:
         [
             # Round 1: preamble (narration) text + a tool call.
             [
-                _llm_chunk(content="Searching."),
+                _llm_chunk(content="Searching.", reasoning_content="round one private reasoning"),
                 _llm_chunk(
                     tool_calls=[
                         {
@@ -468,7 +504,7 @@ async def test_tool_round_then_finish(monkeypatch: pytest.MonkeyPatch) -> None:
             ],
             # Round 2: the model sees the tool result in-protocol and finishes
             # by replying without tool calls.
-            [_llm_chunk(content="Found what was needed.")],
+            [_llm_chunk(content="Found what was needed.", reasoning_content="final reasoning")],
         ]
     )
     pipeline = AgenticChatPipeline(language="en")
@@ -495,6 +531,9 @@ async def test_tool_round_then_finish(monkeypatch: pytest.MonkeyPatch) -> None:
     assistant_tc = [m for m in second_round if m.get("role") == "assistant" and m.get("tool_calls")]
     assert assistant_tc and assistant_tc[0]["tool_calls"][0]["function"]["name"] == "web_search"
     assert assistant_tc[0]["content"] == "Searching."
+    assert assistant_tc[0]["_provider_response_state"] == {
+        "reasoning_content": "round one private reasoning"
+    }
     tool_msgs = [m for m in second_round if m.get("role") == "tool"]
     assert tool_msgs and "tool answer" in tool_msgs[0]["content"]
     result = _result(events)

--- a/tests/api/test_sessions_truncation.py
+++ b/tests/api/test_sessions_truncation.py
@@ -9,6 +9,7 @@ helper mutates that list in place.
 from deeptutor.api.routers.sessions import (
     _TRUNCATION_NOTICE,
     MAX_EVENT_PAYLOAD,
+    _redact_private_message_metadata,
     _truncate_oversized_events,
 )
 
@@ -67,6 +68,24 @@ def test_small_payloads_are_left_untouched():
     # Non-truncatable event type left alone even when oversized.
     assert "_truncated" not in messages[1]["events"][0]
     assert len(messages[1]["events"][0]["content"]) == MAX_EVENT_PAYLOAD + 5
+
+
+def test_redacts_private_provider_response_state():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "answer",
+            "metadata": {
+                "provider_response_state": {"reasoning_content": "private"},
+                "request_snapshot": {"content": "question"},
+            },
+        }
+    ]
+
+    _redact_private_message_metadata(messages)
+
+    assert "provider_response_state" not in messages[0]["metadata"]
+    assert messages[0]["metadata"]["request_snapshot"] == {"content": "question"}
 
 
 def test_handles_messages_without_events_or_malformed_events():

--- a/tests/api/test_unified_ws_turn_runtime.py
+++ b/tests/api/test_unified_ws_turn_runtime.py
@@ -260,6 +260,89 @@ async def test_turn_runtime_replays_events_and_materializes_messages(
 
 
 @pytest.mark.asyncio
+async def test_turn_runtime_persists_private_provider_response_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    runtime = TurnRuntimeManager(store)
+    captured: dict[str, object] = {}
+    state = {"reasoning_content": "private reasoning"}
+
+    class FakeContextBuilder:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def build(self, **_kwargs):
+            return SimpleNamespace(
+                conversation_history=[],
+                conversation_summary="",
+                context_text="",
+                token_count=0,
+                budget=0,
+            )
+
+    class FakeOrchestrator:
+        async def handle(self, context):
+            captured["metadata"] = context.metadata
+            context.metadata["_provider_response_state"] = state
+            yield StreamEvent(
+                type=StreamEventType.CONTENT,
+                source="chat",
+                stage="responding",
+                content="A direct answer",
+                metadata={"call_kind": "llm_final_response"},
+            )
+            yield StreamEvent(type=StreamEventType.DONE, source="chat")
+
+    async def title_after_done(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("deeptutor.services.llm.config.get_llm_config", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        "deeptutor.services.session.context_builder.ContextBuilder", FakeContextBuilder
+    )
+    monkeypatch.setattr("deeptutor.runtime.orchestrator.ChatOrchestrator", FakeOrchestrator)
+    monkeypatch.setattr(runtime, "_maybe_generate_session_title", title_after_done)
+    monkeypatch.setattr(
+        "deeptutor.services.memory.get_memory_store",
+        lambda: SimpleNamespace(read_l3_concat=lambda: "", emit=_noop_async),
+    )
+    monkeypatch.setattr(
+        "deeptutor.services.skill.get_skill_service",
+        _fake_skill_service,
+    )
+    monkeypatch.setattr(
+        "deeptutor.services.persona.get_persona_service",
+        _fake_persona_service,
+    )
+
+    session, turn = await runtime.start_turn(
+        {
+            "type": "start_turn",
+            "content": "hello",
+            "session_id": None,
+            "capability": None,
+            "tools": [],
+            "knowledge_bases": [],
+            "attachments": [],
+            "language": "en",
+            "config": {},
+        }
+    )
+    async for _event in runtime.subscribe_turn(turn["id"], after_seq=0):
+        pass
+
+    detail = await store.get_session_with_messages(session["id"])
+    assert detail is not None
+    assistant = detail["messages"][-1]
+    assert assistant["metadata"]["provider_response_state"] == state
+    metadata = captured["metadata"]
+    assert isinstance(metadata, dict)
+    assert "_provider_response_state" not in metadata
+
+
+@pytest.mark.asyncio
 async def test_turn_runtime_persists_llm_selection_in_turn_snapshot(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,

--- a/tests/core/test_agentic_client_provider_kwargs.py
+++ b/tests/core/test_agentic_client_provider_kwargs.py
@@ -10,6 +10,7 @@ from deeptutor.core.agentic.client import (
     _NATIVE_TOOL_BACKENDS,
     LLMClientConfig,
     _ProviderOpenAIAdapter,
+    _ProviderOpenAIStream,
     build_completion_kwargs,
     build_openai_client,
     can_use_native_tool_calling,
@@ -89,6 +90,34 @@ def test_agentic_kwargs_preserve_legacy_shape_without_binding() -> None:
     )
 
     assert kwargs == {"temperature": 0.2, "max_tokens": 256}
+
+
+@pytest.mark.asyncio
+async def test_provider_stream_exposes_final_reasoning_content() -> None:
+    class FakeProvider:
+        async def chat_stream(self, **_kwargs):
+            return LLMResponse(
+                content="answer",
+                finish_reason="stop",
+                reasoning_content="private reasoning",
+            )
+
+    stream = _ProviderOpenAIStream(
+        provider=FakeProvider(),
+        messages=[],
+        tools=None,
+        model="deepseek-v4-pro",
+        max_tokens=32,
+        temperature=0.7,
+        reasoning_effort=None,
+        tool_choice=None,
+        extra_kwargs={},
+    )
+
+    chunks = [chunk async for chunk in stream]
+
+    final_choice = chunks[-1].choices[0]
+    assert final_choice.provider_specific_fields["reasoning_content"] == "private reasoning"
 
 
 @pytest.mark.parametrize("binding", ["moonshot", "openai", "custom"])

--- a/tests/services/llm/test_openai_compat_reasoning_content.py
+++ b/tests/services/llm/test_openai_compat_reasoning_content.py
@@ -105,6 +105,83 @@ def test_services_deepseek_v4_pro_enables_thinking_by_default() -> None:
     assert kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
 
 
+def test_services_deepseek_replays_persisted_reasoning_content() -> None:
+    provider = ServicesOpenAICompatProvider.__new__(ServicesOpenAICompatProvider)
+    provider.default_model = "deepseek-v4-pro"
+    provider._spec = find_service_provider("deepseek")
+
+    kwargs = provider._build_kwargs(
+        messages=[
+            {
+                "role": "assistant",
+                "content": "previous answer",
+                "_provider_response_state": {"reasoning_content": "private reasoning"},
+            },
+            {"role": "user", "content": "next question"},
+        ],
+        tools=None,
+        model=None,
+        max_tokens=32,
+        temperature=0.7,
+        reasoning_effort=None,
+        tool_choice=None,
+    )
+
+    assistant_message = kwargs["messages"][0]
+    assert assistant_message["reasoning_content"] == "private reasoning"
+    assert "_provider_response_state" not in assistant_message
+
+
+def test_non_deepseek_drops_persisted_reasoning_content() -> None:
+    provider = ServicesOpenAICompatProvider.__new__(ServicesOpenAICompatProvider)
+    provider.default_model = "gpt-test"
+    provider._spec = find_service_provider("openai")
+
+    kwargs = provider._build_kwargs(
+        messages=[
+            {
+                "role": "assistant",
+                "content": "previous answer",
+                "_provider_response_state": {"reasoning_content": "private reasoning"},
+            }
+        ],
+        tools=None,
+        model="gpt-test",
+        max_tokens=32,
+        temperature=0.7,
+        reasoning_effort=None,
+        tool_choice=None,
+    )
+
+    assert "reasoning_content" not in kwargs["messages"][0]
+    assert "_provider_response_state" not in kwargs["messages"][0]
+
+
+def test_responses_body_replays_persisted_native_output_items() -> None:
+    provider = ServicesOpenAICompatProvider.__new__(ServicesOpenAICompatProvider)
+    provider.default_model = "gpt-test"
+    provider._spec = find_service_provider("openai")
+    native_items = [{"type": "reasoning", "id": "rs_1", "summary": []}]
+
+    body = provider._build_responses_body(
+        messages=[
+            {
+                "role": "assistant",
+                "content": "previous answer",
+                "_provider_response_state": {"responses_output_items": native_items},
+            }
+        ],
+        tools=None,
+        model="gpt-test",
+        max_tokens=32,
+        temperature=0.7,
+        reasoning_effort=None,
+        tool_choice=None,
+    )
+
+    assert body["input"] == native_items
+
+
 def test_services_dashscope_minimal_reasoning_uses_enable_thinking_only() -> None:
     kwargs = _build_services_kwargs("dashscope", "minimal")
 

--- a/tests/services/llm/test_openai_responses_converters.py
+++ b/tests/services/llm/test_openai_responses_converters.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from deeptutor.services.llm.provider_core.openai_responses import (
     adapt_chat_kwargs_to_responses,
+    convert_messages,
 )
 
 
@@ -52,3 +53,28 @@ class TestAdaptChatKwargsToResponses:
         source = {"max_completion_tokens": 8192, "temperature": 0.2}
         adapt_chat_kwargs_to_responses(source)
         assert source == {"max_completion_tokens": 8192, "temperature": 0.2}
+
+
+class TestConvertMessages:
+    def test_replays_persisted_native_output_items(self) -> None:
+        native_items = [
+            {"type": "reasoning", "id": "rs_1", "summary": []},
+            {
+                "type": "message",
+                "id": "msg_1",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "previous answer"}],
+            },
+        ]
+
+        _instructions, input_items = convert_messages(
+            [
+                {
+                    "role": "assistant",
+                    "content": "previous answer",
+                    "_provider_response_state": {"responses_output_items": native_items},
+                }
+            ]
+        )
+
+        assert input_items == native_items

--- a/tests/services/session/test_context_builder.py
+++ b/tests/services/session/test_context_builder.py
@@ -265,6 +265,7 @@ class TestBuildHistory:
         message = {
             "role": "assistant",
             "content": before + after,
+            "metadata": {"provider_response_state": {"reasoning_content": "private reasoning"}},
             "events": [
                 {
                     "type": "tool_result",
@@ -301,7 +302,11 @@ class TestBuildHistory:
         assert history == [
             {"role": "assistant", "content": before},
             {"role": "user", "content": clarification},
-            {"role": "assistant", "content": after},
+            {
+                "role": "assistant",
+                "content": after,
+                "_provider_response_state": {"reasoning_content": "private reasoning"},
+            },
         ]
         transcript = format_messages_as_transcript([message])
         assert transcript.index(before) < transcript.index(clarification) < transcript.index(after)
@@ -334,6 +339,22 @@ class TestSelectRecentMessages:
         older, recent = builder._select_recent_messages(messages, recent_budget=10)
         assert len(recent) >= 1
         assert len(older) + len(recent) == len(messages)
+
+    def test_budget_includes_private_provider_response_state(self) -> None:
+        builder = ContextBuilder(store=MagicMock())
+        messages = [
+            {
+                "role": "assistant",
+                "content": "short answer",
+                "metadata": {"provider_response_state": {"reasoning_content": "x" * 1000}},
+            },
+            {"role": "user", "content": "new question"},
+        ]
+
+        older, recent = builder._select_recent_messages(messages, recent_budget=100)
+
+        assert older == messages[:1]
+        assert recent == messages[1:]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/session/test_sqlite_store.py
+++ b/tests/services/session/test_sqlite_store.py
@@ -375,6 +375,23 @@ def test_context_messages_carry_ask_user_events(store: SQLiteSessionStore) -> No
     assert [e["type"] for e in messages[1]["events"]] == ["tool_result", "progress"]
 
 
+def test_context_messages_carry_private_metadata(store: SQLiteSessionStore) -> None:
+    session = asyncio.run(store.create_session())
+    state = {"reasoning_content": "private reasoning"}
+    asyncio.run(
+        store.add_message(
+            session["id"],
+            "assistant",
+            "A direct answer",
+            metadata={"provider_response_state": state},
+        )
+    )
+
+    messages = asyncio.run(store.get_messages_for_context(session["id"]))
+
+    assert messages[0]["metadata"]["provider_response_state"] == state
+
+
 def test_branch_context_messages_carry_ask_user_events(store: SQLiteSessionStore) -> None:
     session = asyncio.run(store.create_session())
     _add_ask_user_turn(store, session["id"])
@@ -383,3 +400,21 @@ def test_branch_context_messages_carry_ask_user_events(store: SQLiteSessionStore
     messages = asyncio.run(store.get_messages_for_context(session["id"], leaf_message_id=leaf))
 
     assert [e["type"] for e in messages[1]["events"]] == ["tool_result", "progress"]
+
+
+def test_branch_context_messages_carry_private_metadata(store: SQLiteSessionStore) -> None:
+    session = asyncio.run(store.create_session())
+    asyncio.run(store.add_message(session["id"], "user", "Question"))
+    state = {"reasoning_content": "branch reasoning"}
+    leaf = asyncio.run(
+        store.add_message(
+            session["id"],
+            "assistant",
+            "A branched answer",
+            metadata={"provider_response_state": state},
+        )
+    )
+
+    messages = asyncio.run(store.get_messages_for_context(session["id"], leaf_message_id=leaf))
+
+    assert messages[-1]["metadata"]["provider_response_state"] == state


### PR DESCRIPTION
### Description

DeepSeek thinking mode requires provider reasoning state to be replayed on subsequent requests. The existing fixes cover the Responses tool-call path and the OpenAI-compatible DeepSeek binding default, but ordinary conversation turns still lose the state after it is persisted with the session.

This patch preserves provider response state for Chat Completions and Responses API turns, carries it through the chat agent loop, persists it as private assistant-message metadata, and rebuilds it in the next-turn context. DeepSeek-compatible Chat Completions requests replay `reasoning_content`; Responses requests replay native output items. Other providers drop the private state.

Session APIs redact `provider_response_state`, token accounting includes the private state, and branch reconstruction preserves it. This is complementary to #1048 and #1059: it addresses persistence across user turns rather than disabling thinking or replaying only within a single tool loop.

### Related Issues

Closes #1058

### Module(s) Affected

- [x] `agents`
- [x] `api`
- [ ] `config`
- [x] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs`
- [ ] `scripts`
- [x] `tests`

### Testing

- `uv run --extra dev pytest -q tests/agents/chat/test_agent_loop.py tests/api/test_sessions_truncation.py tests/api/test_unified_ws_turn_runtime.py tests/core/test_agentic_client_provider_kwargs.py tests/services/llm/test_openai_compat_reasoning_content.py tests/services/llm/test_openai_responses_converters.py tests/services/session/test_context_builder.py tests/services/session/test_sqlite_store.py` — 186 passed.
- `uv run --extra dev ruff check <changed files>` — passed.
- `uv run --extra dev ruff format --check <changed files>` — 18 files already formatted.

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.
