### PR TITLE
fix(agentic): distinguish empty vs missing tool args (#1101)

### DIFF
--- a/deeptutor/capabilities/obsidian/tools.py
+++ b/deeptutor/capabilities/obsidian/tools.py
@@ -290,7 +290,15 @@ class ObsidianCreateNoteTool(_ObsidianTool):
                     type="string",
                     description="Vault-relative path, e.g. 'Summaries/Photosynthesis.md'.",
                 ),
-                ToolParameter(name="content", type="string", description="Markdown body."),
+                ToolParameter(
+                    name="content",
+                    type="string",
+                    description=(
+                        "Markdown body. Must be non-empty — write the complete "
+                        "note text in this call; extend an existing note later "
+                        "with obsidian_append."
+                    ),
+                ),
                 ToolParameter(
                     name="properties",
                     type="object",

--- a/deeptutor/core/agentic/tool_arg_guard.py
+++ b/deeptutor/core/agentic/tool_arg_guard.py
@@ -109,6 +109,33 @@ def required_args(definition: ToolDefinition) -> list[RequiredArg]:
     ]
 
 
+def unsatisfied_required_args(
+    definition: ToolDefinition,
+    args: dict[str, Any],
+) -> tuple[list[RequiredArg], list[RequiredArg]]:
+    """Split unsatisfied required parameters into absent vs present-but-blank.
+
+    Thinking models sometimes deliberately pass ``""`` (scaffold now, fill
+    later). Framing that as "missing" contradicts the model's own view of
+    the call and drives verbatim retries (#1101). The rejection still
+    blocks dispatch — only the corrective wording differs.
+    """
+    absent: list[RequiredArg] = []
+    blank: list[RequiredArg] = []
+    for arg in required_args(definition):
+        if arg.name not in args:
+            absent.append(arg)
+            continue
+        value = args[arg.name]
+        if value is None:
+            absent.append(arg)
+        elif isinstance(value, str) and not value.strip():
+            blank.append(arg)
+        elif not _is_supplied(value):
+            absent.append(arg)
+    return absent, blank
+
+
 def missing_required_args(
     definition: ToolDefinition,
     args: dict[str, Any],
@@ -119,21 +146,50 @@ def missing_required_args(
     augmentation — so an argument the pipeline injects on the model's behalf
     counts as supplied.
     """
-    return [arg for arg in required_args(definition) if not _is_supplied(args.get(arg.name))]
+    absent, blank = unsatisfied_required_args(definition, args)
+    return [*absent, *blank]
 
 
-def missing_args_message(tool_name: str, missing: list[RequiredArg]) -> str:
+def missing_args_message(
+    tool_name: str,
+    missing: list[RequiredArg],
+    *,
+    empty: list[RequiredArg] | None = None,
+) -> str:
     """Corrective ``role=tool`` body for a call that was never dispatched.
 
-    Names the missing arguments and their accepted shape, and says plainly
-    that repeating the same call will fail again — the model's failure mode
-    here is retrying verbatim, not misreading the schema.
+    Names the missing / empty arguments and their accepted shape, and says
+    plainly that repeating the same call will fail again — the model's
+    failure mode here is retrying verbatim, not misreading the schema.
+
+    Pass *absent* keys in ``missing`` and *present-but-blank* keys in
+    ``empty`` so thinking models that deliberately sent ``""`` get feedback
+    that matches what they did (#1101). Legacy callers that only pass a
+    combined ``missing`` list keep the original "without its required
+    argument(s)" framing.
     """
-    named = ", ".join(f"`{arg.name}`" for arg in missing)
-    shapes = "; ".join(arg.describe() for arg in missing)
+    absent = list(missing)
+    blank = list(empty or [])
+
+    clauses: list[str] = []
+    if absent:
+        named = ", ".join(f"`{arg.name}`" for arg in absent)
+        shapes = "; ".join(arg.describe() for arg in absent)
+        clauses.append(
+            f"`{tool_name}` was called without its required argument(s): {named}. "
+            f"Expected: {shapes}."
+        )
+    if blank:
+        named = ", ".join(f"`{arg.name}`" for arg in blank)
+        shapes = "; ".join(arg.describe() for arg in blank)
+        clauses.append(
+            f"`{tool_name}` received empty value(s) for required argument(s): {named}. "
+            "Those keys were present but blank — supply non-empty content "
+            f"(do not re-emit the same empty string). Expected: {shapes}."
+        )
+    body = " ".join(clauses) if clauses else f"`{tool_name}` was called with incomplete arguments."
     return (
-        f"(tool call not dispatched — `{tool_name}` was called without its required "
-        f"argument(s): {named}. Expected: {shapes}. Re-emit the call with those "
+        f"(tool call not dispatched — {body} Re-emit the call with those "
         "arguments filled in; an identical call with empty arguments will be "
         "rejected again without running.)"
     )

--- a/deeptutor/core/agentic/tool_dispatch.py
+++ b/deeptutor/core/agentic/tool_dispatch.py
@@ -28,7 +28,7 @@ from typing import Any
 
 from deeptutor.core.agentic.tool_arg_guard import (
     missing_args_message,
-    missing_required_args,
+    unsatisfied_required_args,
 )
 from deeptutor.core.context import UnifiedContext
 from deeptutor.core.stream_bus import StreamBus
@@ -371,24 +371,40 @@ async def _reject_if_args_missing(
     if definition is None:
         return None
 
-    missing = missing_required_args(definition, exec_args)
-    if not missing:
+    absent, blank = unsatisfied_required_args(definition, exec_args)
+    if not absent and not blank:
         return None
 
-    message = missing_args_message(tool_name, missing)
-    logger.warning(
-        "Rejected %s before dispatch: missing required args %s",
-        tool_name,
-        [arg.name for arg in missing],
-    )
+    message = missing_args_message(tool_name, absent, empty=blank)
+    if blank and not absent:
+        logger.warning(
+            "Rejected %s before dispatch: empty required args %s",
+            tool_name,
+            [arg.name for arg in blank],
+        )
+    elif blank:
+        logger.warning(
+            "Rejected %s before dispatch: missing required args %s; empty required args %s",
+            tool_name,
+            [arg.name for arg in absent],
+            [arg.name for arg in blank],
+        )
+    else:
+        logger.warning(
+            "Rejected %s before dispatch: missing required args %s",
+            tool_name,
+            [arg.name for arg in absent],
+        )
     if trace_meta is not None:
         # Close the sub-trace with a terminal state, as the raising path in
         # ``execute_tool_call`` does — a rejected call must not leave a row
         # that reads as still running. ``progress`` (not ``error``): this is
         # a recoverable per-call correction, and a stream ERROR makes a
         # partner turn re-run the whole turn on its backup model.
+        unsatisfied = [*absent, *blank]
+        reason = "empty" if blank and not absent else "missing"
         await stream.progress(
-            f"{tool_name} not dispatched: missing {', '.join(arg.name for arg in missing)}",
+            f"{tool_name} not dispatched: {reason} {', '.join(arg.name for arg in unsatisfied)}",
             source=source,
             stage=stage,
             metadata=derive_trace_metadata(

--- a/tests/core/agentic/test_tool_arg_guard.py
+++ b/tests/core/agentic/test_tool_arg_guard.py
@@ -24,6 +24,7 @@ from deeptutor.core.agentic.tool_arg_guard import (
     missing_args_message,
     missing_required_args,
     required_args,
+    unsatisfied_required_args,
 )
 from deeptutor.core.agentic.tool_dispatch import dispatch_tool_calls
 from deeptutor.core.context import UnifiedContext
@@ -84,6 +85,49 @@ def test_blank_string_counts_as_missing() -> None:
     assert [arg.name for arg in missing_required_args(definition, {"command": "   "})] == [
         "command"
     ]
+
+
+def test_present_blank_string_is_classified_separately_from_absent() -> None:
+    """Thinking models sometimes pass ``""`` on purpose (#1101). The guard
+    still rejects the call, but the corrective message must say the key was
+    empty — not that it was omitted — or the model retries verbatim."""
+    definition = ToolDefinition(
+        name="obsidian_create_note",
+        description="",
+        parameters=[
+            ToolParameter(name="path", type="string"),
+            ToolParameter(name="content", type="string"),
+        ],
+    )
+    absent, blank = unsatisfied_required_args(
+        definition,
+        {"path": "Hub.md", "content": ""},
+    )
+    assert [arg.name for arg in absent] == []
+    assert [arg.name for arg in blank] == ["content"]
+
+    message = missing_args_message("obsidian_create_note", absent, empty=blank)
+    assert "received empty value(s)" in message
+    assert "`content`" in message
+    assert "present but blank" in message
+    assert "without its required argument(s)" not in message
+
+
+def test_mixed_absent_and_blank_args_are_both_named() -> None:
+    definition = ToolDefinition(
+        name="obsidian_create_note",
+        description="",
+        parameters=[
+            ToolParameter(name="path", type="string"),
+            ToolParameter(name="content", type="string"),
+        ],
+    )
+    absent, blank = unsatisfied_required_args(definition, {"content": "   "})
+    assert [arg.name for arg in absent] == ["path"]
+    assert [arg.name for arg in blank] == ["content"]
+    message = missing_args_message("obsidian_create_note", absent, empty=blank)
+    assert "without its required argument(s): `path`" in message
+    assert "received empty value(s) for required argument(s): `content`" in message
 
 
 def test_empty_collections_are_left_alone() -> None:
@@ -228,6 +272,29 @@ async def test_call_with_empty_arguments_never_reaches_the_tool() -> None:
     # …on a PROGRESS event: a rejected call is recoverable, and a stream ERROR
     # makes a partner turn re-run the whole turn on its backup model.
     assert [e for e in events if e.type == StreamEventType.ERROR] == []
+
+
+@pytest.mark.asyncio
+async def test_call_with_empty_string_arg_names_blank_not_missing() -> None:
+    """#1101: a deliberate ``""`` must not be framed as an omitted key."""
+    tool = _WriteNote()
+    events = await _run_dispatch(
+        [
+            {
+                "id": "c1",
+                "name": "write_note",
+                "arguments": json.dumps({"mode": "", "notebook_id": "nb1"}),
+            }
+        ],
+        _Registry(tool),
+    )
+
+    assert tool.calls == []
+    result = next(e for e in events if e.type == StreamEventType.TOOL_RESULT)
+    assert "received empty value(s)" in result.content
+    assert "`mode`" in result.content
+    assert "without its required argument(s)" not in result.content
+    assert _call_states(events) == ["error"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Pre-dispatch arg guard treated a present-but-blank required string (`content: ""`) the same as an omitted key, so thinking models that deliberately scaffolded `obsidian_create_note` with an empty body got "was called without its required argument(s)" and retried the identical call (#1101).
- Classify absent vs blank; corrective `role=tool` text now says the key was present but empty and must not be re-emitted blank.
- Tighten `obsidian_create_note.content` description to require a non-empty Markdown body.

## Test plan
- [x] `pytest tests/core/agentic/test_tool_arg_guard.py -q` (15 passed)
- [ ] Long-session repro with a thinking model calling `obsidian_create_note` with `content: ""` — rejection message should mention empty/blank, not "without its required argument(s)"
- [ ] Truly omitted args still use the original missing-argument framing

Fixes #1101