### PR TITLE
fix(web): decode unicode escapes in quiz card text

### DIFF
--- a/web/lib/quiz-types.ts
+++ b/web/lib/quiz-types.ts
@@ -2,6 +2,7 @@
  * Shared types for Quiz Generation (deep_question capability).
  */
 
+import { decodeEscapedUnicodeForDisplay } from "./markdown-display";
 import {
   type NormalizedQuizQuestionType,
   normalizeQuizQuestionType,
@@ -78,6 +79,42 @@ export interface QuizFollowupContext {
   ai_judgment?: string;
 }
 
+/** Decode dense ``\\uXXXX`` runs on learner-facing quiz strings (#973 family). */
+function decodeQuizText(value: string | undefined | null): string {
+  return decodeEscapedUnicodeForDisplay(String(value ?? ""));
+}
+
+function decodeQuizOptions(
+  options: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!options || typeof options !== "object") return undefined;
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(options)) {
+    out[key] = decodeQuizText(value);
+  }
+  return out;
+}
+
+function buildQuizQuestionFromQa(qa: Record<string, unknown>): QuizQuestion {
+  return {
+    question_id: String(qa.question_id ?? ""),
+    question: decodeQuizText(qa.question as string | undefined | null),
+    question_type: normalizeQuizQuestionType(qa.question_type),
+    options: decodeQuizOptions(qa.options as Record<string, string> | undefined),
+    correct_answer: decodeQuizText(qa.correct_answer as string | undefined | null),
+    explanation: decodeQuizText(qa.explanation as string | undefined | null),
+    difficulty: qa.difficulty ? String(qa.difficulty) : undefined,
+    concentration: qa.concentration ? String(qa.concentration) : undefined,
+    knowledge_context:
+      qa.metadata &&
+      typeof qa.metadata === "object" &&
+      "knowledge_context" in qa.metadata &&
+      qa.metadata.knowledge_context
+        ? decodeQuizText(String(qa.metadata.knowledge_context))
+        : undefined,
+  };
+}
+
 /**
  * Extract QuizQuestion[] from per-question ``content`` events emitted live
  * by the new ``QuestionPipeline`` while the quizzing phase is running.
@@ -107,16 +144,7 @@ export function extractStreamingQuizQuestions(
     const qa = meta.qa_pair as Record<string, unknown> | undefined;
     if (!qa || typeof qa !== "object" || !qa.question) continue;
     const idx = Number(meta.question_index);
-    const question: QuizQuestion = {
-      question_id: String(qa.question_id ?? ""),
-      question: String(qa.question ?? ""),
-      question_type: normalizeQuizQuestionType(qa.question_type),
-      options: qa.options as Record<string, string> | undefined,
-      correct_answer: String(qa.correct_answer ?? ""),
-      explanation: String(qa.explanation ?? ""),
-      difficulty: qa.difficulty ? String(qa.difficulty) : undefined,
-      concentration: qa.concentration ? String(qa.concentration) : undefined,
-    };
+    const question = buildQuizQuestionFromQa(qa);
     const key = question.question_id || String(idx);
     byId.set(key, {
       idx: Number.isFinite(idx) ? idx : byId.size,
@@ -171,24 +199,7 @@ export function extractQuizQuestions(
   const parsed: Array<QuizQuestion | null> = results.map((item) => {
     const qa = (item.qa_pair ?? item) as Record<string, unknown>;
     if (!qa.question) return null;
-    const question: QuizQuestion = {
-      question_id: String(qa.question_id ?? ""),
-      question: String(qa.question ?? ""),
-      question_type: normalizeQuizQuestionType(qa.question_type),
-      options: qa.options as Record<string, string> | undefined,
-      correct_answer: String(qa.correct_answer ?? ""),
-      explanation: String(qa.explanation ?? ""),
-      difficulty: qa.difficulty ? String(qa.difficulty) : undefined,
-      concentration: qa.concentration ? String(qa.concentration) : undefined,
-      knowledge_context:
-        qa.metadata &&
-        typeof qa.metadata === "object" &&
-        "knowledge_context" in qa.metadata &&
-        qa.metadata.knowledge_context
-          ? String(qa.metadata.knowledge_context)
-          : undefined,
-    };
-    return question;
+    return buildQuizQuestionFromQa(qa);
   });
 
   return parsed.filter(

--- a/web/tests/quiz-question-type.test.ts
+++ b/web/tests/quiz-question-type.test.ts
@@ -74,3 +74,33 @@ test("extractQuizQuestions normalizes legacy question types from payloads", () =
   assert.ok(questions);
   assert.equal(questions?.[0]?.question_type, "choice");
 });
+
+test("extractQuizQuestions decodes dense unicode escapes in card text", () => {
+  const questions = extractQuizQuestions({
+    summary: {
+      results: [
+        {
+          qa_pair: {
+            question_id: "q_1",
+            question:
+              "\\u300c\\u6570\\u5236\\u8f6c\\u6362\\u300d\\u8fd8\\u6ca1\\u8fc7\\u5173\\uff1f",
+            question_type: "choice",
+            options: {
+              A: "\\u662f\\u7684\\uff0c\\u5df2\\u7ecf\\u8fc7\\u5173",
+              B: "\\u8fd8\\u6ca1\\u6709",
+            },
+            correct_answer: "B",
+            explanation:
+              "\\u9898\\u5e72\\u91cc\\u7684\\u8f6c\\u4e49\\u5e94\\u88ab\\u89e3\\u7801",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.ok(questions);
+  assert.equal(questions?.[0]?.question, "「数制转换」还没过关？");
+  assert.equal(questions?.[0]?.options?.A, "是的，已经过关");
+  assert.equal(questions?.[0]?.options?.B, "还没有");
+  assert.equal(questions?.[0]?.explanation, "题干里的转义应被解码");
+});


### PR DESCRIPTION
## Summary
- Decode dense Unicode escape sequences in quiz card text during streaming and final normalization.
- Reuse the existing bounded decoder and preserve ordinary text/code behavior.
- Rebased onto the current `dev` after the v1.6.4 CI repair.

## Verification
- `npm run test:node` — passed (1014 tests)
- `npm run typecheck` — passed
- Earlier clean-base validation: full `npm run check:fast` passed.