### PR TITLE
fix(knowledge): explain scanned PDF parse failures (#431)

### DIFF
--- a/deeptutor/services/rag/pipelines/llamaindex/document_loader.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/document_loader.py
@@ -79,8 +79,16 @@ class LlamaIndexDocumentLoader:
             # archive download) on a synchronous httpx.Client — running it on
             # the event loop stalls every other request for the whole PDF
             # (same class of bug as upstream #761/#777). Hand it to a thread.
-            text, extracted_images = await asyncio.to_thread(self._parse_document, file_path)
-            self._append_if_nonempty(documents, file_path, text)
+            text, extracted_images, parse_engine = await asyncio.to_thread(
+                self._parse_document, file_path
+            )
+            self._append_if_nonempty(
+                documents,
+                file_path,
+                text,
+                parse_engine=parse_engine,
+                extracted_image_count=len(extracted_images),
+            )
             image_sources.extend(extracted_images)
 
         for file_path_str in classification.text_files:
@@ -105,10 +113,10 @@ class LlamaIndexDocumentLoader:
 
         return documents
 
-    def _parse_document(self, file_path: Path) -> tuple[str, list[_ImageSource]]:
+    def _parse_document(self, file_path: Path) -> tuple[str, list[_ImageSource], str]:
         """Parse a document through the shared, engine-pluggable parse layer.
 
-        Returns ``(text, extracted_images)``. A parse failure (engine
+        Returns ``(text, extracted_images, engine)``. A parse failure (engine
         unavailable, unsupported format for the active engine, or models not
         ready) is logged and the file is skipped — matching the sibling
         LightRAG/GraphRAG pipelines — rather than aborting the whole batch.
@@ -122,11 +130,11 @@ class LlamaIndexDocumentLoader:
                 f"Skipped {file_path.name}: the active document-parsing engine could "
                 f"not handle it ({exc}). Change the engine in Settings → Document Parsing."
             )
-            return "", []
+            return "", [], ""
 
         text = parsed.markdown.strip() or self._text_from_blocks(parsed.blocks)
         images = self._collect_asset_images(parsed.asset_dir, origin=file_path)
-        return text, images
+        return text, images, str(parsed.engine or "")
 
     @staticmethod
     def _text_from_blocks(blocks: list[dict] | None) -> str:
@@ -338,7 +346,15 @@ class LlamaIndexDocumentLoader:
             "mimetype": mimetype,
         }
 
-    def _append_if_nonempty(self, documents: list[Any], file_path: Path, text: str) -> None:
+    def _append_if_nonempty(
+        self,
+        documents: list[Any],
+        file_path: Path,
+        text: str,
+        *,
+        parse_engine: str = "",
+        extracted_image_count: int = 0,
+    ) -> None:
         if text.strip():
             documents.append(
                 Document(
@@ -351,4 +367,16 @@ class LlamaIndexDocumentLoader:
             )
             self.logger.info(f"Loaded: {file_path.name} ({len(text)} chars)")
         else:
-            self.logger.warning(f"Skipped empty document: {file_path.name}")
+            if file_path.suffix.lower() == ".pdf" and extracted_image_count:
+                engine_label = parse_engine or "the active parser"
+                self.logger.warning(
+                    "Skipped empty document: %s. The %s engine extracted %d image(s) "
+                    "but no text. This is usually a scanned PDF; use an OCR-capable "
+                    "parsing engine such as MinerU or Docling with OCR enabled. "
+                    "Change the engine in Settings, Document Parsing.",
+                    file_path.name,
+                    engine_label,
+                    extracted_image_count,
+                )
+            else:
+                self.logger.warning(f"Skipped empty document: {file_path.name}")

--- a/tests/services/rag/test_llamaindex_document_loader.py
+++ b/tests/services/rag/test_llamaindex_document_loader.py
@@ -134,6 +134,75 @@ def test_loader_skips_document_when_active_engine_cannot_parse(
     assert "Settings" in caplog.text
 
 
+def test_loader_explains_scanned_pdf_when_parser_yields_images_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    pytest.importorskip("llama_index.core")
+    from deeptutor.services.parsing.types import ParsedDocument
+    from deeptutor.services.rag.pipelines.llamaindex import document_loader as loader_module
+    from deeptutor.services.rag.pipelines.llamaindex.document_loader import (
+        LlamaIndexDocumentLoader,
+    )
+
+    pdf_path = tmp_path / "scan.pdf"
+    pdf_path.write_bytes(b"stub")
+    asset_dir = tmp_path / "assets"
+    asset_dir.mkdir()
+    (asset_dir / "page-1.png").write_bytes(b"\x89PNG\r\n")
+
+    _install_stub_parse_service(
+        monkeypatch,
+        {
+            "scan.pdf": ParsedDocument(
+                markdown="",
+                engine="pymupdf4llm",
+                asset_dir=asset_dir,
+            )
+        },
+    )
+
+    class _TextOnlyClient:
+        config = type("Config", (), {"binding": "openai", "model": "text-embedding"})()
+
+        def supports_multimodal_contents(self) -> bool:
+            return False
+
+    monkeypatch.setattr(loader_module, "get_embedding_client", lambda: _TextOnlyClient())
+
+    with caplog.at_level("WARNING"):
+        documents = asyncio.run(LlamaIndexDocumentLoader().load([str(pdf_path)]))
+
+    assert documents == []
+    assert "pymupdf4llm engine extracted 1 image(s) but no text" in caplog.text
+    assert "scanned PDF" in caplog.text
+    assert "OCR-capable" in caplog.text
+    assert "Settings, Document Parsing" in caplog.text
+
+
+def test_loader_keeps_generic_empty_warning_for_non_pdf(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    pytest.importorskip("llama_index.core")
+    from deeptutor.services.parsing.types import ParsedDocument
+    from deeptutor.services.rag.pipelines.llamaindex.document_loader import (
+        LlamaIndexDocumentLoader,
+    )
+
+    docx_path = tmp_path / "blank.docx"
+    docx_path.write_bytes(b"stub")
+    _install_stub_parse_service(
+        monkeypatch,
+        {"blank.docx": ParsedDocument(markdown="", engine="markitdown")},
+    )
+
+    with caplog.at_level("WARNING"):
+        documents = asyncio.run(LlamaIndexDocumentLoader().load([str(docx_path)]))
+
+    assert documents == []
+    assert caplog.text.count("Skipped empty document: blank.docx") == 1
+    assert "scanned PDF" not in caplog.text
+
+
 def test_loader_indexes_images_extracted_from_parsed_document(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Explain when a PDF produces images but no text and recommend an OCR-capable parsing engine.
- Preserve the generic empty-document warning for non-PDF files and PDFs with no extracted images.
- Keep indexing behavior unchanged.

Fixes #431

## Testing
- `uv run --python 3.13 --extra dev pytest -q tests/services/rag/test_llamaindex_document_loader.py` — 10 passed
- `uv run --python 3.13 --extra dev ruff check deeptutor/services/rag/pipelines/llamaindex/document_loader.py tests/services/rag/test_llamaindex_document_loader.py` — passed
- `uv run --python 3.13 --extra dev ruff format --check deeptutor/services/rag/pipelines/llamaindex/document_loader.py tests/services/rag/test_llamaindex_document_loader.py` — passed