### PR TITLE
fix(cron): guard fcntl for Windows (msvcrt fallback)

### DIFF
--- a/deeptutor/services/cron/repository.py
+++ b/deeptutor/services/cron/repository.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 import contextlib
-import fcntl
 import json
+import os
 from pathlib import Path
 import sqlite3
+import sys
 import time
 from typing import Any, Protocol
 
@@ -49,11 +50,30 @@ class SQLiteCronRepository:
     def _migration_lock(self):
         self._migration_lock_path.parent.mkdir(parents=True, exist_ok=True)
         with self._migration_lock_path.open("a+b") as handle:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            # Mirror ``codex_auth.storage._locked_file``: msvcrt on Windows
+            # (fcntl is Unix-only), so importing this module does not break
+            # ``deeptutor start`` on Windows.
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"\0")
+                handle.flush()
+            handle.seek(0)
+            if sys.platform == "win32":
+                import msvcrt
+
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
             try:
                 yield
             finally:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                handle.seek(0)
+                if sys.platform == "win32":
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
     @staticmethod
     def _is_sqlite(path: Path) -> bool:

--- a/tests/api/test_websocket_routing.py
+++ b/tests/api/test_websocket_routing.py
@@ -19,9 +19,7 @@ def test_websocket_routes_share_one_canonical_namespace() -> None:
         "/ws/partner-groups/{group_id}",
     }
     websocket_routes = {
-        route.path: route
-        for route in app.routes
-        if isinstance(route, APIWebSocketRoute)
+        route.path: route for route in app.routes if isinstance(route, APIWebSocketRoute)
     }
 
     assert set(websocket_routes) == expected_paths

