### PR TITLE
fix: prevent blank space below settings page

### DIFF
--- a/web/features/settings/navigation/settings-scroll.ts
+++ b/web/features/settings/navigation/settings-scroll.ts
@@ -39,8 +39,15 @@ export function scrollToSettingsSection(
 
   scroller.scrollTo({ top: Math.max(0, top), behavior });
 
-  // Fragment navigation may have moved the root scrolling element before the
-  // client handler ran. Keep the full-height application shell pinned.
-  window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+  // Fragment navigation may move the root scrolling element before or after
+  // the client handler runs. Keep the full-height application shell pinned
+  // now and after the anchor's default-action frame.
+  const resetDocumentScroll = () => {
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0;
+  };
+  resetDocumentScroll();
+  requestAnimationFrame(resetDocumentScroll);
   return true;
 }

--- a/web/tests/e2e/settings-navigation.audit.ts
+++ b/web/tests/e2e/settings-navigation.audit.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Settings navigation", () => {
+  test("keeps scrolling inside the settings pane", async ({ page }) => {
+    await page.goto("/settings");
+
+    const settingsScroll = page.locator("[data-settings-scroll]");
+    await expect(settingsScroll).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+
+    const aboutLink = page.locator('a[data-tour="tour-nav-about"]');
+    await aboutLink.click();
+    await expect(page).toHaveURL(/\/settings#about$/);
+    await expect
+      .poll(() => settingsScroll.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
+
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+  });
+
+  test("keeps deep-link scrolling inside the settings pane", async ({
+    page,
+  }) => {
+    await page.goto("/settings#about");
+
+    const settingsScroll = page.locator("[data-settings-scroll]");
+    await expect(settingsScroll).toBeVisible();
+    await expect(page).toHaveURL(/\/settings#about$/);
+    await expect
+      .poll(() => settingsScroll.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
+
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+  });
+});

--- a/web/tests/settings-continuous-navigation.test.ts
+++ b/web/tests/settings-continuous-navigation.test.ts
@@ -83,6 +83,8 @@ test("settings scroll: the outer document tracks nested section anchors", () => 
   );
   assert.match(scrollHelper, /scroller\.scrollTo/);
   assert.match(scrollHelper, /window\.scrollTo/);
+  assert.match(scrollHelper, /document\.documentElement\.scrollTop = 0/);
+  assert.match(scrollHelper, /requestAnimationFrame\(resetDocumentScroll\)/);
 });
 
 test("settings page: heavy sections are split and mounted on demand", () => {


### PR DESCRIPTION
## Summary
- Port the remaining settings-scroll fix onto the current feature-based settings architecture.
- Reset the window, document element, and body immediately and again after the fragment default-action frame.
- Add browser coverage for click navigation and direct deep links.
- Drop the obsolete pre-refactor settings component changes and merge commit.

## Verification
- `npm run test:node` — passed
- `npm run typecheck` — passed
- ESLint on the touched files — passed.