### PR TITLE
feat(video-learning): add timestamped transcript notes (#1137)

### DIFF
--- a/deeptutor/api/routers/notebook.py
+++ b/deeptutor/api/routers/notebook.py
@@ -66,7 +66,14 @@ class AddRecordRequest(BaseModel):
 
     notebook_ids: list[str]
     record_type: Literal[
-        "solve", "question", "research", "chat", "co_writer", "tutorbot", "reading"
+        "solve",
+        "question",
+        "research",
+        "chat",
+        "co_writer",
+        "tutorbot",
+        "reading",
+        "video_learning",
     ]
     title: str
     summary: str = ""

--- a/deeptutor/api/routers/video_learning.py
+++ b/deeptutor/api/routers/video_learning.py
@@ -12,6 +12,7 @@ import httpx
 from pydantic import BaseModel, Field
 from starlette.background import BackgroundTask
 
+from deeptutor.services.notebook.service import NotebookCorruptedError
 from deeptutor.video_learning import (
     TimedMediaError,
     TimedMediaNotFound,
@@ -22,6 +23,7 @@ from deeptutor.video_learning import (
     save_video_learning_settings,
     test_invidious_connection,
 )
+from deeptutor.video_learning import notes as video_notes
 
 router = APIRouter()
 settings_router = APIRouter()
@@ -39,6 +41,15 @@ class ResolveRequest(BaseModel):
 class ProgressRequest(BaseModel):
     time_seconds: float = Field(ge=0, le=24 * 60 * 60)
     duration_seconds: float = Field(default=0, ge=0, le=24 * 60 * 60)
+
+
+class CreateVideoNoteRequest(BaseModel):
+    body: str = Field(min_length=1, max_length=20_000)
+    time_seconds: float = Field(ge=0, le=24 * 60 * 60)
+
+
+class UpdateVideoNoteRequest(BaseModel):
+    body: str = Field(min_length=1, max_length=20_000)
 
 
 class YouTubeSettings(BaseModel):
@@ -63,6 +74,19 @@ def _http_error(exc: Exception) -> HTTPException:
     if isinstance(exc, TimedMediaError):
         return HTTPException(status_code=400, detail=str(exc))
     return HTTPException(status_code=500, detail="Video learning could not complete the request.")
+
+
+def _note_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, NotebookCorruptedError):
+        return HTTPException(
+            status_code=409,
+            detail={
+                "code": "notebook_unreadable",
+                "notebook_id": exc.notebook_id,
+                "message": str(exc),
+            },
+        )
+    return _http_error(exc)
 
 
 @settings_router.get("")
@@ -124,6 +148,48 @@ async def save_video_progress(material_id: str, payload: ProgressRequest) -> dic
         return {"time_seconds": position, "duration_seconds": duration}
     except Exception as exc:
         raise _http_error(exc) from exc
+
+
+@router.get("/materials/{material_id}/notes")
+async def list_video_notes(material_id: str) -> list[dict[str, Any]]:
+    try:
+        return video_notes.list_notes(video_notes.get_notebook_manager(), material_id)
+    except Exception as exc:
+        raise _note_error(exc) from exc
+
+
+@router.post("/materials/{material_id}/notes")
+async def create_video_note(material_id: str, payload: CreateVideoNoteRequest) -> dict[str, Any]:
+    try:
+        return video_notes.create_note(
+            video_notes.get_notebook_manager(),
+            material_id,
+            payload.body,
+            payload.time_seconds,
+        )
+    except Exception as exc:
+        raise _note_error(exc) from exc
+
+
+@router.put("/materials/{material_id}/notes/{note_id}")
+async def update_video_note(
+    material_id: str, note_id: str, payload: UpdateVideoNoteRequest
+) -> dict[str, Any]:
+    try:
+        return video_notes.update_note(
+            video_notes.get_notebook_manager(), material_id, note_id, payload.body
+        )
+    except Exception as exc:
+        raise _note_error(exc) from exc
+
+
+@router.delete("/materials/{material_id}/notes/{note_id}")
+async def delete_video_note(material_id: str, note_id: str) -> dict[str, str]:
+    try:
+        deleted = video_notes.delete_note(video_notes.get_notebook_manager(), material_id, note_id)
+        return {"status": "deleted" if deleted else "missing"}
+    except Exception as exc:
+        raise _note_error(exc) from exc
 
 
 def _vtt_timestamp(value: Any) -> str:

--- a/deeptutor/api/routers/visualizers.py
+++ b/deeptutor/api/routers/visualizers.py
@@ -115,9 +115,7 @@ async def import_visualizer(
         except VisualizerStoreError as exc:
             raise _http_error(exc) from exc
         catalog = registry.public_catalog()
-        public_manifest = next(
-            item for item in catalog if item["id"] == plugin.manifest.id
-        )
+        public_manifest = next(item for item in catalog if item["id"] == plugin.manifest.id)
         return {
             "status": "installed",
             "visualizer": plugin.manifest.id,

--- a/deeptutor/services/notebook/service.py
+++ b/deeptutor/services/notebook/service.py
@@ -36,6 +36,7 @@ class RecordType(str, Enum):
     CO_WRITER = "co_writer"
     TUTORBOT = "tutorbot"
     READING = "reading"
+    VIDEO_LEARNING = "video_learning"
 
 
 class NotebookRecord(BaseModel):
@@ -256,6 +257,20 @@ class NotebookManager:
             self._save_notebook(notebook)
             self._touch_index_entry(notebook_id, notebook)
         return notebook
+
+    def get_or_create_notebook(
+        self, name: str, description: str = "", color: str = "#3B82F6", icon: str = "book"
+    ) -> dict:
+        """Return an existing notebook with this exact name, or create one."""
+        with self._index_lock:
+            for row in self._load_index().get("notebooks", []):
+                if row.get("name") != name:
+                    continue
+                notebook_id = str(row.get("id") or "")
+                notebook = self._load_notebook(notebook_id) if notebook_id else None
+                if notebook:
+                    return notebook
+            return self.create_notebook(name=name, description=description, color=color, icon=icon)
 
     def list_notebooks(self) -> list[dict]:
         """List every notebook on disk, newest first.

--- a/deeptutor/services/subagent/deepseek_harness.py
+++ b/deeptutor/services/subagent/deepseek_harness.py
@@ -53,9 +53,7 @@ class DeepSeekHarnessBackend(SubagentBackend):
             display_name=self.display_name,
             available=ok or sdk,
             version=text if ok else ("Python SDK" if sdk else ""),
-            detail=""
-            if ok or sdk
-            else not_found_detail(text, "dsh CLI / Python SDK not found"),
+            detail="" if ok or sdk else not_found_detail(text, "dsh CLI / Python SDK not found"),
         )
 
     def _build_headless_command(
@@ -65,9 +63,7 @@ class DeepSeekHarnessBackend(SubagentBackend):
         if config.system_prompt.strip():
             prompt = f"{config.system_prompt.strip()}\n\n{question}"
         if images:
-            prompt += "\n\nAttached local files:\n" + "\n".join(
-                f"- {path}" for path in images
-            )
+            prompt += "\n\nAttached local files:\n" + "\n".join(f"- {path}" for path in images)
         return [self.cli_command, "--profile", "headless", *config.extra_args, prompt]
 
     async def consult(
@@ -189,9 +185,7 @@ class DeepSeekHarnessBackend(SubagentBackend):
         if config.system_prompt.strip() and not session_id:
             prompt = f"{config.system_prompt.strip()}\n\n{question}"
         if images:
-            prompt += "\n\nAttached local files:\n" + "\n".join(
-                f"- {path}" for path in images
-            )
+            prompt += "\n\nAttached local files:\n" + "\n".join(f"- {path}" for path in images)
 
         async def publish(event: SubagentEvent) -> None:
             result.event_count += 1

--- a/deeptutor/services/subagent/hermes.py
+++ b/deeptutor/services/subagent/hermes.py
@@ -46,9 +46,7 @@ class HermesBackend(SubagentBackend):
             display_name=self.display_name,
             available=ok,
             version=text if ok else "",
-            detail=""
-            if ok
-            else not_found_detail(text, "hermes CLI not found on PATH"),
+            detail="" if ok else not_found_detail(text, "hermes CLI not found on PATH"),
         )
 
     def _build_command(
@@ -96,9 +94,7 @@ class HermesBackend(SubagentBackend):
         partner_id: str | None = None,  # noqa: ARG002 — partner-only
     ) -> ConsultResult:
         config = config or BackendConfig()
-        cmd = self._build_command(
-            question, session_id=session_id, config=config, images=images
-        )
+        cmd = self._build_command(question, session_id=session_id, config=config, images=images)
         result = ConsultResult(session_id=session_id)
         answer_lines: list[str] = []
         returncode = "0"

--- a/deeptutor/services/subagent/openclaw.py
+++ b/deeptutor/services/subagent/openclaw.py
@@ -44,9 +44,7 @@ class OpenClawBackend(SubagentBackend):
             display_name=self.display_name,
             available=ok,
             version=text if ok else "",
-            detail=""
-            if ok
-            else not_found_detail(text, "openclaw CLI not found on PATH"),
+            detail="" if ok else not_found_detail(text, "openclaw CLI not found on PATH"),
         )
 
     def _build_command(
@@ -62,9 +60,7 @@ class OpenClawBackend(SubagentBackend):
         if config.system_prompt.strip() and fresh_session:
             prompt = f"{config.system_prompt.strip()}\n\n{question}"
         if images:
-            prompt += "\n\nAttached local files:\n" + "\n".join(
-                f"- {path}" for path in images
-            )
+            prompt += "\n\nAttached local files:\n" + "\n".join(f"- {path}" for path in images)
         cmd = [
             self.cli_command,
             "agent",

--- a/deeptutor/video_learning/notes.py
+++ b/deeptutor/video_learning/notes.py
@@ -1,0 +1,205 @@
+"""Persistent notes for timed-media learning materials."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from deeptutor.services.notebook.service import (
+    NotebookCorruptedError,
+    NotebookManager,
+    RecordType,
+    get_notebook_manager,
+)
+from deeptutor.video_learning.service import (
+    TimedMediaError,
+    TimedMediaNotFound,
+    get_timed_media_store,
+)
+
+NOTEBOOK_NAME = "Video Learning"
+MAX_QUOTE_CHARS = 280
+
+
+def _format_time(seconds: float) -> str:
+    total = max(0, int(seconds))
+    hours, remainder = divmod(total, 3600)
+    minutes, seconds_part = divmod(remainder, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{seconds_part:02d}"
+    return f"{minutes}:{seconds_part:02d}"
+
+
+def _clip_text(value: Any, limit: int = MAX_QUOTE_CHARS) -> str:
+    text = " ".join(str(value or "").split())
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 3].rstrip()}..."
+
+
+def _segment_at(material: dict[str, Any], time_seconds: float) -> dict[str, Any] | None:
+    segments = [row for row in material.get("segments") or [] if isinstance(row, dict)]
+    if not segments:
+        cues = [
+            row for row in material.get("transcript", {}).get("cues") or [] if isinstance(row, dict)
+        ]
+        segments = [dict(row, locator=index) for index, row in enumerate(cues, start=1)]
+    containing = [
+        row
+        for row in segments
+        if float(row.get("start") or 0) <= time_seconds <= float(row.get("end") or 0)
+    ]
+    if containing:
+        return containing[-1]
+    preceding = [row for row in segments if float(row.get("start") or 0) <= time_seconds]
+    return preceding[-1] if preceding else (segments[0] if segments else None)
+
+
+def _is_material_note(record: dict[str, Any], material_id: str) -> bool:
+    metadata = record.get("metadata") if isinstance(record.get("metadata"), dict) else {}
+    return (
+        str(record.get("type") or "") == RecordType.VIDEO_LEARNING.value
+        and str(metadata.get("material_id") or "") == material_id
+    )
+
+
+def _matching_records(
+    manager: NotebookManager, material_id: str, note_id: str | None = None
+) -> list[tuple[str, dict[str, Any]]]:
+    for notebook in manager.list_notebooks():
+        if notebook.get("unreadable"):
+            manager.get_notebook(str(notebook.get("id") or ""))
+
+    matches: list[tuple[str, dict[str, Any]]] = []
+    for notebook in manager.list_notebooks():
+        if notebook.get("unreadable"):
+            continue
+        notebook_id = str(notebook.get("id") or "")
+        try:
+            records = manager.get_records(notebook_id)
+        except NotebookCorruptedError:
+            continue
+        for record in records:
+            if not _is_material_note(record, material_id):
+                continue
+            if note_id is not None and str(record.get("id") or "") != note_id:
+                continue
+            matches.append((notebook_id, record))
+    return matches
+
+
+def _note(notebook_id: str, record: dict[str, Any]) -> dict[str, Any]:
+    metadata = record.get("metadata") if isinstance(record.get("metadata"), dict) else {}
+    updated_at = float(metadata.get("updated_at") or record.get("created_at") or 0)
+    return {
+        "notebook_id": notebook_id,
+        "note_id": str(record.get("id") or ""),
+        "material_id": str(metadata.get("material_id") or ""),
+        "body": str(record.get("output") or ""),
+        "time_seconds": float(metadata.get("time_seconds") or 0),
+        "locator": int(metadata.get("locator") or 0),
+        "quote": str(metadata.get("quote") or ""),
+        "created_at": float(record.get("created_at") or 0),
+        "updated_at": updated_at,
+    }
+
+
+def list_notes(manager: NotebookManager, material_id: str) -> list[dict[str, Any]]:
+    get_timed_media_store().get(material_id)
+    unique: dict[str, tuple[str, dict[str, Any]]] = {}
+    for notebook_id, record in _matching_records(manager, material_id):
+        unique.setdefault(str(record.get("id") or ""), (notebook_id, record))
+    notes = [_note(notebook_id, record) for notebook_id, record in unique.values()]
+    notes.sort(key=lambda row: (row["time_seconds"], row["created_at"], row["note_id"]))
+    return notes
+
+
+def create_note(
+    manager: NotebookManager, material_id: str, body: str, time_seconds: float
+) -> dict[str, Any]:
+    clean_body = body.strip()
+    if not clean_body:
+        raise TimedMediaError("A timed-media note needs text.")
+    material = get_timed_media_store().get(material_id)
+    duration = float(material.get("metadata", {}).get("duration_seconds") or 0)
+    if duration and time_seconds > duration:
+        raise TimedMediaError("Timed-media note timestamp is beyond the material duration.")
+
+    segment = _segment_at(material, time_seconds)
+    quote = _clip_text(segment.get("text")) if segment else ""
+    title = _clip_text(
+        str(material.get("metadata", {}).get("title") or "Timed media").strip() or "Timed media",
+        140,
+    )
+    notebook = manager.get_or_create_notebook(
+        NOTEBOOK_NAME,
+        description="Notes captured while learning with timed media.",
+        color="#EF4444",
+        icon="video",
+    )
+    now = time.time()
+    result = manager.add_record(
+        notebook_ids=[str(notebook["id"])],
+        record_type=RecordType.VIDEO_LEARNING,
+        title=f"{title} - {_format_time(time_seconds)}",
+        summary=_clip_text(clean_body, 160),
+        user_query=quote,
+        output=clean_body,
+        metadata={
+            "material_id": material_id,
+            "time_seconds": time_seconds,
+            "locator": int(segment.get("locator") or 0) if segment else 0,
+            "quote": quote,
+            "updated_at": now,
+        },
+    )
+    if not result.get("added_to_notebooks"):
+        raise TimedMediaError("The Video Learning notebook could not be saved.")
+    return _note(str(notebook["id"]), result["record"])
+
+
+def update_note(
+    manager: NotebookManager, material_id: str, note_id: str, body: str
+) -> dict[str, Any]:
+    clean_body = body.strip()
+    if not clean_body:
+        raise TimedMediaError("A timed-media note needs text.")
+    get_timed_media_store().get(material_id)
+    matches = _matching_records(manager, material_id, note_id)
+    if not matches:
+        raise TimedMediaNotFound("Timed-media note was not found.")
+    now = time.time()
+    updated: dict[str, Any] | None = None
+    for notebook_id, record in matches:
+        updated = manager.update_record(
+            notebook_id,
+            str(record.get("id") or ""),
+            summary=_clip_text(clean_body, 160),
+            output=clean_body,
+            metadata={"updated_at": now},
+        )
+    if updated is None:
+        raise TimedMediaNotFound("Timed-media note was not found.")
+    return _note(matches[0][0], updated)
+
+
+def delete_note(manager: NotebookManager, material_id: str, note_id: str) -> bool:
+    get_timed_media_store().get(material_id)
+    matches = _matching_records(manager, material_id, note_id)
+    if not matches:
+        raise TimedMediaNotFound("Timed-media note was not found.")
+    removed = [
+        manager.remove_record(notebook_id, str(record.get("id") or ""))
+        for notebook_id, record in matches
+    ]
+    return any(removed)
+
+
+__all__ = [
+    "NOTEBOOK_NAME",
+    "create_note",
+    "delete_note",
+    "get_notebook_manager",
+    "list_notes",
+    "update_note",
+]

--- a/deeptutor/visualizers/builtin.py
+++ b/deeptutor/visualizers/builtin.py
@@ -43,11 +43,9 @@ def _text_validator(render_type: str):
                     "Interactive HTML must be a complete document with doctype, html, "
                     f"body and script; missing: {', '.join(missing)}",
                 )
