### PR TITLE
test(mastery): cover study context providers (#1161)

### DIFF
--- a/web/tests/mastery-study-contexts.test.ts
+++ b/web/tests/mastery-study-contexts.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import i18next from "i18next";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { initReactI18next } from "react-i18next";
+
+import MasteryStudyLayout from "../app/(utility)/mastery/[pathId]/study/layout";
+import { useReading } from "../context/ReadingContext";
+import { useWatching } from "../context/WatchingContext";
+
+function ContextProbe() {
+  const reading = useReading();
+  const watching = useWatching();
+
+  return createElement(
+    "p",
+    null,
+    `reading:${reading.loading ? "loading" : "idle"} watching:${watching.active ? "active" : "idle"}`,
+  );
+}
+
+test("the mastery study layout provides reading and watching contexts", async () => {
+  await i18next.use(initReactI18next).init({
+    lng: "en",
+    fallbackLng: false,
+    resources: { en: { translation: {} } },
+  });
+  assert.equal(
+    renderToStaticMarkup(
+      createElement(MasteryStudyLayout, null, createElement(ContextProbe)),
+    ),
+    "<p>reading:idle watching:idle</p>",
+  );
+});


### PR DESCRIPTION
## Summary
- add a real React render regression test for the Mastery Study layout
- render a child that calls `useReading()` and `useWatching()` inside the actual layout
- fail if either context provider is removed, preventing the #1161 crash from regressing

## Context
#1161 reported a Mastery Study crash with `useWatching must be used inside WatchingProvider`. Current `dev` already added the missing providers in `7f2da923`; this PR locks that correction into the Web node test suite without changing runtime behavior.

## Testing
- PASS: `npx tsc -p tsconfig.node-tests.json && node -r ./scripts/register-node-test-aliases.cjs --test dist/node-tests/tests/mastery-study-contexts.test.js` (1 passed)
- PASS: `npm run test:node` (843 passed)
- PASS: `npx eslint tests/mastery-study-contexts.test.ts`
- PASS: `git diff --check`

Fixes #1161