### PR TITLE
fix(ci): restore the ruff gate on dev

### DIFF
--- a/deeptutor/api/routers/outputs.py
+++ b/deeptutor/api/routers/outputs.py
@@ -58,9 +58,9 @@ def _resolve_partner_output(relative_path: str) -> Path | None:
         partner_id = str(partner.get("partner_id") or "").strip()
         if not partner_id:
             continue
-        candidate = get_path_service_for_scope(partner_scope(partner_id)).resolve_public_output_path(
-            relative_path
-        )
+        candidate = get_path_service_for_scope(
+            partner_scope(partner_id)
+        ).resolve_public_output_path(relative_path)
         if candidate is not None:
             matches.append(candidate)
             if len(matches) > 1:

--- a/deeptutor/learning/pending.py
+++ b/deeptutor/learning/pending.py
@@ -14,10 +14,10 @@ from dataclasses import dataclass
 import re
 from typing import TYPE_CHECKING, Any
 
+from deeptutor.utils.text_display import decode_escaped_unicode_for_display
+
 if TYPE_CHECKING:
     from deeptutor.learning.models import PendingQuestion
-
-from deeptutor.utils.text_display import decode_escaped_unicode_for_display
 
 
 OPTION_PREFIX_RE = re.compile(r"^\s*([A-Z])\s*[.:：、)）-]\s*(.+)$", re.IGNORECASE | re.DOTALL)


### PR DESCRIPTION
The `Lint and Format` job is currently failing on `dev`, which turns every open PR's CI red regardless of its own contents.

Two causes, both formatting-only:

- **#1050** added `from deeptutor.utils.text_display import ...` *after* the `if TYPE_CHECKING:` block in `deeptutor/learning/pending.py`, so `ruff check .` reports `I001 Import block is un-sorted or un-formatted`. Moved into the import block above `TYPE_CHECKING`.
- **#1017** left a long `get_path_service_for_scope(...).resolve_public_output_path(...)` call in `deeptutor/api/routers/outputs.py` that `ruff format` wraps differently, so `ruff format --check .` reports one file would be reformatted.

My fault on both — I read the diffs but did not re-check their CI before merging.

## Verification

Local ruff is 0.16.0, matching the pin in `.github/workflows/tests.yml`:

- `ruff check .` — All checks passed!
- `ruff format --check .` — 1404 files already formatted

No behaviour changes.