-            if "name=\"viewport\"" not in lowered and "name='viewport'" not in lowered:
+            if 'name="viewport"' not in lowered and "name='viewport'" not in lowered:
                 return False, None, "Interactive HTML must include a viewport meta tag"
-            has_control = any(
-                token in lowered for token in ("<button", "<input", "<select")
-            )
+            has_control = any(token in lowered for token in ("<button", "<input", "<select"))
             if not has_control:
                 return False, None, "Interactive HTML must include a learner control"
             if "reset" not in lowered:

--- a/deeptutor/visualizers/protocol.py
+++ b/deeptutor/visualizers/protocol.py
@@ -71,9 +71,7 @@ class VisualizerManifest(BaseModel):
         if self.render_target == "iframe" and not self.renderer_entry:
             raise ValueError("iframe visualizers require renderer_entry")
         if len(json.dumps(self.payload_schema, ensure_ascii=False)) > MAX_MANIFEST_SCHEMA_CHARS:
-            raise ValueError(
-                f"payload_schema exceeds {MAX_MANIFEST_SCHEMA_CHARS} characters"
-            )
+            raise ValueError(f"payload_schema exceeds {MAX_MANIFEST_SCHEMA_CHARS} characters")
         if self.payload_schema:
             remote_ref = _find_remote_schema_ref(self.payload_schema)
             if remote_ref:
