### PR TITLE
fix(ima): add ima.qq.com to the media-URL allowlist

### DIFF
--- a/deeptutor/services/rag/pipelines/ima/media.py
+++ b/deeptutor/services/rag/pipelines/ima/media.py
@@ -9,7 +9,8 @@ tool read documents through exactly one implementation.
 Security boundary
 -----------------
 The download URL arrives inside an API response, so it is treated as untrusted
-input: it must be HTTPS and inside Tencent COS (:data:`_COS_ROOT_DOMAIN`), which
+input: it must be HTTPS and served from a trusted Tencent domain (Tencent COS
+or IMA's own resource host, :data:`_ALLOWED_MEDIA_ROOT_DOMAINS`), which
 prevents a tampered or buggy response from turning retrieval into an SSRF
 primitive. Redirects are not followed, IMA's own credentials are never attached
 to this separate client, and hop-by-hop / identity headers are stripped from
@@ -35,9 +36,10 @@ from deeptutor.utils.document_extractor import (
 
 from .envelope import ImaAPIError
 
-# Official IMA media links are short-lived Tencent COS URLs; the downloader
-# refuses anything outside that boundary.
-_COS_ROOT_DOMAIN = "myqcloud.com"
+# Official IMA media links are short-lived Tencent COS download URLs, and
+# note/file content is served from IMA's own resource host (res-pkb.ima.qq.com);
+# the downloader refuses anything outside these trusted Tencent domains.
+_ALLOWED_MEDIA_ROOT_DOMAINS = ("myqcloud.com", "ima.qq.com")
 
 # Headers we never forward, whatever the API response asks for: hop-by-hop
 # fields and anything that would carry identity to COS.
@@ -140,7 +142,9 @@ def validate_media_url(url: str) -> None:
     hostname = (parsed.hostname or "").rstrip(".").lower()
     if parsed.scheme != "https" or not hostname:
         raise ImaAPIError("IMA media URL must use HTTPS.")
-    if hostname != _COS_ROOT_DOMAIN and not hostname.endswith(f".{_COS_ROOT_DOMAIN}"):
+    if not any(
+        hostname == root or hostname.endswith(f".{root}") for root in _ALLOWED_MEDIA_ROOT_DOMAINS
+    ):
         raise ImaAPIError("IMA media URL is outside Tencent COS.")
 
 

--- a/tests/services/rag/test_ima_pipeline.py
+++ b/tests/services/rag/test_ima_pipeline.py
@@ -323,6 +323,25 @@ class TestClientWire:
         with pytest.raises(ImaAPIError):
             asyncio.run(_client(handler).get_media_content("m-file"))
 
+    def test_file_media_accepts_ima_qq_com_resource_url(self) -> None:
+        media_url = "https://res-pkb.ima.qq.com/pkb-1/notes.txt"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "POST":
+                return _ok({"media_type": 1, "url_info": {"url": media_url}})
+            return httpx.Response(
+                200,
+                content=b"full file text",
+                headers={"content-type": "text/plain"},
+            )
+
+        media = asyncio.run(_client(handler).get_media_content("m-file"))
+
+        assert media == ImaMediaContent(
+            data=b"full file text",
+            filename="notes.txt",
+        )
+
     def test_file_media_rejects_content_length_over_budget(self) -> None:
         media_url = "https://bucket.cos.ap-guangzhou.myqcloud.com/file.pdf"
 


### PR DESCRIPTION
### Description
**What changed**
- Broaden the IMA media-URL allowlist in `deeptutor/services/rag/pipelines/ima/media.py` from a single Tencent COS  root domain (`myqcloud.com`) to a trusted-domain tuple  `("myqcloud.com", "ima.qq.com")`, accepting exact hosts and subdomains of both.
- Add a regression test `test_file_media_accepts_ima_qq_com_resource_url`  covering full-text download from IMA's own resource host.

**What problem it solves**
- IMA serves full-text media from `res-pkb.ima.qq.com`, not only Tencent COS (`myqcloud.com`). The old allowlist rejected every non-COS host, so full-text  reads of IMA knowledge items failed with `ImaAPIError: IMA media URL is outside Tencent COS.` Full-text reads now work again.
- The SSRF guard is preserved: HTTPS-only, no redirects, and only exact trusted Tencent domains are accepted; non-HTTPS URLs, arbitrary hosts, and spoofed  subdomains (`myqcloud.com.evil.test`) remain rejected.

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

