### PR TITLE
fix(update): detect source checkouts before enabling auto-update

### DIFF
--- a/deeptutor/services/app_update.py
+++ b/deeptutor/services/app_update.py
@@ -166,6 +166,15 @@ def _distribution_direct_url() -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else {}
 
 
+def _running_from_source_checkout() -> bool:
+    """Return whether the imported package lives in a Git source checkout."""
+    try:
+        checkout_root = Path(__file__).resolve().parents[2]
+    except IndexError:
+        return False
+    return (checkout_root / ".git").exists() and (checkout_root / "pyproject.toml").is_file()
+
+
 def detect_installation() -> Installation:
     """Classify only layouts whose update ownership is unambiguous."""
 
@@ -176,6 +185,15 @@ def detect_installation() -> Installation:
             automatic_update=False,
             command="docker pull ghcr.io/hkuds/deeptutor:latest",
             reason="Container images are updated and recreated by the Docker host.",
+        )
+
+    if _running_from_source_checkout():
+        return Installation(
+            mode="source",
+            current_version=__version__,
+            automatic_update=False,
+            command="git pull && pip install -e .",
+            reason="Source checkouts stay under the developer's Git workflow.",
         )
 
     direct_url = _distribution_direct_url()

--- a/tests/services/test_app_update.py
+++ b/tests/services/test_app_update.py
@@ -151,6 +151,7 @@ def test_detect_installation_keeps_source_and_docker_host_managed(
     assert app_update.detect_installation().mode == "docker"
 
     monkeypatch.setattr(app_update, "_running_in_container", lambda: False)
+    monkeypatch.setattr(app_update, "_running_from_source_checkout", lambda: False)
     monkeypatch.setattr(
         app_update,
         "_distribution_direct_url",
@@ -164,6 +165,33 @@ def test_detect_installation_keeps_source_and_docker_host_managed(
     installation = app_update.detect_installation()
     assert installation.mode == "pypi"
     assert installation.automatic_update is True
+
+
+def test_detect_installation_prefers_source_checkout_when_metadata_is_shadowed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    checkout_root = tmp_path / "DeepTutor"
+    module_path = checkout_root / "deeptutor" / "services" / "app_update.py"
+    module_path.parent.mkdir(parents=True)
+    module_path.touch()
+    (checkout_root / ".git").mkdir()
+    (checkout_root / "pyproject.toml").write_text(
+        '[project]\nname = "deeptutor"\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(app_update, "__file__", str(module_path))
+    monkeypatch.setattr(app_update, "_running_in_container", lambda: False)
+    monkeypatch.setattr(app_update, "_distribution_direct_url", lambda: {})
+    monkeypatch.setattr(app_update.sys, "prefix", str(tmp_path / "venv"))
+    monkeypatch.setattr(app_update.sys, "base_prefix", str(tmp_path / "base"))
+
+    installation = app_update.detect_installation()
+
+    assert installation.mode == "source"
+    assert installation.automatic_update is False
+    assert installation.command == "git pull && pip install -e ."
 
 
 def test_update_job_store_persists_trusted_lifecycle(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Detect source checkouts before enabling application self-update.
- Keep source installations on their normal Git/developer update path.
- Remove unrelated reader, WebSocket-formatting, CI, and route-test commits that were previously stacked on this branch.
- Rebased onto current `dev`.

## Verification
- `pytest tests/services/test_app_update.py -q` — 11 passed
- `ruff check` and `ruff format --check` on touched files — passed.