@@ -118,9 +116,7 @@ class VisualizationEnvelope(BaseModel):
     render_type: str
     renderer: RendererRef
     payload: VisualizationPayload
-    presentation: VisualizationPresentation = Field(
-        default_factory=VisualizationPresentation
-    )
+    presentation: VisualizationPresentation = Field(default_factory=VisualizationPresentation)
     interaction: VisualizationInteraction = Field(default_factory=VisualizationInteraction)
     fallback: dict[str, Any] = Field(default_factory=dict)
 

--- a/deeptutor/visualizers/registry.py
+++ b/deeptutor/visualizers/registry.py
@@ -31,12 +31,8 @@ class VisualizerRegistry:
             installed.add(plugin.manifest.id)
         for plugin in bundled_visualizers():
             catalog.setdefault(plugin.manifest.id, plugin)
-            if (
-                plugin.manifest.id in explicitly_installed
-                or (
-                    plugin.manifest.default_installed
-                    and plugin.manifest.id not in uninstalled
-                )
+            if plugin.manifest.id in explicitly_installed or (
+                plugin.manifest.default_installed and plugin.manifest.id not in uninstalled
             ):
                 installed.add(plugin.manifest.id)
         for manifest, root in self.store.user_packages():
@@ -138,9 +134,8 @@ class VisualizerRegistry:
             manifest = plugin.manifest
             schema = ""
             if manifest.payload_schema:
-                schema = (
-                    "\nPayload JSON Schema:\n"
-                    + json.dumps(manifest.payload_schema, ensure_ascii=False, indent=2)
+                schema = "\nPayload JSON Schema:\n" + json.dumps(
+                    manifest.payload_schema, ensure_ascii=False, indent=2
                 )
             blocks.append(
                 f"### {manifest.id} — {manifest.display_name}\n"

--- a/deeptutor/visualizers/store.py
+++ b/deeptutor/visualizers/store.py
@@ -48,9 +48,7 @@ class VisualizerStore:
 
         service = get_path_service()
         self.root = (root or (service.get_user_root() / "visualizers")).resolve()
-        self.state_file = (
-            state_file or service.get_settings_file("visualizers.json")
-        ).resolve()
+        self.state_file = (state_file or service.get_settings_file("visualizers.json")).resolve()
 
     def state(self) -> dict[str, list[str]]:
         try:
@@ -151,9 +149,7 @@ class VisualizerStore:
                 raise VisualizerStoreError(f"invalid visualizer.json: {exc}") from exc
             self._validate_imported_manifest(manifest, package_root)
             if manifest.id in (reserved_ids or set()):
-                raise VisualizerStoreError(
-                    f"visualizer id is reserved by the host: {manifest.id}"
-                )
+                raise VisualizerStoreError(f"visualizer id is reserved by the host: {manifest.id}")
             destination = (self.root / manifest.id).resolve()
             if not destination.is_relative_to(self.root):
                 raise VisualizerStoreError("visualizer id escapes the installation root")

--- a/deeptutor/visualizers/tool.py
+++ b/deeptutor/visualizers/tool.py
@@ -70,11 +70,15 @@ class SubmitVisualizationTool(BaseTool):
             registry = get_visualizer_registry()
 
         visualizer_id = str(kwargs.get("visualizer") or "").strip().lower()
-        requested = str(
-            kwargs.get("_requested_visualizer")
-            or context.metadata.get(REQUESTED_VISUALIZER_KEY)
-            or "auto"
-        ).strip().lower()
+        requested = (
+            str(
+                kwargs.get("_requested_visualizer")
+                or context.metadata.get(REQUESTED_VISUALIZER_KEY)
+                or "auto"
+            )
+            .strip()
+            .lower()
+        )
         if requested != "auto" and visualizer_id != requested:
             return ToolResult(
                 content=(
@@ -105,8 +109,7 @@ class SubmitVisualizationTool(BaseTool):
         entry_url = ""
         if plugin.manifest.render_target == "iframe":
             entry_url = (
-                f"/api/v1/visualizers/{plugin.manifest.id}/assets/"
-                f"{plugin.manifest.renderer_entry}"
+                f"/api/v1/visualizers/{plugin.manifest.id}/assets/{plugin.manifest.renderer_entry}"
             )
         envelope = VisualizationEnvelope(
             render_type=plugin.manifest.id,
@@ -124,9 +127,7 @@ class SubmitVisualizationTool(BaseTool):
                 alt_text=str(kwargs.get("alt_text") or "").strip()[:2000],
             ),
             interaction=VisualizationInteraction(
-                events=["prompt", "resize"]
-                if plugin.manifest.render_target == "iframe"
-                else [],
+                events=["prompt", "resize"] if plugin.manifest.render_target == "iframe" else [],
             ),
             fallback={"renderer": "svg"} if visualizer_id != "svg" else {},
         )

--- a/tests/api/test_visualizers_router.py
+++ b/tests/api/test_visualizers_router.py
@@ -74,9 +74,7 @@ def test_visualizer_catalog_install_import_and_asset_routes(
     assert imported.status_code == 200
     assert imported.json()["visualizer"] == "fraction_tiles"
 
-    asset = client.get(
-        "/api/v1/visualizers/fraction_tiles/assets/index.html"
-    )
+    asset = client.get("/api/v1/visualizers/fraction_tiles/assets/index.html")
     assert asset.status_code == 200
     assert "Fraction Tiles" in asset.text
     assert "connect-src 'none'" in asset.headers["content-security-policy"]
@@ -84,9 +82,7 @@ def test_visualizer_catalog_install_import_and_asset_routes(
 
     disabled = client.post("/api/v1/visualizers/fraction_tiles/disable")
     assert disabled.status_code == 200
-    assert client.get(
-        "/api/v1/visualizers/fraction_tiles/assets/index.html"
-    ).status_code == 404
+    assert client.get("/api/v1/visualizers/fraction_tiles/assets/index.html").status_code == 404
 
     assert client.post("/api/v1/visualizers/fraction_tiles/enable").status_code == 200
     assert client.delete("/api/v1/visualizers/fraction_tiles").status_code == 200

--- a/tests/video_learning/test_router.py
+++ b/tests/video_learning/test_router.py
@@ -59,7 +59,15 @@ def test_main_mounts_settings_as_admin_only_and_learning_as_authenticated() -> N
     from deeptutor.api.main import app
 
     mounts: dict[str, set[object]] = {}
+    routes: list[object] = []
     for route in app.routes:
+        effective_candidates = getattr(route, "effective_candidates", None)
+        if callable(effective_candidates):
+            routes.extend(effective_candidates())
+        else:
+            routes.append(route)
+
+    for route in routes:
         path = str(getattr(route, "path", ""))
         if path.startswith("/api/v1/settings/video-learning"):
             key = "/api/v1/settings/video-learning"
@@ -67,9 +75,10 @@ def test_main_mounts_settings_as_admin_only_and_learning_as_authenticated() -> N
             key = "/api/v1/video-learning"
         else:
             continue
-        mounts.setdefault(key, set()).update(
-            dependency.call for dependency in route.dependant.dependencies
-        )
+        dependencies = list(getattr(route, "dependencies", ()) or ())
+        if not dependencies and hasattr(route, "dependant"):
+            dependencies = route.dependant.dependencies
+        mounts.setdefault(key, set()).update(dependency.dependency for dependency in dependencies)
     assert require_admin in mounts["/api/v1/settings/video-learning"]
     assert require_auth in mounts["/api/v1/video-learning"]
 

--- a/tests/video_learning/test_router.py
+++ b/tests/video_learning/test_router.py
@@ -9,6 +9,8 @@ import pytest
 
 from deeptutor.api.routers import video_learning
 from deeptutor.api.routers.auth import require_admin, require_auth
+from deeptutor.services.notebook.service import NotebookManager
+from deeptutor.video_learning import notes as video_notes
 from deeptutor.video_learning import service
 
 
@@ -22,11 +24,21 @@ class _Paths:
 
 
 @pytest.fixture
-def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
+def notebook_manager(tmp_path: Path) -> NotebookManager:
+    return NotebookManager(base_dir=str(tmp_path / "notebooks"))
+
+
+@pytest.fixture
+def client(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    notebook_manager: NotebookManager,
+) -> TestClient:
     monkeypatch.setattr(service, "get_current_path_service", lambda: _Paths(tmp_path))
     monkeypatch.setattr(
         service, "video_learning_settings_path", lambda: tmp_path / "video_learning.json"
     )
+    monkeypatch.setattr(video_notes, "get_notebook_manager", lambda: notebook_manager)
     app = FastAPI()
     app.include_router(video_learning.router, prefix="/api/v1/video-learning")
     return TestClient(app)
@@ -98,6 +110,83 @@ def test_progress_clamps_to_duration_and_unknown_material_is_404(client: TestCli
 
     missing = client.get("/api/v1/video-learning/materials/0123456789abcdef")
     assert missing.status_code == 404
+
+
+def test_video_notes_use_notebook_storage_and_stay_material_scoped(
+    client: TestClient,
+    notebook_manager: NotebookManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    material = _material()
+    service.get_timed_media_store().save(material)
+    material_id = str(material["material_id"])
+    notes_url = f"/api/v1/video-learning/materials/{material_id}/notes"
+
+    created_response = client.post(
+        notes_url, json={"body": "  Revisit the opening idea.  ", "time_seconds": 2}
+    )
+
+    assert created_response.status_code == 200
+    created = created_response.json()
+    assert created["material_id"] == material_id
+    assert created["body"] == "Revisit the opening idea."
+    assert created["time_seconds"] == 2.0
+    assert created["locator"] == 1
+    assert "one" in created["quote"]
+    assert created["notebook_id"]
+
+    notebook = notebook_manager.get_notebook(created["notebook_id"])
+    assert notebook is not None
+    assert notebook["name"] == video_notes.NOTEBOOK_NAME
+    assert notebook["records"][0]["type"] == "video_learning"
+    assert notebook["records"][0]["metadata"]["material_id"] == material_id
+    persisted = str(notebook)
+    assert "https://youtu.be" not in persisted
+    assert "provider_cache" not in persisted
+    assert "dQw4w9WgXcQ" not in persisted
+
+    material["metadata"]["title"] = "T" * 300
+    material["transcript"]["cues"][0]["text"] = "q" * 400
+    service.get_timed_media_store().save(material)
+    bounded_response = client.post(notes_url, json={"body": "Note", "time_seconds": 2})
+    assert bounded_response.status_code == 200
+    assert len(bounded_response.json()["quote"]) <= 280
+    records = notebook_manager.get_notebook(created["notebook_id"])["records"]
+    assert len(records[-1]["title"]) <= 160
+
+    updated_response = client.put(
+        f"{notes_url}/{created['note_id']}", json={"body": "Updated note."}
+    )
+    assert updated_response.status_code == 200
+    assert updated_response.json()["body"] == "Updated note."
+    assert (
+        notebook_manager.get_notebook(created["notebook_id"])["records"][0]["summary"]
+        == "Updated note."
+    )
+
+    other_manager = NotebookManager(
+        base_dir=str(notebook_manager.base_dir.parent / "other-account-notebooks")
+    )
+    monkeypatch.setattr(video_notes, "get_notebook_manager", lambda: other_manager)
+    assert client.get(notes_url).json() == []
+
+    monkeypatch.setattr(video_notes, "get_notebook_manager", lambda: notebook_manager)
+    for note in client.get(notes_url).json():
+        delete_response = client.delete(f"{notes_url}/{note['note_id']}")
+        assert delete_response.status_code == 200
+    assert client.get(notes_url).json() == []
+
+
+def test_video_note_errors_are_bounded_and_useful(client: TestClient) -> None:
+    material = _material(duration=100)
+    service.get_timed_media_store().save(material)
+    notes_url = f"/api/v1/video-learning/materials/{material['material_id']}/notes"
+
+    assert client.post(notes_url, json={"body": " ", "time_seconds": 2}).status_code == 400
+    assert client.post(notes_url, json={"body": "Note", "time_seconds": 101}).status_code == 400
+    assert client.post(notes_url, json={"body": "", "time_seconds": 2}).status_code == 422
+    assert client.get("/api/v1/video-learning/materials/0123456789abcdef/notes").status_code == 404
+    assert client.put(f"{notes_url}/missing-note", json={"body": "Note"}).status_code == 404
 
 
 def test_progress_does_not_replace_known_duration_with_client_value(client: TestClient) -> None:

--- a/tests/visualizers/test_registry_and_tool.py
+++ b/tests/visualizers/test_registry_and_tool.py
@@ -72,9 +72,7 @@ def test_registry_lifecycle_for_bundled_and_imported_types(tmp_path: Path) -> No
     ok, _, error = plugin.validate_payload('{"min":0,"max":10}')
     assert ok is False
     assert "schema violation" in error
-    ok, data, error = plugin.validate_payload(
-        '{"min":0,"max":10,"points":[2,5,8]}'
-    )
+    ok, data, error = plugin.validate_payload('{"min":0,"max":10,"points":[2,5,8]}')
     assert ok is True, error
     assert data["points"] == [2, 5, 8]
     assert "Payload JSON Schema" in registry.prompt_catalog("number_line")
@@ -123,8 +121,8 @@ def test_core_visualizer_quality_gates(tmp_path: Path) -> None:
     assert ok is False
     assert "complete document" in error
     ok, _, error = html.validate_payload(
-        "<!doctype html><html><head><meta name=\"viewport\" content=\"width=device-width\">"
-        "</head><body><label>Value <input></label><button id=\"reset\">Reset</button>"
+        '<!doctype html><html><head><meta name="viewport" content="width=device-width">'
+        '</head><body><label>Value <input></label><button id="reset">Reset</button>'
         "<script>document.querySelector('#reset').onclick=()=>{};</script></body></html>"
     )
     assert ok is True, error
@@ -152,9 +150,7 @@ async def test_submit_tool_validates_and_commits_geogebra_envelope(tmp_path: Pat
         _visualizer_registry=registry,
         _requested_visualizer="geogebra",
         visualizer="geogebra",
-        payload=json.dumps(
-            {"app_name": "geometry", "commands": ["A=(0,0)", "B=(4,0)"]}
-        ),
+        payload=json.dumps({"app_name": "geometry", "commands": ["A=(0,0)", "B=(4,0)"]}),
     )
     assert missing_view.success is False
     assert "coordinate bounds is required" in missing_view.content

--- a/web/components/notebook/NotebookRecordRow.tsx
+++ b/web/components/notebook/NotebookRecordRow.tsx
@@ -10,6 +10,7 @@ import {
   NotebookPen,
   Pencil,
   Search,
+  Video,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
@@ -67,6 +68,11 @@ const BADGES: Record<
     className:
       "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300",
     icon: Pencil,
+  },
+  video_learning: {
+    labelKey: "Video Learning",
+    className: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
+    icon: Video,
   },
 };
 

--- a/web/components/watching/WatchingPane.tsx
+++ b/web/components/watching/WatchingPane.tsx
@@ -3,21 +3,36 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertTriangle,
+  Check,
+  Captions,
   ExternalLink,
   Loader2,
+  Pencil,
   Play,
   RotateCcw,
+  StickyNote,
+  Trash2,
   X,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { useWatching } from "@/context/WatchingContext";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import type { PlayerController } from "@/lib/video-player-controller";
-import { saveVideoProgress } from "@/lib/video-learning-api";
+import {
+  createVideoNote,
+  deleteVideoNote,
+  listVideoNotes,
+  saveVideoProgress,
+  updateVideoNote,
+  type VideoNote,
+} from "@/lib/video-learning-api";
 import { videoTimeFromHref } from "@/lib/watching-citations";
 import { WatchingPlayer } from "./WatchingPlayer";
 
 export const WATCHING_ASK_EVENT = "dt:watching-ask";
+
+type WatchTab = "transcript" | "notes";
 
 export function WatchingPane({ onClose }: { onClose(): void }) {
   const { t } = useTranslation();
@@ -35,8 +50,17 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
   } = useWatching();
   const [input, setInput] = useState("");
   const [playerError, setPlayerError] = useState<string | null>(null);
+  const [tab, setTab] = useState<WatchTab>("transcript");
   const [time, setTime] = useState(0);
   const [duration, setDuration] = useState(0);
+  const [notes, setNotes] = useState<VideoNote[]>([]);
+  const [notesLoading, setNotesLoading] = useState(false);
+  const [notesError, setNotesError] = useState<string | null>(null);
+  const [noteDraft, setNoteDraft] = useState("");
+  const [editingNoteId, setEditingNoteId] = useState<string | null>(null);
+  const [editingDraft, setEditingDraft] = useState("");
+  const [noteBusy, setNoteBusy] = useState(false);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const controllerRef = useRef<PlayerController | null>(null);
   const lastSavedRef = useRef(0);
   const stateRef = useRef({ time: 0, duration: 0 });
@@ -128,6 +152,114 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
         detail: { timeSeconds: time, text: cue.text },
       }),
     );
+  };
+
+  const materialId = material?.material_id ?? null;
+  const reloadNotes = useCallback(async () => {
+    if (!materialId) return;
+    setNotesLoading(true);
+    setNotesError(null);
+    try {
+      setNotes(await listVideoNotes(materialId));
+    } catch (caught) {
+      setNotesError(
+        caught instanceof Error
+          ? caught.message
+          : t("Notes could not be loaded."),
+      );
+    } finally {
+      setNotesLoading(false);
+    }
+  }, [materialId, t]);
+
+  useEffect(() => {
+    if (!materialId) {
+      setNotes([]);
+      setNotesError(null);
+      setNotesLoading(false);
+      setNoteDraft("");
+      setEditingNoteId(null);
+      return;
+    }
+    void reloadNotes();
+  }, [materialId, reloadNotes]);
+
+  const sortNotes = (rows: VideoNote[]) =>
+    [...rows].sort(
+      (left, right) =>
+        left.time_seconds - right.time_seconds ||
+        left.created_at - right.created_at ||
+        left.note_id.localeCompare(right.note_id),
+    );
+
+  const addNote = async () => {
+    if (!material || !noteDraft.trim() || noteBusy) return;
+    setNoteBusy(true);
+    setNotesError(null);
+    try {
+      const saved = await createVideoNote(
+        material.material_id,
+        noteDraft.trim(),
+        time,
+      );
+      setNotes((current) => sortNotes([...current, saved]));
+      setNoteDraft("");
+    } catch (caught) {
+      setNotesError(
+        caught instanceof Error ? caught.message : t("Note was not saved."),
+      );
+    } finally {
+      setNoteBusy(false);
+    }
+  };
+
+  const saveEditedNote = async () => {
+    if (!material || !editingNoteId || !editingDraft.trim() || noteBusy) return;
+    setNoteBusy(true);
+    setNotesError(null);
+    try {
+      const saved = await updateVideoNote(
+        material.material_id,
+        editingNoteId,
+        editingDraft.trim(),
+      );
+      setNotes((current) =>
+        sortNotes(
+          current.map((note) => (note.note_id === saved.note_id ? saved : note)),
+        ),
+      );
+      setEditingNoteId(null);
+      setEditingDraft("");
+    } catch (caught) {
+      setNotesError(
+        caught instanceof Error ? caught.message : t("Note was not saved."),
+      );
+    } finally {
+      setNoteBusy(false);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!material || !pendingDeleteId || noteBusy) return;
+    setNoteBusy(true);
+    setNotesError(null);
+    try {
+      await deleteVideoNote(material.material_id, pendingDeleteId);
+      setNotes((current) =>
+        current.filter((note) => note.note_id !== pendingDeleteId),
+      );
+      if (editingNoteId === pendingDeleteId) {
+        setEditingNoteId(null);
+        setEditingDraft("");
+      }
+      setPendingDeleteId(null);
+    } catch (caught) {
+      setNotesError(
+        caught instanceof Error ? caught.message : t("Note was not deleted."),
+      );
+    } finally {
+      setNoteBusy(false);
+    }
   };
 
   const closePane = () => {
@@ -297,48 +429,235 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
             </a>
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto p-4">
-            {material.transcript.status !== "ready" ? (
-              <div className="rounded-lg border border-[var(--border)] p-4 text-sm text-[var(--muted-foreground)]">
-                {t(
-                  "Transcript learning is unavailable ({{reason}}). Playback still works, but Explain here is disabled.",
-                  {
-                    reason: material.transcript.reason || t("no captions"),
-                  },
+            <div
+              className="mb-3 grid w-full max-w-56 grid-cols-2 rounded-lg bg-[var(--muted)] p-1"
+              role="tablist"
+              aria-label={t("Video learning panels")}
+            >
+              {(["transcript", "notes"] as const).map((item) => (
+                <button
+                  key={item}
+                  type="button"
+                  role="tab"
+                  aria-selected={tab === item}
+                  onClick={() => {
+                    setTab(item);
+                    setEditingNoteId(null);
+                  }}
+                  className={`flex items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium ${tab === item ? "bg-[var(--background)] shadow-sm" : "text-[var(--muted-foreground)]"}`}
+                >
+                  {item === "transcript" ? (
+                    <>
+                      <Captions className="h-3.5 w-3.5" />
+                      {t("Transcript")}
+                    </>
+                  ) : (
+                    <>
+                      <StickyNote className="h-3.5 w-3.5" />
+                      {t("Video notes")}
+                    </>
+                  )}
+                </button>
+              ))}
+            </div>
+
+            {tab === "transcript" ? (
+              material.transcript.status !== "ready" ? (
+                <div className="rounded-lg border border-[var(--border)] p-4 text-sm text-[var(--muted-foreground)]">
+                  {t(
+                    "Transcript learning is unavailable ({{reason}}). Playback still works, but Explain here is disabled.",
+                    {
+                      reason: material.transcript.reason || t("no captions"),
+                    },
+                  )}
+                </div>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    onClick={askHere}
+                    disabled={!cue}
+                    className="mb-3 rounded-lg bg-[var(--primary)] px-3 py-2 text-sm text-[var(--primary-foreground)] disabled:opacity-50"
+                  >
+                    {t("Explain here")}
+                  </button>
+                  <div className="space-y-1">
+                    {material.transcript.cues.map((row, index) => {
+                      const active = row === cue;
+                      return (
+                        <button
+                          key={`${row.start}-${index}`}
+                          type="button"
+                          onClick={() => controllerRef.current?.seek(row.start)}
+                          className={`flex w-full gap-3 rounded-md px-2 py-1.5 text-left text-sm ${active ? "bg-blue-500/15 ring-1 ring-blue-500/30" : "hover:bg-[var(--muted)]"}`}
+                        >
+                          <span className="shrink-0 tabular-nums text-blue-600">
+                            {formatTime(row.start)}
+                          </span>
+                          <span>{row.text}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </>
+              )
+            ) : (
+              <div className="space-y-3">
+                <form
+                  className="space-y-2"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void addNote();
+                  }}
+                >
+                  <textarea
+                    value={noteDraft}
+                    onChange={(event) => setNoteDraft(event.target.value)}
+                    placeholder={t("Note at {{time}}", {
+                      time: formatTime(time),
+                    })}
+                    className="min-h-20 w-full resize-y rounded-lg border border-[var(--border)] bg-transparent px-3 py-2 text-sm"
+                  />
+                  <button
+                    type="submit"
+                    disabled={noteBusy || !noteDraft.trim()}
+                    className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-2 text-sm text-[var(--primary-foreground)] disabled:opacity-50"
+                  >
+                    {noteBusy ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Check className="h-4 w-4" />
+                    )}
+                    {t("Add video note")}
+                  </button>
+                </form>
+
+                {notesError && (
+                  <p
+                    role="alert"
+                    className="rounded-lg border border-[var(--border)] bg-[var(--muted)] px-3 py-2 text-sm text-[var(--destructive)]"
+                  >
+                    {notesError}
+                  </p>
+                )}
+
+                {notesLoading ? (
+                  <p className="flex items-center gap-2 text-sm text-[var(--muted-foreground)]">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    {t("Loading notes.")}
+                  </p>
+                ) : notes.length ? (
+                  notes.map((note) => (
+                    <article
+                      key={`${note.notebook_id}:${note.note_id}`}
+                      className="rounded-lg border border-[var(--border)] p-3"
+                    >
+                      <div className="flex items-start gap-2">
+                        <button
+                          type="button"
+                          onClick={() =>
+                            controllerRef.current?.seek(note.time_seconds)
+                          }
+                          className="shrink-0 rounded px-1.5 py-0.5 font-mono text-xs tabular-nums text-blue-600 hover:bg-blue-500/10"
+                        >
+                          {formatTime(note.time_seconds)}
+                        </button>
+                        <div className="min-w-0 flex-1">
+                          {editingNoteId === note.note_id ? (
+                            <textarea
+                              value={editingDraft}
+                              onChange={(event) =>
+                                setEditingDraft(event.target.value)
+                              }
+                              aria-label={t("Edit note at {{time}}", {
+                                time: formatTime(note.time_seconds),
+                              })}
+                              className="min-h-20 w-full resize-y rounded-lg border border-[var(--border)] bg-transparent px-2 py-1.5 text-sm"
+                            />
+                          ) : (
+                            <p className="whitespace-pre-wrap text-sm">
+                              {note.body}
+                            </p>
+                          )}
+                          {note.quote && (
+                            <blockquote className="mt-2 border-l-2 border-[var(--border)] pl-2 text-xs text-[var(--muted-foreground)]">
+                              {note.quote}
+                            </blockquote>
+                          )}
+                        </div>
+                        <div className="flex shrink-0 items-center gap-1">
+                          {editingNoteId === note.note_id ? (
+                            <>
+                              <button
+                                type="button"
+                                onClick={() => void saveEditedNote()}
+                                disabled={noteBusy || !editingDraft.trim()}
+                                className="rounded-md p-1.5 hover:bg-[var(--muted)] disabled:opacity-50"
+                                aria-label={t("Save video note")}
+                              >
+                                <Check className="h-4 w-4" />
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => setEditingNoteId(null)}
+                                disabled={noteBusy}
+                                className="rounded-md p-1.5 hover:bg-[var(--muted)] disabled:opacity-50"
+                                aria-label={t("Cancel")}
+                              >
+                                <X className="h-4 w-4" />
+                              </button>
+                            </>
+                          ) : (
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setEditingNoteId(note.note_id);
+                                setEditingDraft(note.body);
+                              }}
+                              disabled={noteBusy}
+                              className="rounded-md p-1.5 hover:bg-[var(--muted)] disabled:opacity-50"
+                              aria-label={t("Edit note at {{time}}", {
+                                time: formatTime(note.time_seconds),
+                              })}
+                            >
+                              <Pencil className="h-4 w-4" />
+                            </button>
+                          )}
+                          <button
+                            type="button"
+                            onClick={() => setPendingDeleteId(note.note_id)}
+                            disabled={noteBusy}
+                            className="rounded-md p-1.5 text-[var(--destructive)] hover:bg-[var(--destructive)]/10 disabled:opacity-50"
+                            aria-label={t("Delete note at {{time}}", {
+                              time: formatTime(note.time_seconds),
+                            })}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
+                      </div>
+                    </article>
+                  ))
+                ) : (
+                  !notesError && <p className="text-sm">{t("No notes yet.")}</p>
                 )}
               </div>
-            ) : (
-              <>
-                <button
-                  type="button"
-                  onClick={askHere}
-                  disabled={!cue}
-                  className="mb-3 rounded-lg bg-[var(--primary)] px-3 py-2 text-sm text-[var(--primary-foreground)] disabled:opacity-50"
-                >
-                  {t("Explain here")}
-                </button>
-                <div className="space-y-1">
-                  {material.transcript.cues.map((row, index) => {
-                    const active = row === cue;
-                    return (
-                      <button
-                        key={`${row.start}-${index}`}
-                        type="button"
-                        onClick={() => controllerRef.current?.seek(row.start)}
-                        className={`flex w-full gap-3 rounded-md px-2 py-1.5 text-left text-sm ${active ? "bg-blue-500/15 ring-1 ring-blue-500/30" : "hover:bg-[var(--muted)]"}`}
-                      >
-                        <span className="shrink-0 tabular-nums text-blue-600">
-                          {formatTime(row.start)}
-                        </span>
-                        <span>{row.text}</span>
-                      </button>
-                    );
-                  })}
-                </div>
-              </>
             )}
           </div>
         </div>
       )}
+
+      <ConfirmDialog
+        open={Boolean(pendingDeleteId)}
+        title={t("Delete this note?")}
+        confirmLabel={t("Delete")}
+        tone="danger"
+        busy={noteBusy}
+        onConfirm={() => void confirmDelete()}
+        onCancel={() => setPendingDeleteId(null)}
+      >
+        {t("This note will be removed from Video Learning.")}
+      </ConfirmDialog>
     </section>
   );
 }

--- a/web/lib/notebook-api.ts
+++ b/web/lib/notebook-api.ts
@@ -16,7 +16,8 @@ export type NotebookRecordType =
   | "chat"
   | "co_writer"
   | "reading"
-  | "tutorbot";
+  | "tutorbot"
+  | "video_learning";
 
 export interface NotebookSummary {
   id: string;

--- a/web/lib/video-learning-api.ts
+++ b/web/lib/video-learning-api.ts
@@ -57,6 +57,18 @@ export interface TimedMediaMaterial {
   playback: VideoPlayback;
 }
 
+export interface VideoNote {
+  notebook_id: string;
+  note_id: string;
+  material_id: string;
+  body: string;
+  time_seconds: number;
+  locator: number;
+  quote: string;
+  created_at: number;
+  updated_at: number;
+}
+
 export interface VideoLearningSettings {
   version: 1;
   default_provider: VideoProvider;
@@ -67,11 +79,84 @@ export interface VideoLearningSettings {
 async function unwrap<T>(response: Response): Promise<T> {
   if (!response.ok) {
     const payload = await response.json().catch(() => ({}));
+    const detail = (payload as { detail?: unknown })?.detail;
+    const message =
+      typeof detail === "string"
+        ? detail
+        : typeof (detail as { message?: unknown } | undefined)?.message ===
+            "string"
+          ? (detail as { message: string }).message
+          : null;
     throw new Error(
-      String(payload?.detail || `Request failed (${response.status})`),
+      message || `Request failed (${response.status})`,
     );
   }
   return (await response.json()) as T;
+}
+
+export async function listVideoNotes(
+  materialId: string,
+): Promise<VideoNote[]> {
+  return unwrap(
+    await apiFetch(
+      apiUrl(
+        `/api/v1/video-learning/materials/${encodeURIComponent(materialId)}/notes`,
+      ),
+      { cache: "no-store" },
+    ),
+  );
+}
+
+export async function createVideoNote(
+  materialId: string,
+  body: string,
+  timeSeconds: number,
+): Promise<VideoNote> {
+  return unwrap(
+    await apiFetch(
+      apiUrl(
+        `/api/v1/video-learning/materials/${encodeURIComponent(materialId)}/notes`,
+      ),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body, time_seconds: timeSeconds }),
+      },
+    ),
+  );
+}
+
+export async function updateVideoNote(
+  materialId: string,
+  noteId: string,
+  body: string,
+): Promise<VideoNote> {
+  return unwrap(
+    await apiFetch(
+      apiUrl(
+        `/api/v1/video-learning/materials/${encodeURIComponent(materialId)}/notes/${encodeURIComponent(noteId)}`,
+      ),
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body }),
+      },
+    ),
+  );
+}
+
+export async function deleteVideoNote(
+  materialId: string,
+  noteId: string,
+): Promise<void> {
+  await unwrap(
+    await apiFetch(
+      apiUrl(
+        `/api/v1/video-learning/materials/${encodeURIComponent(materialId)}/notes/${encodeURIComponent(noteId)}`,
+      ),
+      { method: "DELETE" },
+    ),
+  );
 }
 
 export async function resolveVideo(

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -4260,5 +4260,19 @@
   "Explain this part of the video": "Explain this part of the video",
   "YouTube Player API did not initialize.": "YouTube Player API did not initialize.",
   "YouTube Player API timed out.": "YouTube Player API timed out.",
-  "YouTube Player API could not be loaded.": "YouTube Player API could not be loaded."
+  "YouTube Player API could not be loaded.": "YouTube Player API could not be loaded.",
+  "Video notes": "Video notes",
+  "Add video note": "Add video note",
+  "Save video note": "Save video note",
+  "Note at {{time}}": "Note at {{time}}",
+  "Edit note at {{time}}": "Edit note at {{time}}",
+  "Delete note at {{time}}": "Delete note at {{time}}",
+  "Delete this note?": "Delete this note?",
+  "This note will be removed from Video Learning.": "This note will be removed from Video Learning.",
+  "No notes yet.": "No notes yet.",
+  "Loading notes.": "Loading notes.",
+  "Notes could not be loaded.": "Notes could not be loaded.",
+  "Note was not saved.": "Note was not saved.",
+  "Note was not deleted.": "Note was not deleted.",
+  "Video learning panels": "Video learning panels"
 }

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -4260,5 +4260,19 @@
   "Explain this part of the video": "解释视频的这一部分",
   "YouTube Player API did not initialize.": "YouTube Player API 未能初始化。",
   "YouTube Player API timed out.": "YouTube Player API 加载超时。",
