### PR TITLE
fix(web): give WatchingContext a safe inactive default

### DIFF
--- a/web/context/WatchingContext.tsx
+++ b/web/context/WatchingContext.tsx
@@ -45,7 +45,32 @@ interface WatchingContextValue {
   setActive(active: boolean): void;
 }
 
-const WatchingContext = createContext<WatchingContextValue | null>(null);
+function noop(): void {}
+async function asyncNoop(): Promise<void> {}
+
+/**
+ * Inactive defaults, matching ReadingContext: AssistantResponse (and any
+ * other shared bubble) may call useWatching outside a WatchingProvider —
+ * e.g. utility routes that host chat without mounting the player. Throwing
+ * there blanked the whole mastery study page (#1161). The real provider
+ * still owns player state when present.
+ */
+const INACTIVE_WATCHING: WatchingContextValue = {
+  material: null,
+  active: false,
+  loading: false,
+  error: null,
+  lastUrl: "",
+  openUrl: asyncNoop,
+  refresh: asyncNoop,
+  refreshTranscript: asyncNoop,
+  close: noop,
+  reportTime: noop,
+  clearError: noop,
+  setActive: noop,
+};
+
+const WatchingContext = createContext<WatchingContextValue>(INACTIVE_WATCHING);
 
 export function WatchingProvider({ children }: { children: ReactNode }) {
   const { t } = useTranslation();
@@ -192,8 +217,5 @@ export function WatchingProvider({ children }: { children: ReactNode }) {
 }
 
 export function useWatching(): WatchingContextValue {
-  const context = useContext(WatchingContext);
-  if (!context)
-    throw new Error("useWatching must be used inside WatchingProvider");
-  return context;
+  return useContext(WatchingContext);
 }

--- a/web/tests/watching-context-default.test.ts
+++ b/web/tests/watching-context-default.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { useWatching } from "../context/WatchingContext";
+
+function WatchingProbe() {
+  const watching = useWatching();
+  return createElement(
+    "p",
+    null,
+    `active:${watching.active ? "yes" : "no"} material:${watching.material ? "yes" : "no"}`,
+  );
+}
+
+test("useWatching is safe outside WatchingProvider", () => {
+  assert.equal(
+    renderToStaticMarkup(createElement(WatchingProbe)),
+    "<p>active:no material:no</p>",
+  );
+});


### PR DESCRIPTION
## Summary
- Give `WatchingContext` an inactive default value (same pattern as `ReadingContext`) so `useWatching()` no longer throws outside `WatchingProvider`.
- `AssistantResponse` calls `useWatching` for video timestamp linkification; on utility routes that host chat without the player (e.g. Mastery Study on v1.6.2), the hard throw blanked the page / tripped the Next error boundary after send.
- Add a node render test that `useWatching` is safe with no provider.

## Related
- Related #1161
- Related #1172 / #1173 (same crash family: study page loads, send → "This page couldn't load")
- Complements layout provider coverage in #1167

## Test plan
- [x] `cd web && npm run test:node -- watching-context-default`
- [x] Mastery Study no longer hard-crashes on `useWatching must be used inside WatchingProvider` — pinned by `npm run test:node -- watching-context-default` (renders the watcher outside any provider and asserts the inactive default)
- [ ] On `/home` with Watching pane active, video timestamp linkification still works — needs a running app with a live watching session; the provider path is unchanged by this PR