--- a/tests/services/cron/test_cron_repository.py
+++ b/tests/services/cron/test_cron_repository.py
@@ -1,0 +1,81 @@
+"""SQLiteCronRepository migration lock: cross-platform branches and mutual exclusion."""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from deeptutor.services.cron import repository
+
+
+class TestMigrationLock:
+    def test_acquire_release_round_trip(self, tmp_path):
+        repo = repository.SQLiteCronRepository(tmp_path / "cron.db")
+        with repo._migration_lock():
+            assert repo._migration_lock_path.exists()
+
+    def test_mutually_excludes_concurrent_holders(self, tmp_path):
+        repo = repository.SQLiteCronRepository(tmp_path / "cron.db")
+        entered = threading.Event()
+
+        def holder():
+            with repo._migration_lock():
+                entered.set()
+                time.sleep(0.3)
+
+        t = threading.Thread(target=holder)
+        t.start()
+        assert entered.wait(2)
+        started = time.monotonic()
+        with repo._migration_lock():
+            waited = time.monotonic() - started
+        t.join(timeout=5)
+        assert not t.is_alive()
+        # A second acquirer must block until the holder releases its lock.
+        assert waited >= 0.2
+
+    def test_module_does_not_bind_fcntl_at_import(self):
+        # Top-level ``import fcntl`` breaks ``deeptutor start`` on Windows (#1140).
+        assert "fcntl" not in repository.__dict__
+
+    def test_uses_msvcrt_locking_on_windows(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
+        repo = repository.SQLiteCronRepository(tmp_path / "cron.db")
+        calls: list[tuple[int, int]] = []
+        fake_msvcrt = SimpleNamespace(
+            LK_LOCK=1,
+            LK_UNLCK=2,
+            locking=lambda _fileno, mode, length: calls.append((mode, length)),
+        )
+        monkeypatch.setattr(repository, "sys", SimpleNamespace(platform="win32"))
+        monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
+
+        with repo._migration_lock():
+            assert calls == [(fake_msvcrt.LK_LOCK, 1)]
+
+        assert calls == [
+            (fake_msvcrt.LK_LOCK, 1),
+            (fake_msvcrt.LK_UNLCK, 1),
+        ]
+
+    def test_uses_fcntl_locking_on_posix(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
+        repo = repository.SQLiteCronRepository(tmp_path / "cron.db")
+        calls: list[int] = []
+        fake_fcntl = SimpleNamespace(
+            LOCK_EX=1,
+            LOCK_UN=2,
+            flock=lambda _fileno, mode: calls.append(mode),
+        )
+        monkeypatch.setattr(repository, "sys", SimpleNamespace(platform="linux"))
+        monkeypatch.setitem(sys.modules, "fcntl", fake_fcntl)
+
+        with repo._migration_lock():
+            assert calls == [fake_fcntl.LOCK_EX]
+
+        assert calls == [
+            fake_fcntl.LOCK_EX,
+            fake_fcntl.LOCK_UN,
+        ]


### PR DESCRIPTION
### Description
 deeptutor/services/cron/repository.py had a bare top-level import fcntl, which is a POSIX-only module. On Windows, importing deeptutor.services.cron (triggered by the background leader's _start_cron path) raised ModuleNotFoundError: No module named 'fcntl', so the cron service silently failed to start even though the app appeared usable.                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                        
 The migration lock was rewritten to be cross-platform by mirroring the existing codex_auth.storage._locked_file pattern:                                                                                                                                                               
                                                                                                                                                                                                                                                                                        
 - Windows (sys.platform == "win32"): uses msvcrt.locking(LK_LOCK / LK_UNLCK), including the \0 seed byte msvcrt requires for locking a non-empty region.                                                                                                                               
 - POSIX: unchanged behavior via fcntl.flock(LOCK_EX / LOCK_UN), imported lazily inside the branch.                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                        
 This was the last unguarded fcntl usage in the repository — the other 7 sites already had platform guards (verified via codebase-memory graph). No public contract changed; lock semantics (mutual exclusion, crash-safe release on fd close) are preserved on both platforms.         
                                                                                                                                                                                                                                                                                        
 Tests added in tests/services/cron/test_cron_repository.py:                                                                                                                                                                                                                            
 - real msvcrt round-trip + mutual-exclusion (executed on Windows)                                                                                                                                                                                                                      
 - branch behavior via fake-injection for both msvcrt (Windows) and fcntl (POSIX) lock call sequences                                                                                                                                                                                   
 - regression guard asserting no top-level import fcntl 

### Related Issues
 - Closes #… (first noticed when deeptutor start logged ModuleNotFoundError: No module named 'fcntl' on Windows 11)                                                                                                                                                                     

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
 - Verification: tests/services/cron/ 32 passed (3 runs, including full-suite conditions with Redis); ruff/import-linter/architecture checks green. Full suite: 6191 passed; 58 failures are platform/environment-specific (bwrap sandbox, macOS launcher, missing local redis pip  package) with zero overlap with cron.   
 
 
 
 ### Logs
```
 ModuleNotFoundError: No module named 'fcntl'                                                                                                                                                                                                                                           
   backend  ERROR   deeptutor.runtime.background_leader - Background leader loop failed on worker fy:7368:4cf058a9                                                                                                                                                                      
   backend  Traceback (most recent call last):                                                                                                                                                                                                                                          
   backend    File "D:\DeepTutor\deeptutor\runtime\background_leader.py", line 82, in _run                                                                                                                                                                                  
   backend      await self._while_leader(self._start_services())                                                                                                                                                                                                                        
   backend    File "D:\DeepTutor\deeptutor\runtime\background_leader.py", line 173, in _while_leader                                                                                                                                                                        
   backend      await operation_task                                                                                                                                                                                                                                                    
   backend    File "D:\DeepTutor\deeptutor\runtime\background_leader.py", line 204, in _start_services                                                                                                                                                                      
   backend      await callback()                                                                                                                                                                                                                                                        
   backend    File "D:\DeepTutor\deeptutor\api\main.py", line 187, in start_cron                                                                                                                                                                                            
   backend      from deeptutor.services.cron import get_cron_service                                                                                                                                                                                                                    
   backend    File "D:\DeepTutor\deeptutor\services\cron__init_.py", line 3, in <module>                                                                                                                                                                                    
   backend      from deeptutor.services.cron.repository import CronRepository, SQLiteCronRepository                                                                                                                                                                                     
   backend    File "D:\DeepTutor\deeptutor\services\cron\repository.py", line 7, in <module>                                                                                                                                                                                
   backend      import fcntl                                                                                                                                                                                                                                                            
   backend  ModuleNotFoundError: No module named 'fcntl'                                                                                                                                                                                                                                
   backend  ERROR   deeptutor.runtime.background_leader - Background leader loop failed on worker fy:7368:4cf058a9 
```