### PR TITLE
feat(learner): add guardian authorization (#994)

### DIFF
--- a/deeptutor/multi_user/audit.py
+++ b/deeptutor/multi_user/audit.py
@@ -78,3 +78,25 @@ def log_admin_action(
     if summary:
         payload["summary"] = summary
     _write(payload)
+
+
+def log_guardian_action(
+    action: str,
+    guardian_user_id: str,
+    learner_user_id: str,
+    summary: dict[str, Any] | None = None,
+) -> None:
+    """Record an action performed through an explicit guardian relationship."""
+    user = get_current_user()
+    payload: dict[str, Any] = {
+        "time": datetime.now(timezone.utc).isoformat(),
+        "actor_id": user.id,
+        "actor_username": user.username,
+        "actor_role": user.role,
+        "action": action,
+        "guardian_user_id": guardian_user_id,
+        "learner_user_id": learner_user_id,
+    }
+    if summary:
+        payload["summary"] = summary
+    _write(payload)

--- a/deeptutor/multi_user/guardians.py
+++ b/deeptutor/multi_user/guardians.py
@@ -1,0 +1,219 @@
+"""Explicit guardian-to-learner authorization records."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import json
+import threading
+from typing import Any
+from uuid import uuid4
+
+from deeptutor.services.file_io import atomic_write_text
+
+from .identity import get_user_by_id
+from .paths import SYSTEM_ROOT
+
+GUARDIANS_FILE = SYSTEM_ROOT / "guardians.json"
+GUARDIAN_PERMISSIONS = frozenset({"assign_materials", "view_reports", "reset_credentials"})
+
+_GUARDIANS_WRITE_LOCK = threading.Lock()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _canonical_record(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    relationship_id = str(value.get("id") or f"ga_{uuid4().hex}")
+    guardian_user_id = str(value.get("guardian_user_id") or "")
+    learner_user_id = str(value.get("learner_user_id") or "")
+    if not guardian_user_id or not learner_user_id:
+        return None
+    raw_permissions = value.get("permissions") if isinstance(value.get("permissions"), list) else []
+    permissions = sorted(
+        {
+            str(item)
+            for item in raw_permissions
+            if isinstance(raw_permissions, list) and str(item) in GUARDIAN_PERMISSIONS
+        }
+    )
+    revoked_at = value.get("revoked_at")
+    return {
+        "id": relationship_id,
+        "guardian_user_id": guardian_user_id,
+        "learner_user_id": learner_user_id,
+        "permissions": permissions,
+        "granted_at": str(value.get("granted_at") or _utc_now()),
+        "revoked_at": str(revoked_at) if revoked_at else None,
+        "revoked_by": str(value.get("revoked_by") or "") if revoked_at else "",
+        "revocation_reason": (str(value.get("revocation_reason") or "") if revoked_at else ""),
+    }
+
+
+def _load_records() -> list[dict[str, Any]]:
+    try:
+        loaded = json.loads(GUARDIANS_FILE.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    if not isinstance(loaded, list):
+        return []
+    records: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for value in loaded:
+        record = _canonical_record(value)
+        if record is None or record["id"] in seen:
+            continue
+        seen.add(record["id"])
+        records.append(record)
+    return records
+
+
+def _write_records(records: list[dict[str, Any]]) -> None:
+    GUARDIANS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(GUARDIANS_FILE, json.dumps(records, indent=2, ensure_ascii=False))
+
+
+def _require_ordinary_user(user_id: str, label: str) -> None:
+    user_record = get_user_by_id(user_id)
+    if user_record is None:
+        raise ValueError(f"Unknown {label} user id: {user_id}")
+    _username, record = user_record
+    if str(record.get("role") or "user") == "admin":
+        raise ValueError(f"Admin users cannot be {label}s.")
+
+
+def authorize_guardian(
+    guardian_user_id: str,
+    learner_user_id: str,
+    permissions: set[str] | frozenset[str] | list[str],
+) -> dict[str, Any]:
+    _require_ordinary_user(guardian_user_id, "guardian")
+    _require_ordinary_user(learner_user_id, "learner")
+    if guardian_user_id == learner_user_id:
+        raise ValueError("A user cannot guard their own account.")
+    allowed = sorted({item for item in permissions if item in GUARDIAN_PERMISSIONS})
+    if not allowed:
+        raise ValueError("At least one guardian permission is required.")
+
+    with _GUARDIANS_WRITE_LOCK:
+        records = _load_records()
+        if any(
+            record["guardian_user_id"] == guardian_user_id
+            and record["learner_user_id"] == learner_user_id
+            and record["revoked_at"] is None
+            for record in records
+        ):
+            raise ValueError("This guardian is already authorized for the learner.")
+        if any(
+            record["guardian_user_id"] == learner_user_id
+            and record["learner_user_id"] == guardian_user_id
+            and record["revoked_at"] is None
+            for record in records
+        ):
+            raise ValueError("A learner cannot guard their active guardian.")
+        record = {
+            "id": f"ga_{uuid4().hex}",
+            "guardian_user_id": guardian_user_id,
+            "learner_user_id": learner_user_id,
+            "permissions": allowed,
+            "granted_at": _utc_now(),
+            "revoked_at": None,
+            "revoked_by": "",
+            "revocation_reason": "",
+        }
+        records.append(record)
+        _write_records(records)
+    return deepcopy(record)
+
+
+def list_relationships(
+    *,
+    guardian_user_id: str | None = None,
+    learner_user_id: str | None = None,
+    include_revoked: bool = False,
+) -> list[dict[str, Any]]:
+    return [
+        deepcopy(record)
+        for record in _load_records()
+        if (include_revoked or record["revoked_at"] is None)
+        and (guardian_user_id is None or record["guardian_user_id"] == guardian_user_id)
+        and (learner_user_id is None or record["learner_user_id"] == learner_user_id)
+    ]
+
+
+def relationship_by_id(relationship_id: str) -> dict[str, Any] | None:
+    for record in _load_records():
+        if record["id"] == relationship_id:
+            return deepcopy(record)
+    return None
+
+
+def revoke_guardian(
+    relationship_id: str,
+    *,
+    revoked_by: str,
+    reason: str = "",
+) -> dict[str, Any] | None:
+    with _GUARDIANS_WRITE_LOCK:
+        records = _load_records()
+        for record in records:
+            if record["id"] != relationship_id:
+                continue
+            if record["revoked_at"] is None:
+                record["revoked_at"] = _utc_now()
+                record["revoked_by"] = revoked_by
+                record["revocation_reason"] = reason
+                _write_records(records)
+            return deepcopy(record)
+    return None
+
+
+def revoke_relationships_for_user(user_id: str, *, reason: str) -> int:
+    with _GUARDIANS_WRITE_LOCK:
+        records = _load_records()
+        changed = 0
+        now = _utc_now()
+        for record in records:
+            if user_id not in (
+                record["guardian_user_id"],
+                record["learner_user_id"],
+            ):
+                continue
+            if record["revoked_at"] is not None:
+                continue
+            record["revoked_at"] = now
+            record["revoked_by"] = "system"
+            record["revocation_reason"] = reason
+            changed += 1
+        if changed:
+            _write_records(records)
+    return changed
+
+
+def guardian_can_access(
+    guardian_user_id: str,
+    learner_user_id: str,
+    permission: str,
+) -> bool:
+    return any(
+        record["guardian_user_id"] == guardian_user_id
+        and record["learner_user_id"] == learner_user_id
+        and record["revoked_at"] is None
+        and permission in record["permissions"]
+        for record in _load_records()
+    )
+
+
+__all__ = [
+    "GUARDIANS_FILE",
+    "GUARDIAN_PERMISSIONS",
+    "authorize_guardian",
+    "guardian_can_access",
+    "list_relationships",
+    "relationship_by_id",
+    "revoke_guardian",
+    "revoke_relationships_for_user",
+]

--- a/deeptutor/multi_user/identity.py
+++ b/deeptutor/multi_user/identity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from datetime import datetime, timezone
 import json
 import logging
@@ -325,12 +326,37 @@ def remove_book_permission_overrides(book_id: str) -> list[str]:
 def delete_user(username: str) -> bool:
     if not USERS_FILE.exists():
         return False
-    users = load_users()
-    if username not in users:
-        return False
-    users.pop(username, None)
-    _write_users(users)
+    with _USERS_WRITE_LOCK:
+        users = load_users()
+        record = users.get(username)
+        if record is None:
+            return False
+        user_id = str(record.get("id") or "")
+        users.pop(username, None)
+        _write_users(users)
+    try:
+        from .guardians import revoke_relationships_for_user
+
+        # Route guards also revalidate both accounts, so a rare cleanup failure
+        # can never make a deleted-user relationship usable.
+        revoke_relationships_for_user(user_id, reason="user_deleted")
+    except Exception:
+        logger.exception("Could not revoke guardian relationships after user deletion")
     return True
+
+
+def set_password(username: str, hashed_password: str) -> dict[str, Any] | None:
+    """Replace one account's password hash without changing its identity fields."""
+    if not USERS_FILE.exists():
+        return None
+    with _USERS_WRITE_LOCK:
+        users = load_users()
+        record = users.get(username)
+        if record is None:
+            return None
+        record["hash"] = hashed_password
+        _write_users(users)
+        return deepcopy(record)
 
 
 def set_avatar(username: str, avatar: str) -> bool:

--- a/deeptutor/multi_user/router.py
+++ b/deeptutor/multi_user/router.py
@@ -3,21 +3,35 @@
 from __future__ import annotations
 
 import asyncio
+import secrets
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field, StrictBool
+from pydantic import BaseModel, Field, StrictBool, field_validator
 
-from deeptutor.api.routers.auth import require_admin
+from deeptutor.api.routers.auth import require_admin, require_auth
 from deeptutor.knowledge.manager import KnowledgeBaseManager
+from deeptutor.services.auth import POCKETBASE_ENABLED, hash_password
 from deeptutor.services.config.model_catalog import ModelCatalogService
 from deeptutor.services.skill.service import SkillService
 
-from .audit import log_admin_action
+from .audit import log_admin_action, log_guardian_action
 from .book_permission import BookDefaultLevel, BookPermission, BookPermissionLevel
 from .context import get_current_user
 from .grants import load_grant, save_grant
-from .identity import get_user_by_id, list_user_info, set_book_permission
+from .guardians import (
+    GUARDIAN_PERMISSIONS,
+    authorize_guardian,
+    guardian_can_access,
+    list_relationships,
+    revoke_guardian,
+)
+from .identity import (
+    get_user_by_id,
+    list_user_info,
+    set_book_permission,
+    set_password,
+)
 from .knowledge_access import admin_kb_base_dir
 from .model_access import is_owner_bound
 from .paths import get_admin_path_service
@@ -33,6 +47,36 @@ class BookPermissionPayload(BaseModel):
     create: StrictBool = True
     default: BookDefaultLevel = "none"
     books: dict[str, BookPermissionLevel] = Field(default_factory=dict)
+
+
+class GuardianAuthorizationPayload(BaseModel):
+    guardian_user_id: str = Field(min_length=1, max_length=64)
+    learner_user_id: str = Field(min_length=1, max_length=64)
+    permissions: list[str] = Field(default_factory=lambda: sorted(GUARDIAN_PERMISSIONS))
+
+    @field_validator("permissions")
+    @classmethod
+    def permissions_valid(cls, value: list[str]) -> list[str]:
+        permissions = sorted(set(value))
+        if not permissions or not set(permissions).issubset(GUARDIAN_PERMISSIONS):
+            raise ValueError("Unknown guardian permission")
+        return permissions
+
+
+class GuardianMaterialsPayload(BaseModel):
+    book_ids: list[str]
+
+    @field_validator("book_ids")
+    @classmethod
+    def book_ids_valid(cls, value: list[str]) -> list[str]:
+        book_ids: list[str] = []
+        for raw_id in value:
+            book_id = raw_id.strip()
+            if not book_id:
+                raise ValueError("Book ids cannot be empty")
+            if book_id not in book_ids:
+                book_ids.append(book_id)
+        return book_ids
 
 
 class SkillInstallPayload(BaseModel):
@@ -130,6 +174,33 @@ def _require_assignable_user(user_id: str) -> tuple[str, dict[str, Any]]:
     return username, record
 
 
+def _users_by_id() -> dict[str, dict[str, Any]]:
+    return {str(user.get("id") or ""): user for user in list_user_info()}
+
+
+def _relationship_view(
+    relationship: dict[str, Any], users: dict[str, dict[str, Any]]
+) -> dict[str, Any]:
+    guardian = users.get(relationship["guardian_user_id"], {})
+    learner = users.get(relationship["learner_user_id"], {})
+    return {
+        **relationship,
+        "guardian_username": str(guardian.get("username") or ""),
+        "learner_username": str(learner.get("username") or ""),
+    }
+
+
+def _require_guardian_access(
+    current: object, learner_user_id: str, permission: str
+) -> tuple[str, dict[str, Any], str]:
+    guardian_user_id = str(getattr(current, "user_id", "") or "")
+    _guardian_username, _guardian_record = _require_assignable_user(guardian_user_id)
+    learner_username, learner_record = _require_assignable_user(learner_user_id)
+    if not guardian_can_access(guardian_user_id, learner_user_id, permission):
+        raise HTTPException(status_code=403, detail="Guardian authorization required")
+    return learner_username, learner_record, guardian_user_id
+
+
 @router.get("/admin/resources")
 async def admin_resources(_: object = Depends(require_admin)) -> dict[str, Any]:
     """Everything an admin can assign to a user: models, KBs, skills, and
@@ -152,6 +223,198 @@ async def admin_books(_: object = Depends(require_admin)) -> dict[str, Any]:
     from .book_access import admin_book_catalog
 
     return {"books": admin_book_catalog()}
+
+
+@router.get("/guardians")
+async def list_guardian_relationships(
+    include_revoked: bool = False,
+    _: object = Depends(require_admin),
+) -> dict[str, Any]:
+    users = _users_by_id()
+    relationships = [
+        _relationship_view(relationship, users)
+        for relationship in list_relationships(include_revoked=include_revoked)
+    ]
+    return {"relationships": relationships}
+
+
+@router.post("/guardians", status_code=201)
+async def authorize_guardian_relationship(
+    payload: GuardianAuthorizationPayload,
+    current: object = Depends(require_admin),
+) -> dict[str, Any]:
+    _require_assignable_user(payload.guardian_user_id)
+    _require_assignable_user(payload.learner_user_id)
+    try:
+        relationship = authorize_guardian(
+            payload.guardian_user_id,
+            payload.learner_user_id,
+            payload.permissions,
+        )
+    except ValueError as exc:
+        message = str(exc)
+        status_code = 409 if "already authorized" in message else 400
+        raise HTTPException(status_code=status_code, detail=message) from exc
+    log_admin_action(
+        "guardian_authorize",
+        target_user_id=payload.learner_user_id,
+        summary={
+            "relationship_id": relationship["id"],
+            "guardian_user_id": payload.guardian_user_id,
+            "permissions": relationship["permissions"],
+        },
+    )
+    return {
+        "relationship": _relationship_view(relationship, _users_by_id()),
+        "actor_username": str(getattr(current, "username", "") or ""),
+    }
+
+
+@router.delete("/guardians/{relationship_id}")
+async def revoke_guardian_relationship(
+    relationship_id: str,
+    current: object = Depends(require_admin),
+) -> dict[str, Any]:
+    revoked_by = str(getattr(current, "user_id", "") or "")
+    relationship = revoke_guardian(relationship_id, revoked_by=revoked_by)
+    if relationship is None:
+        raise HTTPException(status_code=404, detail="Guardian relationship not found")
+    log_admin_action(
+        "guardian_revoke",
+        target_user_id=relationship["learner_user_id"],
+        summary={
+            "relationship_id": relationship["id"],
+            "guardian_user_id": relationship["guardian_user_id"],
+        },
+    )
+    return {
+        "relationship": _relationship_view(relationship, _users_by_id()),
+        "ok": True,
+    }
+
+
+@router.get("/me/guardianships")
+async def my_guardianships(
+    current: object = Depends(require_auth),
+) -> dict[str, Any]:
+    guardian_user_id = str(getattr(current, "user_id", "") or "")
+    _require_assignable_user(guardian_user_id)
+    users = _users_by_id()
+    relationships = [
+        _relationship_view(relationship, users)
+        for relationship in list_relationships(guardian_user_id=guardian_user_id)
+    ]
+    return {"relationships": relationships}
+
+
+@router.get("/learners/{learner_user_id}/guardian-report")
+async def guardian_report(
+    learner_user_id: str,
+    current: object = Depends(require_auth),
+) -> dict[str, Any]:
+    learner_username, learner_record, guardian_user_id = _require_guardian_access(
+        current, learner_user_id, "view_reports"
+    )
+    from .book_access import admin_book_catalog
+    from .book_permission import normalize_book_permission, public_permission_dict
+
+    permission = normalize_book_permission(learner_record.get("book_permission"))
+    permission_dict = public_permission_dict(permission)
+    assigned_materials = [
+        {**book, "permission": permission.level_for(book["book_id"])}
+        for book in admin_book_catalog()
+        if permission.level_for(book["book_id"]) != "none"
+    ]
+    grant = load_grant(learner_user_id)
+    log_guardian_action(
+        "guardian_report_view",
+        guardian_user_id=guardian_user_id,
+        learner_user_id=learner_user_id,
+        summary={"assigned_material_count": len(assigned_materials)},
+    )
+    return {
+        "learner": {
+            "id": learner_user_id,
+            "username": learner_username,
+            "disabled": bool(learner_record.get("disabled", False)),
+        },
+        "book_permission": permission_dict,
+        "assigned_materials": assigned_materials,
+        "grant_summary": {
+            "model_count": len(grant.get("models", {}).get("llm", []) or []),
+            "knowledge_base_count": len(grant.get("knowledge_bases") or []),
+            "skill_count": len(grant.get("skills") or []),
+            "enabled_tools": grant.get("enabled_tools"),
+        },
+    }
+
+
+@router.put("/learners/{learner_user_id}/materials")
+async def assign_guardian_materials(
+    learner_user_id: str,
+    payload: GuardianMaterialsPayload,
+    current: object = Depends(require_auth),
+) -> dict[str, Any]:
+    learner_username, learner_record, guardian_user_id = _require_guardian_access(
+        current, learner_user_id, "assign_materials"
+    )
+    from .book_access import shared_book_exists
+    from .book_permission import (
+        BookPermission,
+        normalize_book_permission,
+        public_permission_dict,
+    )
+
+    unknown = next(
+        (book_id for book_id in payload.book_ids if not shared_book_exists(book_id)),
+        None,
+    )
+    if unknown:
+        raise HTTPException(status_code=400, detail=f"Unknown approved book id: {unknown}")
+
+    # Guardians hand out the admin-approved catalogue as read-only material.
+    # Admins remain the only source of edit/create capability.
+    existing = normalize_book_permission(learner_record.get("book_permission"))
+    permission = BookPermission(
+        create=existing.create,
+        default=existing.default,
+        books=tuple((book_id, "read") for book_id in payload.book_ids),
+    )
+    if not set_book_permission(learner_username, permission):
+        raise HTTPException(status_code=404, detail="User not found")
+    result = public_permission_dict(permission)
+    log_guardian_action(
+        "guardian_material_assign",
+        guardian_user_id=guardian_user_id,
+        learner_user_id=learner_user_id,
+        summary={"book_ids": payload.book_ids, "read_only": True},
+    )
+    return {"book_permission": result}
+
+
+@router.post("/learners/{learner_user_id}/credentials/reset")
+async def reset_learner_credentials(
+    learner_user_id: str,
+    current: object = Depends(require_auth),
+) -> dict[str, Any]:
+    learner_username, _learner_record, guardian_user_id = _require_guardian_access(
+        current, learner_user_id, "reset_credentials"
+    )
+    if POCKETBASE_ENABLED:
+        raise HTTPException(
+            status_code=400,
+            detail="Guardian credential reset requires built-in local authentication.",
+        )
+    temporary_password = secrets.token_urlsafe(18)
+    if set_password(learner_username, hash_password(temporary_password)) is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    log_guardian_action(
+        "guardian_credential_reset",
+        guardian_user_id=guardian_user_id,
+        learner_user_id=learner_user_id,
+        summary={"credential_reset": True},
+    )
+    return {"temporary_password": temporary_password}
 
 
 @router.get("/users/{user_id}/grants")

--- a/tests/multi_user/conftest.py
+++ b/tests/multi_user/conftest.py
@@ -24,7 +24,7 @@ def mu_isolated_root(tmp_path, monkeypatch) -> Path:
     Also clears the ``_path_services`` cache so ``get_path_service()`` can be
     re-resolved per test without leaking instances created in earlier tests.
     """
-    from deeptutor.multi_user import grants, identity, paths
+    from deeptutor.multi_user import audit, grants, guardians, identity, paths
 
     project_root = tmp_path
     admin_root = (project_root / "data").resolve()
@@ -55,6 +55,8 @@ def mu_isolated_root(tmp_path, monkeypatch) -> Path:
     )
 
     monkeypatch.setattr(grants, "GRANTS_DIR", system_root / "grants")
+    monkeypatch.setattr(guardians, "GUARDIANS_FILE", system_root / "guardians.json")
+    monkeypatch.setattr(audit, "SYSTEM_ROOT", system_root)
 
     # The ``auth.json`` bootstrap admin is process-global state rather than a
     # path, and it now takes part in the first-user promotion decision (#849).

--- a/tests/multi_user/test_guardians.py
+++ b/tests/multi_user/test_guardians.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _client(mu_isolated_root, monkeypatch) -> tuple[TestClient, dict]:
+    from deeptutor.api.routers import auth as auth_router
+    from deeptutor.book import engine as engine_module
+    from deeptutor.book import storage as storage_module
+    from deeptutor.book.models import Book
+    from deeptutor.book.storage import BookStorage
+    from deeptutor.multi_user import router as multi_user_router
+    from deeptutor.multi_user.identity import save_user
+    from deeptutor.multi_user.paths import get_admin_path_service
+    from deeptutor.services.auth import TokenPayload, hash_password
+
+    root = save_user("root", hash_password("root-password"), role="admin")
+    guardian = save_user("guardian", hash_password("guardian-password"))
+    learner = save_user("learner", hash_password("learner-password"))
+    stranger = save_user("stranger", hash_password("stranger-password"))
+    tokens = {
+        "root-token": TokenPayload(username="root", role="admin", user_id=root["id"]),
+        "guardian-token": TokenPayload(username="guardian", role="user", user_id=guardian["id"]),
+        "learner-token": TokenPayload(username="learner", role="user", user_id=learner["id"]),
+        "stranger-token": TokenPayload(username="stranger", role="user", user_id=stranger["id"]),
+    }
+    monkeypatch.setattr(auth_router, "AUTH_ENABLED", True)
+    monkeypatch.setattr(auth_router, "decode_token", lambda token: tokens.get(token))
+    monkeypatch.setattr(multi_user_router, "POCKETBASE_ENABLED", False)
+
+    storage_module._storages.clear()
+    engine_module._engines.clear()
+    BookStorage(path_service=get_admin_path_service()).save_book(
+        Book(id="bk_approved", title="Approved")
+    )
+    BookStorage(path_service=get_admin_path_service()).save_book(
+        Book(id="bk_private", title="Private")
+    )
+
+    app = FastAPI()
+    app.include_router(multi_user_router.router, prefix="/api/v1/multi-user")
+    return TestClient(app), {
+        "root": root,
+        "guardian": guardian,
+        "learner": learner,
+    }
+
+
+def test_admin_can_authorize_and_revoke_guardians(mu_isolated_root, monkeypatch):
+    client, users = _client(mu_isolated_root, monkeypatch)
+    guardian_id = users["guardian"]["id"]
+    learner_id = users["learner"]["id"]
+
+    self_relation = client.post(
+        "/api/v1/multi-user/guardians",
+        headers=_auth("root-token"),
+        json={
+            "guardian_user_id": guardian_id,
+            "learner_user_id": guardian_id,
+            "permissions": ["view_reports"],
+        },
+    )
+    assert self_relation.status_code == 400
+
+    admin_target = client.post(
+        "/api/v1/multi-user/guardians",
+        headers=_auth("root-token"),
+        json={
+            "guardian_user_id": users["root"]["id"],
+            "learner_user_id": learner_id,
+            "permissions": ["view_reports"],
+        },
+    )
+    assert admin_target.status_code == 403
+
+    created = client.post(
+        "/api/v1/multi-user/guardians",
+        headers=_auth("root-token"),
+        json={"guardian_user_id": guardian_id, "learner_user_id": learner_id},
+    )
+    assert created.status_code == 201
+    relationship = created.json()["relationship"]
+    assert relationship["guardian_username"] == "guardian"
+    assert relationship["learner_username"] == "learner"
+    assert relationship["revoked_at"] is None
+
+    duplicate = client.post(
+        "/api/v1/multi-user/guardians",
+        headers=_auth("root-token"),
+        json={"guardian_user_id": guardian_id, "learner_user_id": learner_id},
+    )
+    assert duplicate.status_code == 409
+
+    reverse = client.post(
+        "/api/v1/multi-user/guardians",
+        headers=_auth("root-token"),
+        json={"guardian_user_id": learner_id, "learner_user_id": guardian_id},
+    )
+    assert reverse.status_code == 400
+
+    mine = client.get("/api/v1/multi-user/me/guardianships", headers=_auth("guardian-token"))
+    assert mine.status_code == 200
+    assert mine.json()["relationships"][0]["id"] == relationship["id"]
+
+    revoked = client.delete(
+        f"/api/v1/multi-user/guardians/{relationship['id']}",
+        headers=_auth("root-token"),
+    )
+    assert revoked.status_code == 200
+    assert revoked.json()["relationship"]["revoked_at"] is not None
+    assert (
+        client.get("/api/v1/multi-user/me/guardianships", headers=_auth("guardian-token")).json()[
+            "relationships"
+        ]
+        == []
+    )
+    assert (
+        client.get(
+            "/api/v1/multi-user/guardians",
+            headers=_auth("root-token"),
+        ).json()["relationships"]
+        == []
+    )
+    history = client.get(
+        "/api/v1/multi-user/guardians",
+        headers=_auth("root-token"),
+        params={"include_revoked": True},
+    ).json()["relationships"]
+    assert len(history) == 1
+
+
+def test_guardian_report_requires_active_relationship_and_is_audited(mu_isolated_root, monkeypatch):
+    client, users = _client(mu_isolated_root, monkeypatch)
+    guardian_id = users["guardian"]["id"]
+    learner_id = users["learner"]["id"]
+    report_url = f"/api/v1/multi-user/learners/{learner_id}/guardian-report"
+
+    assert client.get(report_url, headers=_auth("stranger-token")).status_code == 403
+    assert client.get(report_url, headers=_auth("learner-token")).status_code == 403
+    assert client.get(report_url, headers=_auth("guardian-token")).status_code == 403
+
+    created = client.post(
+        "/api/v1/multi-user/guardians",
+        headers=_auth("root-token"),
+        json={
+            "guardian_user_id": guardian_id,
+            "learner_user_id": learner_id,
+            "permissions": ["view_reports"],
+        },
+    )
+    assert created.status_code == 201
+
+    report = client.get(report_url, headers=_auth("guardian-token"))
+    assert report.status_code == 200
+    body = report.json()
+    assert body["learner"]["username"] == "learner"
+    assert body["assigned_materials"] == []
+    assert body["book_permission"]["default"] == "none"
+
+    audit_path = mu_isolated_root / "data" / "system" / "audit" / "usage.jsonl"
+    events = [json.loads(line) for line in audit_path.read_text().splitlines()]
+    report_event = next(event for event in events if event["action"] == "guardian_report_view")
+    assert report_event["guardian_user_id"] == guardian_id
+    assert report_event["learner_user_id"] == learner_id
+    assert "learner-password" not in audit_path.read_text()
+
+
+def test_guardian_can_assign_only_read_access_to_approved_books(mu_isolated_root, monkeypatch):
+    client, users = _client(mu_isolated_root, monkeypatch)
+    learner_id = users["learner"]["id"]
+    created = client.post(
+        "/api/v1/multi-user/guardians",
+        headers=_auth("root-token"),
+        json={
+            "guardian_user_id": users["guardian"]["id"],
+            "learner_user_id": learner_id,
+            "permissions": ["assign_materials", "view_reports"],
+        },
+    )
+    assert created.status_code == 201
+
+    materials_url = f"/api/v1/multi-user/learners/{learner_id}/materials"
+    denied = client.put(materials_url, headers=_auth("stranger-token"), json={"book_ids": []})
+    assert denied.status_code == 403
+    unknown = client.put(
+        materials_url,
+        headers=_auth("guardian-token"),
+        json={"book_ids": ["bk_missing"]},
+    )
+    assert unknown.status_code == 400
+    assert unknown.json()["detail"] == "Unknown approved book id: bk_missing"
+
+    assigned = client.put(
+        materials_url,
+        headers=_auth("guardian-token"),
+        json={"book_ids": ["bk_private", "bk_approved"]},
+    )
+    assert assigned.status_code == 200
+    permission = assigned.json()["book_permission"]
+    assert permission["books"] == {"bk_private": "read", "bk_approved": "read"}
+    assert permission["create"] is True
+    assert permission["default"] == "none"
+
+    report = client.get(
+        f"/api/v1/multi-user/learners/{learner_id}/guardian-report",
+        headers=_auth("guardian-token"),
+    )
+    assert report.status_code == 200
+    assert {item["book_id"] for item in report.json()["assigned_materials"]} == {
+        "bk_private",
+        "bk_approved",
+    }
+
+    reset = client.post(
+        f"/api/v1/multi-user/learners/{learner_id}/credentials/reset",
+        headers=_auth("guardian-token"),
+    )
+    assert reset.status_code == 403
+
+
+def test_guardian_can_reset_local_credentials_once_and_audit_hides_secret(
+    mu_isolated_root, monkeypatch
+):
+    client, users = _client(mu_isolated_root, monkeypatch)
+    learner_id = users["learner"]["id"]
+    created = client.post(
+        "/api/v1/multi-user/guardians",
+        headers=_auth("root-token"),
+        json={
+            "guardian_user_id": users["guardian"]["id"],
+            "learner_user_id": learner_id,
+            "permissions": ["reset_credentials"],
+        },
+    )
+    assert created.status_code == 201
+
+    from deeptutor.multi_user import router as multi_user_router
+    from deeptutor.services.auth import verify_password
+
+    monkeypatch.setattr(multi_user_router, "POCKETBASE_ENABLED", True)
+    unsupported = client.post(
+        f"/api/v1/multi-user/learners/{learner_id}/credentials/reset",
+        headers=_auth("guardian-token"),
+    )
+    assert unsupported.status_code == 400
+    monkeypatch.setattr(multi_user_router, "POCKETBASE_ENABLED", False)
+
+    reset = client.post(
+        f"/api/v1/multi-user/learners/{learner_id}/credentials/reset",
+        headers=_auth("guardian-token"),
+    )
+    assert reset.status_code == 200
+    temporary_password = reset.json()["temporary_password"]
+    assert len(temporary_password) >= 16
+
+    from deeptutor.multi_user.identity import load_users
+
+    learner_hash = load_users()["learner"]["hash"]
+    assert verify_password("learner-password", learner_hash) is False
+    assert verify_password(temporary_password, learner_hash) is True
+
+    audit_path = mu_isolated_root / "data" / "system" / "audit" / "usage.jsonl"
+    assert temporary_password not in audit_path.read_text()
+
+
+def test_user_deletion_revokes_related_guardian_records(mu_isolated_root, monkeypatch):
+    client, users = _client(mu_isolated_root, monkeypatch)
+    created = client.post(
+        "/api/v1/multi-user/guardians",
+        headers=_auth("root-token"),
+        json={
+            "guardian_user_id": users["guardian"]["id"],
+            "learner_user_id": users["learner"]["id"],
+            "permissions": ["view_reports"],
+        },
+    )
+    assert created.status_code == 201
+
+    from deeptutor.multi_user.identity import delete_user
+
+    assert delete_user("learner") is True
+    history = client.get(
+        "/api/v1/multi-user/guardians",
+        headers=_auth("root-token"),
+        params={"include_revoked": True},
+    ).json()["relationships"]
+    assert len(history) == 1
+    assert history[0]["revoked_at"] is not None
+    assert history[0]["revocation_reason"] == "user_deleted"


### PR DESCRIPTION
## Summary

- Add explicit guardian-to-learner authorization records for ordinary user accounts, with revocation history and automatic revocation when either account is deleted.
- Add admin APIs for listing, granting, and revoking scoped guardian permissions.
- Let an authorized guardian view a learner supervision report, assign admin-approved shared books as read-only material, and reset a learner's built-in local credential.
- Record authorization changes and guardian actions in the existing audit stream without logging temporary passwords.

## Implementation notes

- Guardian and learner remain ordinary `user` accounts; this does not add a third identity role.
- Permissions are explicit: `assign_materials`, `view_reports`, and `reset_credentials`. Missing or malformed relationship records fail closed.
- Guardians can only assign books that already exist in the admin shared catalogue, and can only grant read access. Admin-managed create/edit/default permissions remain authoritative.
- PocketBase mode receives a clear unsupported response for credential reset because this PR only enforces the local JSON identity store.
- Credential reset replaces the stored password hash. Session-wide token revocation remains part of the existing stateless JWT lifecycle rather than being introduced here.
- This establishes the reusable guardian relationship layer. Once the learner preset/policy work lands, its material allowlist can consume these authorizations without another identity model.

Fixes #994
Part of #992

## Verification

- `PYTHONPATH=. .venv/bin/pytest -q tests/multi_user`
- `PYTHONPATH=. .venv/bin/pytest -q tests/multi_user/test_guardians.py`
- `PYTHONPATH=. .venv/bin/pytest -q tests/multi_user tests/api/test_book_permission_api.py tests/api/test_auth_contextvar.py`
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
