### PR TITLE
docs: fix stale AGENTS.md paths for capability_result and app facade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,9 +66,9 @@ Multi-stage pipelines that own the turn:
 | `math_animator`  | concept_analysis → concept_design → code_generation → code_retry → summary → render_output |
 
 All capabilities converge on `emit_capability_result()` in
-`deeptutor/capabilities/_shared.py` so every turn emits the same envelope
-(response payload + `cost_summary` from `UsageTracker`). Status copy and
-prompts are i18n'd via `capabilities/prompts/{en,zh}/<name>.yaml`.
+`deeptutor/agents/_shared/capability_result.py` so every turn emits the same
+envelope (response payload + `cost_summary` from `UsageTracker`). Status copy
+and prompts are i18n'd via `capabilities/prompts/{en,zh}/<name>.yaml`.
 
 ## CLI Usage
 
@@ -112,7 +112,7 @@ deeptutor start                   # backend + frontend together
 | `deeptutor/core/context.py`                | `UnifiedContext` dataclass            |
 | `deeptutor/tools/builtin/__init__.py`      | All built-in tool wrappers           |
 | `deeptutor/capabilities/`                  | Built-in capability implementations  |
-| `deeptutor/app.py`                         | `DeepTutorApp` — Python SDK facade    |
+| `deeptutor/app/facade.py`                  | `DeepTutorApp` — Python SDK facade    |
 | `deeptutor_cli/main.py`                    | Typer CLI entry point                |
 | `deeptutor/api/routers/unified_ws.py`      | Unified WebSocket endpoint           |
 


### PR DESCRIPTION
### Summary
Fixes two stale code paths in `AGENTS.md` that no longer match the repository layout.

1. `emit_capability_result()` lives at `deeptutor/agents/_shared/capability_result.py`, not `deeptutor/capabilities/_shared.py` (that file does not exist).
2. The `DeepTutorApp` SDK facade lives at `deeptutor/app/facade.py`, not `deeptutor/app.py`.

### Verification
- `deeptutor/agents/_shared/capability_result.py` exists and defines `emit_capability_result`; `deeptutor/capabilities/_shared.py` does not exist.
- `deeptutor/app/facade.py` exists and defines `DeepTutorApp`; `deeptutor/app.py` does not exist.
- `python3 scripts/check_repo_hygiene.py` passes; no trailing whitespace; file ends with a newline.