### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,10 @@ Project-root `.env` is **not** read as an application config file. For a minimal
 
 </details>
 
+## ☁️ One-Click Deploy
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/DeepTutor/)
+
 ## 📖 Explore DeepTutor
 
 Start with the main surfaces you will use day to day: Chat, Partners, My Agents, Co-Writer, Book, Knowledge Center, Learning Space, Memory, and Settings. The tour then covers Multi-User deployments for shared, isolated workspaces.


### PR DESCRIPTION
Adds a RepoCloud one-click deploy button to the README, placed in a new "☁️ One-Click Deploy" section between the "Get Started" and "Explore DeepTutor" sections.

 - Adds new `## ☁️ One-Click Deploy` section with deploy button
 - Button links to https://repocloud.io/details/DeepTutor/