### PR TITLE
fix: persist reindex terminal state

### DIFF
--- a/deeptutor/api/routers/knowledge.py
+++ b/deeptutor/api/routers/knowledge.py
@@ -2860,26 +2860,47 @@ async def run_reindex_task(kb_name: str, base_dir: str, task_id: str, signature_
                     meta_err,
                 )
 
-            manager = get_kb_manager()
-            manager.update_kb_status(
-                name=kb_name,
-                status="ready",
-                progress={
-                    "stage": "completed",
-                    "message": "Re-index complete",
-                    "percent": 100,
-                    "current": len(file_paths),
-                    "total": len(file_paths),
-                    "task_id": task_id,
-                    "timestamp": completed_at,
-                    "indexed_count": len(file_paths),
-                    "index_changed": True,
-                    "index_action": "reindex",
-                },
+            progress_tracker.update(
+                ProgressStage.COMPLETED,
+                "Re-index complete",
+                current=len(file_paths),
+                total=len(file_paths),
+                indexed_count=len(file_paths),
+                index_changed=True,
+                index_action="reindex",
             )
+            try:
+                with open(progress_tracker.progress_file, encoding="utf-8") as handle:
+                    persisted_progress = json.load(handle)
+            except Exception as progress_err:
+                raise RuntimeError(
+                    f"Re-index terminal state was not persisted for '{kb_name}'."
+                ) from progress_err
+            expected_terminal_progress = {
+                "stage": ProgressStage.COMPLETED.value,
+                "task_id": task_id,
+                "progress_percent": 100,
+                "current": len(file_paths),
+                "total": len(file_paths),
+                "indexed_count": len(file_paths),
+                "index_changed": True,
+                "index_action": "reindex",
+            }
+            if not isinstance(persisted_progress, dict) or any(
+                persisted_progress.get(key) != value
+                for key, value in expected_terminal_progress.items()
+            ):
+                raise RuntimeError(f"Re-index terminal state was not persisted for '{kb_name}'.")
+            manager = get_kb_manager()
+            # ProgressTracker persists through its own manager instance. Refresh
+            # this cached instance before clearing flags so stale processing
+            # state cannot overwrite the completed status it just wrote.
+            manager.config = manager._load_config()
             # Clear the legacy mismatch / needs_reindex flags now that an
             # index version matching the active config exists on disk.
             kb_entry = manager.config.get("knowledge_bases", {}).get(kb_name) or {}
+            if kb_entry.get("status") != "ready":
+                raise RuntimeError(f"Re-index terminal state was not persisted for '{kb_name}'.")
             mutated = False
             if kb_entry.get("needs_reindex"):
                 kb_entry["needs_reindex"] = False

--- a/tests/api/test_knowledge_router.py
+++ b/tests/api/test_knowledge_router.py
@@ -4,6 +4,7 @@ import asyncio
 import importlib
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -1412,6 +1413,179 @@ def test_reindex_error_status_bypasses_existing_match_noop(monkeypatch, tmp_path
     assert body["noop"] is False
     assert isinstance(body.get("task_id"), str) and body["task_id"]
     assert manager.config["knowledge_bases"]["failed-kb"]["status"] == "initializing"
+
+
+def test_reindex_task_persists_completed_progress(monkeypatch, tmp_path: Path) -> None:
+    base_dir = tmp_path / "knowledge_bases"
+    raw_dir = base_dir / "kb" / "raw"
+    raw_dir.mkdir(parents=True)
+    (raw_dir / "fixture.txt").write_text("synthetic fixture", encoding="utf-8")
+    (base_dir / "kb_config.json").write_text(
+        json.dumps(
+            {
+                "knowledge_bases": {
+                    "kb": {
+                        "path": "kb",
+                        "rag_provider": "lightrag",
+                        "status": "processing",
+                        "needs_reindex": True,
+                        "embedding_mismatch": {"reason": "test"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class _SuccessfulRagService:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def initialize(self, *_args, **kwargs) -> bool:
+            kwargs["progress_callback"](1, 1)
+            return True
+
+    rag_service_module = importlib.import_module("deeptutor.services.rag.service")
+    manager_module = importlib.import_module("deeptutor.knowledge.manager")
+    manager = manager_module.KnowledgeBaseManager(base_dir=str(base_dir))
+    monkeypatch.setattr(rag_service_module, "RAGService", _SuccessfulRagService)
+    monkeypatch.setattr(
+        knowledge_router_module,
+        "get_kb_manager",
+        lambda: manager,
+    )
+
+    asyncio.run(
+        knowledge_router_module.run_reindex_task(
+            kb_name="kb",
+            base_dir=str(base_dir),
+            task_id="reindex-success-test",
+            signature_hash="lightrag",
+        )
+    )
+
+    progress = json.loads((base_dir / "kb" / ".progress.json").read_text(encoding="utf-8"))
+    assert progress == {
+        "kb_name": "kb",
+        "task_id": "reindex-success-test",
+        "stage": "completed",
+        "message": "Re-index complete",
+        "current": 1,
+        "total": 1,
+        "file_name": "",
+        "progress_percent": 100,
+        "timestamp": progress["timestamp"],
+        "indexed_count": 1,
+        "index_changed": True,
+        "index_action": "reindex",
+    }
+    monkeypatch.setattr(
+        knowledge_router_module,
+        "resolve_kb",
+        lambda _name: SimpleNamespace(name="kb", base_dir=base_dir),
+    )
+    with TestClient(_build_app()) as client:
+        response = client.get("/api/v1/knowledge/kb/progress")
+    assert response.status_code == 200
+    assert response.json() == progress
+
+    persisted = json.loads((base_dir / "kb_config.json").read_text(encoding="utf-8"))
+    entry = persisted["knowledge_bases"]["kb"]
+    assert entry["status"] == "ready"
+    assert "progress" not in entry
+    assert entry["last_indexed_count"] == 1
+    assert entry["last_indexed_action"] == "reindex"
+    assert entry["needs_reindex"] is False
+    assert "embedding_mismatch" not in entry
+
+
+@pytest.mark.parametrize("failed_sink", ["progress_file", "central_config"])
+def test_reindex_task_fails_closed_when_terminal_progress_is_not_persisted(
+    monkeypatch, tmp_path: Path, failed_sink: str
+) -> None:
+    base_dir = tmp_path / "knowledge_bases"
+    raw_dir = base_dir / "kb" / "raw"
+    raw_dir.mkdir(parents=True)
+    (raw_dir / "fixture.txt").write_text("synthetic fixture", encoding="utf-8")
+    (base_dir / "kb_config.json").write_text(
+        json.dumps(
+            {
+                "knowledge_bases": {
+                    "kb": {
+                        "path": "kb",
+                        "rag_provider": "lightrag",
+                        "status": "processing",
+                        "needs_reindex": True,
+                        "embedding_mismatch": {"reason": "test"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class _SuccessfulRagService:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def initialize(self, *_args, **kwargs) -> bool:
+            kwargs["progress_callback"](1, 1)
+            return True
+
+    rag_service_module = importlib.import_module("deeptutor.services.rag.service")
+    manager_module = importlib.import_module("deeptutor.knowledge.manager")
+    progress_module = importlib.import_module("deeptutor.knowledge.progress_tracker")
+    task_manager = knowledge_router_module.TaskIDManager.get_instance()
+    task_id = knowledge_router_module._build_unique_task_id(
+        "kb_reindex", f"terminal-persistence-{failed_sink}"
+    )
+    manager = manager_module.KnowledgeBaseManager(base_dir=str(base_dir))
+    monkeypatch.setattr(rag_service_module, "RAGService", _SuccessfulRagService)
+    monkeypatch.setattr(knowledge_router_module, "get_kb_manager", lambda: manager)
+
+    if failed_sink == "progress_file":
+        original_atomic_write_json = progress_module.atomic_write_json
+
+        def _fail_completed_progress_file(path: Path, payload: dict) -> None:
+            if path.name == ".progress.json" and payload.get("stage") == "completed":
+                raise OSError("synthetic completed progress failure")
+            original_atomic_write_json(path, payload)
+
+        monkeypatch.setattr(progress_module, "atomic_write_json", _fail_completed_progress_file)
+    else:
+        original_update_kb_status = manager_module.KnowledgeBaseManager.update_kb_status
+
+        def _fail_ready_status(self, name: str, status: str, progress=None) -> None:
+            if name == "kb" and status == "ready":
+                raise OSError("synthetic ready status failure")
+            original_update_kb_status(self, name=name, status=status, progress=progress)
+
+        monkeypatch.setattr(
+            manager_module.KnowledgeBaseManager,
+            "update_kb_status",
+            _fail_ready_status,
+        )
+
+    asyncio.run(
+        knowledge_router_module.run_reindex_task(
+            kb_name="kb",
+            base_dir=str(base_dir),
+            task_id=task_id,
+            signature_hash="lightrag",
+        )
+    )
+
+    task = task_manager.get_task_metadata(task_id)
+    assert task is not None
+    assert task["status"] == "error"
+    assert "terminal state" in task["error"]
+    progress = json.loads((base_dir / "kb" / ".progress.json").read_text(encoding="utf-8"))
+    assert progress["stage"] == "error"
+    persisted = json.loads((base_dir / "kb_config.json").read_text(encoding="utf-8"))
+    entry = persisted["knowledge_bases"]["kb"]
+    assert entry["status"] == "error"
+    assert entry["needs_reindex"] is True
+    assert entry["embedding_mismatch"] == {"reason": "test"}
 
 
 def test_retry_error_status_queues_reindex(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
### Description

Successful reindex tasks currently update the central knowledge-base status without persisting the completed per-KB progress record used by the progress endpoint. They can then clear reindex flags and report task completion without verifying either terminal sink.

This change writes terminal progress through `ProgressTracker`, reads back the exact completed task/count/action fields, refreshes and verifies the central `ready` state, and only then clears reindex flags and emits completion. Missing or mismatched terminal persistence follows the existing error path and retains the retry signals.

### Related Issues

- Related to #1069

### Module(s) Affected

- [ ] `agents`
- [x] `api`
- [ ] `config`
- [ ] `core`
- [x] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist

- [x] I have read and followed the contribution guidelines.
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues. (Candidate files pass; the exact base has unrelated Web Prettier drift.)
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (not necessary for this persistence fix).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

- Exact base: `ce7c2dc2dc6b7ae3063e81be29608bdba4723a25` (`dev`).
- Exact-head validation: 218 API/knowledge tests passed on Python 3.11.16; the three new terminal-state cases passed; same-script base/head reproduction changed from exit 1 to exit 0.
- Validation used an isolated synthetic home only. Target-file pre-commit passed. Hosted CI was not run before publication; remote checks remain pending or unverified until they complete.
