### PR TITLE
fix(video-learning): avoid Unix-only fcntl import on Windows

### DIFF
--- a/deeptutor/video_learning/service.py
+++ b/deeptutor/video_learning/service.py
@@ -6,12 +6,13 @@ import asyncio
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
-import fcntl
 import hashlib
 import ipaddress
 import json
+import os
 from pathlib import Path
 import re
+import sys
 from typing import Any, Awaitable, Callable, Literal
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
@@ -324,12 +325,31 @@ class TimedMediaStore:
             raise TimedMediaNotFound("Timed media material was not found.")
         lock_root = self.root / ".locks"
         lock_root.mkdir(parents=True, exist_ok=True)
-        with (lock_root / f"{material_id}.lock").open("a+", encoding="utf-8") as handle:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        # Binary + msvcrt on Windows (fcntl is Unix-only). Mirror
+        # ``codex_auth.storage`` so importing this module does not break
+        # ``deeptutor start`` on Windows (#1140 / #1143).
+        with (lock_root / f"{material_id}.lock").open("a+b") as handle:
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"\0")
+                handle.flush()
+            handle.seek(0)
+            if sys.platform == "win32":
+                import msvcrt
+
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
             try:
                 yield
             finally:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                handle.seek(0)
+                if sys.platform == "win32":
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 def get_timed_media_store() -> TimedMediaStore:

--- a/tests/video_learning/test_service.py
+++ b/tests/video_learning/test_service.py
@@ -341,3 +341,17 @@ async def test_refresh_invidious_transcript_does_not_overwrite_on_failure(
     stored = store.get(material_id)
     assert stored["transcript"] == original["transcript"]
     assert stored["learning"] == original["learning"]
+
+
+def test_service_module_does_not_bind_fcntl_at_import() -> None:
+    # Top-level ``import fcntl`` breaks ``deeptutor start`` on Windows (#1140).
+    assert "fcntl" not in service.__dict__
+
+
+def test_timed_media_store_lock_is_cross_platform(isolated: Path) -> None:
+    store = service.TimedMediaStore(root=isolated / "workspace" / "timed_media")
+    material_id = "a" * 32
+    with store.lock(material_id):
+        lock_path = store.root / ".locks" / f"{material_id}.lock"
+        assert lock_path.is_file()
+        assert lock_path.stat().st_size >= 1


### PR DESCRIPTION
## Summary
- `deeptutor/video_learning/service.py` imported Unix-only `fcntl` at module load, so `deeptutor start` crashed on Windows with `No module named 'fcntl'` (#1140 / #1143).
- Make `TimedMediaStore.lock` cross-platform (`msvcrt` on Windows, `fcntl` elsewhere), matching `codex_auth.storage`.

## Test plan
- [x] `pytest tests/video_learning/test_service.py::test_service_module_does_not_bind_fcntl_at_import tests/video_learning/test_service.py::test_timed_media_store_lock_is_cross_platform -q` (2 passed on Windows)
- [ ] On Windows: `python -c "from deeptutor.video_learning import service"` succeeds
- [ ] On Windows: `deeptutor start` no longer fails with `No module named 'fcntl'`

Fixes #1140
Fixes #1143
