### PR TITLE
fix(launcher): detect IPv6 loopback port listeners (#1096)

### DIFF
--- a/deeptutor/runtime/launcher.py
+++ b/deeptutor/runtime/launcher.py
@@ -43,6 +43,7 @@ SOURCE_BUILD_EXCLUDED_DIRS = {
     "test-results",
     "coverage",
 }
+LOOPBACK_HOSTS = ("127.0.0.1", "::1")
 
 
 def _apply_single_user_allocator_env(env: dict[str, str]) -> None:
@@ -217,12 +218,16 @@ def _spawn(command: list[str], *, cwd: Path, env: dict[str, str], name: str) -> 
     return ManagedProcess(name=name, process=process, pgid=_get_pgid(process.pid))
 
 
-def _port_accepts_connection(port: int) -> bool:
+def _host_accepts_connection(host: str, port: int) -> bool:
     try:
-        with socket.create_connection(("127.0.0.1", port), timeout=0.25):
+        with socket.create_connection((host, port), timeout=0.25):
             return True
     except OSError:
         return False
+
+
+def _port_accepts_connection(port: int) -> bool:
+    return any(_host_accepts_connection(host, port) for host in LOOPBACK_HOSTS)
 
 
 def _port_listeners(port: int) -> list[tuple[int, str]]:

--- a/tests/runtime/test_launcher.py
+++ b/tests/runtime/test_launcher.py
@@ -14,6 +14,31 @@ class _FakeTty:
         return True
 
 
+class _AcceptedConnection:
+    def __enter__(self) -> "_AcceptedConnection":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+def test_port_probe_detects_ipv6_only_loopback_listener(monkeypatch) -> None:
+    """Unix launchers may bind only to ::1 (issue #1096)."""
+    attempts: list[tuple[str, int]] = []
+
+    def fake_create_connection(address, timeout):
+        host, port = address
+        attempts.append((host, port))
+        if host == "::1":
+            return _AcceptedConnection()
+        raise ConnectionRefusedError
+
+    monkeypatch.setattr(launcher.socket, "create_connection", fake_create_connection)
+
+    assert launcher._port_accepts_connection(3782)
+    assert attempts == [("127.0.0.1", 3782), ("::1", 3782)]
+
+
 def test_packaged_web_cache_replaces_next_public_placeholders(tmp_path: Path) -> None:
     packaged = tmp_path / "pkg"
     (packaged / ".next" / "static").mkdir(parents=True)


### PR DESCRIPTION
## Summary

- Probe both IPv4 and IPv6 loopback addresses when deciding whether a launcher port is occupied.
- Keep the behavior shared by port-conflict resolution, source frontend reuse, and kill-and-wait handling.
- Add regression coverage for an IPv6-only `::1` listener.

Fixes #1096.

## Test plan

- [x] Reproduced the issue against an ephemeral `::1` listener before the change (`detected: false`).
- [x] Verified the same listener is detected after the change (`detected: true`).
- [x] Verified `_resolve_port_conflicts()` now reports the occupied port instead of proceeding.
- [x] `python -m pytest tests/runtime/test_launcher.py -q`
- [x] `python -m pytest tests/runtime -q`
- [x] `python -m ruff check deeptutor/runtime/launcher.py tests/runtime/test_launcher.py`
- [x] `python -m ruff format --check deeptutor/runtime/launcher.py tests/runtime/test_launcher.py`
