### PR TITLE
fix(web): localize organized session placeholder titles

### DIFF
--- a/web/components/courses/OrganizedSessionList.tsx
+++ b/web/components/courses/OrganizedSessionList.tsx
@@ -89,6 +89,9 @@ export default function OrganizedSessionList({
   onOrganize,
 }: OrganizedSessionListProps) {
   const { t } = useTranslation();
+  // Backend writes the English sentinel "New conversation" until the LLM
+  // title lands; mirror SessionList by showing a localized, breathing label.
+  const placeholderLabel = t("New chat");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draftTitle, setDraftTitle] = useState("");
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
@@ -243,16 +246,19 @@ export default function OrganizedSessionList({
               }}
               className="min-w-0 flex-1 rounded border border-[var(--border)] bg-[var(--background)] px-1.5 py-0.5 text-[12px] outline-none focus:border-[var(--ring)]"
             />
+          ) : isPlaceholderSessionTitle(session.title) ? (
+            <span
+              className="dt-breathing-text min-w-0 flex-1 truncate text-[12.5px] italic text-[var(--muted-foreground)]"
+              title={placeholderLabel}
+            >
+              {placeholderLabel}
+            </span>
           ) : (
             <span
-              className={`min-w-0 flex-1 truncate text-[12.5px] ${
-                isPlaceholderSessionTitle(session.title)
-                  ? "italic opacity-70"
-                  : ""
-              }`}
+              className="min-w-0 flex-1 truncate text-[12.5px]"
               title={session.title}
             >
-              {session.title || t("New chat")}
+              {session.title}
             </span>
           )}
           {pinned ? <Pin size={10} className="shrink-0 opacity-55" /> : null}

--- a/web/lib/session-title.ts
+++ b/web/lib/session-title.ts
@@ -6,3 +6,15 @@ export function isPlaceholderSessionTitle(
   const value = (title ?? "").trim();
   return value === "" || value === DEFAULT_SESSION_TITLE;
 }
+
+/**
+ * Swap the backend sentinel (or empty title) for a localized sidebar label.
+ * Real user/LLM titles pass through unchanged.
+ */
+export function displaySessionTitle(
+  title: string | null | undefined,
+  placeholderLabel: string,
+): string {
+  if (isPlaceholderSessionTitle(title)) return placeholderLabel;
+  return (title ?? "").trim();
+}

--- a/web/tests/session-title.test.ts
+++ b/web/tests/session-title.test.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { isPlaceholderSessionTitle } from "../lib/session-title";
+import {
+  displaySessionTitle,
+  isPlaceholderSessionTitle,
+} from "../lib/session-title";
 
 test("empty and backend-default session titles are placeholders", () => {
   assert.equal(isPlaceholderSessionTitle(""), true);
@@ -11,4 +14,11 @@ test("empty and backend-default session titles are placeholders", () => {
 test("user and generated session titles remain business data", () => {
   assert.equal(isPlaceholderSessionTitle("New Conversation"), false);
   assert.equal(isPlaceholderSessionTitle("傅里叶变换"), false);
+});
+
+test("displaySessionTitle localizes placeholders and keeps real titles", () => {
+  assert.equal(displaySessionTitle("", "新对话"), "新对话");
+  assert.equal(displaySessionTitle("New conversation", "新对话"), "新对话");
+  assert.equal(displaySessionTitle("  New conversation  ", "新对话"), "新对话");
+  assert.equal(displaySessionTitle("傅里叶变换", "新对话"), "傅里叶变换");
 });


### PR DESCRIPTION
﻿## Summary
- `OrganizedSessionList` (sidebar / Space / courses) was rendering the backend English sentinel `New conversation` literally, while `SessionList` already swaps it for a localized breathing `New chat` label.
- Reuse the same placeholder path: detect `isPlaceholderSessionTitle`, show `t("New chat")` with `dt-breathing-text`.
- Add `displaySessionTitle` helper + regression coverage in `session-title` tests.

## Test plan
- [x] `npm run test:node -- session-title` (663 passed, including new `displaySessionTitle` cases)
- [ ] In a zh-CN UI, open Home sidebar with an untitled/new session under the organized tree — title should read the localized New chat string with breathing style, not `New conversation`
- [ ] Rename a session — real title still shows unchanged
