### PR TITLE
fix(partners): localize partner session placeholder titles

### DIFF
--- a/web/components/partners/PartnerArchives.tsx
+++ b/web/components/partners/PartnerArchives.tsx
@@ -18,6 +18,7 @@ import {
   type PartnerSessionInfo,
 } from "@/lib/partners-api";
 import type { ExportableMessage } from "@/lib/chat-export";
+import { displaySessionTitle } from "@/lib/session-title";
 
 interface HistoryMessage {
   role: string;
@@ -203,8 +204,10 @@ export default function PartnerArchives({
                   <MessageSquareText className="h-3.5 w-3.5 shrink-0 text-[var(--muted-foreground)]" />
                 )}
                 <span className="min-w-0 flex-1 truncate text-[12.5px] font-medium text-[var(--foreground)]">
-                  {session.title ||
-                    (session.archived ? t("Archived") : t("New conversation"))}
+                  {displaySessionTitle(
+                    session.title,
+                    session.archived ? t("Archived") : t("New conversation"),
+                  )}
                 </span>
                 <span className="text-[11px] text-[var(--muted-foreground)]">
                   {session.message_count}
@@ -236,10 +239,12 @@ export default function PartnerArchives({
               <div className="flex items-center justify-between gap-3">
                 <div className="min-w-0">
                   <h3 className="truncate text-[13px] font-medium text-[var(--foreground)]">
-                    {selected.title ||
-                      (selected.archived
+                    {displaySessionTitle(
+                      selected.title,
+                      selected.archived
                         ? t("Archived conversation")
-                        : t("New conversation"))}
+                        : t("New conversation"),
+                    )}
                   </h3>
                   <p className="text-[11.5px] text-[var(--muted-foreground)]">
                     {(selected.archived ? `${t("Archived")} · ` : "") +

--- a/web/components/partners/PartnerChat.tsx
+++ b/web/components/partners/PartnerChat.tsx
@@ -25,6 +25,7 @@ import {
   resumePartnerSession,
 } from "@/lib/partners-api";
 import { freshPartnerSessionKey } from "@/lib/partner-session";
+import { displaySessionTitle } from "@/lib/session-title";
 import { createPartnerDraftPublisher } from "@/lib/partner-chat-draft";
 import { ReconnectingWebSocket } from "@/lib/reconnecting-websocket";
 import type { ExportableMessage } from "@/lib/chat-export";
@@ -685,7 +686,7 @@ export default function PartnerChat({
               .map(
                 (s) =>
                   `- \`${s.session_key}\`${s.archived ? ` (${t("Archived")})` : ""} — ${
-                    s.title || t("New conversation")
+                    displaySessionTitle(s.title, t("New conversation"))
                   } · ${s.message_count}`,
               )
               .join("\n");

--- a/web/lib/session-title.ts
+++ b/web/lib/session-title.ts
@@ -6,3 +6,15 @@ export function isPlaceholderSessionTitle(
   const value = (title ?? "").trim();
   return value === "" || value === DEFAULT_SESSION_TITLE;
 }
+
+/**
+ * Swap the backend sentinel (or empty title) for a localized label.
+ * Real user/LLM titles pass through unchanged.
+ */
+export function displaySessionTitle(
+  title: string | null | undefined,
+  placeholderLabel: string,
+): string {
+  if (isPlaceholderSessionTitle(title)) return placeholderLabel;
+  return (title ?? "").trim();
+}

--- a/web/tests/session-title.test.ts
+++ b/web/tests/session-title.test.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { isPlaceholderSessionTitle } from "../lib/session-title";
+import {
+  displaySessionTitle,
+  isPlaceholderSessionTitle,
+} from "../lib/session-title";
 
 test("empty and backend-default session titles are placeholders", () => {
   assert.equal(isPlaceholderSessionTitle(""), true);
@@ -11,4 +14,11 @@ test("empty and backend-default session titles are placeholders", () => {
 test("user and generated session titles remain business data", () => {
   assert.equal(isPlaceholderSessionTitle("New Conversation"), false);
   assert.equal(isPlaceholderSessionTitle("傅里叶变换"), false);
+});
+
+test("displaySessionTitle localizes placeholders for lists and partner UI", () => {
+  assert.equal(displaySessionTitle("", "新对话"), "新对话");
+  assert.equal(displaySessionTitle("New conversation", "新对话"), "新对话");
+  assert.equal(displaySessionTitle("  New conversation  ", "已归档"), "已归档");
+  assert.equal(displaySessionTitle("傅里叶变换", "新对话"), "傅里叶变换");
 });


### PR DESCRIPTION
## Summary
- Partner Archives list/header and PartnerChat `/sessions` used `title || t("New conversation")`, so the backend English sentinel `New conversation` rendered literally in non-English locales.
- Reuse `displaySessionTitle` so empty titles and the sentinel map to the localized placeholder (archived rows keep their archived label).

## Test plan
- [x] `npm run test:node -- session-title` (passed)
- [ ] zh-CN Partners → Archives: untitled/`New conversation` sessions show localized New conversation (or Archived), not raw English sentinel as a "real" title
- [ ] `/sessions` slash output uses the same localized placeholder
- [ ] Named partner sessions still show their real titles

Related: #1086 / #1095 (same sentinel class on other surfaces).