### PR TITLE
fix(web): localize MyAgentsPicker placeholder titles

### DIFF
--- a/web/components/chat/MyAgentsPicker.tsx
+++ b/web/components/chat/MyAgentsPicker.tsx
@@ -39,6 +39,7 @@ import {
   readImportMeta,
 } from "@/lib/chat-import/attribution";
 import { normalizeMessageContent, truncateText } from "@/lib/message-content";
+import { isPlaceholderSessionTitle } from "@/lib/session-title";
 
 interface MyAgentsPickerProps {
   open: boolean;
@@ -106,6 +107,10 @@ function isoMs(value: string | undefined): number {
   return Number.isNaN(ms) ? 0 : ms;
 }
 
+function formatSessionRowTitle(title: string, placeholderLabel: string): string {
+  return isPlaceholderSessionTitle(title) ? placeholderLabel : title.trim();
+}
+
 /**
  * Reference picker for agent conversations. Two sources feed one unified list:
  * imported Claude Code / Codex conversations (stored as normal sessions, so a
@@ -122,6 +127,11 @@ export default function MyAgentsPicker({
   onApply,
 }: MyAgentsPickerProps) {
   const { t, i18n } = useTranslation();
+  // Backend writes the English sentinel "New conversation" until the LLM title
+  // lands; mirror SessionList with a localized "New chat" label.
+  const placeholderLabel = t("New chat");
+  const formatRowTitle = (title: string) =>
+    formatSessionRowTitle(title, placeholderLabel);
   const [sessions, setSessions] = useState<
     Awaited<ReturnType<typeof listImportedSessions>>
   >([]);
@@ -315,7 +325,7 @@ export default function MyAgentsPicker({
     for (const row of rows) {
       if (activeAgent !== ALL && row.ownerKey !== activeAgent) continue;
       if (keyword) {
-        const title = row.title.toLowerCase();
+        const title = formatRowTitle(row.title).toLowerCase();
         const last = normalizeMessageContent(row.lastMessage).toLowerCase();
         if (!title.includes(keyword) && !last.includes(keyword)) continue;
       }
@@ -333,14 +343,13 @@ export default function MyAgentsPicker({
       map.set(row.groupKey, group);
     }
     return Array.from(map.values()).sort((a, b) => b.latest - a.latest);
-  }, [rows, activeAgent, query]);
+  }, [rows, activeAgent, query, placeholderLabel]);
 
   const titleById = useMemo(() => {
     const map = new Map<string, string>();
-    for (const row of rows)
-      map.set(row.id, row.title || t("Untitled conversation"));
+    for (const row of rows) map.set(row.id, formatRowTitle(row.title));
     return map;
-  }, [rows, t]);
+  }, [rows, placeholderLabel]);
 
   const toggleSession = (id: string) =>
     setSelectedIds((prev) =>
@@ -401,7 +410,7 @@ export default function MyAgentsPicker({
   const handleApply = () => {
     const selected = selectedIds.map((id) => ({
       sessionId: id,
-      title: titleById.get(id) || t("Untitled conversation"),
+      title: titleById.get(id) || placeholderLabel,
     }));
     onApply(selected);
     onClose();
@@ -570,7 +579,7 @@ export default function MyAgentsPicker({
                                   </div>
                                   <div className="min-w-0 flex-1">
                                     <span className="block truncate text-[14px] font-medium text-[var(--foreground)]">
-                                      {row.title || t("Untitled conversation")}
+                                      {formatRowTitle(row.title)}
                                     </span>
                                     {row.lastMessage ? (
                                       <p className="mt-1 line-clamp-2 text-[12px] leading-5 text-[var(--muted-foreground)]">
@@ -676,6 +685,7 @@ function PreviewPane({
   onToggleSelect: () => void;
 }) {
   const { t } = useTranslation();
+  const placeholderLabel = t("New chat");
   const { row, messages, loading } = preview;
   const visible = (messages ?? []).filter(
     (m) => (m.content || "").trim() && m.role !== "system",
@@ -693,7 +703,7 @@ function PreviewPane({
         </button>
         <div className="min-w-0 flex-1">
           <div className="truncate text-[13px] font-semibold text-[var(--foreground)]">
-            {row.title || t("Untitled conversation")}
+            {formatSessionRowTitle(row.title, placeholderLabel)}
           </div>
           <div className="text-[11px] text-[var(--muted-foreground)]">
             {row.messageCount || visible.length} {t("messages")}


### PR DESCRIPTION
## Summary
- `MyAgentsPicker` treated the backend sentinel `New conversation` as a real title (and empty titles as `Untitled conversation`), so the agent conversation picker list, preview header, and applied session chips showed English instead of the localized `New chat` used by `SessionList`.
- Reuse `isPlaceholderSessionTitle` via a small `formatSessionRowTitle` helper so imported and partner sessions match the rest of the chat UI.

## Test plan
- [ ] Open agent conversation picker with an untitled/`New conversation` session — list + preview show localized New chat
- [ ] Apply that session — composer chip title is localized, not `New conversation` / `Untitled conversation`
- [ ] Named sessions still show their real titles
- [ ] Search by localized placeholder label finds untitled sessions

Related: #1086, #1095, #1121 (same sentinel pattern across session pickers).
