### PR TITLE
fix: provide contexts for mastery study

### DIFF
--- a/web/app/(utility)/mastery/[pathId]/study/layout.tsx
+++ b/web/app/(utility)/mastery/[pathId]/study/layout.tsx
@@ -1,6 +1,8 @@
 import { GeogebraTabProvider } from "@/context/GeogebraTabContext";
 import { QuizFollowupProvider } from "@/context/QuizFollowupContext";
 import { UnifiedChatProvider } from "@/context/UnifiedChatContext";
+import { ReadingProvider } from "@/context/ReadingContext";
+import { WatchingProvider } from "@/context/WatchingContext";
 
 /**
  * The chat engine is scoped to the study session, not to the whole Mastery
@@ -12,10 +14,14 @@ export default function MasteryStudyLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <UnifiedChatProvider>
-      <QuizFollowupProvider>
-        <GeogebraTabProvider>{children}</GeogebraTabProvider>
-      </QuizFollowupProvider>
-    </UnifiedChatProvider>
+    <ReadingProvider>
+      <WatchingProvider>
+        <UnifiedChatProvider>
+          <QuizFollowupProvider>
+            <GeogebraTabProvider>{children}</GeogebraTabProvider>
+          </QuizFollowupProvider>
+        </UnifiedChatProvider>
+      </WatchingProvider>
+    </ReadingProvider>
   );
 }


### PR DESCRIPTION
### Description
Fix a regression where Mastery Study pages failed to render because the shared `AssistantResponse` component uses reading and watching contexts that were not provided by the dedicated Mastery Study layout.

The layout now provides `ReadingProvider` and `WatchingProvider` around the existing chat, quiz, and GeoGebra providers.

### Related Issues
- Fixes the Mastery Study page runtime error: `useWatching must be used inside WatchingProvider`.

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the contribution guidelines.
- [x] My code follows the project's coding standards.
- [x] I have run the relevant checks and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
Validation performed:
- `npm run build` — passed; Mastery Study route generated as dynamic route.
- `npm run test:node` — passed (774 tests).
- `git diff --check` — passed.
- Commit hooks for the changed file — passed.
- Manually verified the page in development mode after the provider fix.
