### PR TITLE
fix(chat): select newly sent branch (#739)

### DIFF
--- a/web/context/UnifiedChatContext.tsx
+++ b/web/context/UnifiedChatContext.tsx
@@ -29,7 +29,11 @@ import {
 } from "@/lib/session-api";
 import { normalizeMarkdownForDisplay } from "@/lib/markdown-display";
 import { normalizeMessageContent } from "@/lib/message-content";
-import { buildVisiblePath, tipMessageId } from "@/lib/message-branches";
+import {
+  buildVisiblePath,
+  selectChildBranch,
+  tipMessageId,
+} from "@/lib/message-branches";
 import { nextOptimisticId, resolvePersistedMessage } from "@/lib/optimistic-id";
 import { reconcileTurnIds } from "@/lib/turn-reconcile";
 import {
@@ -392,6 +396,11 @@ function reducer(state: ProviderState, action: Action): ProviderState {
     case "ADD_USER_MSG": {
       const session =
         state.sessions[action.key] ?? createSessionEntry(action.key);
+      const userId = nextOptimisticId();
+      const parentId =
+        action.parentMessageId === undefined
+          ? null
+          : action.parentMessageId;
       return {
         ...state,
         sessions: {
@@ -401,14 +410,11 @@ function reducer(state: ProviderState, action: Action): ProviderState {
             messages: [
               ...session.messages,
               {
-                id: nextOptimisticId(),
+                id: userId,
                 role: "user",
                 content: action.content,
                 capability: action.capability || "",
-                parentMessageId:
-                  action.parentMessageId === undefined
-                    ? null
-                    : action.parentMessageId,
+                parentMessageId: parentId,
                 ...(action.attachments?.length
                   ? { attachments: action.attachments }
                   : {}),
@@ -417,6 +423,11 @@ function reducer(state: ProviderState, action: Action): ProviderState {
                   : {}),
               },
             ],
+            selectedBranches: selectChildBranch(
+              session.selectedBranches,
+              parentId,
+              userId,
+            ),
             updatedAt: Date.now(),
           },
         },

--- a/web/lib/message-branches.ts
+++ b/web/lib/message-branches.ts
@@ -155,6 +155,23 @@ export function buildVisiblePath(
   return { messages: visible, siblingsByMessageId };
 }
 
+/** Select a freshly-created child at a branch point.
+ *
+ * Sending a message can create a sibling even when the parent previously had
+ * only one visible child (notably message edits). Persisting that choice with
+ * the optimistic id also lets reconcileTurnIds remap it to the server id.
+ */
+export function selectChildBranch(
+  selectedBranches: Record<string, number>,
+  parentId: number | null,
+  childId: number,
+): Record<string, number> {
+  return {
+    ...selectedBranches,
+    [parentKey(parentId)]: childId,
+  };
+}
+
 /**
  * Find the most recent child id under ``parentId`` from a flat message
  * list. Used after an edit to auto-select the freshly persisted sibling.

--- a/web/tests/optimistic-id.test.ts
+++ b/web/tests/optimistic-id.test.ts
@@ -5,7 +5,11 @@ import {
   resolvePersistedMessage,
 } from "../lib/optimistic-id";
 import { reconcileTurnIds } from "../lib/turn-reconcile";
-import { buildVisiblePath, tipMessageId } from "../lib/message-branches";
+import {
+  buildVisiblePath,
+  selectChildBranch,
+  tipMessageId,
+} from "../lib/message-branches";
 import type { MessageItem } from "../context/UnifiedChatContext";
 
 test("optimistic ids are negative and strictly decreasing", () => {
@@ -101,5 +105,89 @@ test("the previous reply stays visible once the next turn is queued", () => {
   assert.deepEqual(
     visible.messages.map((m) => m.content),
     ["q1", "a1", "q2"],
+  );
+});
+
+test("a freshly edited sibling overrides the previously selected branch", () => {
+  const messages = [
+    { id: 10, role: "user" as const, content: "q1", parentMessageId: null },
+    {
+      id: 11,
+      role: "assistant" as const,
+      content: "a1",
+      parentMessageId: 10,
+    },
+    {
+      id: 12,
+      role: "user" as const,
+      content: "original q2",
+      parentMessageId: 11,
+    },
+    {
+      id: -20,
+      role: "user" as const,
+      content: "edited q2",
+      parentMessageId: 11,
+    },
+  ];
+
+  const selectedBranches = selectChildBranch({ "11": 12 }, 11, -20);
+  const visible = buildVisiblePath(
+    messages as unknown as MessageItem[],
+    selectedBranches,
+  );
+
+  assert.deepEqual(
+    visible.messages.map((message) => message.content),
+    ["q1", "a1", "edited q2"],
+  );
+});
+
+test("the edited branch and its reply survive optimistic id reconciliation", () => {
+  const editedId = nextOptimisticId();
+  const replyId = nextOptimisticId();
+  const messages = [
+    { id: 10, role: "user" as const, content: "q1", parentMessageId: null },
+    {
+      id: 11,
+      role: "assistant" as const,
+      content: "a1",
+      parentMessageId: 10,
+    },
+    {
+      id: 12,
+      role: "user" as const,
+      content: "original q2",
+      parentMessageId: 11,
+    },
+    {
+      id: editedId,
+      role: "user" as const,
+      content: "edited q2",
+      parentMessageId: 11,
+    },
+    {
+      id: replyId,
+      role: "assistant" as const,
+      content: "edited a2",
+      parentMessageId: editedId,
+      events: [{ turn_id: "turn_2" }],
+    },
+  ];
+
+  const reconciled = reconcileTurnIds(
+    messages as unknown as MessageItem[],
+    selectChildBranch({}, 11, editedId),
+    { turnId: "turn_2", userMessageId: 30, assistantMessageId: 31 },
+  );
+  const visible = buildVisiblePath(
+    reconciled.messages,
+    reconciled.selectedBranches,
+  );
+
+  assert.equal(reconciled.selectedBranches["11"], 30);
+  assert.deepEqual(
+    visible.messages.map((message) => message.content),
+    ["q1", "a1", "edited q2", "edited a2"],
   );
 });


### PR DESCRIPTION
## Summary

- Select the optimistic child branch when a new user turn is appended, so an edit cannot keep the visible path pinned to the original sibling.
- Let turn reconciliation remap that selection from the client-generated ID to persisted IDs.
- Add regression coverage for both the immediate visible path and post-turn reconciliation.

Fixes #739

## Verification

- `npm run test:node -- web/tests/optimistic-id.test.ts` -- 654/654 passed.
- `npm exec tsc -- --noEmit --pretty false` -- passed.
- `npm run lint` -- passed with 56 pre-existing warnings and no errors.
- `git merge-base --is-ancestor origin/dev HEAD` -- passed on the latest `dev`.
