### PR TITLE
fix(llm): replay Responses reasoning output items

### DIFF
--- a/deeptutor/agents/chat/agent_loop.py
+++ b/deeptutor/agents/chat/agent_loop.py
@@ -888,10 +888,7 @@ class AgentLoop:
                     provider_fields = getattr(choice, "provider_specific_fields", None)
                     if isinstance(provider_fields, dict):
                         native_items = provider_fields.get("native_output_items")
-                        if isinstance(native_items, list) and any(
-                            isinstance(item, dict) and item.get("type") == "reasoning"
-                            for item in native_items
-                        ):
+                        if isinstance(native_items, list):
                             response_output_items = [
                                 dict(item) for item in native_items if isinstance(item, dict)
                             ]

--- a/deeptutor/core/agentic/client.py
+++ b/deeptutor/core/agentic/client.py
@@ -413,6 +413,7 @@ class _ProviderOpenAIAdapter:
                 SimpleNamespace(
                     message=SimpleNamespace(
                         content=response.content or "",
+                        reasoning_content=response.reasoning_content,
                         tool_calls=[
                             _openai_tool_call(tool_call, index=index)
                             for index, tool_call in enumerate(response.tool_calls or [])
@@ -454,6 +455,7 @@ class _ProviderOpenAIStream:
         self._queue: asyncio.Queue[Any] | None = None
         self._task: asyncio.Task[None] | None = None
         self._emitted_content = False
+        self._emitted_reasoning = False
 
     def __aiter__(self) -> "_ProviderOpenAIStream":
         if self._queue is None:
@@ -484,6 +486,11 @@ class _ProviderOpenAIStream:
                 self._emitted_content = True
                 await self._queue.put(_openai_stream_chunk(content=text))
 
+        async def _on_reasoning_delta(text: str) -> None:
+            if text:
+                self._emitted_reasoning = True
+                await self._queue.put(_openai_stream_chunk(reasoning_content=text))
+
         try:
             response = await self._provider.chat_stream(
                 messages=self._messages,
@@ -494,10 +501,15 @@ class _ProviderOpenAIStream:
                 reasoning_effort=self._reasoning_effort,
                 tool_choice=self._tool_choice,
                 on_content_delta=_on_content_delta,
+                on_reasoning_delta=_on_reasoning_delta,
                 **self._extra_kwargs,
             )
             if response.content and not self._emitted_content:
                 await self._queue.put(_openai_stream_chunk(content=response.content))
+            if response.reasoning_content and not self._emitted_reasoning:
+                await self._queue.put(
+                    _openai_stream_chunk(reasoning_content=response.reasoning_content)
+                )
             for index, tool_call in enumerate(response.tool_calls or []):
                 await self._queue.put(_openai_stream_chunk(tool_call=tool_call, index=index))
             provider_fields = dict(response.provider_specific_fields or {})
@@ -538,6 +550,7 @@ def _openai_tool_call(tool_call: Any, *, index: int) -> Any:
 def _openai_stream_chunk(
     *,
     content: str | None = None,
+    reasoning_content: str | None = None,
     tool_call: Any | None = None,
     index: int = 0,
     finish_reason: str | None = None,
@@ -550,7 +563,11 @@ def _openai_stream_chunk(
     return SimpleNamespace(
         choices=[
             SimpleNamespace(
-                delta=SimpleNamespace(content=content, tool_calls=tool_calls),
+                delta=SimpleNamespace(
+                    content=content,
+                    reasoning_content=reasoning_content,
+                    tool_calls=tool_calls,
+                ),
                 finish_reason=finish_reason,
                 provider_specific_fields=provider_specific_fields,
             )

--- a/deeptutor/services/llm/provider_core/openai_compat_provider.py
+++ b/deeptutor/services/llm/provider_core/openai_compat_provider.py
@@ -318,6 +318,13 @@ class OpenAICompatProvider(LLMProvider):
             prepared.append(clean)
 
         sanitized = LLMProvider._sanitize_request_messages(prepared, _ALLOWED_MSG_KEYS)
+        if responses_api:
+            # Responses continuation identifies a function_call_output by the
+            # provider's original call_id. Shortening that id (the legacy
+            # Chat Completions compatibility rule below) breaks the exact
+            # function_call -> function_call_output replay contract.
+            return sanitized
+
         id_map: dict[str, str] = {}
 
         def map_id(value: Any) -> Any:

--- a/deeptutor/services/llm/provider_core/openai_responses/parsing.py
+++ b/deeptutor/services/llm/provider_core/openai_responses/parsing.py
@@ -75,19 +75,11 @@ def _reasoning_text_from_item(item: dict[str, Any]) -> tuple[str, str]:
     summary_parts: list[str] = []
     for block in item.get("content") or []:
         block = _dump_model(block)
-        if (
-            isinstance(block, dict)
-            and block.get("type") == "reasoning_text"
-            and block.get("text")
-        ):
+        if isinstance(block, dict) and block.get("type") == "reasoning_text" and block.get("text"):
             reasoning_parts.append(str(block["text"]))
     for block in item.get("summary") or []:
         block = _dump_model(block)
-        if (
-            isinstance(block, dict)
-            and block.get("type") == "summary_text"
-            and block.get("text")
-        ):
+        if isinstance(block, dict) and block.get("type") == "summary_text" and block.get("text"):
             summary_parts.append(str(block["text"]))
     return "".join(reasoning_parts), "".join(summary_parts)
 

--- a/deeptutor/services/llm/provider_core/openai_responses/parsing.py
+++ b/deeptutor/services/llm/provider_core/openai_responses/parsing.py
@@ -25,6 +25,12 @@ FINISH_REASON_MAP = {
 # DeepSeek name the item "web_search_call"; "web_search" is accepted
 # defensively for providers that shorten it.
 _WEB_SEARCH_ITEM_TYPES = {"web_search_call", "web_search"}
+_NATIVE_OUTPUT_ITEM_TYPES = {
+    "reasoning",
+    "message",
+    "function_call",
+    *_WEB_SEARCH_ITEM_TYPES,
+}
 
 
 def _dump_model(value: Any) -> Any:
@@ -61,6 +67,47 @@ def _citations_from_content_blocks(blocks: Any) -> list[dict[str, str]]:
             if citation:
                 citations.append(citation)
     return citations
+
+
+def _reasoning_text_from_item(item: dict[str, Any]) -> tuple[str, str]:
+    """Return raw reasoning text and summary fallback from one output item."""
+    reasoning_parts: list[str] = []
+    summary_parts: list[str] = []
+    for block in item.get("content") or []:
+        block = _dump_model(block)
+        if (
+            isinstance(block, dict)
+            and block.get("type") == "reasoning_text"
+            and block.get("text")
+        ):
+            reasoning_parts.append(str(block["text"]))
+    for block in item.get("summary") or []:
+        block = _dump_model(block)
+        if (
+            isinstance(block, dict)
+            and block.get("type") == "summary_text"
+            and block.get("text")
+        ):
+            summary_parts.append(str(block["text"]))
+    return "".join(reasoning_parts), "".join(summary_parts)
+
+
+def _emit_native_output_item(
+    item: dict[str, Any],
+    *,
+    seen_item_ids: set[str],
+    on_provider_event: Callable[[str, dict[str, Any]], None] | None,
+) -> None:
+    """Emit a complete replayable item once, preserving done-event order."""
+    if item.get("type") not in _NATIVE_OUTPUT_ITEM_TYPES:
+        return
+    item_id = str(item.get("id") or "")
+    if item_id:
+        if item_id in seen_item_ids:
+            return
+        seen_item_ids.add(item_id)
+    if on_provider_event:
+        on_provider_event("output_item", dict(item))
 
 
 def map_finish_reason(status: str | None) -> str:
@@ -224,6 +271,7 @@ async def iter_sse(response: httpx.Response) -> AsyncGenerator[dict[str, Any], N
 async def consume_sse(
     response: httpx.Response,
     on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+    on_reasoning_delta: Callable[[str], Awaitable[None]] | None = None,
     on_provider_event: Callable[[str, dict[str, Any]], None] | None = None,
 ) -> tuple[str, list[ToolCallRequest], str]:
     """Consume a Responses API SSE stream."""
@@ -231,7 +279,9 @@ async def consume_sse(
     tool_calls: list[ToolCallRequest] = []
     tool_call_buffers = _ToolCallBuffers()
     finish_reason = "stop"
-    seen_web_search_items: set[str] = set()
+    raw_reasoning = ""
+    summary_reasoning = ""
+    seen_output_item_ids: set[str] = set()
 
     async for event in iter_sse(response):
         event_type = event.get("type")
@@ -256,6 +306,21 @@ async def consume_sse(
             citation = _citation_from_annotation(event.get("annotation"))
             if citation and on_provider_event:
                 on_provider_event("citation", citation)
+        elif event_type == "response.reasoning_text.delta":
+            delta_text = event.get("delta") or ""
+            raw_reasoning += delta_text
+            if on_reasoning_delta and delta_text:
+                await on_reasoning_delta(delta_text)
+        elif event_type == "response.reasoning_text.done":
+            if not raw_reasoning:
+                raw_reasoning = event.get("text") or ""
+                if on_reasoning_delta and raw_reasoning:
+                    await on_reasoning_delta(raw_reasoning)
+        elif event_type == "response.reasoning_summary_text.delta":
+            summary_reasoning += event.get("delta") or ""
+        elif event_type == "response.reasoning_summary_text.done":
+            if not summary_reasoning:
+                summary_reasoning = event.get("text") or ""
         elif event_type == "response.function_call_arguments.delta":
             tool_call_buffers.append(
                 event.get("delta") or "",
@@ -270,13 +335,19 @@ async def consume_sse(
             )
         elif event_type == "response.output_item.done":
             item = event.get("item") or {}
-            if item.get("type") in _WEB_SEARCH_ITEM_TYPES:
-                item_id = str(item.get("id") or "")
-                if item_id and item_id not in seen_web_search_items:
-                    seen_web_search_items.add(item_id)
-                    if on_provider_event:
-                        on_provider_event("output_item", dict(item))
-                continue
+            _emit_native_output_item(
+                item,
+                seen_item_ids=seen_output_item_ids,
+                on_provider_event=on_provider_event,
+            )
+            if item.get("type") == "reasoning" and not raw_reasoning:
+                item_reasoning, item_summary = _reasoning_text_from_item(item)
+                if item_reasoning:
+                    raw_reasoning = item_reasoning
+                    if on_reasoning_delta:
+                        await on_reasoning_delta(item_reasoning)
+                elif not summary_reasoning:
+                    summary_reasoning = item_summary
             if item.get("type") == "function_call":
                 call_id = item.get("call_id")
                 if not call_id:
@@ -300,6 +371,8 @@ async def consume_sse(
         elif event_type in {"error", "response.failed"}:
             raise RuntimeError(f"Response failed: {_response_error_detail(event)[:500]}")
 
+    if not raw_reasoning and summary_reasoning and on_reasoning_delta:
+        await on_reasoning_delta(summary_reasoning)
     return content, tool_calls, finish_reason
 
 
@@ -312,9 +385,11 @@ def parse_response_output(response: Any) -> LLMResponse:
     output = response.get("output") or []
     content_parts: list[str] = []
     tool_calls: list[ToolCallRequest] = []
-    reasoning_content: str | None = None
+    raw_reasoning_parts: list[str] = []
+    summary_reasoning_parts: list[str] = []
     native_output_items: list[dict[str, Any]] = []
     native_citations: list[dict[str, str]] = []
+    seen_output_item_ids: set[str] = set()
 
     for item in output:
         item = _dump_model(item)
@@ -322,6 +397,12 @@ def parse_response_output(response: Any) -> LLMResponse:
             continue
 
         item_type = item.get("type")
+        if item_type in _NATIVE_OUTPUT_ITEM_TYPES:
+            item_id = str(item.get("id") or "")
+            if not item_id or item_id not in seen_output_item_ids:
+                if item_id:
+                    seen_output_item_ids.add(item_id)
+                native_output_items.append(dict(item))
         if item_type == "message":
             for block in item.get("content") or []:
                 block = _dump_model(block)
@@ -331,18 +412,16 @@ def parse_response_output(response: Any) -> LLMResponse:
                     content_parts.append(block.get("text") or "")
                     native_citations.extend(_citations_from_content_blocks([block]))
         elif item_type == "reasoning":
-            for summary in item.get("summary") or []:
-                summary = _dump_model(summary)
-                if not isinstance(summary, dict):
-                    continue
-                if summary.get("type") == "summary_text" and summary.get("text"):
-                    reasoning_content = (reasoning_content or "") + summary["text"]
+            item_reasoning, item_summary = _reasoning_text_from_item(item)
+            if item_reasoning:
+                raw_reasoning_parts.append(item_reasoning)
+            if item_summary:
+                summary_reasoning_parts.append(item_summary)
         elif item_type in _WEB_SEARCH_ITEM_TYPES:
             # This action already ran inside the provider and accompanies a
             # terminal answer. Preserve it verbatim as provider metadata; do
             # not synthesize a local ToolCallRequest and trigger a fake second
             # agent-loop round.
-            native_output_items.append(dict(item))
             native_citations.extend(_citations_from_content_blocks(item.get("results")))
         elif item_type == "function_call":
             call_id = item.get("call_id") or ""
@@ -361,6 +440,7 @@ def parse_response_output(response: Any) -> LLMResponse:
     usage = token_counts(response.get("usage"), prompt="input_tokens", completion="output_tokens")
 
     finish_reason = map_finish_reason(response.get("status"))
+    reasoning_content = "".join(raw_reasoning_parts) or "".join(summary_reasoning_parts) or None
     provider_specific_fields: dict[str, Any] = {}
     if native_output_items or native_citations:
         provider_specific_fields = {
@@ -372,7 +452,7 @@ def parse_response_output(response: Any) -> LLMResponse:
         tool_calls=tool_calls,
         finish_reason=finish_reason,
         usage=usage,
-        reasoning_content=reasoning_content if isinstance(reasoning_content, str) else None,
+        reasoning_content=reasoning_content,
         provider_specific_fields=provider_specific_fields,
     )
 
@@ -389,8 +469,9 @@ async def consume_sdk_stream(
     tool_call_buffers = _ToolCallBuffers()
     finish_reason = "stop"
     usage: dict[str, int] = {}
-    reasoning_content: str | None = None
-    seen_web_search_items: set[str] = set()
+    raw_reasoning = ""
+    summary_reasoning = ""
+    seen_output_item_ids: set[str] = set()
 
     async for event in stream:
         event_type = getattr(event, "type", None)
@@ -415,6 +496,21 @@ async def consume_sdk_stream(
             citation = _citation_from_annotation(getattr(event, "annotation", None))
             if citation and on_provider_event:
                 on_provider_event("citation", citation)
+        elif event_type == "response.reasoning_text.delta":
+            delta_text = getattr(event, "delta", "") or ""
+            raw_reasoning += delta_text
+            if on_reasoning_delta and delta_text:
+                await on_reasoning_delta(delta_text)
+        elif event_type == "response.reasoning_text.done":
+            if not raw_reasoning:
+                raw_reasoning = getattr(event, "text", "") or ""
+                if on_reasoning_delta and raw_reasoning:
+                    await on_reasoning_delta(raw_reasoning)
+        elif event_type == "response.reasoning_summary_text.delta":
+            summary_reasoning += getattr(event, "delta", "") or ""
+        elif event_type == "response.reasoning_summary_text.done":
+            if not summary_reasoning:
+                summary_reasoning = getattr(event, "text", "") or ""
         elif event_type == "response.function_call_arguments.delta":
             tool_call_buffers.append(
                 getattr(event, "delta", "") or "",
@@ -430,13 +526,20 @@ async def consume_sdk_stream(
         elif event_type == "response.output_item.done":
             item = getattr(event, "item", None)
             item_dict = _dump_model(item) if item is not None else None
-            if isinstance(item_dict, dict) and item_dict.get("type") in _WEB_SEARCH_ITEM_TYPES:
-                item_id = str(item_dict.get("id") or "")
-                if item_id and item_id not in seen_web_search_items:
-                    seen_web_search_items.add(item_id)
-                    if on_provider_event:
-                        on_provider_event("output_item", dict(item_dict))
-                continue
+            if isinstance(item_dict, dict):
+                _emit_native_output_item(
+                    item_dict,
+                    seen_item_ids=seen_output_item_ids,
+                    on_provider_event=on_provider_event,
+                )
+                if item_dict.get("type") == "reasoning" and not raw_reasoning:
+                    item_reasoning, item_summary = _reasoning_text_from_item(item_dict)
+                    if item_reasoning:
+                        raw_reasoning = item_reasoning
+                        if on_reasoning_delta:
+                            await on_reasoning_delta(item_reasoning)
+                    elif not summary_reasoning:
+                        summary_reasoning = item_summary
             if item and getattr(item, "type", None) == "function_call":
                 call_id = getattr(item, "call_id", None)
                 if not call_id:
@@ -454,11 +557,6 @@ async def consume_sdk_stream(
                         or "{}",
                     )
                 )
-        elif event_type == "response.reasoning_summary_text.delta":
-            delta_text = getattr(event, "delta", "") or ""
-            reasoning_content = (reasoning_content or "") + delta_text
-            if on_reasoning_delta and delta_text:
-                await on_reasoning_delta(delta_text)
         elif event_type == "response.completed":
             response = getattr(event, "response", None)
             status = getattr(response, "status", None) if response is not None else None
@@ -470,4 +568,7 @@ async def consume_sdk_stream(
         elif event_type in {"error", "response.failed"}:
             raise RuntimeError(f"Response failed: {_response_error_detail(event)[:500]}")
 
+    if not raw_reasoning and summary_reasoning and on_reasoning_delta:
+        await on_reasoning_delta(summary_reasoning)
+    reasoning_content = raw_reasoning or summary_reasoning or None
     return content, tool_calls, finish_reason, usage, reasoning_content

--- a/deeptutor/services/session/provider_response_state.py
+++ b/deeptutor/services/session/provider_response_state.py
@@ -13,7 +13,9 @@ MAX_RESPONSE_OUTPUT_BYTES = 256 * 1024
 # agentic loop can legitimately need on the next request.  In particular,
 # function_call_output is an input item built from our own tool message and
 # must never be accepted from persisted provider state.
-_ALLOWED_RESPONSE_OUTPUT_TYPES = frozenset({"reasoning", "message", "function_call"})
+_ALLOWED_RESPONSE_OUTPUT_TYPES = frozenset(
+    {"reasoning", "message", "function_call", "web_search_call", "web_search"}
+)
 _PRIVATE_MESSAGE_METADATA_KEYS = frozenset({"provider_response_state"})
 
 

--- a/tests/agents/chat/test_agent_loop.py
+++ b/tests/agents/chat/test_agent_loop.py
@@ -501,7 +501,21 @@ async def test_finish_round_persists_provider_response_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     registry = _Registry()
-    native_items = [{"type": "reasoning", "id": "rs_1", "summary": []}]
+    native_items = [
+        {
+            "type": "reasoning",
+            "id": "rs_1",
+            "content": [{"type": "reasoning_text", "text": "private reasoning"}],
+            "encrypted_content": "opaque",
+        },
+        {
+            "type": "message",
+            "id": "msg_1",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "A direct answer."}],
+            "phase": "final_answer",
+        },
+    ]
     client = _ScriptedChatClient(
         [
             [
@@ -528,10 +542,60 @@ async def test_finish_round_persists_provider_response_state(
 
 
 @pytest.mark.asyncio
+async def test_finish_round_persists_native_items_without_reasoning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    native_items = [
+        {
+            "type": "message",
+            "id": "msg_1",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "A direct answer."}],
+        }
+    ]
+    client = _ScriptedChatClient(
+        [
+            [
+                _llm_chunk(
+                    content="A direct answer.",
+                    provider_specific_fields={"native_output_items": native_items},
+                )
+            ]
+        ]
+    )
+    pipeline = AgenticChatPipeline(language="en")
+    pipeline.registry = _Registry()
+    monkeypatch.setattr(pipeline, "_compose_enabled_tools", lambda _context: [])
+    monkeypatch.setattr(pipeline, "_build_openai_client", lambda: client)
+    context = UnifiedContext(session_id="s1", user_message="Hello")
+
+    await _run(pipeline, context)
+
+    assert context.metadata["_provider_response_state"] == {
+        "responses_output_items": native_items
+    }
+
+
+@pytest.mark.asyncio
 async def test_tool_round_then_finish(monkeypatch: pytest.MonkeyPatch) -> None:
     """A tool round (narration text + a tool call) is followed by a tool-less
     finish round whose text is the answer — two LLM calls, no respond pass."""
     registry = _Registry()
+    first_round_native_items = [
+        {
+            "type": "reasoning",
+            "id": "rs_1",
+            "content": [{"type": "reasoning_text", "text": "round one private reasoning"}],
+            "encrypted_content": "opaque",
+        },
+        {
+            "type": "function_call",
+            "id": "fc_1",
+            "call_id": "call-1",
+            "name": "web_search",
+            "arguments": '{"query":"Fourier transform"}',
+        },
+    ]
     client = _ScriptedChatClient(
         [
             # Round 1: preamble (narration) text + a tool call.
@@ -544,7 +608,10 @@ async def test_tool_round_then_finish(monkeypatch: pytest.MonkeyPatch) -> None:
                             "name": "web_search",
                             "arguments": json.dumps({"query": "Fourier transform"}),
                         }
-                    ]
+                    ],
+                    provider_specific_fields={
+                        "native_output_items": first_round_native_items
+                    },
                 ),
             ],
             # Round 2: the model sees the tool result in-protocol and finishes
@@ -577,7 +644,8 @@ async def test_tool_round_then_finish(monkeypatch: pytest.MonkeyPatch) -> None:
     assert assistant_tc and assistant_tc[0]["tool_calls"][0]["function"]["name"] == "web_search"
     assert assistant_tc[0]["content"] == "Searching."
     assert assistant_tc[0]["_provider_response_state"] == {
-        "reasoning_content": "round one private reasoning"
+        "responses_output_items": first_round_native_items,
+        "reasoning_content": "round one private reasoning",
     }
     tool_msgs = [m for m in second_round if m.get("role") == "tool"]
     assert tool_msgs and "tool answer" in tool_msgs[0]["content"]

--- a/tests/agents/chat/test_agent_loop.py
+++ b/tests/agents/chat/test_agent_loop.py
@@ -571,9 +571,7 @@ async def test_finish_round_persists_native_items_without_reasoning(
 
     await _run(pipeline, context)
 
-    assert context.metadata["_provider_response_state"] == {
-        "responses_output_items": native_items
-    }
+    assert context.metadata["_provider_response_state"] == {"responses_output_items": native_items}
 
 
 @pytest.mark.asyncio
@@ -609,9 +607,7 @@ async def test_tool_round_then_finish(monkeypatch: pytest.MonkeyPatch) -> None:
                             "arguments": json.dumps({"query": "Fourier transform"}),
                         }
                     ],
-                    provider_specific_fields={
-                        "native_output_items": first_round_native_items
-                    },
+                    provider_specific_fields={"native_output_items": first_round_native_items},
                 ),
             ],
             # Round 2: the model sees the tool result in-protocol and finishes

--- a/tests/core/test_agentic_client_provider_kwargs.py
+++ b/tests/core/test_agentic_client_provider_kwargs.py
@@ -116,8 +116,69 @@ async def test_provider_stream_exposes_final_reasoning_content() -> None:
 
     chunks = [chunk async for chunk in stream]
 
+    reasoning_deltas = [
+        chunk.choices[0].delta.reasoning_content
+        for chunk in chunks
+        if chunk.choices[0].delta.reasoning_content
+    ]
     final_choice = chunks[-1].choices[0]
+    assert reasoning_deltas == ["private reasoning"]
     assert final_choice.provider_specific_fields["reasoning_content"] == "private reasoning"
+
+
+@pytest.mark.asyncio
+async def test_provider_stream_does_not_repeat_streamed_reasoning_fallback() -> None:
+    class FakeProvider:
+        async def chat_stream(self, **kwargs):
+            await kwargs["on_reasoning_delta"]("first ")
+            await kwargs["on_reasoning_delta"]("second")
+            return LLMResponse(
+                content="answer",
+                finish_reason="stop",
+                reasoning_content="first second",
+            )
+
+    stream = _ProviderOpenAIStream(
+        provider=FakeProvider(),
+        messages=[],
+        tools=None,
+        model="reasoning-model",
+        max_tokens=32,
+        temperature=0.7,
+        reasoning_effort=None,
+        tool_choice=None,
+        extra_kwargs={},
+    )
+
+    chunks = [chunk async for chunk in stream]
+
+    assert [
+        chunk.choices[0].delta.reasoning_content
+        for chunk in chunks
+        if chunk.choices[0].delta.reasoning_content
+    ] == ["first ", "second"]
+
+
+@pytest.mark.asyncio
+async def test_provider_nonstream_exposes_reasoning_and_json_tool_arguments() -> None:
+    class FakeProvider:
+        async def chat(self, **_kwargs):
+            return LLMResponse(
+                content=None,
+                reasoning_content="private reasoning",
+                tool_calls=[
+                    ToolCallRequest(id="call_1|fc_1", name="lookup", arguments={"topic": "fft"})
+                ],
+                finish_reason="stop",
+            )
+
+    adapter = _ProviderOpenAIAdapter(FakeProvider())
+
+    response = await adapter.chat.completions.create(messages=[], stream=False)
+
+    message = response.choices[0].message
+    assert message.reasoning_content == "private reasoning"
+    assert message.tool_calls[0].function.arguments == '{"topic": "fft"}'
 
 
 @pytest.mark.parametrize("binding", ["moonshot", "openai", "custom"])

--- a/tests/services/llm/test_native_web_search.py
+++ b/tests/services/llm/test_native_web_search.py
@@ -279,7 +279,7 @@ class TestParseServerExecutedWebSearch:
         assert result.content == "FFT is O(N log N)."
         assert result.tool_calls == []
         fields = result.provider_specific_fields
-        assert fields["native_output_items"] == [response["output"][0]]
+        assert fields["native_output_items"] == response["output"]
         assert fields["citations"] == [
             {"url": "https://example.com/paper", "title": "Cooley-Tukey"}
         ]

--- a/tests/services/llm/test_openai_compat_reasoning_content.py
+++ b/tests/services/llm/test_openai_compat_reasoning_content.py
@@ -205,6 +205,59 @@ def test_responses_body_replays_persisted_native_output_items() -> None:
     assert body["input"] == native_items
 
 
+def test_responses_body_preserves_provider_call_id_for_tool_output() -> None:
+    provider = ServicesOpenAICompatProvider.__new__(ServicesOpenAICompatProvider)
+    provider.default_model = "gpt-test"
+    provider._spec = find_service_provider("openai")
+    native_items = [
+        {"type": "reasoning", "id": "rs_1", "encrypted_content": "opaque"},
+        {
+            "type": "function_call",
+            "id": "fc_1",
+            "call_id": "call_provider_original",
+            "name": "lookup",
+            "arguments": '{"topic":"fft"}',
+        },
+    ]
+
+    body = provider._build_responses_body(
+        messages=[
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_provider_original|fc_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": '{"topic":"fft"}'},
+                    }
+                ],
+                "_provider_response_state": {"responses_output_items": native_items},
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_provider_original|fc_1",
+                "content": "tool result",
+            },
+        ],
+        tools=None,
+        model="gpt-test",
+        max_tokens=32,
+        temperature=0.7,
+        reasoning_effort=None,
+        tool_choice=None,
+    )
+
+    assert body["input"] == [
+        *native_items,
+        {
+            "type": "function_call_output",
+            "call_id": "call_provider_original",
+            "output": "tool result",
+        },
+    ]
+
+
 def test_services_dashscope_minimal_reasoning_uses_enable_thinking_only() -> None:
     kwargs = _build_services_kwargs("dashscope", "minimal")
 

--- a/tests/services/llm/test_openai_compat_wire_api.py
+++ b/tests/services/llm/test_openai_compat_wire_api.py
@@ -211,6 +211,12 @@ async def test_forced_responses_agentic_stream_maps_tool_calls(monkeypatch) -> N
     class FakeResponses:
         async def create(self, **kwargs):
             captured["request"] = kwargs
+            reasoning_item = SimpleNamespace(
+                type="reasoning",
+                id="rs_123",
+                content=[{"type": "reasoning_text", "text": "inspect protocol"}],
+                encrypted_content="opaque",
+            )
             item = SimpleNamespace(
                 type="function_call",
                 id="fc_123",
@@ -220,6 +226,10 @@ async def test_forced_responses_agentic_stream_maps_tool_calls(monkeypatch) -> N
             )
 
             async def events():
+                yield SimpleNamespace(
+                    type="response.reasoning_text.delta", delta="inspect protocol"
+                )
+                yield SimpleNamespace(type="response.output_item.done", item=reasoning_item)
                 yield SimpleNamespace(type="response.output_item.added", item=item)
                 yield SimpleNamespace(type="response.output_item.done", item=item)
                 yield SimpleNamespace(
@@ -280,8 +290,18 @@ async def test_forced_responses_agentic_stream_maps_tool_calls(monkeypatch) -> N
     assert captured["request"]["stream"] is True
     assert captured["request"]["tools"][0]["name"] == "lookup"
     assert "messages" not in captured["request"]
+    assert [
+        chunk.choices[0].delta.reasoning_content
+        for chunk in chunks
+        if chunk.choices[0].delta.reasoning_content
+    ] == ["inspect protocol"]
     assert chunks[-2].choices[0].delta.tool_calls[0].function.name == "lookup"
+    assert chunks[-2].choices[0].delta.tool_calls[0].function.arguments == '{"query": "protocol"}'
     assert chunks[-1].choices[0].finish_reason == "tool_calls"
+    assert [
+        item["type"]
+        for item in chunks[-1].choices[0].provider_specific_fields["native_output_items"]
+    ] == ["reasoning", "function_call"]
 
 
 class _EndpointError(RuntimeError):

--- a/tests/services/llm/test_openai_responses_converters.py
+++ b/tests/services/llm/test_openai_responses_converters.py
@@ -78,3 +78,52 @@ class TestConvertMessages:
         )
 
         assert input_items == native_items
+
+    def test_replays_reasoning_call_and_tool_output_without_changing_arguments(self) -> None:
+        native_items = [
+            {
+                "type": "reasoning",
+                "id": "rs_1",
+                "content": [{"type": "reasoning_text", "text": "private"}],
+                "encrypted_content": "opaque",
+            },
+            {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_1",
+                "name": "lookup",
+                "arguments": '{"topic":"geometry"}',
+                "caller": "assistant",
+            },
+        ]
+
+        _instructions, input_items = convert_messages(
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1|fc_1",
+                            "type": "function",
+                            "function": {
+                                "name": "lookup",
+                                "arguments": '{"topic":"geometry"}',
+                            },
+                        }
+                    ],
+                    "_provider_response_state": {"responses_output_items": native_items},
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1|fc_1",
+                    "content": "tool result",
+                },
+            ]
+        )
+
+        assert input_items == [
+            *native_items,
+            {"type": "function_call_output", "call_id": "call_1", "output": "tool result"},
+        ]
+        assert isinstance(input_items[1]["arguments"], str)

--- a/tests/services/llm/test_openai_responses_parsing.py
+++ b/tests/services/llm/test_openai_responses_parsing.py
@@ -272,9 +272,7 @@ async def test_summary_reasoning_remains_supported(consumer: str) -> None:
         _, _, _, _, reasoning = await consume_sdk_stream(
             _sdk_events(
                 [
-                    SimpleNamespace(
-                        type="response.reasoning_summary_text.delta", delta="summary "
-                    ),
+                    SimpleNamespace(type="response.reasoning_summary_text.delta", delta="summary "),
                     SimpleNamespace(
                         type="response.reasoning_summary_text.delta", delta="reasoning"
                     ),

--- a/tests/services/llm/test_openai_responses_parsing.py
+++ b/tests/services/llm/test_openai_responses_parsing.py
@@ -10,6 +10,7 @@ import pytest
 from deeptutor.services.llm.provider_core.openai_responses.parsing import (
     consume_sdk_stream,
     consume_sse,
+    parse_response_output,
 )
 
 
@@ -26,6 +27,61 @@ class _SSEFixture:
 async def _sdk_events(events):
     for event in events:
         yield event
+
+
+class _SDKItem(SimpleNamespace):
+    def model_dump(self):
+        return dict(vars(self))
+
+
+def test_nonstream_prefers_reasoning_text_and_preserves_complete_output_order() -> None:
+    output = [
+        {
+            "type": "reasoning",
+            "id": "rs_1",
+            "content": [{"type": "reasoning_text", "text": "raw reasoning"}],
+            "summary": [{"type": "summary_text", "text": "summary fallback"}],
+            "encrypted_content": "encrypted-token",
+            "status": "completed",
+        },
+        {
+            "type": "message",
+            "id": "msg_1",
+            "role": "assistant",
+            "phase": "final_answer",
+            "content": [{"type": "output_text", "text": "visible answer"}],
+            "status": "completed",
+        },
+    ]
+
+    result = parse_response_output(
+        {
+            "output": output,
+            "status": "completed",
+            "usage": {"input_tokens": 3, "output_tokens": 5},
+        }
+    )
+
+    assert result.content == "visible answer"
+    assert result.reasoning_content == "raw reasoning"
+    assert result.provider_specific_fields["native_output_items"] == output
+
+
+def test_nonstream_uses_summary_only_when_raw_reasoning_is_absent() -> None:
+    result = parse_response_output(
+        {
+            "output": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [{"type": "summary_text", "text": "summary only"}],
+                }
+            ],
+            "status": "completed",
+        }
+    )
+
+    assert result.reasoning_content == "summary only"
 
 
 @pytest.mark.asyncio
@@ -99,6 +155,136 @@ async def test_sdk_arguments_can_be_correlated_by_item_id() -> None:
     assert len(tool_calls) == 1
     assert tool_calls[0].id == "call_1|fc_1"
     assert tool_calls[0].arguments == {"topic": "geometry"}
+
+
+@pytest.mark.asyncio
+async def test_sdk_deepseek_reasoning_text_and_function_call_are_forwarded_in_order() -> None:
+    reasoning_item = _SDKItem(
+        type="reasoning",
+        id="rs_1",
+        content=[{"type": "reasoning_text", "text": "inspect then call"}],
+        encrypted_content="encrypted-token",
+        status="completed",
+    )
+    function_item = _SDKItem(
+        type="function_call",
+        id="fc_1",
+        call_id="call_1",
+        name="lookup",
+        arguments='{"topic":"geometry"}',
+        status="completed",
+        caller="assistant",
+    )
+    events = [
+        SimpleNamespace(type="response.reasoning_text.delta", delta="inspect "),
+        SimpleNamespace(type="response.reasoning_text.delta", delta="then call"),
+        SimpleNamespace(type="response.reasoning_text.done", text="inspect then call"),
+        SimpleNamespace(type="response.output_item.done", item=reasoning_item),
+        SimpleNamespace(type="response.output_item.added", item=function_item),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_1",
+            arguments='{"topic":"geometry"}',
+        ),
+        SimpleNamespace(type="response.output_item.done", item=function_item),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed", usage=None),
+        ),
+    ]
+    reasoning_deltas: list[str] = []
+    provider_events: list[tuple[str, dict]] = []
+
+    _, tool_calls, _, _, reasoning = await consume_sdk_stream(
+        _sdk_events(events),
+        on_reasoning_delta=lambda text: _append_async(reasoning_deltas, text),
+        on_provider_event=lambda kind, payload: provider_events.append((kind, payload)),
+    )
+
+    assert reasoning == "inspect then call"
+    assert reasoning_deltas == ["inspect ", "then call"]
+    assert tool_calls[0].arguments == {"topic": "geometry"}
+    assert [payload for kind, payload in provider_events if kind == "output_item"] == [
+        reasoning_item.model_dump(),
+        function_item.model_dump(),
+    ]
+
+
+async def _append_async(values: list[str], value: str) -> None:
+    values.append(value)
+
+
+@pytest.mark.asyncio
+async def test_sse_supports_reasoning_text_and_preserves_message_item() -> None:
+    reasoning_item = {
+        "type": "reasoning",
+        "id": "rs_1",
+        "content": [{"type": "reasoning_text", "text": "raw"}],
+        "encrypted_content": "encrypted-token",
+    }
+    message_item = {
+        "type": "message",
+        "id": "msg_1",
+        "role": "assistant",
+        "phase": "final_answer",
+        "content": [{"type": "output_text", "text": "answer"}],
+    }
+    events = [
+        {"type": "response.reasoning_text.delta", "delta": "raw"},
+        {"type": "response.reasoning_text.done", "text": "raw"},
+        {"type": "response.output_item.done", "item": reasoning_item},
+        {"type": "response.output_text.delta", "delta": "answer"},
+        {"type": "response.output_item.done", "item": message_item},
+    ]
+    reasoning_deltas: list[str] = []
+    provider_events: list[tuple[str, dict]] = []
+
+    content, _, _ = await consume_sse(
+        _SSEFixture(events),
+        on_reasoning_delta=lambda text: _append_async(reasoning_deltas, text),
+        on_provider_event=lambda kind, payload: provider_events.append((kind, payload)),
+    )
+
+    assert content == "answer"
+    assert reasoning_deltas == ["raw"]
+    assert [payload for kind, payload in provider_events if kind == "output_item"] == [
+        reasoning_item,
+        message_item,
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("consumer", ["sse", "sdk"])
+async def test_summary_reasoning_remains_supported(consumer: str) -> None:
+    reasoning_deltas: list[str] = []
+    if consumer == "sse":
+        await consume_sse(
+            _SSEFixture(
+                [
+                    {"type": "response.reasoning_summary_text.delta", "delta": "summary "},
+                    {"type": "response.reasoning_summary_text.delta", "delta": "reasoning"},
+                ]
+            ),
+            on_reasoning_delta=lambda text: _append_async(reasoning_deltas, text),
+        )
+        reasoning = "".join(reasoning_deltas)
+    else:
+        _, _, _, _, reasoning = await consume_sdk_stream(
+            _sdk_events(
+                [
+                    SimpleNamespace(
+                        type="response.reasoning_summary_text.delta", delta="summary "
+                    ),
+                    SimpleNamespace(
+                        type="response.reasoning_summary_text.delta", delta="reasoning"
+                    ),
+                ]
+            ),
+            on_reasoning_delta=lambda text: _append_async(reasoning_deltas, text),
+        )
+
+    assert reasoning == "summary reasoning"
+    assert reasoning_deltas == ["summary reasoning"]
 
 
 @pytest.mark.asyncio

--- a/tests/services/session/test_provider_response_state.py
+++ b/tests/services/session/test_provider_response_state.py
@@ -67,6 +67,29 @@ def test_normalize_drops_oversized_or_unknown_protocol_state() -> None:
     )
 
 
+def test_normalize_preserves_native_web_search_items_in_order() -> None:
+    items = [
+        {"type": "reasoning", "id": "rs_1", "encrypted_content": "opaque"},
+        {
+            "type": "web_search_call",
+            "id": "ws_1",
+            "status": "completed",
+            "action": {"type": "search", "query": "fft"},
+        },
+        {"type": "web_search", "id": "ws_2", "status": "completed"},
+        {
+            "type": "message",
+            "id": "msg_1",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "answer"}],
+        },
+    ]
+
+    state = normalize_provider_response_state({"responses_output_items": items})
+
+    assert state == {"responses_output_items": items}
+
+
 def test_redact_private_message_metadata_preserves_public_metadata() -> None:
     messages = [
         {


### PR DESCRIPTION
## Summary

- parse raw Responses API reasoning text events and fall back to reasoning summaries only when raw text is unavailable
- preserve complete ordered reasoning, message, function call, and native web search output items for stateless replay with `store=false`
- forward reasoning deltas through the OpenAI-style agent adapter and persist private provider state without exposing reasoning publicly
- preserve provider function call IDs across Responses continuations so tool outputs match the original call

## Validation

- `152 passed` in the targeted Responses, adapter, agent loop, native web search, and session-state suite on the latest `dev`
- `658 passed` in the broader `tests/services/llm`, `tests/agents/chat`, and `tests/services/session` suite in the configured workspace
- Ruff and `git diff --check` passed
- live DeepSeek V4 Flash smoke tests passed for two-turn Responses chat, thinking-mode function continuation, and `wire_api=auto` native web search

No public API, configuration format, database schema, routing policy, or DeepSeek-specific fallback was added.