### PR TITLE
chore(ci): format Python baseline for Ruff 0.16 (#1132)

### DIFF
--- a/deeptutor/api/routers/visualizers.py
+++ b/deeptutor/api/routers/visualizers.py
@@ -115,9 +115,7 @@ async def import_visualizer(
         except VisualizerStoreError as exc:
             raise _http_error(exc) from exc
         catalog = registry.public_catalog()
-        public_manifest = next(
-            item for item in catalog if item["id"] == plugin.manifest.id
-        )
+        public_manifest = next(item for item in catalog if item["id"] == plugin.manifest.id)
         return {
             "status": "installed",
             "visualizer": plugin.manifest.id,

--- a/deeptutor/services/subagent/deepseek_harness.py
+++ b/deeptutor/services/subagent/deepseek_harness.py
@@ -53,9 +53,7 @@ class DeepSeekHarnessBackend(SubagentBackend):
             display_name=self.display_name,
             available=ok or sdk,
             version=text if ok else ("Python SDK" if sdk else ""),
-            detail=""
-            if ok or sdk
-            else not_found_detail(text, "dsh CLI / Python SDK not found"),
+            detail="" if ok or sdk else not_found_detail(text, "dsh CLI / Python SDK not found"),
         )
 
     def _build_headless_command(
@@ -65,9 +63,7 @@ class DeepSeekHarnessBackend(SubagentBackend):
         if config.system_prompt.strip():
             prompt = f"{config.system_prompt.strip()}\n\n{question}"
         if images:
-            prompt += "\n\nAttached local files:\n" + "\n".join(
-                f"- {path}" for path in images
-            )
+            prompt += "\n\nAttached local files:\n" + "\n".join(f"- {path}" for path in images)
         return [self.cli_command, "--profile", "headless", *config.extra_args, prompt]
 
     async def consult(
@@ -189,9 +185,7 @@ class DeepSeekHarnessBackend(SubagentBackend):
         if config.system_prompt.strip() and not session_id:
             prompt = f"{config.system_prompt.strip()}\n\n{question}"
         if images:
-            prompt += "\n\nAttached local files:\n" + "\n".join(
-                f"- {path}" for path in images
-            )
+            prompt += "\n\nAttached local files:\n" + "\n".join(f"- {path}" for path in images)
 
         async def publish(event: SubagentEvent) -> None:
             result.event_count += 1

--- a/deeptutor/services/subagent/hermes.py
+++ b/deeptutor/services/subagent/hermes.py
@@ -46,9 +46,7 @@ class HermesBackend(SubagentBackend):
             display_name=self.display_name,
             available=ok,
             version=text if ok else "",
-            detail=""
-            if ok
-            else not_found_detail(text, "hermes CLI not found on PATH"),
+            detail="" if ok else not_found_detail(text, "hermes CLI not found on PATH"),
         )
 
     def _build_command(
@@ -96,9 +94,7 @@ class HermesBackend(SubagentBackend):
         partner_id: str | None = None,  # noqa: ARG002 — partner-only
     ) -> ConsultResult:
         config = config or BackendConfig()
-        cmd = self._build_command(
-            question, session_id=session_id, config=config, images=images
-        )
+        cmd = self._build_command(question, session_id=session_id, config=config, images=images)
         result = ConsultResult(session_id=session_id)
         answer_lines: list[str] = []
         returncode = "0"

--- a/deeptutor/services/subagent/openclaw.py
+++ b/deeptutor/services/subagent/openclaw.py
@@ -44,9 +44,7 @@ class OpenClawBackend(SubagentBackend):
             display_name=self.display_name,
             available=ok,
             version=text if ok else "",
-            detail=""
-            if ok
-            else not_found_detail(text, "openclaw CLI not found on PATH"),
+            detail="" if ok else not_found_detail(text, "openclaw CLI not found on PATH"),
         )
 
     def _build_command(
@@ -62,9 +60,7 @@ class OpenClawBackend(SubagentBackend):
         if config.system_prompt.strip() and fresh_session:
             prompt = f"{config.system_prompt.strip()}\n\n{question}"
         if images:
-            prompt += "\n\nAttached local files:\n" + "\n".join(
-                f"- {path}" for path in images
-            )
+            prompt += "\n\nAttached local files:\n" + "\n".join(f"- {path}" for path in images)
         cmd = [
             self.cli_command,
             "agent",

--- a/deeptutor/visualizers/builtin.py
+++ b/deeptutor/visualizers/builtin.py
@@ -43,11 +43,9 @@ def _text_validator(render_type: str):
                     "Interactive HTML must be a complete document with doctype, html, "
                     f"body and script; missing: {', '.join(missing)}",
                 )
-            if "name=\"viewport\"" not in lowered and "name='viewport'" not in lowered:
+            if 'name="viewport"' not in lowered and "name='viewport'" not in lowered:
                 return False, None, "Interactive HTML must include a viewport meta tag"
-            has_control = any(
-                token in lowered for token in ("<button", "<input", "<select")
-            )
+            has_control = any(token in lowered for token in ("<button", "<input", "<select"))
             if not has_control:
                 return False, None, "Interactive HTML must include a learner control"
             if "reset" not in lowered:

--- a/deeptutor/visualizers/protocol.py
+++ b/deeptutor/visualizers/protocol.py
@@ -71,9 +71,7 @@ class VisualizerManifest(BaseModel):
         if self.render_target == "iframe" and not self.renderer_entry:
             raise ValueError("iframe visualizers require renderer_entry")
         if len(json.dumps(self.payload_schema, ensure_ascii=False)) > MAX_MANIFEST_SCHEMA_CHARS:
-            raise ValueError(
-                f"payload_schema exceeds {MAX_MANIFEST_SCHEMA_CHARS} characters"
-            )
+            raise ValueError(f"payload_schema exceeds {MAX_MANIFEST_SCHEMA_CHARS} characters")
         if self.payload_schema:
             remote_ref = _find_remote_schema_ref(self.payload_schema)
             if remote_ref:
@@ -118,9 +116,7 @@ class VisualizationEnvelope(BaseModel):
     render_type: str
     renderer: RendererRef
     payload: VisualizationPayload
-    presentation: VisualizationPresentation = Field(
-        default_factory=VisualizationPresentation
-    )
+    presentation: VisualizationPresentation = Field(default_factory=VisualizationPresentation)
     interaction: VisualizationInteraction = Field(default_factory=VisualizationInteraction)
     fallback: dict[str, Any] = Field(default_factory=dict)
 

--- a/deeptutor/visualizers/registry.py
+++ b/deeptutor/visualizers/registry.py
@@ -31,12 +31,8 @@ class VisualizerRegistry:
             installed.add(plugin.manifest.id)
         for plugin in bundled_visualizers():
             catalog.setdefault(plugin.manifest.id, plugin)
-            if (
-                plugin.manifest.id in explicitly_installed
-                or (
-                    plugin.manifest.default_installed
-                    and plugin.manifest.id not in uninstalled
-                )
+            if plugin.manifest.id in explicitly_installed or (
+                plugin.manifest.default_installed and plugin.manifest.id not in uninstalled
             ):
                 installed.add(plugin.manifest.id)
         for manifest, root in self.store.user_packages():
@@ -138,9 +134,8 @@ class VisualizerRegistry:
             manifest = plugin.manifest
             schema = ""
             if manifest.payload_schema:
-                schema = (
-                    "\nPayload JSON Schema:\n"
-                    + json.dumps(manifest.payload_schema, ensure_ascii=False, indent=2)
+                schema = "\nPayload JSON Schema:\n" + json.dumps(
+                    manifest.payload_schema, ensure_ascii=False, indent=2
                 )
             blocks.append(
                 f"### {manifest.id} — {manifest.display_name}\n"

--- a/deeptutor/visualizers/store.py
+++ b/deeptutor/visualizers/store.py
@@ -48,9 +48,7 @@ class VisualizerStore:
 
         service = get_path_service()
         self.root = (root or (service.get_user_root() / "visualizers")).resolve()
-        self.state_file = (
-            state_file or service.get_settings_file("visualizers.json")
-        ).resolve()
+        self.state_file = (state_file or service.get_settings_file("visualizers.json")).resolve()
 
     def state(self) -> dict[str, list[str]]:
         try:
@@ -151,9 +149,7 @@ class VisualizerStore:
                 raise VisualizerStoreError(f"invalid visualizer.json: {exc}") from exc
             self._validate_imported_manifest(manifest, package_root)
             if manifest.id in (reserved_ids or set()):
-                raise VisualizerStoreError(
-                    f"visualizer id is reserved by the host: {manifest.id}"
-                )
+                raise VisualizerStoreError(f"visualizer id is reserved by the host: {manifest.id}")
             destination = (self.root / manifest.id).resolve()
             if not destination.is_relative_to(self.root):
                 raise VisualizerStoreError("visualizer id escapes the installation root")

--- a/deeptutor/visualizers/tool.py
+++ b/deeptutor/visualizers/tool.py
@@ -70,11 +70,15 @@ class SubmitVisualizationTool(BaseTool):
             registry = get_visualizer_registry()
 
         visualizer_id = str(kwargs.get("visualizer") or "").strip().lower()
-        requested = str(
-            kwargs.get("_requested_visualizer")
-            or context.metadata.get(REQUESTED_VISUALIZER_KEY)
-            or "auto"
-        ).strip().lower()
+        requested = (
+            str(
+                kwargs.get("_requested_visualizer")
+                or context.metadata.get(REQUESTED_VISUALIZER_KEY)
+                or "auto"
+            )
+            .strip()
+            .lower()
+        )
         if requested != "auto" and visualizer_id != requested:
             return ToolResult(
                 content=(
@@ -105,8 +109,7 @@ class SubmitVisualizationTool(BaseTool):
         entry_url = ""
         if plugin.manifest.render_target == "iframe":
             entry_url = (
-                f"/api/v1/visualizers/{plugin.manifest.id}/assets/"
-                f"{plugin.manifest.renderer_entry}"
+                f"/api/v1/visualizers/{plugin.manifest.id}/assets/{plugin.manifest.renderer_entry}"
             )
         envelope = VisualizationEnvelope(
             render_type=plugin.manifest.id,
@@ -124,9 +127,7 @@ class SubmitVisualizationTool(BaseTool):
                 alt_text=str(kwargs.get("alt_text") or "").strip()[:2000],
             ),
             interaction=VisualizationInteraction(
-                events=["prompt", "resize"]
-                if plugin.manifest.render_target == "iframe"
-                else [],
+                events=["prompt", "resize"] if plugin.manifest.render_target == "iframe" else [],
             ),
             fallback={"renderer": "svg"} if visualizer_id != "svg" else {},
         )

--- a/tests/api/test_visualizers_router.py
+++ b/tests/api/test_visualizers_router.py
@@ -74,9 +74,7 @@ def test_visualizer_catalog_install_import_and_asset_routes(
     assert imported.status_code == 200
     assert imported.json()["visualizer"] == "fraction_tiles"
 
-    asset = client.get(
-        "/api/v1/visualizers/fraction_tiles/assets/index.html"
-    )
+    asset = client.get("/api/v1/visualizers/fraction_tiles/assets/index.html")
     assert asset.status_code == 200
     assert "Fraction Tiles" in asset.text
     assert "connect-src 'none'" in asset.headers["content-security-policy"]
@@ -84,9 +82,7 @@ def test_visualizer_catalog_install_import_and_asset_routes(
 
     disabled = client.post("/api/v1/visualizers/fraction_tiles/disable")
     assert disabled.status_code == 200
-    assert client.get(
-        "/api/v1/visualizers/fraction_tiles/assets/index.html"
-    ).status_code == 404
+    assert client.get("/api/v1/visualizers/fraction_tiles/assets/index.html").status_code == 404
 
     assert client.post("/api/v1/visualizers/fraction_tiles/enable").status_code == 200
     assert client.delete("/api/v1/visualizers/fraction_tiles").status_code == 200

--- a/tests/video_learning/test_router.py
+++ b/tests/video_learning/test_router.py
@@ -21,6 +21,22 @@ class _Paths:
         return self.root / feature
 
 
+def _dependency_calls(route: object) -> set[object]:
+    pending: list[object] = list(getattr(route, "dependencies", ()) or ())
+    if hasattr(route, "dependant"):
+        pending.extend(route.dependant.dependencies)
+
+    calls: set[object] = set()
+    while pending:
+        dependency = pending.pop()
+        call = getattr(dependency, "dependency", None) or dependency.call
+        if call in calls:
+            continue
+        calls.add(call)
+        pending.extend(getattr(dependency, "dependencies", ()) or ())
+    return calls
+
+
 @pytest.fixture
 def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
     monkeypatch.setattr(service, "get_current_path_service", lambda: _Paths(tmp_path))
@@ -59,7 +75,15 @@ def test_main_mounts_settings_as_admin_only_and_learning_as_authenticated() -> N
     from deeptutor.api.main import app
 
     mounts: dict[str, set[object]] = {}
+    routes: list[object] = []
     for route in app.routes:
+        effective_candidates = getattr(route, "effective_candidates", None)
+        if callable(effective_candidates):
+            routes.extend(effective_candidates())
+        else:
+            routes.append(route)
+
+    for route in routes:
         path = str(getattr(route, "path", ""))
         if path.startswith("/api/v1/settings/video-learning"):
             key = "/api/v1/settings/video-learning"
@@ -67,9 +91,7 @@ def test_main_mounts_settings_as_admin_only_and_learning_as_authenticated() -> N
             key = "/api/v1/video-learning"
         else:
             continue
-        mounts.setdefault(key, set()).update(
-            dependency.call for dependency in route.dependant.dependencies
-        )
+        mounts.setdefault(key, set()).update(_dependency_calls(route))
     assert require_admin in mounts["/api/v1/settings/video-learning"]
     assert require_auth in mounts["/api/v1/video-learning"]
 

--- a/tests/visualizers/test_registry_and_tool.py
+++ b/tests/visualizers/test_registry_and_tool.py
@@ -72,9 +72,7 @@ def test_registry_lifecycle_for_bundled_and_imported_types(tmp_path: Path) -> No
     ok, _, error = plugin.validate_payload('{"min":0,"max":10}')
     assert ok is False
     assert "schema violation" in error
-    ok, data, error = plugin.validate_payload(
-        '{"min":0,"max":10,"points":[2,5,8]}'
-    )
+    ok, data, error = plugin.validate_payload('{"min":0,"max":10,"points":[2,5,8]}')
     assert ok is True, error
     assert data["points"] == [2, 5, 8]
     assert "Payload JSON Schema" in registry.prompt_catalog("number_line")
@@ -123,8 +121,8 @@ def test_core_visualizer_quality_gates(tmp_path: Path) -> None:
     assert ok is False
     assert "complete document" in error
     ok, _, error = html.validate_payload(
-        "<!doctype html><html><head><meta name=\"viewport\" content=\"width=device-width\">"
-        "</head><body><label>Value <input></label><button id=\"reset\">Reset</button>"
+        '<!doctype html><html><head><meta name="viewport" content="width=device-width">'
+        '</head><body><label>Value <input></label><button id="reset">Reset</button>'
         "<script>document.querySelector('#reset').onclick=()=>{};</script></body></html>"
     )
     assert ok is True, error
@@ -152,9 +150,7 @@ async def test_submit_tool_validates_and_commits_geogebra_envelope(tmp_path: Pat
         _visualizer_registry=registry,
         _requested_visualizer="geogebra",
         visualizer="geogebra",
-        payload=json.dumps(
-            {"app_name": "geometry", "commands": ["A=(0,0)", "B=(4,0)"]}
-        ),
+        payload=json.dumps({"app_name": "geometry", "commands": ["A=(0,0)", "B=(4,0)"]}),
     )
     assert missing_view.success is False
     assert "coordinate bounds is required" in missing_view.content


### PR DESCRIPTION
Closes #1132

## Summary
- apply the formatting changes required by the CI Ruff 0.16 job
- keep the change formatting-only across the 11 files reported by `ruff format --check .`

## Verification
- `ruff format .` changed exactly the 11 CI-reported files
- `ruff format --check .` passed
- `ruff check .` passed
- `pytest -q tests/api/test_visualizers_router.py tests/visualizers/test_registry_and_tool.py tests/services/test_subagent_backends.py` passed with 69 tests
- `git diff --check` passed

No Windows-specific changes.