### PR TITLE
fix(llm): enable DeepSeek Pro native web search (#846)

### DIFF
--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -330,7 +330,7 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         default_api_base="https://api.deepseek.com",
         thinking_style="thinking_type",
         reasoning_model_patterns=("deepseek-v4-pro", "deepseek-reasoner"),
-        native_web_search_models=("deepseek-v4-flash",),
+        native_web_search_models=("deepseek-v4-flash", "deepseek-v4-pro"),
     ),
     ProviderSpec(
         name="gemini",

--- a/tests/services/llm/test_native_web_search.py
+++ b/tests/services/llm/test_native_web_search.py
@@ -103,12 +103,13 @@ def _provider(model: str) -> OpenAICompatProvider:
     )
 
 
-def test_only_supported_deepseek_model_uses_responses_for_native_search() -> None:
+def test_supported_deepseek_models_use_responses_for_native_search() -> None:
     assert _provider("deepseek-v4-flash")._should_use_responses_api(
         "deepseek-v4-flash", None, _TOOLS
     )
-    assert not _provider("deepseek-v4-pro")._should_use_responses_api(
-        "deepseek-v4-pro", None, _TOOLS
+    assert _provider("deepseek-v4-pro")._should_use_responses_api("deepseek-v4-pro", None, _TOOLS)
+    assert not _provider("deepseek-reasoner")._should_use_responses_api(
+        "deepseek-reasoner", None, _TOOLS
     )
     assert not _provider("deepseek-v4-flash")._should_use_responses_api(
         "deepseek-v4-flash", None, None
@@ -125,6 +126,15 @@ def test_native_mapping_is_model_scoped() -> None:
         None,
         None,
     )
+    reasoner_body = _provider("deepseek-reasoner")._build_responses_body(
+        [{"role": "user", "content": "latest news"}],
+        _TOOLS,
+        "deepseek-reasoner",
+        256,
+        0.7,
+        None,
+        None,
+    )
     pro_body = _provider("deepseek-v4-pro")._build_responses_body(
         [{"role": "user", "content": "latest news"}],
         _TOOLS,
@@ -135,10 +145,11 @@ def test_native_mapping_is_model_scoped() -> None:
         None,
     )
     assert flash_body["tools"] == [{"type": "web_search"}]
-    assert pro_body["tools"][0]["type"] == "function"
+    assert pro_body["tools"] == [{"type": "web_search"}]
+    assert reasoner_body["tools"][0]["type"] == "function"
 
 
-def test_agent_client_routes_only_supported_model_through_provider_adapter(monkeypatch) -> None:
+def test_agent_client_routes_supported_models_through_provider_adapter(monkeypatch) -> None:
     sentinel = object()
     monkeypatch.setattr(
         client_module,
@@ -153,14 +164,21 @@ def test_agent_client_routes_only_supported_model_through_provider_adapter(monke
         api_key="k",
         base_url="https://api.deepseek.com",
     )
+    reasoner = LLMClientConfig(
+        binding="deepseek",
+        model="deepseek-reasoner",
+        api_key="k",
+        base_url="https://api.deepseek.com",
+    )
+    assert client_module._build_native_provider_adapter(flash, spec) is sentinel
     pro = LLMClientConfig(
         binding="deepseek",
         model="deepseek-v4-pro",
         api_key="k",
         base_url="https://api.deepseek.com",
     )
-    assert client_module._build_native_provider_adapter(flash, spec) is sentinel
-    assert client_module._build_native_provider_adapter(pro, spec) is None
+    assert client_module._build_native_provider_adapter(pro, spec) is sentinel
+    assert client_module._build_native_provider_adapter(reasoner, spec) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `deepseek-v4-pro` to the DeepSeek native web-search model allowlist so it uses the existing Responses API adapter.
- Keep unrelated DeepSeek models on ordinary Chat Completions unless another Responses gate applies.
- Extend native-search routing and request-body tests to cover both documented V4 models while retaining a negative model guard.

## Testing
- `python -m pytest -q tests/services/llm/test_native_web_search.py tests/services/test_provider_registry.py tests/core/test_agentic_client_provider_kwargs.py` — 48 passed.
- `python -m ruff check deeptutor/services/provider_registry.py tests/services/llm/test_native_web_search.py` — passed.
- `python -m ruff format --check deeptutor/services/provider_registry.py tests/services/llm/test_native_web_search.py` — passed.

Fixes #846