### PR TITLE
fix(mastery): restore Save to Notebook and turn navigator

### DIFF
--- a/web/components/space/learning/MasteryStudy.tsx
+++ b/web/components/space/learning/MasteryStudy.tsx
@@ -5,6 +5,7 @@ import { browserStorage } from "@/shared/storage";
 import Link from "next/link";
 import {
   ArrowLeft,
+  BookmarkPlus,
   Compass,
   Flag,
   Loader2,
@@ -13,7 +14,8 @@ import {
   PanelRight,
   Sparkles,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import dynamic from "next/dynamic";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ChatMessageList } from "@/features/chat/messages";
@@ -22,6 +24,7 @@ import { buildSessionActivity } from "@/components/chat/home/SessionActivityPane
 import SessionViewerPanel, {
   type SessionViewerPanelHandle,
 } from "@/components/chat/home/SessionViewerPanel";
+import { TurnNavigator } from "@/components/chat/home/TurnNavigator";
 import { useChatStateAdapter } from "@/features/chat/ChatStateAdapter";
 import { TurnStatusBar } from "@/features/chat/components/turn";
 import { turnViewState } from "@/features/chat/model/turn-state";
@@ -29,10 +32,16 @@ import { useChatAutoScroll } from "@/hooks/useChatAutoScroll";
 import { useMasteryStudySession } from "@/hooks/useMasteryStudySession";
 import { useMeasuredHeight } from "@/hooks/useMeasuredHeight";
 import { useResearchOutlineContinuation } from "@/hooks/useResearchOutlineContinuation";
+import { buildChatOutline } from "@/lib/chat-outline";
 import { fetchMasteryAskHint, type MasteryTopic } from "@/lib/learning-api";
 import { consumePendingPrompt } from "@/lib/pending-prompt";
 import { hasPendingAskUser } from "@/lib/ask-user-state";
 import { workspaceActionNeedsConfiguration } from "@/lib/workspace-mode";
+
+const SaveToNotebookModal = dynamic(
+  () => import("@/components/notebook/SaveToNotebookModal"),
+  { ssr: false },
+);
 
 import { topicDisplayName, type Translate } from "./format";
 import { LevelUpCelebration } from "./LevelUpCelebration";
@@ -99,7 +108,49 @@ export function MasteryStudy({
   const prefillInputRef = useRef<((text: string) => void) | null>(null);
   const viewerPanelRef = useRef<SessionViewerPanelHandle | null>(null);
   const [viewerOpen, setViewerOpen] = useState(false);
+  const [showSaveModal, setShowSaveModal] = useState(false);
   const sessionActivity = buildSessionActivity(state.messages);
+  const chatOutline = useMemo(
+    () => buildChatOutline(state.messages, state.selectedBranches),
+    [state.messages, state.selectedBranches],
+  );
+  const chatSaveMessages = useMemo(
+    () =>
+      state.messages.map((msg) => ({
+        role: msg.role,
+        content: msg.content,
+        capability: msg.capability,
+      })),
+    [state.messages],
+  );
+  const chatSavePayload = useMemo(() => {
+    if (!state.messages.length) return null;
+    const title =
+      state.messages
+        .find((msg) => msg.role === "user")
+        ?.content.trim()
+        .slice(0, 80) || "Mastery Path Session";
+    return {
+      recordType: "chat" as const,
+      title,
+      userQuery: "",
+      output: "",
+      metadata: {
+        source: "mastery_path",
+        capability: state.activeCapability || "mastery_path",
+        ui_language: state.language,
+        session_id: state.sessionId,
+        path_id: pathId,
+        total_message_count: state.messages.length,
+      },
+    };
+  }, [
+    pathId,
+    state.activeCapability,
+    state.language,
+    state.messages,
+    state.sessionId,
+  ]);
   /* ── Transcript scrolling ────────────────────────────────────────────
      Was a bare `scrollIntoView` keyed on message count — no notion of the
      user having scrolled away, so it yanked the view back to the bottom
@@ -119,6 +170,7 @@ export function MasteryStudy({
     containerRef: messagesContainerRef,
     endRef: messagesEndRef,
     shouldAutoScrollRef,
+    scrollToBottom,
     handleScroll: handleMessagesScroll,
   } = useChatAutoScroll({
     hasMessages,
@@ -128,6 +180,42 @@ export function MasteryStudy({
     lastMessageContent: lastMessage?.content,
     lastEventCount: lastMessage?.events?.length,
   });
+  const jumpToTurn = useCallback(
+    (key: string) => {
+      const container = messagesContainerRef.current;
+      const target = container?.querySelector<HTMLElement>(
+        `[data-turn-key="${key}"]`,
+      );
+      if (!container || !target) return;
+      // Release the streaming pin first: without this, a jump made while
+      // a turn is generating would be snapped straight back to the bottom
+      // by ``useChatAutoScroll``'s next content-growth pin.
+      shouldAutoScrollRef.current = false;
+      const offset =
+        target.getBoundingClientRect().top -
+        container.getBoundingClientRect().top;
+      // 56 px clears the scrollport's top fade so the bubble lands fully
+      // opaque rather than half-dissolved under the mask.
+      container.scrollTo({
+        top: container.scrollTop + offset - 56,
+        behavior: "smooth",
+      });
+      const bubble =
+        target.querySelector<HTMLElement>("[data-turn-bubble]") ?? target;
+      bubble.classList.remove("turn-flash");
+      // Force a reflow so clicking the same tick twice replays the flash
+      // instead of silently re-adding a class that is already settled.
+      void bubble.offsetWidth;
+      bubble.classList.add("turn-flash");
+      window.setTimeout(() => bubble.classList.remove("turn-flash"), 1300);
+    },
+    [messagesContainerRef, shouldAutoScrollRef],
+  );
+  /** Leave history and start following the live end of the turn again. */
+  const resumeFollowingLatest = useCallback(() => {
+    shouldAutoScrollRef.current = true;
+    scrollToBottom("instant");
+  }, [scrollToBottom, shouldAutoScrollRef]);
   // A new turn is the clearest possible "show me the answer" — re-arm the
   // pin even if a previous turn's browsing had released it.
   useEffect(() => {
@@ -338,6 +426,16 @@ export function MasteryStudy({
         <div className="flex shrink-0 items-center gap-1.5 pl-2">
           <button
             type="button"
+            onClick={() => setShowSaveModal(true)}
+            disabled={!chatSavePayload}
+            className="flex h-8 w-8 items-center justify-center rounded-lg text-[var(--muted-foreground)] transition-colors hover:bg-[var(--muted)]/60 hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
+            title={t("Save to Notebook")}
+            aria-label={t("Save to Notebook")}
+          >
+            <BookmarkPlus className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
             onClick={() => setViewerOpen((open) => !open)}
             className="flex h-8 w-8 items-center justify-center rounded-lg text-[var(--muted-foreground)] transition-colors hover:bg-[var(--muted)]/60 hover:text-[var(--foreground)]"
             aria-label={t("Activity")}
@@ -373,109 +471,125 @@ export function MasteryStudy({
         </aside>
 
         <section className="flex min-w-0 flex-1 flex-col bg-[var(--background)]">
-          <div
-            ref={messagesContainerRef}
-            // Opts this scrollport into the global `overflow-anchor: none`
-            // rule; without it the browser's own scroll anchoring fights
-            // the pin every time a code block or KaTeX span reflows.
-            data-chat-scroll-root="true"
-            onScroll={() => {
-              const container = messagesContainerRef.current;
-              if (!container) return;
-              const distanceFromBottom =
-                container.scrollHeight -
-                container.scrollTop -
-                container.clientHeight;
-              // Arm-only while streaming: position alone should never
-              // RELEASE the pin mid-turn (a gesture already does that,
-              // unconditionally, inside the hook) — only ever confirm the
-              // user scrolled back down to resume following.
-              if (distanceFromBottom < 80) {
-                shouldAutoScrollRef.current = true;
-              } else if (!state.isStreaming) {
-                handleMessagesScroll();
-              }
-            }}
-            className="min-h-0 flex-1 overflow-y-auto [scrollbar-gutter:stable]"
-          >
-            <div className="mx-auto w-full max-w-[900px] px-4 pb-8 pt-7 sm:px-7">
-              {sessionLoading ? (
-                <div className="flex min-h-[45vh] flex-col items-center justify-center text-sm text-[var(--muted-foreground)]">
-                  <Loader2 className="mb-3 h-5 w-5 animate-spin" />
-                  {t("Reopening this session…")}
-                </div>
-              ) : sessionError ? (
-                <div className="mx-auto mt-20 max-w-md rounded-xl border border-red-500/20 bg-red-500/5 p-6 text-center">
-                  <MessageCircle className="mx-auto h-8 w-8 text-red-500/60" />
-                  <h2 className="mt-3 text-sm font-semibold">
-                    {t("The session did not open")}
-                  </h2>
-                  <p className="mt-2 text-xs leading-5 text-[var(--muted-foreground)]">
-                    {sessionError}
-                  </p>
-                  <Link
-                    href={`/mastery/${encodeURIComponent(pathId)}/sessions`}
-                    className="mt-4 inline-flex rounded-xl bg-[var(--primary)] px-3 py-2 text-xs font-medium text-[var(--primary-foreground)]"
-                  >
-                    {t("Start a new session")}
-                  </Link>
-                </div>
-              ) : !hasMessages ? (
-                <div className="mx-auto flex min-h-[54vh] max-w-2xl flex-col items-center justify-center text-center">
-                  <div className="text-[12px] text-[var(--muted-foreground)]">
-                    {t("Next up")}
+          {/* Positioned wrapper spanning exactly the scrollport, so the
+              turn navigator can overlay the left gutter without living
+              inside the scroll container. */}
+          <div className="relative flex min-h-0 flex-1 flex-col">
+            <div
+              ref={messagesContainerRef}
+              // Opts this scrollport into the global `overflow-anchor: none`
+              // rule; without it the browser's own scroll anchoring fights
+              // the pin every time a code block or KaTeX span reflows.
+              data-chat-scroll-root="true"
+              onScroll={() => {
+                const container = messagesContainerRef.current;
+                if (!container) return;
+                const distanceFromBottom =
+                  container.scrollHeight -
+                  container.scrollTop -
+                  container.clientHeight;
+                // Arm-only while streaming: position alone should never
+                // RELEASE the pin mid-turn (a gesture already does that,
+                // unconditionally, inside the hook) — only ever confirm the
+                // user scrolled back down to resume following.
+                if (distanceFromBottom < 80) {
+                  shouldAutoScrollRef.current = true;
+                } else if (!state.isStreaming) {
+                  handleMessagesScroll();
+                }
+              }}
+              className="min-h-0 flex-1 overflow-y-auto [scrollbar-gutter:stable]"
+            >
+              <div
+                data-chat-column="true"
+                className="mx-auto w-full max-w-[900px] px-4 pb-8 pt-7 sm:px-7"
+              >
+                {sessionLoading ? (
+                  <div className="flex min-h-[45vh] flex-col items-center justify-center text-sm text-[var(--muted-foreground)]">
+                    <Loader2 className="mb-3 h-5 w-5 animate-spin" />
+                    {t("Reopening this session…")}
                   </div>
-                  <h2 className="mt-1.5 font-serif text-[20px] font-semibold tracking-[-0.01em] text-[var(--foreground)]">
-                    {waypoint.name}
-                  </h2>
-                  <p className="mt-2 max-w-xl text-sm leading-6 text-[var(--muted-foreground)]">
-                    {t(
-                      "Your tutor adapts to your answers. Begin with a quick check, an intuitive explanation, or a challenge.",
-                    )}
-                  </p>
-                  <div className="mt-7 grid w-full gap-2 sm:grid-cols-3">
-                    {STARTERS.map((starter) => {
-                      const Icon = starter.icon;
-                      const label = t(starter.key);
-                      return (
-                        <button
-                          key={starter.key}
-                          type="button"
-                          onClick={() => startFromPrompt(label)}
-                          disabled={state.isStreaming || sessionLoading}
-                          className="group rounded-lg border border-[var(--border)] bg-[var(--card)] p-4 text-left transition hover:-translate-y-0.5 hover:border-[var(--primary)]/35 disabled:opacity-50"
-                        >
-                          <Icon className="h-4 w-4 text-[var(--primary)]" />
-                          <span className="mt-3 block text-xs font-medium leading-5 text-[var(--foreground)]">
-                            {label}
-                          </span>
-                        </button>
-                      );
-                    })}
+                ) : sessionError ? (
+                  <div className="mx-auto mt-20 max-w-md rounded-xl border border-red-500/20 bg-red-500/5 p-6 text-center">
+                    <MessageCircle className="mx-auto h-8 w-8 text-red-500/60" />
+                    <h2 className="mt-3 text-sm font-semibold">
+                      {t("The session did not open")}
+                    </h2>
+                    <p className="mt-2 text-xs leading-5 text-[var(--muted-foreground)]">
+                      {sessionError}
+                    </p>
+                    <Link
+                      href={`/mastery/${encodeURIComponent(pathId)}/sessions`}
+                      className="mt-4 inline-flex rounded-xl bg-[var(--primary)] px-3 py-2 text-xs font-medium text-[var(--primary-foreground)]"
+                    >
+                      {t("Start a new session")}
+                    </Link>
                   </div>
-                </div>
-              ) : (
-                <div className="space-y-9">
-                  <ChatMessageList
-                    messages={state.messages}
-                    isStreaming={state.isStreaming}
-                    sessionId={state.sessionId}
-                    language={state.language}
-                    onCopyAssistantMessage={copyAssistantMessage}
-                    onRegenerateMessage={regenerateLastMessage}
-                    onDeleteTurn={deleteTurn}
-                    selectedBranches={state.selectedBranches}
-                    onEditMessage={editMessage}
-                    onSwitchBranch={switchBranch}
-                    onSubmitUserReply={submitUserReply}
-                    onConfirmOutline={confirmResearchOutline}
-                    availableKbNames={new Set(knowledgeBases)}
-                    showModeBadge={false}
-                  />
-                </div>
-              )}
-              <div ref={messagesEndRef} className="h-px" />
+                ) : !hasMessages ? (
+                  <div className="mx-auto flex min-h-[54vh] max-w-2xl flex-col items-center justify-center text-center">
+                    <div className="text-[12px] text-[var(--muted-foreground)]">
+                      {t("Next up")}
+                    </div>
+                    <h2 className="mt-1.5 font-serif text-[20px] font-semibold tracking-[-0.01em] text-[var(--foreground)]">
+                      {waypoint.name}
+                    </h2>
+                    <p className="mt-2 max-w-xl text-sm leading-6 text-[var(--muted-foreground)]">
+                      {t(
+                        "Your tutor adapts to your answers. Begin with a quick check, an intuitive explanation, or a challenge.",
+                      )}
+                    </p>
+                    <div className="mt-7 grid w-full gap-2 sm:grid-cols-3">
+                      {STARTERS.map((starter) => {
+                        const Icon = starter.icon;
+                        const label = t(starter.key);
+                        return (
+                          <button
+                            key={starter.key}
+                            type="button"
+                            onClick={() => startFromPrompt(label)}
+                            disabled={state.isStreaming || sessionLoading}
+                            className="group rounded-lg border border-[var(--border)] bg-[var(--card)] p-4 text-left transition hover:-translate-y-0.5 hover:border-[var(--primary)]/35 disabled:opacity-50"
+                          >
+                            <Icon className="h-4 w-4 text-[var(--primary)]" />
+                            <span className="mt-3 block text-xs font-medium leading-5 text-[var(--foreground)]">
+                              {label}
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="space-y-9">
+                    <ChatMessageList
+                      messages={state.messages}
+                      isStreaming={state.isStreaming}
+                      sessionId={state.sessionId}
+                      language={state.language}
+                      onCopyAssistantMessage={copyAssistantMessage}
+                      onRegenerateMessage={regenerateLastMessage}
+                      onDeleteTurn={deleteTurn}
+                      selectedBranches={state.selectedBranches}
+                      onEditMessage={editMessage}
+                      onSwitchBranch={switchBranch}
+                      onSubmitUserReply={submitUserReply}
+                      onConfirmOutline={confirmResearchOutline}
+                      availableKbNames={new Set(knowledgeBases)}
+                      showModeBadge={false}
+                    />
+                  </div>
+                )}
+                <div ref={messagesEndRef} className="h-px" />
+              </div>
             </div>
+            {hasMessages ? (
+              <TurnNavigator
+                entries={chatOutline}
+                scrollRootRef={messagesContainerRef}
+                onJump={jumpToTurn}
+                onJumpToBottom={resumeFollowingLatest}
+              />
+            ) : null}
           </div>
 
           {!sessionError && (
@@ -518,6 +632,12 @@ export function MasteryStudy({
         onAutoOpen={() => setViewerOpen(true)}
       />
       <ChatViewerBridges viewerPanelRef={viewerPanelRef} />
+      <SaveToNotebookModal
+        open={showSaveModal}
+        payload={chatSavePayload}
+        messages={chatSaveMessages}
+        onClose={() => setShowSaveModal(false)}
+      />
     </main>
   );
 }

--- a/web/tests/mastery-study-notebook-nav.test.ts
+++ b/web/tests/mastery-study-notebook-nav.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+function source(file: string): string {
+  return readFileSync(path.resolve(process.cwd(), file), "utf8");
+}
+
+/**
+ * Mastery Study used to ship only a progress outline rail and Activity panel,
+ * dropping the chat turn navigator and Save-to-Notebook entry that regular
+ * chat still exposes (#1182). Guard the wiring so those tools stay available
+ * on the study surface.
+ */
+test("MasteryStudy restores turn navigation and Save to Notebook", () => {
+  const study = source("components/space/learning/MasteryStudy.tsx");
+
+  assert.match(study, /import \{ TurnNavigator \}/);
+  assert.match(study, /from "@\/lib\/chat-outline"/);
+  assert.match(study, /buildChatOutline\(/);
+  assert.match(study, /<TurnNavigator/);
+  assert.match(study, /data-chat-column="true"/);
+  assert.match(study, /SaveToNotebookModal/);
+  assert.match(study, /t\("Save to Notebook"\)/);
+  assert.match(study, /BookmarkPlus/);
+  assert.match(study, /setShowSaveModal\(true\)/);
+});


### PR DESCRIPTION
## Summary
- Restore the chat **turn navigator** (left-gutter jump rail) on Mastery Study, matching `ChatWorkspace`: `buildChatOutline` + `TurnNavigator` over a positioned scrollport with `data-chat-column`.
- Restore the header **Save to Notebook** action and `SaveToNotebookModal` so mastery sessions can be filed like regular chat (metadata tags `source: mastery_path`).
- Keep the existing progress `StudyOutline` rail; it answers “where am I on the map,” while the turn navigator answers “jump to a prior question.”

## Related
- Fixes #1182

## Test plan
- [x] `cd web && npm run test:node -- mastery-study-notebook-nav`
- [ ] Open `/mastery/{pathId}/sessions/{sessionId}` with a multi-turn transcript — left gutter ticks jump to turns; Alt+↑/↓ still work
- [ ] Header bookmark opens Save to Notebook with selectable messages; save lands in a notebook
- [ ] Empty / loading study states leave Save disabled and hide the turn rail