### PR TITLE
fix(web): localize HistorySessionPicker placeholder titles

### DIFF
--- a/web/components/chat/HistorySessionPicker.tsx
+++ b/web/components/chat/HistorySessionPicker.tsx
@@ -20,6 +20,7 @@ import {
   type SessionSummary,
 } from "@/lib/session-api";
 import { normalizeMessageContent, truncateText } from "@/lib/message-content";
+import { displaySessionTitle } from "@/lib/session-title";
 
 export interface SelectedHistorySession {
   sessionId: string;
@@ -53,6 +54,9 @@ export default function HistorySessionPicker({
   onApply,
 }: HistorySessionPickerProps) {
   const { t } = useTranslation();
+  // Backend writes the English sentinel "New conversation" until the LLM
+  // title lands; mirror SessionList with a localized "New chat" label.
+  const placeholderLabel = t("New chat");
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [query, setQuery] = useState("");
@@ -146,7 +150,7 @@ export default function HistorySessionPicker({
       .filter((session) => selectedIds.includes(sessionKey(session)))
       .map((session) => ({
         sessionId: sessionKey(session),
-        title: session.title || t("Untitled session"),
+        title: displaySessionTitle(session.title, placeholderLabel),
       }));
     onApply(selected);
     onClose();
@@ -246,7 +250,7 @@ export default function HistorySessionPicker({
                         </span>
                         <span className="min-w-0 flex-1">
                           <span className="block truncate text-[13px] font-medium text-[var(--foreground)]">
-                            {session.title || t("Untitled session")}
+                            {displaySessionTitle(session.title, placeholderLabel)}
                           </span>
                           <span className="mt-0.5 flex items-center gap-1.5 text-[11px] text-[var(--muted-foreground)]/85">
                             <MessageSquare size={11} strokeWidth={1.8} />
@@ -272,7 +276,10 @@ export default function HistorySessionPicker({
                 <div className="flex items-start justify-between gap-3 border-b border-[var(--border)]/70 px-5 py-3.5">
                   <div className="min-w-0">
                     <div className="truncate text-[14px] font-semibold text-[var(--foreground)]">
-                      {activeSession.title || t("Untitled session")}
+                      {displaySessionTitle(
+                        activeSession.title,
+                        placeholderLabel,
+                      )}
                     </div>
                     <div className="mt-0.5 flex items-center gap-2.5 text-[11px] text-[var(--muted-foreground)]">
                       <span>

--- a/web/lib/session-title.ts
+++ b/web/lib/session-title.ts
@@ -6,3 +6,15 @@ export function isPlaceholderSessionTitle(
   const value = (title ?? "").trim();
   return value === "" || value === DEFAULT_SESSION_TITLE;
 }
+
+/**
+ * Swap the backend sentinel (or empty title) for a localized sidebar label.
+ * Real user/LLM titles pass through unchanged.
+ */
+export function displaySessionTitle(
+  title: string | null | undefined,
+  placeholderLabel: string,
+): string {
+  if (isPlaceholderSessionTitle(title)) return placeholderLabel;
+  return (title ?? "").trim();
+}

--- a/web/tests/session-title.test.ts
+++ b/web/tests/session-title.test.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { isPlaceholderSessionTitle } from "../lib/session-title";
+import {
+  displaySessionTitle,
+  isPlaceholderSessionTitle,
+} from "../lib/session-title";
 
 test("empty and backend-default session titles are placeholders", () => {
   assert.equal(isPlaceholderSessionTitle(""), true);
@@ -11,4 +14,11 @@ test("empty and backend-default session titles are placeholders", () => {
 test("user and generated session titles remain business data", () => {
   assert.equal(isPlaceholderSessionTitle("New Conversation"), false);
   assert.equal(isPlaceholderSessionTitle("傅里叶变换"), false);
+});
+
+test("displaySessionTitle localizes placeholders for history picker and lists", () => {
+  assert.equal(displaySessionTitle("", "新对话"), "新对话");
+  assert.equal(displaySessionTitle("New conversation", "新对话"), "新对话");
+  assert.equal(displaySessionTitle("  New conversation  ", "新对话"), "新对话");
+  assert.equal(displaySessionTitle("傅里叶变换", "新对话"), "傅里叶变换");
 });


### PR DESCRIPTION
## Summary
- `HistorySessionPicker` treated the backend sentinel `New conversation` as a real title (and empty titles as `Untitled session`), so the picker list, preview header, and composer chips showed English instead of the localized `New chat` used by `SessionList`.
- Reuse `displaySessionTitle` / `isPlaceholderSessionTitle` so untitled sessions match the rest of the chat UI.

## Test plan
- [x] `npm run test:node -- session-title` (passed, including `displaySessionTitle` cases)
- [ ] Open history picker with an untitled/`New conversation` session — list + preview show localized New chat
- [ ] Apply that session — composer chip title is localized, not `New conversation` / `Untitled session`
- [ ] Named sessions still show their real titles

Related: #1086 (OrganizedSessionList); this covers the history-picker surface.