### PR TITLE
feat(video-learning): keep active transcript cues visible (#1164)

### DIFF
--- a/web/components/watching/WatchingPane.tsx
+++ b/web/components/watching/WatchingPane.tsx
@@ -524,6 +524,17 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
             onTouchMove={() => {
               if (tab === "transcript") setFollowTranscript(false);
             }}
+            onPointerDown={(event) => {
+              // Native scrollbar drags target the scroll container itself.
+              // Pointer events from cue/control buttons bubble through here
+              // and must keep their own click semantics.
+              if (
+                tab === "transcript" &&
+                event.target === event.currentTarget
+              ) {
+                setFollowTranscript(false);
+              }
+            }}
             onKeyDown={(event) => {
               if (
                 tab === "transcript" &&

--- a/web/components/watching/WatchingPane.tsx
+++ b/web/components/watching/WatchingPane.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertTriangle,
+  ChevronsDown,
   Check,
   Captions,
   Copy,
@@ -68,7 +69,9 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
   const [notesCopied, setNotesCopied] = useState(false);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const notesExportRequestRef = useRef(0);
+  const [followTranscript, setFollowTranscript] = useState(true);
   const controllerRef = useRef<PlayerController | null>(null);
+  const transcriptListRef = useRef<HTMLDivElement | null>(null);
   const activeMaterialIdRef = useRef(materialId);
   const lastSavedRef = useRef(0);
   const stateRef = useRef({ time: 0, duration: 0 });
@@ -142,6 +145,26 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
       ),
     [material, time],
   );
+
+  useEffect(() => {
+    setFollowTranscript(true);
+  }, [materialId]);
+
+  useEffect(() => {
+    if (!followTranscript || tab !== "transcript" || !cue) return;
+    const list = transcriptListRef.current;
+    const activeRow = list?.querySelector<HTMLButtonElement>(
+      '[data-active-cue="true"]',
+    );
+    if (!list || !activeRow) return;
+    const rowTop =
+      activeRow.getBoundingClientRect().top -
+      list.getBoundingClientRect().top +
+      list.scrollTop -
+      list.clientHeight / 2 +
+      activeRow.clientHeight / 2;
+    list.scrollTo({ top: Math.max(0, rowTop), behavior: "smooth" });
+  }, [cue, followTranscript, tab]);
 
   const submit = async (providerOverride?: "youtube") => {
     const url = (providerOverride ? lastUrl || input : input).trim();
@@ -490,7 +513,33 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
               {t("Open official")} <ExternalLink className="h-3 w-3" />
             </a>
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          <div
+            ref={transcriptListRef}
+            data-testid="video-transcript-list"
+            className="min-h-0 flex-1 overflow-y-auto p-4"
+            onWheel={(event) => {
+              if (tab !== "transcript") return;
+              setFollowTranscript(false);
+            }}
+            onTouchMove={() => {
+              if (tab === "transcript") setFollowTranscript(false);
+            }}
+            onKeyDown={(event) => {
+              if (
+                tab === "transcript" &&
+                [
+                  "ArrowDown",
+                  "ArrowUp",
+                  "PageDown",
+                  "PageUp",
+                  "Home",
+                  "End",
+                ].includes(event.key)
+              ) {
+                setFollowTranscript(false);
+              }
+            }}
+          >
             <div
               className="mb-3 grid w-full max-w-56 grid-cols-2 rounded-lg bg-[var(--muted)] p-1"
               role="tablist"
@@ -547,14 +596,25 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
                 </div>
               ) : (
                 <>
-                  <button
-                    type="button"
-                    onClick={askHere}
-                    disabled={!cue}
-                    className="mb-3 rounded-lg bg-[var(--primary)] px-3 py-2 text-sm text-[var(--primary-foreground)] disabled:opacity-50"
-                  >
-                    {t("Explain here")}
-                  </button>
+                  <div className="mb-3 flex flex-wrap items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={askHere}
+                      disabled={!cue}
+                      className="rounded-lg bg-[var(--primary)] px-3 py-2 text-sm text-[var(--primary-foreground)] disabled:opacity-50"
+                    >
+                      {t("Explain here")}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setFollowTranscript((current) => !current)}
+                      aria-pressed={followTranscript}
+                      className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm font-medium ${followTranscript ? "border-[var(--primary)] text-[var(--primary)]" : "border-[var(--border)] text-[var(--muted-foreground)]"}`}
+                    >
+                      <ChevronsDown className="h-4 w-4" />
+                      {t("Follow playback")}
+                    </button>
+                  </div>
                   <div className="space-y-1">
                     {material.transcript.cues.map((row, index) => {
                       const active = row === cue;
@@ -562,6 +622,7 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
                         <button
                           key={`${row.start}-${index}`}
                           type="button"
+                          data-active-cue={active ? "true" : undefined}
                           onClick={() => controllerRef.current?.seek(row.start)}
                           className={`flex w-full gap-3 rounded-md px-2 py-1.5 text-left text-sm ${active ? "bg-blue-500/15 ring-1 ring-blue-500/30" : "hover:bg-[var(--muted)]"}`}
                         >

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -4449,6 +4449,7 @@
   "no captions": "no captions",
   "Retry captions": "Retry captions",
   "Explain here": "Explain here",
+  "Follow playback": "Follow playback",
   "YouTube playback failed.": "YouTube playback failed.",
   "YouTube learning video": "YouTube learning video",
   "The configured Invidious stream could not be played.": "The configured Invidious stream could not be played.",

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -4449,6 +4449,7 @@
   "no captions": "没有字幕",
   "Retry captions": "重试字幕",
   "Explain here": "解释此处",
+  "Follow playback": "跟随播放",
   "YouTube playback failed.": "YouTube 播放失败。",
   "YouTube learning video": "YouTube 学习视频",
   "The configured Invidious stream could not be played.": "无法播放已配置的 Invidious 视频流。",

--- a/web/tests/e2e/video-learning.audit.ts
+++ b/web/tests/e2e/video-learning.audit.ts
@@ -26,6 +26,16 @@ test("YouTube learning survives reload and switches to Invidious without silent 
     created_at: number;
     updated_at: number;
   }> = [];
+  const transcriptCues = [
+    { start: 7, end: 12, text: "The first grounded concept." },
+    ...Array.from({ length: 60 }, (_, index) => ({
+      start: 13 + index,
+      end: 14 + index,
+      text: `Intermediate lesson detail ${index + 1}.`,
+    })),
+    { start: 70, end: 75, text: "The second grounded concept." },
+    { start: 110, end: 115, text: "The third grounded concept." },
+  ];
 
   const material = (selected: "youtube" | "invidious") => ({
     version: 1,
@@ -48,10 +58,7 @@ test("YouTube learning survives reload and switches to Invidious without silent 
           reason: "",
           language: "en",
           source: selected,
-          cues: [
-            { start: 7, end: 12, text: "The first grounded concept." },
-            { start: 70, end: 75, text: "The second grounded concept." },
-          ],
+          cues: transcriptCues,
         }
       : {
           status: "unavailable",
@@ -124,6 +131,11 @@ test("YouTube learning survives reload and switches to Invidious without silent 
       playVideo() {}
       pauseVideo() {}
       destroy() {
+        const players = (
+          window as typeof window & { __fakePlayers?: FakePlayer[] }
+        ).__fakePlayers;
+        const index = players?.indexOf(this) ?? -1;
+        if (index >= 0) players?.splice(index, 1);
         this.element.remove();
       }
     }
@@ -272,6 +284,52 @@ test("YouTube learning survives reload and switches to Invidious without silent 
     page.getByText("The first grounded concept.").locator(".."),
   ).toHaveClass(/ring-1/);
 
+  const transcriptList = page.getByTestId("video-transcript-list");
+  const followButton = page.getByRole("button", { name: "Follow playback" });
+  await expect(followButton).toHaveAttribute("aria-pressed", "true");
+  await page.evaluate(() => {
+    const player = (
+      window as typeof window & { __fakePlayers: Array<{ current: number }> }
+    ).__fakePlayers.at(-1);
+    if (player) player.current = 74;
+  });
+  await expect(
+    page.getByText("The second grounded concept.").locator(".."),
+  ).toHaveClass(/ring-1/);
+  await expect
+    .poll(() => transcriptList.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(100);
+
+  await transcriptList.hover();
+  await page.mouse.wheel(0, 20);
+  await expect(followButton).toHaveAttribute("aria-pressed", "false");
+  const pausedScrollTop = await transcriptList.evaluate(
+    (element) => element.scrollTop,
+  );
+  await page.evaluate(() => {
+    const player = (
+      window as typeof window & { __fakePlayers: Array<{ current: number }> }
+    ).__fakePlayers.at(-1);
+    if (player) player.current = 112;
+  });
+  await expect(
+    page.getByText("The third grounded concept.").locator(".."),
+  ).toHaveClass(/ring-1/);
+  await expect
+    .poll(() => transcriptList.evaluate((element) => element.scrollTop))
+    .toBe(pausedScrollTop);
+  await followButton.click();
+  await expect(followButton).toHaveAttribute("aria-pressed", "true");
+  await expect
+    .poll(() => transcriptList.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(pausedScrollTop);
+
+  await page.evaluate(() => {
+    const player = (
+      window as typeof window & { __fakePlayers: Array<{ current: number }> }
+    ).__fakePlayers.at(-1);
+    if (player) player.current = 8;
+  });
   await page.getByRole("tab", { name: "Video notes" }).click();
   await expect(page.getByText("No notes yet.")).toBeVisible();
   await expect(page.getByRole("button", { name: "Copy notes" })).toBeDisabled();

--- a/web/tests/e2e/video-learning.audit.ts
+++ b/web/tests/e2e/video-learning.audit.ts
@@ -324,6 +324,11 @@ test("YouTube learning survives reload and switches to Invidious without silent 
     .poll(() => transcriptList.evaluate((element) => element.scrollTop))
     .toBeGreaterThan(pausedScrollTop);
 
+  await transcriptList.dispatchEvent("pointerdown", { pointerType: "mouse" });
+  await expect(followButton).toHaveAttribute("aria-pressed", "false");
+  await followButton.click();
+  await expect(followButton).toHaveAttribute("aria-pressed", "true");
+
   await page.evaluate(() => {
     const player = (
       window as typeof window & { __fakePlayers: Array<{ current: number }> }


### PR DESCRIPTION
Closes #1164
Refs #997

## Summary
- keep the active transcript cue centered as playback advances
- pause following on wheel, touch, keyboard navigation, and native scrollbar drag
- preserve cue/control button click behavior while detecting scrollbar pointer interaction
- add a bilingual pressed-state control to resume following immediately
- extend the immersive-watching browser audit for long transcripts, manual pause/resume, and timestamp seeking
- rebuild directly on the current `dev` baseline without unrelated CI history

## Verification
- `cd web && npm run test:node` — 1015 passed
- `cd web && npm run typecheck`
- `cd web && npm run i18n:check`
- targeted ESLint passes
- `cd web && npm run audit -- tests/e2e/video-learning.audit.ts` — 1 passed
