### PR TITLE
chore(lint): restore dev formatting

### DIFF
--- a/deeptutor/api/routers/outputs.py
+++ b/deeptutor/api/routers/outputs.py
@@ -58,9 +58,9 @@ def _resolve_partner_output(relative_path: str) -> Path | None:
         partner_id = str(partner.get("partner_id") or "").strip()
         if not partner_id:
             continue
-        candidate = get_path_service_for_scope(partner_scope(partner_id)).resolve_public_output_path(
-            relative_path
-        )
+        candidate = get_path_service_for_scope(
+            partner_scope(partner_id)
+        ).resolve_public_output_path(relative_path)
         if candidate is not None:
             matches.append(candidate)
             if len(matches) > 1:

--- a/deeptutor/learning/pending.py
+++ b/deeptutor/learning/pending.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
 
 from deeptutor.utils.text_display import decode_escaped_unicode_for_display
 
-
 OPTION_PREFIX_RE = re.compile(r"^\s*([A-Z])\s*[.:：、)）-]\s*(.+)$", re.IGNORECASE | re.DOTALL)
 
 


### PR DESCRIPTION
### Description

Restore the current `dev` branch's Ruff gate after two recent merges introduced mechanical formatting violations:

- remove the extra blank line flagged by `I001` in `deeptutor/learning/pending.py`;
- apply Ruff's expected wrapping in `deeptutor/api/routers/outputs.py`.

No behavior changes are intended.

### Related Issues

- None; CI baseline repair.

### Module(s) Affected

- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs`
- [ ] `scripts`
- [ ] `tests`
- [x] `Other`: CI lint baseline

### Validation

- `ruff check .` — passed.
- `ruff format --check .` — passed (1404 files).
- `git diff --check` — passed.