-  "YouTube Player API could not be loaded.": "无法加载 YouTube Player API。"
+  "YouTube Player API could not be loaded.": "无法加载 YouTube Player API。",
+  "Video notes": "视频笔记",
+  "Add video note": "添加视频笔记",
+  "Save video note": "保存视频笔记",
+  "Note at {{time}}": "{{time}} 的笔记",
+  "Edit note at {{time}}": "编辑 {{time}} 的笔记",
+  "Delete note at {{time}}": "删除 {{time}} 的笔记",
+  "Delete this note?": "删除这条笔记？",
+  "This note will be removed from Video Learning.": "这条笔记将从视频学习中移除。",
+  "No notes yet.": "暂无笔记。",
+  "Loading notes.": "正在加载笔记。",
+  "Notes could not be loaded.": "无法加载笔记。",
+  "Note was not saved.": "笔记未保存。",
+  "Note was not deleted.": "笔记未删除。",
+  "Video learning panels": "视频学习面板"
 }

--- a/web/tests/e2e/video-learning.audit.ts
+++ b/web/tests/e2e/video-learning.audit.ts
@@ -9,6 +9,18 @@ test("YouTube learning survives reload and switches to Invidious without silent 
   let invidiousOffline = false;
   let savedPosition = 0;
   let nativeResolveCount = 0;
+  let nextNoteId = 1;
+  const notes: Array<{
+    notebook_id: string;
+    note_id: string;
+    material_id: string;
+    body: string;
+    time_seconds: number;
+    locator: number;
+    quote: string;
+    created_at: number;
+    updated_at: number;
+  }> = [];
 
   const material = (selected: "youtube" | "invidious") => ({
     version: 1,
@@ -141,6 +153,40 @@ test("YouTube learning survives reload and switches to Invidious without silent 
       savedPosition = body.time_seconds;
       return json({ time_seconds: savedPosition, duration_seconds: 120 });
     }
+    if (path.endsWith("/notes") && request.method() === "GET") {
+      return json(notes);
+    }
+    if (path.endsWith("/notes") && request.method() === "POST") {
+      const body = request.postDataJSON() as { body: string; time_seconds: number };
+      const note = {
+        notebook_id: "video-notes",
+        note_id: `note-${nextNoteId++}`,
+        material_id: MATERIAL_ID,
+        body: body.body,
+        time_seconds: body.time_seconds,
+        locator: 1,
+        quote: "The first grounded concept.",
+        created_at: Date.now() / 1000,
+        updated_at: Date.now() / 1000,
+      };
+      notes.push(note);
+      return json(note);
+    }
+    const noteMatch = /\/materials\/[^/]+\/notes\/([^/]+)$/.exec(path);
+    if (noteMatch) {
+      const noteId = noteMatch[1];
+      const index = notes.findIndex((note) => note.note_id === noteId);
+      if (index === -1) return json({ detail: "Note not found" }, 404);
+      if (request.method() === "PUT") {
+        const body = request.postDataJSON() as { body: string };
+        notes[index] = { ...notes[index], body: body.body, updated_at: Date.now() / 1000 };
+        return json(notes[index]);
+      }
+      if (request.method() === "DELETE") {
+        notes.splice(index, 1);
+        return json({ status: "deleted" });
+      }
+    }
     if (path.endsWith("/subtitles.vtt")) {
       return route.fulfill({
         status: 200,
@@ -183,6 +229,58 @@ test("YouTube learning survives reload and switches to Invidious without silent 
   await expect(
     page.getByText("The first grounded concept.").locator(".."),
   ).toHaveClass(/ring-1/);
+
+  await page.getByRole("tab", { name: "Video notes" }).click();
+  await expect(page.getByText("No notes yet.")).toBeVisible();
+  await page
+    .getByPlaceholder("Note at 0:08")
+    .fill("First timestamped note");
+  await page.getByRole("button", { name: "Add video note" }).click();
+  await expect(page.getByText("First timestamped note")).toBeVisible();
+  await expect(page.getByText("The first grounded concept.")).toBeVisible();
+
+  await page.reload();
+  await page.getByRole("button", { name: "Chat", exact: true }).click();
+  await page
+    .getByRole("button", { name: /Immersive Watching/ })
+    .last()
+    .click();
+  await expect(page.getByText("Timestamped lesson")).toBeVisible();
+  await page.getByRole("tab", { name: "Video notes" }).click();
+  await expect(page.getByText("First timestamped note")).toBeVisible();
+
+  await page.evaluate(() => {
+    const player = (
+      window as typeof window & { __fakePlayers: Array<{ current: number }> }
+    ).__fakePlayers.at(-1);
+    if (player) player.current = 70;
+  });
+  await page.getByRole("button", { name: "0:08", exact: true }).click();
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const player = (
+          window as typeof window & { __fakePlayers: Array<{ current: number }> }
+        ).__fakePlayers.at(-1);
+        return player?.current || 0;
+      }),
+    )
+    .toBe(8);
+
+  await page.getByRole("button", { name: "Edit note at 0:08" }).click();
+  await page
+    .getByLabel("Edit note at 0:08")
+    .locator("..")
+    .locator("textarea")
+    .fill("Updated timestamped note");
+  await page.getByRole("button", { name: "Save video note" }).click();
+  await expect(page.getByText("Updated timestamped note")).toBeVisible();
+
+  await page.getByRole("button", { name: "Delete note at 0:08" }).click();
+  await page.getByRole("button", { name: "Delete", exact: true }).click();
+  await expect(page.getByText("No notes yet.")).toBeVisible();
+  await page.getByRole("tab", { name: "Transcript" }).click();
+
   await page.getByRole("button", { name: "Explain here" }).click();
   await expect(page.locator("textarea")).toHaveValue(
     /\[0:08\] The first grounded concept\./,


### PR DESCRIPTION
## Summary

- Add timestamped transcript notes with create, list, edit, and delete APIs for video learning.
- Reuse the existing Notes storage while scoping records to the current account and material.
- Store only a bounded transcript quote; omit playback URLs, credentials, full transcripts, and provider caches.
- Add timestamp-based seeking and note management to the Watching UI.
- Cover router behavior, permission/account isolation, quote bounds, and UI flows with focused tests.

Closes #1137

## Test evidence

- `pytest` focused video-learning/backend suite: 60 passed.
- `ruff check` and `ruff format --check`: passed.
- Web test suite: 774 tests passed.
- Web lint and i18n checks: passed.
- Existing lint/i18n warnings are confined to untouched files.

## Compatibility

- No schema migration is required because the implementation reuses Notes storage.
- No Windows-specific behavior is introduced.
