### PR TITLE
feat: add MiniMax Token Plan as a first-class LLM provider

### DIFF
--- a/deeptutor/services/llm/capabilities.py
+++ b/deeptutor/services/llm/capabilities.py
@@ -90,6 +90,15 @@ PROVIDER_CAPABILITIES: dict[str, dict[str, object]] = {
         "system_in_messages": False,
         "has_thinking_tags": False,
     },
+    "minimax_coding_plan_anthropic": {
+        "supports_response_format": False,
+        "supports_streaming": True,
+        "supports_tools": True,
+        "supports_vision": True,
+        "vision_url_supported": False,
+        "system_in_messages": False,
+        "has_thinking_tags": False,
+    },
     "codebuddy": {
         "supports_response_format": False,
         "supports_streaming": True,
@@ -214,6 +223,13 @@ PROVIDER_CAPABILITIES: dict[str, dict[str, object]] = {
     # function calling for M-series text models. Response-format support is
     # still disabled by the model override below.
     "minimax": {
+        "supports_response_format": False,
+        "supports_streaming": True,
+        "supports_tools": True,
+        "supports_vision": False,
+        "system_in_messages": True,
+    },
+    "minimax_coding_plan": {
         "supports_response_format": False,
         "supports_streaming": True,
         "supports_tools": True,

--- a/deeptutor/services/llm/cloud_provider.py
+++ b/deeptutor/services/llm/cloud_provider.py
@@ -97,6 +97,7 @@ _BINDINGS_WITH_EXTRA_BODY_THINKING = frozenset(
         "byteplus",
         "byteplus_coding_plan",
         "minimax",
+        "minimax_coding_plan",
     }
 )
 

--- a/deeptutor/services/llm/reasoning_params.py
+++ b/deeptutor/services/llm/reasoning_params.py
@@ -17,6 +17,7 @@ _PROVIDER_THINKING_STYLES = {
     "byteplus_coding_plan": "thinking_type",
     "dashscope": "enable_thinking",
     "minimax": "reasoning_split",
+    "minimax_coding_plan": "reasoning_split",
 }
 _PROVIDER_REASONING_PATTERNS = {
     "deepseek": ("deepseek-v4-pro", "deepseek-reasoner"),

--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -95,6 +95,13 @@ PROVIDER_ALIASES = {
     "volcengineCodingPlan": "volcengine_coding_plan",
     "bytepluscodingplan": "byteplus_coding_plan",
     "byteplusCodingPlan": "byteplus_coding_plan",
+    "minimaxcodingplan": "minimax_coding_plan",
+    "minimaxCodingPlan": "minimax_coding_plan",
+    "minimax_token_plan": "minimax_coding_plan",
+    "minimaxtokenplan": "minimax_coding_plan",
+    "minimaxcodingplananthropic": "minimax_coding_plan_anthropic",
+    "minimax_token_plan_anthropic": "minimax_coding_plan_anthropic",
+    "minimaxtokenplananthropic": "minimax_coding_plan_anthropic",
     "github-copilot": "github_copilot",
     "openai-codex": "openai_codex",
     "codebuddy-code": "codebuddy",
@@ -383,9 +390,12 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
     # MiniMax runs two separate platforms: global (platform.minimax.io /
     # api.minimax.io) and mainland China (platform.minimaxi.com /
     # api.minimaxi.com). Keys are issued per platform and are NOT
-    # interchangeable. The global endpoint is the default here; China-platform
-    # users must override base_url to https://api.minimaxi.com/v1 (or
-    # https://api.minimaxi.com/anthropic) *and* use a China-platform key.
+    # interchangeable. ``minimax`` / ``minimax_anthropic`` default to the
+    # global PAYG endpoints. Token Plan (formerly Coding Plan) subscription
+    # keys start with ``sk-cp-`` and are most often issued on the China
+    # platform, so the Token Plan bindings default to api.minimaxi.com.
+    # Override base_url to api.minimax.io when the key is from the global
+    # Token Plan.
     ProviderSpec(
         name="minimax",
         keywords=("minimax",),
@@ -402,6 +412,24 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         display_name="MiniMax (Anthropic)",
         backend="anthropic",
         default_api_base="https://api.minimax.io/anthropic",
+    ),
+    ProviderSpec(
+        name="minimax_coding_plan",
+        keywords=("minimax-plan", "minimax_coding_plan"),
+        env_key="MINIMAX_API_KEY",
+        display_name="MiniMax Token Plan",
+        backend="openai_compat",
+        detect_by_key_prefix="sk-cp-",
+        default_api_base="https://api.minimaxi.com/v1",
+        thinking_style="reasoning_split",
+    ),
+    ProviderSpec(
+        name="minimax_coding_plan_anthropic",
+        keywords=("minimax_coding_plan_anthropic",),
+        env_key="MINIMAX_API_KEY",
+        display_name="MiniMax Token Plan (Anthropic)",
+        backend="anthropic",
+        default_api_base="https://api.minimaxi.com/anthropic",
     ),
     ProviderSpec(
         name="mistral",

--- a/deeptutor_cli/init_wizard.py
+++ b/deeptutor_cli/init_wizard.py
@@ -44,6 +44,7 @@ FEATURED_LLM_PROVIDERS: tuple[str, ...] = (
     "dashscope",
     "zhipu",
     "moonshot",
+    "minimax_coding_plan",
     "gemini",
     "siliconflow",
     "openrouter",
@@ -64,6 +65,14 @@ LLM_FALLBACK_MODELS: dict[str, tuple[str, ...]] = {
     "dashscope": ("qwen-plus", "qwen-turbo", "qwen-max", "qwen3-coder-plus"),
     "zhipu": ("glm-4.6", "glm-4.5", "glm-4-flash"),
     "moonshot": ("kimi-k2.6", "kimi-k2.5", "kimi-latest"),
+    "minimax": ("MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"),
+    "minimax_coding_plan": ("MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"),
+    "minimax_coding_plan_anthropic": (
+        "MiniMax-M3",
+        "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
+    ),
+    "minimax_anthropic": ("MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"),
     "gemini": ("gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"),
     "siliconflow": (
         "Qwen/Qwen3-Coder-480B-A35B-Instruct",

--- a/tests/api/test_settings_router.py
+++ b/tests/api/test_settings_router.py
@@ -592,6 +592,15 @@ def test_llm_provider_choices_include_novita() -> None:
     assert llm["novita"]["base_url"] == "https://api.novita.ai/openai"
 
 
+def test_llm_provider_choices_include_minimax_token_plan() -> None:
+    llm = {item["value"]: item for item in settings_router._provider_choices()["llm"]}
+
+    assert llm["minimax_coding_plan"]["label"] == "MiniMax Token Plan"
+    assert llm["minimax_coding_plan"]["base_url"] == "https://api.minimaxi.com/v1"
+    assert llm["minimax_coding_plan_anthropic"]["label"] == "MiniMax Token Plan (Anthropic)"
+    assert llm["minimax_coding_plan_anthropic"]["base_url"] == "https://api.minimaxi.com/anthropic"
+
+
 def test_llm_provider_choices_include_edenai() -> None:
     llm = {item["value"]: item for item in settings_router._provider_choices()["llm"]}
 

--- a/tests/core/test_agentic_client_provider_kwargs.py
+++ b/tests/core/test_agentic_client_provider_kwargs.py
@@ -356,6 +356,11 @@ async def test_direct_openai_gpt5_agentic_tools_use_provider_adapter(monkeypatch
 def test_anthropic_backend_can_use_native_tool_calling() -> None:
     assert can_use_native_tool_calling(binding="custom_anthropic", model="claude-test") is True
     assert can_use_native_tool_calling(binding="minimax_anthropic", model="MiniMax-M3") is True
+    assert can_use_native_tool_calling(binding="minimax_coding_plan_anthropic", model="MiniMax-M3") is True
+    assert (
+        can_use_native_tool_calling(binding="minimax_coding_plan_anthropic", model="MiniMax-M3")
+        is True
+    )
 
 
 def test_custom_qwen_can_use_native_tool_calling() -> None:
@@ -392,6 +397,7 @@ def test_registered_cloud_openai_compat_providers_enable_native_tools() -> None:
         "novita",
         "volcengine_coding_plan",
         "byteplus_coding_plan",
+        "minimax_coding_plan",
     ):
         assert can_use_native_tool_calling(binding=binding, model=None) is True, binding
 

--- a/tests/services/config/test_provider_runtime.py
+++ b/tests/services/config/test_provider_runtime.py
@@ -416,6 +416,44 @@ def test_llm_minimax_anthropic_binding_uses_anthropic_endpoint() -> None:
     assert resolved.effective_url == "https://api.minimax.io/anthropic"
 
 
+def test_llm_minimax_coding_plan_binding_uses_china_token_plan_endpoint() -> None:
+    catalog = _build_catalog(
+        llm_profile={
+            "id": "llm-p",
+            "name": "LLM",
+            "binding": "minimax_coding_plan",
+            "base_url": "",
+            "api_key": "sk-cp-token-plan",
+            "api_version": "",
+            "extra_headers": {},
+            "models": [{"id": "llm-m", "name": "m", "model": "MiniMax-M3"}],
+        }
+    )
+    resolved = resolve_llm_runtime_config(catalog=catalog)
+    assert resolved.provider_name == "minimax_coding_plan"
+    assert resolved.provider_mode == "standard"
+    assert resolved.effective_url == "https://api.minimaxi.com/v1"
+
+
+def test_llm_minimax_coding_plan_anthropic_binding_uses_china_anthropic_endpoint() -> None:
+    catalog = _build_catalog(
+        llm_profile={
+            "id": "llm-p",
+            "name": "LLM",
+            "binding": "minimax_coding_plan_anthropic",
+            "base_url": "",
+            "api_key": "sk-cp-token-plan",
+            "api_version": "",
+            "extra_headers": {},
+            "models": [{"id": "llm-m", "name": "c", "model": "MiniMax-M3"}],
+        }
+    )
+    resolved = resolve_llm_runtime_config(catalog=catalog)
+    assert resolved.provider_name == "minimax_coding_plan_anthropic"
+    assert resolved.provider_mode == "standard"
+    assert resolved.effective_url == "https://api.minimaxi.com/anthropic"
+
+
 def test_llm_custom_anthropic_binding_stays_direct() -> None:
     catalog = _build_catalog(
         llm_profile={

--- a/tests/services/llm/test_capabilities.py
+++ b/tests/services/llm/test_capabilities.py
@@ -76,6 +76,14 @@ def test_minimax_openai_compat_supports_tools_without_response_format() -> None:
     assert supports_response_format("minimax", "MiniMax-M2.7") is False
     assert supports_tools("minimax", "MiniMax-M2.7-highspeed") is True
     assert supports_response_format("minimax", "MiniMax-M2.7-highspeed") is False
+    assert supports_tools("minimax_coding_plan", "MiniMax-M3") is True
+    assert supports_response_format("minimax_coding_plan", "MiniMax-M3") is False
+    assert supports_tools("minimax_coding_plan_anthropic", "MiniMax-M3") is True
+    assert supports_vision("minimax_coding_plan_anthropic", "MiniMax-M3") is True
+    assert supports_tools("minimax_coding_plan", "MiniMax-M3") is True
+    assert supports_response_format("minimax_coding_plan", "MiniMax-M3") is False
+    assert supports_tools("minimax_coding_plan_anthropic", "MiniMax-M3") is True
+    assert supports_response_format("minimax_coding_plan_anthropic", "MiniMax-M3") is False
 
 
 def test_siliconflow_openai_compat_supports_tools_for_deepseek() -> None:

--- a/tests/services/test_provider_registry.py
+++ b/tests/services/test_provider_registry.py
@@ -39,6 +39,28 @@ def test_edenai_provider_aliases_and_base_detection() -> None:
     assert find_gateway(api_base="https://api.edenai.run/v3") == spec
 
 
+def test_minimax_token_plan_aliases_and_key_detection() -> None:
+    spec = find_by_name("minimax_coding_plan")
+
+    assert spec is not None
+    assert spec.display_name == "MiniMax Token Plan"
+    assert spec.backend == "openai_compat"
+    assert spec.default_api_base == "https://api.minimaxi.com/v1"
+    assert spec.detect_by_key_prefix == "sk-cp-"
+    assert find_by_name("minimax-coding-plan") == spec
+    assert find_by_name("minimax_token_plan") == spec
+    assert find_by_name("minimaxTokenPlan") == spec
+    assert find_gateway(api_key="sk-cp-test-key") == spec
+    assert find_gateway(api_key="sk-api-payg-key") != spec
+
+    anthropic = find_by_name("minimax_coding_plan_anthropic")
+    assert anthropic is not None
+    assert anthropic.display_name == "MiniMax Token Plan (Anthropic)"
+    assert anthropic.backend == "anthropic"
+    assert anthropic.default_api_base == "https://api.minimaxi.com/anthropic"
+    assert find_by_name("minimax_token_plan_anthropic") == anthropic
+
+
 def test_novita_provider_aliases_and_base_detection() -> None:
     spec = find_by_name("novita")
 

--- a/web/components/common/ProviderIcon.tsx
+++ b/web/components/common/ProviderIcon.tsx
@@ -32,6 +32,8 @@ const PROVIDER_ICONS: Record<string, { file: string; mono?: boolean }> = {
   moonshot: { file: "moonshot.svg", mono: true },
   minimax: { file: "minimax-color.svg" },
   minimax_anthropic: { file: "minimax-color.svg" },
+  minimax_coding_plan: { file: "minimax-color.svg" },
+  minimax_coding_plan_anthropic: { file: "minimax-color.svg" },
   mistral: { file: "mistral-color.svg" },
   stepfun: { file: "stepfun-color.svg" },
   xiaomi_mimo: { file: "xiaomimimo.svg", mono: true },

--- a/web/lib/reasoning-effort.ts
+++ b/web/lib/reasoning-effort.ts
@@ -42,6 +42,7 @@ const BINARY_THINKING_PROVIDERS = new Set([
   "byteplus_coding_plan",
   "dashscope",
   "minimax",
+  "minimax_coding_plan",
 ]);
 
 function includesAny(value: string, patterns: string[]): boolean {
@@ -139,6 +140,7 @@ export function reasoningEffortOptions(
   if (BINARY_THINKING_PROVIDERS.has(provider)) {
     const supported =
       provider === "minimax" ||
+      provider === "minimax_coding_plan" ||
       includesAny(modelName, [
         "deepseek-reasoner",
         "deepseek-v4-pro",

--- a/web/tests/reasoning-effort.test.ts
+++ b/web/tests/reasoning-effort.test.ts
@@ -92,6 +92,12 @@ test("known reasoning families get conservative provider-specific choices", () =
     "high",
   ]);
   assert.deepEqual(values("dashscope", "qwen3-max"), ["", "minimal", "high"]);
+  assert.deepEqual(values("minimax", "MiniMax-M3"), ["", "minimal", "high"]);
+  assert.deepEqual(values("minimax_coding_plan", "MiniMax-M3"), [
+    "",
+    "minimal",
+    "high",
+  ]);
 });
 
 test("OpenAI-compatible gateways expose explicit effort levels", () => {


### PR DESCRIPTION
### Description

Add first-class **MiniMax Token Plan** (formerly Coding Plan) bindings so a subscription key can be imported the same way VolcEngine / BytePlus Coding Plan already work.

Existing `minimax` / `minimax_anthropic` stay on the global PAYG defaults (`api.minimax.io`). Token Plan keys (`sk-cp-…`) are usually China-platform credentials and are not interchangeable with PAYG keys, so the new bindings default to `api.minimaxi.com`.

Settings → Models now lists:

- `minimax_coding_plan` — OpenAI-compatible, `https://api.minimaxi.com/v1`
- `minimax_coding_plan_anthropic` — Anthropic-compatible, `https://api.minimaxi.com/anthropic`

`sk-cp-` keys are auto-detected to the OpenAI-compatible Token Plan binding. Global Token Plan users can still override `base_url` to `api.minimax.io`. The init wizard also features Token Plan and falls back to `MiniMax-M3`.

### Related Issues
- N/A

### Module(s) Affected
- [x] `config`
- [x] `services`
- [x] `web` (Frontend)
- [x] `tests`

### Testing
- [x] `pytest` for the new provider/registry/runtime/settings/capability cases (7 passed)
- [x] Existing MiniMax PAYG bindings still resolve to `api.minimax.io`

### Checklist
- [x] I have read and followed the contribution guidelines.
- [x] My code follows the project's coding standards.
- [x] I have added relevant tests for my changes.
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
Mainland China Token Plan is the default because that is where most `sk-cp-` keys are issued. Override `base_url` to `https://api.minimax.io/v1` (or `/anthropic`) when the key is from the global platform.

Made with [Cursor](https://cursor.com)