### PR TITLE
fix(video-learning): defer restored material loading (#1168)

### DIFF
--- a/web/context/WatchingContext.tsx
+++ b/web/context/WatchingContext.tsx
@@ -69,6 +69,7 @@ export function WatchingProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
+    if (!active || material) return;
     const materialId = browserStorage.readRaw("local", LAST_MATERIAL_KEY);
     if (!materialId) return;
     const sourceUrl = browserStorage.readRaw("local", LAST_URL_KEY) || "";
@@ -85,7 +86,7 @@ export function WatchingProvider({ children }: { children: ReactNode }) {
         browserStorage.removeRaw("local", LAST_MATERIAL_KEY);
       })
       .finally(() => setLoading(false));
-  }, [accept, t]);
+  }, [accept, active, material, t]);
 
   const openUrl = useCallback(
     async (url: string, language = "", providerOverride?: VideoProvider) => {

--- a/web/tests/e2e/video-learning.audit.ts
+++ b/web/tests/e2e/video-learning.audit.ts
@@ -9,6 +9,7 @@ test("YouTube learning survives reload and switches to Invidious without silent 
   let invidiousOffline = false;
   let transcriptReady = true;
   let transcriptRefreshCount = 0;
+  let materialRequestCount = 0;
   let savedPosition = 0;
   let nativeResolveCount = 0;
   let nextNoteId = 1;
@@ -161,6 +162,7 @@ test("YouTube learning survives reload and switches to Invidious without silent 
       return json(material(body.provider_override || provider));
     }
     if (path === `/api/video-learning/materials/${MATERIAL_ID}`) {
+      materialRequestCount += 1;
       if (provider === "invidious" && invidiousOffline) {
         return json({ detail: "Invidious is offline" }, 400);
       }
@@ -264,7 +266,11 @@ test("YouTube learning survives reload and switches to Invidious without silent 
   await expect(page.getByText("First timestamped note")).toBeVisible();
   await expect(page.getByText("The first grounded concept.")).toBeVisible();
 
-  await page.reload();
+  await page.goto("/");
+  await page.waitForTimeout(100);
+  expect(materialRequestCount).toBe(0);
+  await page.goto("/chat?capability=immersive_watching");
+  await expect.poll(() => materialRequestCount).toBe(1);
   await expect(page.getByText("Timestamped lesson")).toBeVisible();
   await page.getByRole("tab", { name: "Video notes" }).click();
   await expect(page.getByText("First timestamped note")).toBeVisible();


### PR DESCRIPTION
## Summary
- restore persisted video material only while the immersive-watching surface is active
- avoid background material API requests from unrelated routes
- add a browser audit that leaves the watching route and verifies no restore request occurs until the route is active again
- rebuild the branch directly on the current `dev` baseline, without the unrelated historical CI stack

## Verification
- `cd web && npm run test:node` — 1013 passed
- `cd web && npm run typecheck`
- `cd web && npx eslint context/WatchingContext.tsx tests/e2e/video-learning.audit.ts`
- `cd web && npm run audit -- tests/e2e/video-learning.audit.ts` — 1 passed (with local Next server)
