### PR TITLE
perf(session): lazily load turn event traces

### DIFF
--- a/deeptutor/api/routers/sessions.py
+++ b/deeptutor/api/routers/sessions.py
@@ -165,6 +165,20 @@ async def get_session(session_id: str):
     return session
 
 
+@router.get("/{session_id}/messages/{message_id}/events")
+async def get_message_events(
+    session_id: str,
+    message_id: str,
+    after_seq: int = Query(default=0, ge=0),
+    limit: int = Query(default=500, ge=1, le=1000),
+):
+    store = get_session_store()
+    trace = await store.get_message_trace(session_id, message_id, after_seq, limit)
+    if trace is None:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return trace
+
+
 @router.get("/{session_id}/ask-hint")
 async def get_session_ask_hint(session_id: str) -> dict[str, Any]:
     """One line the user is likely to type next, for the home composer placeholder."""

--- a/deeptutor/services/session/event_preview.py
+++ b/deeptutor/services/session/event_preview.py
@@ -54,24 +54,23 @@ def _is_critical(event: dict[str, Any]) -> bool:
 def _truncate_legacy_payloads(event: dict[str, Any]) -> dict[str, Any]:
     """Bound old embedded payloads without mutating the source event."""
     truncated = False
+    bounded = copy.deepcopy(event)
 
     def cap(container: dict[str, Any], field: str) -> None:
         nonlocal truncated
         value = container.get(field)
         if isinstance(value, str) and len(value) > MAX_LEGACY_EVENT_PAYLOAD_CHARS:
-            container[field] = (
-                value[:MAX_LEGACY_EVENT_PAYLOAD_CHARS] + _TRUNCATION_NOTICE
-            )
+            container[field] = value[:MAX_LEGACY_EVENT_PAYLOAD_CHARS] + _TRUNCATION_NOTICE
             truncated = True
 
-    cap(event, "content")
-    metadata = event.get("metadata")
+    cap(bounded, "content")
+    metadata = bounded.get("metadata")
     if isinstance(metadata, dict):
         tool_metadata = metadata.get("tool_metadata")
         if isinstance(tool_metadata, dict):
             cap(tool_metadata, "content")
             cap(tool_metadata, "answer")
-    return event if not truncated else copy.deepcopy(event)
+    return bounded if truncated else event
 
 
 def compact_trace_preview(

--- a/deeptutor/services/session/event_preview.py
+++ b/deeptutor/services/session/event_preview.py
@@ -1,0 +1,135 @@
+"""Bounded event previews used by session-detail responses.
+
+``turn_events`` remains the authoritative full trace. Session lists only need
+enough semantic state to render a completed message, resume pending input, and
+offer the trace disclosure; the complete trace is fetched on demand.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any
+
+MAX_TRACE_PREVIEW_EVENTS = 200
+MAX_TRACE_PREVIEW_BYTES = 128 * 1024
+MAX_LEGACY_EVENT_PAYLOAD_CHARS = 16 * 1024
+_TRUNCATION_NOTICE = "...[truncated]"
+_TERMINAL_EVENT_TYPES = frozenset({"done", "error", "cancelled"})
+_SEMANTIC_EVENT_TYPES = _TERMINAL_EVENT_TYPES | {
+    "result",
+    "tool_call",
+    "tool_result",
+}
+
+
+def _metadata(event: dict[str, Any]) -> dict[str, Any]:
+    metadata = event.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _is_semantic(event: dict[str, Any]) -> bool:
+    event_type = str(event.get("type") or "")
+    if event_type in _SEMANTIC_EVENT_TYPES:
+        return True
+    return _has_ask_user(event)
+
+
+def _has_ask_user(event: dict[str, Any]) -> bool:
+    metadata = _metadata(event)
+    return bool(
+        metadata.get("ask_user")
+        or metadata.get("ask_user_resolved")
+        or isinstance(metadata.get("tool_metadata"), dict)
+        and isinstance(metadata["tool_metadata"].get("ask_user"), dict)
+    )
+
+
+def _is_critical(event: dict[str, Any]) -> bool:
+    if str(event.get("type") or "") in _TERMINAL_EVENT_TYPES | {"result"}:
+        return True
+    return _has_ask_user(event)
+
+
+def _truncate_legacy_payloads(event: dict[str, Any]) -> dict[str, Any]:
+    """Bound old embedded payloads without mutating the source event."""
+    truncated = False
+
+    def cap(container: dict[str, Any], field: str) -> None:
+        nonlocal truncated
+        value = container.get(field)
+        if isinstance(value, str) and len(value) > MAX_LEGACY_EVENT_PAYLOAD_CHARS:
+            container[field] = (
+                value[:MAX_LEGACY_EVENT_PAYLOAD_CHARS] + _TRUNCATION_NOTICE
+            )
+            truncated = True
+
+    cap(event, "content")
+    metadata = event.get("metadata")
+    if isinstance(metadata, dict):
+        tool_metadata = metadata.get("tool_metadata")
+        if isinstance(tool_metadata, dict):
+            cap(tool_metadata, "content")
+            cap(tool_metadata, "answer")
+    return event if not truncated else copy.deepcopy(event)
+
+
+def compact_trace_preview(
+    events: list[dict[str, Any]],
+    *,
+    max_events: int = MAX_TRACE_PREVIEW_EVENTS,
+    max_bytes: int = MAX_TRACE_PREVIEW_BYTES,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Return a bounded semantic preview and whether any event was omitted."""
+    semantic = [
+        (index, event)
+        for index, event in enumerate(events)
+        if isinstance(event, dict) and _is_semantic(event)
+    ]
+    # Ask_user, results, errors, and terminal state outrank ordinary trace rows.
+    # Keep the most recent critical rows, then fill toward the turn's tail.
+    critical = {index for index, event in semantic if _is_critical(event)}
+    if len(critical) > max_events:
+        ordered_critical = sorted(critical)
+        critical = set(ordered_critical[-max_events:])
+    selected_indices = set(critical)
+    for index, _event in reversed(semantic):
+        if len(selected_indices) >= max_events:
+            break
+        selected_indices.add(index)
+    selected = [event for index, event in semantic if index in selected_indices]
+    result: list[dict[str, Any]] = []
+    used_bytes = 0
+    for event in selected:
+        bounded = _truncate_legacy_payloads(event)
+        size = len(json.dumps(bounded, ensure_ascii=False, default=str).encode("utf-8"))
+        if result and used_bytes + size > max_bytes:
+            continue
+        if not result and size > max_bytes:
+            bounded = {
+                "type": bounded.get("type", ""),
+                "turn_id": bounded.get("turn_id"),
+                "session_id": bounded.get("session_id"),
+                "seq": bounded.get("seq"),
+                "content": _TRUNCATION_NOTICE,
+                "_truncated": True,
+            }
+            size = len(json.dumps(bounded, ensure_ascii=False, default=str).encode("utf-8"))
+        result.append(bounded)
+        used_bytes += size
+
+    omitted = len(events) != len(result) or len(selected) != len(result)
+    terminal = next(
+        (
+            event
+            for event in reversed(result)
+            if str(event.get("type") or "") in _TERMINAL_EVENT_TYPES
+        ),
+        None,
+    )
+    if terminal is None:
+        for event in reversed(events):
+            if isinstance(event, dict) and str(event.get("type") or "") in _TERMINAL_EVENT_TYPES:
+                result.append(copy.deepcopy(event))
+                break
+    return result, omitted

--- a/deeptutor/services/session/pocketbase_store.py
+++ b/deeptutor/services/session/pocketbase_store.py
@@ -26,6 +26,7 @@ from typing import Any
 import uuid
 
 from .ask_user_trace import filter_ask_user_events
+from .event_preview import compact_trace_preview
 from .provider_response_state import redact_private_message_metadata
 from .scope import StoreScope
 from .workspace_preferences import upgrade_workspace_preferences
@@ -648,7 +649,62 @@ class PocketBaseSessionStore:
 
         try:
             records = await asyncio.to_thread(_get)
-            return [self._message_record_to_dict(r) for r in records]
+            turns = await asyncio.to_thread(
+                lambda: _pb()
+                .collection("turns")
+                .get_full_list(query_params={"filter": f'session_id="{sid}"'})
+            )
+            turns_by_message = {
+                str(getattr(turn, "assistant_message_id", "") or ""): turn
+                for turn in turns
+                if getattr(turn, "assistant_message_id", None)
+            }
+            event_rows = await asyncio.to_thread(
+                lambda: _pb()
+                .collection("turn_events")
+                .get_full_list(query_params={"filter": f'session_id="{sid}"', "sort": "seq"})
+            )
+            events_by_turn: dict[str, list[dict[str, Any]]] = {}
+            for row in event_rows:
+                turn_id = str(getattr(row, "turn_id", "") or "")
+                events_by_turn.setdefault(turn_id, []).append(
+                    {
+                        "type": getattr(row, "type", ""),
+                        "source": getattr(row, "source", "") or "",
+                        "stage": getattr(row, "stage", "") or "",
+                        "content": getattr(row, "content", "") or "",
+                        "metadata": _json_loads(getattr(row, "metadata_json", None), {}),
+                        "session_id": sid,
+                        "turn_id": turn_id,
+                        "seq": int(getattr(row, "seq", 0) or 0),
+                        "timestamp": _to_float(getattr(row, "event_timestamp", None)),
+                    }
+                )
+            result: list[dict[str, Any]] = []
+            for record in records:
+                message = self._message_record_to_dict(record)
+                turn = turns_by_message.get(str(record.id))
+                if record.role == "assistant" and turn is not None:
+                    turn_id = str(getattr(turn, "turn_id", turn.id) or "")
+                    events = events_by_turn.get(turn_id, [])
+                    message["events"], omitted = compact_trace_preview(events)
+                    message["trace"] = {
+                        "turn_id": turn_id,
+                        "total": len(events),
+                        "last_seq": int(events[-1]["seq"]) if events else 0,
+                        "truncated": omitted,
+                    }
+                elif record.role == "assistant":
+                    legacy_events = message["events"]
+                    message["events"], omitted = compact_trace_preview(legacy_events)
+                    message["trace"] = {
+                        "turn_id": None,
+                        "total": len(legacy_events),
+                        "last_seq": 0,
+                        "truncated": omitted,
+                    }
+                result.append(message)
+            return result
         except Exception as exc:
             logger.warning(f"get_messages failed: {exc}")
             return []
@@ -740,6 +796,7 @@ class PocketBaseSessionStore:
                         "state_version": 1,
                         "failure_code": "",
                         "retryable": False,
+                        "assistant_message_id": None,
                     }
                 )
             )
@@ -761,6 +818,7 @@ class PocketBaseSessionStore:
             "state_version": 1,
             "failure_code": "",
             "retryable": False,
+            "assistant_message_id": None,
         }
 
     async def create_turn(self, session_id: str, capability: str = "") -> dict[str, Any]:
@@ -914,7 +972,93 @@ class PocketBaseSessionStore:
             "state_version": int(getattr(record, "state_version", 1) or 1),
             "failure_code": getattr(record, "failure_code", "") or "",
             "retryable": bool(getattr(record, "retryable", False)),
+            "assistant_message_id": getattr(record, "assistant_message_id", None),
         }
+
+    async def link_turn_message(self, turn_id: str, assistant_message_id: int | str) -> bool:
+        tid = _validate_id(turn_id, "turn_id")
+
+        def _link() -> bool:
+            turns = (
+                _pb()
+                .collection("turns")
+                .get_full_list(query_params={"filter": f'turn_id="{tid}"'})
+            )
+            if not turns:
+                return False
+            record = turns[0]
+            if getattr(record, "assistant_message_id", None):
+                return False
+            _pb().collection("turns").update(
+                record.id,
+                {
+                    "assistant_message_id": str(assistant_message_id),
+                    "turn_updated_at": time.time(),
+                },
+            )
+            return True
+
+        return await asyncio.to_thread(_link)
+
+    async def get_message_trace(
+        self,
+        session_id: str,
+        message_id: int | str,
+        after_seq: int = 0,
+        limit: int | None = None,
+    ) -> dict[str, Any] | None:
+        sid = _validate_id(session_id, "session_id")
+        mid = str(message_id)
+        row_limit = 500 if limit is None else min(1000, max(1, int(limit)))
+
+        def _get():
+            messages = (
+                _pb()
+                .collection("messages")
+                .get_full_list(query_params={"filter": f'id="{mid}" && session_id="{sid}"'})
+            )
+            if not messages:
+                return None
+            turns = (
+                _pb()
+                .collection("turns")
+                .get_full_list(query_params={"filter": f'assistant_message_id="{mid}"'})
+            )
+            if not turns:
+                return None
+            turn = turns[0]
+            rows = _pb().collection("turn_events").get_full_list(
+                query_params={"filter": f'turn_id="{turn["turn_id"]}"', "sort": "seq"}
+            )
+            events = [
+                {
+                    "type": getattr(row, "type", ""),
+                    "source": getattr(row, "source", "") or "",
+                    "stage": getattr(row, "stage", "") or "",
+                    "content": getattr(row, "content", "") or "",
+                    "metadata": _json_loads(getattr(row, "metadata_json", None), {}),
+                    "session_id": sid,
+                    "turn_id": turn["turn_id"],
+                    "seq": int(getattr(row, "seq", 0) or 0),
+                    "timestamp": _to_float(getattr(row, "event_timestamp", None)),
+                }
+                for row in rows
+            ]
+            selected = [event for event in events if int(event.get("seq") or 0) > after_seq]
+            selected = selected[:row_limit]
+            complete = not events or int(selected[-1]["seq"]) >= int(events[-1]["seq"])
+            return {
+                "session_id": sid,
+                "message_id": message_id,
+                "turn_id": turn["turn_id"],
+                "events": selected,
+                "total": len(events),
+                "last_seq": int(events[-1]["seq"]) if events else 0,
+                "next_seq": None if complete else int(selected[-1]["seq"]),
+                "complete": complete,
+            }
+
+        return await asyncio.to_thread(_get)
 
     # ------------------------------------------------------------------
     # Turn events — synchronously durable before terminal transition

--- a/deeptutor/services/session/pocketbase_store.py
+++ b/deeptutor/services/session/pocketbase_store.py
@@ -26,7 +26,7 @@ from typing import Any
 import uuid
 
 from .ask_user_trace import filter_ask_user_events
-from .event_preview import compact_trace_preview
+from .event_preview import MAX_TRACE_PREVIEW_EVENTS, compact_trace_preview
 from .provider_response_state import redact_private_message_metadata
 from .scope import StoreScope
 from .workspace_preferences import upgrade_workspace_preferences
@@ -632,68 +632,80 @@ class PocketBaseSessionStore:
             logger.warning(f"get_last_message failed: {exc}")
             return None
 
+    @staticmethod
+    def _event_record_to_payload(row: Any, session_id: str, turn_id: str) -> dict[str, Any]:
+        return {
+            "type": getattr(row, "type", ""),
+            "source": getattr(row, "source", "") or "",
+            "stage": getattr(row, "stage", "") or "",
+            "content": getattr(row, "content", "") or "",
+            "metadata": _json_loads(getattr(row, "metadata_json", None), {}),
+            "session_id": session_id,
+            "turn_id": turn_id,
+            "seq": int(getattr(row, "seq", 0) or 0),
+            "timestamp": _to_float(getattr(row, "event_timestamp", None)),
+        }
+
+    @staticmethod
+    def _page_items(page: Any) -> list[Any]:
+        return list(getattr(page, "items", ()) or ())
+
+    @staticmethod
+    def _page_total(page: Any) -> int:
+        value = getattr(page, "total_items", getattr(page, "totalItems", None))
+        return max(
+            0, int(value if value is not None else len(PocketBaseSessionStore._page_items(page)))
+        )
+
+    def _trace_preview(
+        self, pb: Any, *, session_id: str, turn_id: str
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        turn_id = _validate_id(turn_id, "turn_id")
+        page = pb.collection("turn_events").get_list(
+            1,
+            MAX_TRACE_PREVIEW_EVENTS,
+            query_params={"filter": f'turn_id="{turn_id}"', "sort": "-seq"},
+        )
+        rows = list(reversed(self._page_items(page)))
+        events = [self._event_record_to_payload(row, session_id, turn_id) for row in rows]
+        preview, omitted = compact_trace_preview(events)
+        total = self._page_total(page)
+        last_seq = int(getattr(rows[-1], "seq", 0) or 0) if rows else 0
+        return preview, {
+            "turn_id": turn_id,
+            "total": total,
+            "last_seq": last_seq,
+            "truncated": omitted or total != len(preview),
+        }
+
     async def get_messages(self, session_id: str) -> list[dict[str, Any]]:
         sid = _validate_id(session_id, "session_id")
 
-        def _get():
-            return (
-                _pb()
-                .collection("messages")
-                .get_full_list(
-                    query_params={
-                        "filter": f'session_id="{sid}"',
-                        "sort": "msg_created_at",
-                    }
-                )
+        def _get() -> list[dict[str, Any]]:
+            pb = _pb()
+            records = pb.collection("messages").get_full_list(
+                query_params={
+                    "filter": f'session_id="{sid}"',
+                    "sort": "msg_created_at",
+                }
             )
-
-        try:
-            records = await asyncio.to_thread(_get)
-            turns = await asyncio.to_thread(
-                lambda: _pb()
-                .collection("turns")
-                .get_full_list(query_params={"filter": f'session_id="{sid}"'})
+            turns = pb.collection("turns").get_full_list(
+                query_params={"filter": f'session_id="{sid}"'}
             )
             turns_by_message = {
                 str(getattr(turn, "assistant_message_id", "") or ""): turn
                 for turn in turns
                 if getattr(turn, "assistant_message_id", None)
             }
-            event_rows = await asyncio.to_thread(
-                lambda: _pb()
-                .collection("turn_events")
-                .get_full_list(query_params={"filter": f'session_id="{sid}"', "sort": "seq"})
-            )
-            events_by_turn: dict[str, list[dict[str, Any]]] = {}
-            for row in event_rows:
-                turn_id = str(getattr(row, "turn_id", "") or "")
-                events_by_turn.setdefault(turn_id, []).append(
-                    {
-                        "type": getattr(row, "type", ""),
-                        "source": getattr(row, "source", "") or "",
-                        "stage": getattr(row, "stage", "") or "",
-                        "content": getattr(row, "content", "") or "",
-                        "metadata": _json_loads(getattr(row, "metadata_json", None), {}),
-                        "session_id": sid,
-                        "turn_id": turn_id,
-                        "seq": int(getattr(row, "seq", 0) or 0),
-                        "timestamp": _to_float(getattr(row, "event_timestamp", None)),
-                    }
-                )
             result: list[dict[str, Any]] = []
             for record in records:
                 message = self._message_record_to_dict(record)
                 turn = turns_by_message.get(str(record.id))
                 if record.role == "assistant" and turn is not None:
                     turn_id = str(getattr(turn, "turn_id", turn.id) or "")
-                    events = events_by_turn.get(turn_id, [])
-                    message["events"], omitted = compact_trace_preview(events)
-                    message["trace"] = {
-                        "turn_id": turn_id,
-                        "total": len(events),
-                        "last_seq": int(events[-1]["seq"]) if events else 0,
-                        "truncated": omitted,
-                    }
+                    message["events"], message["trace"] = self._trace_preview(
+                        pb, session_id=sid, turn_id=turn_id
+                    )
                 elif record.role == "assistant":
                     legacy_events = message["events"]
                     message["events"], omitted = compact_trace_preview(legacy_events)
@@ -705,6 +717,9 @@ class PocketBaseSessionStore:
                     }
                 result.append(message)
             return result
+
+        try:
+            return await asyncio.to_thread(_get)
         except Exception as exc:
             logger.warning(f"get_messages failed: {exc}")
             return []
@@ -977,13 +992,15 @@ class PocketBaseSessionStore:
 
     async def link_turn_message(self, turn_id: str, assistant_message_id: int | str) -> bool:
         tid = _validate_id(turn_id, "turn_id")
+        message_id = _validate_id(str(assistant_message_id), "assistant_message_id")
 
         def _link() -> bool:
-            turns = (
+            page = (
                 _pb()
                 .collection("turns")
-                .get_full_list(query_params={"filter": f'turn_id="{tid}"'})
+                .get_list(1, 1, query_params={"filter": f'turn_id="{tid}"'})
             )
+            turns = self._page_items(page)
             if not turns:
                 return False
             record = turns[0]
@@ -992,7 +1009,7 @@ class PocketBaseSessionStore:
             _pb().collection("turns").update(
                 record.id,
                 {
-                    "assistant_message_id": str(assistant_message_id),
+                    "assistant_message_id": message_id,
                     "turn_updated_at": time.time(),
                 },
             )
@@ -1007,54 +1024,65 @@ class PocketBaseSessionStore:
         after_seq: int = 0,
         limit: int | None = None,
     ) -> dict[str, Any] | None:
-        sid = _validate_id(session_id, "session_id")
-        mid = str(message_id)
+        try:
+            sid = _validate_id(session_id, "session_id")
+            mid = _validate_id(str(message_id), "message_id")
+        except ValueError:
+            return None
         row_limit = 500 if limit is None else min(1000, max(1, int(limit)))
+        uid = _current_user_id()
 
         def _get():
-            messages = (
-                _pb()
-                .collection("messages")
-                .get_full_list(query_params={"filter": f'id="{mid}" && session_id="{sid}"'})
+            pb = _pb()
+            if _find_session_record(pb, sid, uid) is None:
+                return None
+            message_page = pb.collection("messages").get_list(
+                1,
+                1,
+                query_params={"filter": f'id="{mid}" && session_id="{sid}"'},
             )
+            messages = self._page_items(message_page)
             if not messages:
                 return None
-            turns = (
-                _pb()
-                .collection("turns")
-                .get_full_list(query_params={"filter": f'assistant_message_id="{mid}"'})
+            turn_page = pb.collection("turns").get_list(
+                1,
+                1,
+                query_params={"filter": f'assistant_message_id="{mid}"'},
             )
+            turns = self._page_items(turn_page)
             if not turns:
                 return None
             turn = turns[0]
-            rows = _pb().collection("turn_events").get_full_list(
-                query_params={"filter": f'turn_id="{turn["turn_id"]}"', "sort": "seq"}
+            turn_id = str(getattr(turn, "turn_id", getattr(turn, "id", "")) or "")
+            stats_page = pb.collection("turn_events").get_list(
+                1,
+                1,
+                query_params={"filter": f'turn_id="{turn_id}"', "sort": "-seq"},
+            )
+            last_rows = self._page_items(stats_page)
+            last_seq = int(getattr(last_rows[0], "seq", 0) or 0) if last_rows else 0
+            event_page = pb.collection("turn_events").get_list(
+                1,
+                row_limit,
+                query_params={
+                    "filter": f'turn_id="{turn_id}" && seq>{max(0, int(after_seq))}',
+                    "sort": "seq",
+                },
             )
             events = [
-                {
-                    "type": getattr(row, "type", ""),
-                    "source": getattr(row, "source", "") or "",
-                    "stage": getattr(row, "stage", "") or "",
-                    "content": getattr(row, "content", "") or "",
-                    "metadata": _json_loads(getattr(row, "metadata_json", None), {}),
-                    "session_id": sid,
-                    "turn_id": turn["turn_id"],
-                    "seq": int(getattr(row, "seq", 0) or 0),
-                    "timestamp": _to_float(getattr(row, "event_timestamp", None)),
-                }
-                for row in rows
+                self._event_record_to_payload(row, sid, turn_id)
+                for row in self._page_items(event_page)
             ]
-            selected = [event for event in events if int(event.get("seq") or 0) > after_seq]
-            selected = selected[:row_limit]
-            complete = not events or int(selected[-1]["seq"]) >= int(events[-1]["seq"])
+            loaded_seq = int(events[-1]["seq"]) if events else max(0, int(after_seq))
+            complete = loaded_seq >= last_seq
             return {
                 "session_id": sid,
                 "message_id": message_id,
-                "turn_id": turn["turn_id"],
-                "events": selected,
-                "total": len(events),
-                "last_seq": int(events[-1]["seq"]) if events else 0,
-                "next_seq": None if complete else int(selected[-1]["seq"]),
+                "turn_id": turn_id,
+                "events": events,
+                "total": self._page_total(stats_page),
+                "last_seq": last_seq,
+                "next_seq": None if complete else loaded_seq,
                 "complete": complete,
             }
 

--- a/deeptutor/services/session/protocol.py
+++ b/deeptutor/services/session/protocol.py
@@ -132,9 +132,7 @@ class SessionStoreProtocol(SessionRepository, TurnRepository, MessageRepository,
 
     async def get_turn_events(self, turn_id: str, after_seq: int = 0) -> list[dict[str, Any]]: ...
 
-    async def link_turn_message(
-        self, turn_id: str, assistant_message_id: int | str
-    ) -> bool: ...
+    async def link_turn_message(self, turn_id: str, assistant_message_id: int | str) -> bool: ...
 
     async def get_message_trace(
         self,

--- a/deeptutor/services/session/protocol.py
+++ b/deeptutor/services/session/protocol.py
@@ -132,6 +132,18 @@ class SessionStoreProtocol(SessionRepository, TurnRepository, MessageRepository,
 
     async def get_turn_events(self, turn_id: str, after_seq: int = 0) -> list[dict[str, Any]]: ...
 
+    async def link_turn_message(
+        self, turn_id: str, assistant_message_id: int | str
+    ) -> bool: ...
+
+    async def get_message_trace(
+        self,
+        session_id: str,
+        message_id: int | str,
+        after_seq: int = 0,
+        limit: int | None = None,
+    ) -> dict[str, Any] | None: ...
+
     async def update_session_title(self, session_id: str, title: str) -> bool: ...
 
     async def delete_session(self, session_id: str) -> bool: ...

--- a/deeptutor/services/session/sqlite_store.py
+++ b/deeptutor/services/session/sqlite_store.py
@@ -25,7 +25,8 @@ except ImportError:  # pragma: no cover - exercised only on Windows
 from deeptutor.services.path_service import get_path_service
 from deeptutor.utils.secret_files import ensure_private_directory, ensure_private_file
 
-from .ask_user_trace import select_ask_user_events
+from .ask_user_trace import filter_ask_user_events, select_ask_user_events
+from .event_preview import compact_trace_preview
 from .provider_response_state import redact_private_message_metadata
 from .workspace_preferences import upgrade_workspace_preferences
 
@@ -116,6 +117,7 @@ class TurnRecord:
     state_version: int = 1
     failure_code: str = ""
     retryable: bool = False
+    assistant_message_id: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -134,6 +136,7 @@ class TurnRecord:
             "state_version": self.state_version,
             "failure_code": self.failure_code,
             "retryable": self.retryable,
+            "assistant_message_id": self.assistant_message_id,
         }
 
 
@@ -274,7 +277,8 @@ class SQLiteSessionStore:
                     fencing_token INTEGER NOT NULL DEFAULT 0,
                     state_version INTEGER NOT NULL DEFAULT 1,
                     failure_code TEXT DEFAULT '',
-                    retryable INTEGER NOT NULL DEFAULT 0
+                    retryable INTEGER NOT NULL DEFAULT 0,
+                    assistant_message_id INTEGER
                 );
 
                 CREATE INDEX IF NOT EXISTS idx_turns_session_updated
@@ -452,6 +456,32 @@ class SQLiteSessionStore:
         for name, definition in additions.items():
             if name not in columns:
                 conn.execute(f"ALTER TABLE turns ADD COLUMN {name} {definition}")
+        if "assistant_message_id" not in columns:
+            conn.execute("ALTER TABLE turns ADD COLUMN assistant_message_id INTEGER")
+            # v1.6.3 already persisted DONE with the assistant row id. Recover
+            # those links once so old traces can be served from turn_events.
+            conn.execute(
+                """
+                UPDATE turns
+                SET assistant_message_id = (
+                    SELECT CAST(json_extract(event.value, '$.metadata.assistant_message_id') AS INTEGER)
+                    FROM messages AS m, json_each(m.events_json) AS event
+                    WHERE m.session_id = turns.session_id
+                      AND m.role = 'assistant'
+                      AND json_extract(event.value, '$.type') = 'done'
+                      AND json_extract(event.value, '$.turn_id') = turns.id
+                      AND json_extract(event.value, '$.metadata.assistant_message_id') IS NOT NULL
+                    LIMIT 1
+                )
+                WHERE assistant_message_id IS NULL
+                """
+            )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_turns_assistant_message
+            ON turns(assistant_message_id)
+            """
+        )
 
         duplicate_rows = conn.execute(
             """
@@ -778,6 +808,11 @@ class SQLiteSessionStore:
             state_version=(int(row["state_version"] or 1) if "state_version" in row.keys() else 1),
             failure_code=(row["failure_code"] or "" if "failure_code" in row.keys() else ""),
             retryable=(bool(row["retryable"]) if "retryable" in row.keys() else False),
+            assistant_message_id=(
+                row["assistant_message_id"]
+                if "assistant_message_id" in row.keys()
+                else None
+            ),
         ).to_dict()
 
     def _begin_turn_sync(
@@ -1034,6 +1069,20 @@ class SQLiteSessionStore:
             and (event.get("metadata") or {}) == _json_loads(row["metadata_json"], {})
         )
 
+    @staticmethod
+    def _turn_event_row_to_payload(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "type": row["type"],
+            "source": row["source"] or "",
+            "stage": row["stage"] or "",
+            "content": row["content"] or "",
+            "metadata": _json_loads(row["metadata_json"], {}),
+            "session_id": "",
+            "turn_id": row["turn_id"],
+            "seq": row["seq"],
+            "timestamp": row["timestamp"],
+        }
+
     def _append_turn_events_sync(
         self,
         turn_id: str,
@@ -1170,6 +1219,103 @@ class SQLiteSessionStore:
 
     async def get_events(self, turn_id: str, after_seq: int = 0) -> list[dict[str, Any]]:
         return await self.get_turn_events(turn_id, after_seq)
+
+    def _link_turn_message_sync(self, turn_id: str, assistant_message_id: int) -> bool:
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                UPDATE turns
+                SET assistant_message_id = ?, updated_at = ?
+                WHERE id = ?
+                  AND session_id = (SELECT session_id FROM messages WHERE id = ?)
+                  AND assistant_message_id IS NULL
+                """,
+                (int(assistant_message_id), time.time(), turn_id, int(assistant_message_id)),
+            )
+            conn.commit()
+        return cur.rowcount > 0
+
+    async def link_turn_message(self, turn_id: str, assistant_message_id: int) -> bool:
+        return await self._run(self._link_turn_message_sync, turn_id, int(assistant_message_id))
+
+    def _get_message_trace_sync(
+        self,
+        session_id: str,
+        message_id: int,
+        after_seq: int = 0,
+        limit: int | None = None,
+    ) -> dict[str, Any] | None:
+        row_limit = 500 if limit is None else min(1000, max(1, int(limit)))
+        with self._connect() as conn:
+            message = conn.execute(
+                """
+                SELECT m.id, m.role, t.id AS turn_id
+                FROM messages AS m
+                LEFT JOIN turns AS t ON t.assistant_message_id = m.id
+                WHERE m.id = ? AND m.session_id = ?
+                """,
+                (int(message_id), session_id),
+            ).fetchone()
+            if message is None:
+                return None
+            turn_id = message["turn_id"]
+            if turn_id is None:
+                return {
+                    "session_id": session_id,
+                    "message_id": int(message_id),
+                    "turn_id": None,
+                    "events": [],
+                    "total": 0,
+                    "last_seq": 0,
+                    "next_seq": None,
+                    "complete": True,
+                }
+            turn = conn.execute(
+                "SELECT session_id FROM turns WHERE id = ?", (turn_id,)
+            ).fetchone()
+            stats = conn.execute(
+                """
+                SELECT COUNT(*) AS total, COALESCE(MAX(seq), 0) AS last_seq
+                FROM turn_events WHERE turn_id = ?
+                """,
+                (turn_id,),
+            ).fetchone()
+            rows = conn.execute(
+                """
+                SELECT turn_id, seq, type, source, stage, content, metadata_json, timestamp
+                FROM turn_events
+                WHERE turn_id = ? AND seq > ?
+                ORDER BY seq ASC
+                LIMIT ?
+                """,
+                (turn_id, max(0, int(after_seq)), row_limit),
+            ).fetchall()
+            events = [self._turn_event_row_to_payload(row) for row in rows]
+            for event in events:
+                event["session_id"] = turn["session_id"] if turn else ""
+            last_loaded = events[-1]["seq"] if events else int(after_seq)
+            complete = last_loaded >= int(stats["last_seq"])
+            return {
+                "session_id": session_id,
+                "message_id": int(message_id),
+                "turn_id": turn_id,
+                "events": events,
+                "total": int(stats["total"]),
+                "last_seq": int(stats["last_seq"]),
+                "next_seq": None if complete else last_loaded,
+                "complete": complete,
+            }
+
+    async def get_message_trace(
+        self,
+        session_id: str,
+        message_id: int,
+        after_seq: int = 0,
+        limit: int | None = None,
+    ) -> dict[str, Any] | None:
+        return await self._run(
+            self._get_message_trace_sync, session_id, int(message_id), after_seq, limit
+        )
 
     def _update_session_title_sync(self, session_id: str, title: str) -> bool:
         with self._connect() as conn:
@@ -1616,7 +1762,12 @@ class SQLiteSessionStore:
     ) -> dict[str, Any] | None:
         return await self._run(self._get_last_message_sync, session_id, role)
 
-    def _serialize_message(self, row: sqlite3.Row) -> dict[str, Any]:
+    def _serialize_message(
+        self,
+        row: sqlite3.Row,
+        events: list[dict[str, Any]] | None = None,
+        trace: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         row_keys = row.keys()
         parent_id = row["parent_message_id"] if "parent_message_id" in row_keys else None
         return {
@@ -1625,26 +1776,81 @@ class SQLiteSessionStore:
             "role": row["role"],
             "content": row["content"],
             "capability": row["capability"] or "",
-            "events": _json_loads(row["events_json"], []),
+            "events": _json_loads(row["events_json"], []) if events is None else events,
             "attachments": _json_loads(row["attachments_json"], []),
             "metadata": _json_loads(row["metadata_json"], {}),
             "created_at": row["created_at"],
             "parent_message_id": int(parent_id) if parent_id is not None else None,
+            **({"trace": trace} if trace is not None else {}),
         }
+
+    def _canonical_trace_preview_sync(
+        self, conn: sqlite3.Connection, turn_id: str
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        turn = conn.execute(
+            "SELECT session_id FROM turns WHERE id = ?", (turn_id,)
+        ).fetchone()
+        rows = conn.execute(
+            """
+            SELECT turn_id, seq, type, source, stage, content, metadata_json, timestamp
+            FROM turn_events WHERE turn_id = ? ORDER BY seq ASC
+            """,
+            (turn_id,),
+        ).fetchall()
+        events = [self._turn_event_row_to_payload(row) for row in rows]
+        for event in events:
+            event["session_id"] = turn["session_id"] if turn else ""
+        preview, omitted = compact_trace_preview(events)
+        metadata = {
+            "turn_id": turn_id,
+            "total": len(events),
+            "last_seq": events[-1]["seq"] if events else 0,
+            "truncated": omitted,
+        }
+        return preview, metadata
 
     def _get_messages_sync(self, session_id: str) -> list[dict[str, Any]]:
         with self._connect() as conn:
             rows = conn.execute(
                 """
-                SELECT id, session_id, role, content, capability, events_json,
-                       attachments_json, metadata_json, created_at, parent_message_id
-                FROM messages
-                WHERE session_id = ?
-                ORDER BY id ASC
+                SELECT m.id, m.session_id, m.role, m.content, m.capability,
+                       m.events_json, m.attachments_json, m.metadata_json,
+                       m.created_at, m.parent_message_id, t.id AS trace_turn_id
+                FROM messages AS m
+                LEFT JOIN turns AS t ON t.assistant_message_id = m.id
+                WHERE m.session_id = ?
+                ORDER BY m.id ASC
                 """,
                 (session_id,),
             ).fetchall()
-        return [self._serialize_message(row) for row in rows]
+            result: list[dict[str, Any]] = []
+            for row in rows:
+                turn_id = row["trace_turn_id"]
+                if row["role"] == "assistant" and turn_id is not None:
+                    events, trace = self._canonical_trace_preview_sync(conn, turn_id)
+                    result.append(self._serialize_message(row, events=events, trace=trace))
+                    continue
+                legacy_events = _json_loads(row["events_json"], [])
+                if row["role"] == "assistant" and isinstance(legacy_events, list):
+                    events, omitted = compact_trace_preview(legacy_events)
+                    result.append(
+                        self._serialize_message(
+                            row,
+                            events=events,
+                            trace={
+                                "turn_id": None,
+                                "total": len(legacy_events),
+                                "last_seq": max(
+                                    [int(event.get("seq") or 0) for event in legacy_events]
+                                    or [0]
+                                ),
+                                "truncated": omitted,
+                            },
+                        )
+                    )
+                    continue
+                result.append(self._serialize_message(row))
+        return result
 
     def _get_message_path_sync(self, session_id: str, leaf_message_id: int) -> list[dict[str, Any]]:
         """Return the chain of messages from the session root down to
@@ -1691,11 +1897,12 @@ class SQLiteSessionStore:
             if leaf_message_id is None:
                 rows = conn.execute(
                     """
-                    SELECT id, role, content, events_json, metadata_json
-                    FROM messages
-                    WHERE session_id = ?
-                      AND role IN ('user', 'assistant', 'system')
-                    ORDER BY id ASC
+                    SELECT m.id, m.role, m.content, m.events_json, m.metadata_json, t.id AS turn_id
+                    FROM messages AS m
+                    LEFT JOIN turns AS t ON t.assistant_message_id = m.id
+                    WHERE m.session_id = ?
+                      AND m.role IN ('user', 'assistant', 'system')
+                    ORDER BY m.id ASC
                     """,
                     (session_id,),
                 ).fetchall()
@@ -1704,7 +1911,13 @@ class SQLiteSessionStore:
                         "id": row["id"],
                         "role": row["role"],
                         "content": row["content"] or "",
-                        "events": select_ask_user_events(row["events_json"]),
+                        "events": (
+                            filter_ask_user_events(
+                                self._get_turn_events_sync(row["turn_id"])
+                            )
+                            if row["turn_id"] is not None
+                            else select_ask_user_events(row["events_json"])
+                        ),
                         "metadata": _json_loads(row["metadata_json"], {}),
                     }
                     for row in rows
@@ -1717,10 +1930,12 @@ class SQLiteSessionStore:
             while current is not None and safety > 0:
                 row = conn.execute(
                     """
-                    SELECT id, role, content, events_json, metadata_json, parent_message_id
-                    FROM messages
-                    WHERE id = ? AND session_id = ?
-                      AND role IN ('user', 'assistant', 'system')
+                    SELECT m.id, m.role, m.content, m.events_json, m.metadata_json,
+                           m.parent_message_id, t.id AS turn_id
+                    FROM messages AS m
+                    LEFT JOIN turns AS t ON t.assistant_message_id = m.id
+                    WHERE m.id = ? AND m.session_id = ?
+                      AND m.role IN ('user', 'assistant', 'system')
                     """,
                     (current, session_id),
                 ).fetchone()
@@ -1731,7 +1946,13 @@ class SQLiteSessionStore:
                         "id": row["id"],
                         "role": row["role"],
                         "content": row["content"] or "",
-                        "events": select_ask_user_events(row["events_json"]),
+                        "events": (
+                            filter_ask_user_events(
+                                self._get_turn_events_sync(row["turn_id"])
+                            )
+                            if row["turn_id"] is not None
+                            else select_ask_user_events(row["events_json"])
+                        ),
                         "metadata": _json_loads(row["metadata_json"], {}),
                     }
                 )

--- a/deeptutor/services/session/sqlite_store.py
+++ b/deeptutor/services/session/sqlite_store.py
@@ -25,8 +25,8 @@ except ImportError:  # pragma: no cover - exercised only on Windows
 from deeptutor.services.path_service import get_path_service
 from deeptutor.utils.secret_files import ensure_private_directory, ensure_private_file
 
-from .ask_user_trace import filter_ask_user_events, select_ask_user_events
-from .event_preview import compact_trace_preview
+from .ask_user_trace import select_ask_user_events
+from .event_preview import MAX_TRACE_PREVIEW_EVENTS, compact_trace_preview
 from .provider_response_state import redact_private_message_metadata
 from .workspace_preferences import upgrade_workspace_preferences
 
@@ -464,7 +464,7 @@ class SQLiteSessionStore:
                 """
                 UPDATE turns
                 SET assistant_message_id = (
-                    SELECT CAST(json_extract(event.value, '$.metadata.assistant_message_id') AS INTEGER)
+                    SELECT m.id
                     FROM messages AS m, json_each(m.events_json) AS event
                     WHERE m.session_id = turns.session_id
                       AND m.role = 'assistant'
@@ -478,8 +478,9 @@ class SQLiteSessionStore:
             )
         conn.execute(
             """
-            CREATE INDEX IF NOT EXISTS idx_turns_assistant_message
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_turns_assistant_message
             ON turns(assistant_message_id)
+            WHERE assistant_message_id IS NOT NULL
             """
         )
 
@@ -809,9 +810,7 @@ class SQLiteSessionStore:
             failure_code=(row["failure_code"] or "" if "failure_code" in row.keys() else ""),
             retryable=(bool(row["retryable"]) if "retryable" in row.keys() else False),
             assistant_message_id=(
-                row["assistant_message_id"]
-                if "assistant_message_id" in row.keys()
-                else None
+                row["assistant_message_id"] if "assistant_message_id" in row.keys() else None
             ),
         ).to_dict()
 
@@ -1270,9 +1269,7 @@ class SQLiteSessionStore:
                     "next_seq": None,
                     "complete": True,
                 }
-            turn = conn.execute(
-                "SELECT session_id FROM turns WHERE id = ?", (turn_id,)
-            ).fetchone()
+            turn = conn.execute("SELECT session_id FROM turns WHERE id = ?", (turn_id,)).fetchone()
             stats = conn.execute(
                 """
                 SELECT COUNT(*) AS total, COALESCE(MAX(seq), 0) AS last_seq
@@ -1309,12 +1306,20 @@ class SQLiteSessionStore:
     async def get_message_trace(
         self,
         session_id: str,
-        message_id: int,
+        message_id: int | str,
         after_seq: int = 0,
         limit: int | None = None,
     ) -> dict[str, Any] | None:
+        try:
+            resolved_message_id = int(message_id)
+        except (TypeError, ValueError):
+            return None
         return await self._run(
-            self._get_message_trace_sync, session_id, int(message_id), after_seq, limit
+            self._get_message_trace_sync,
+            session_id,
+            resolved_message_id,
+            after_seq,
+            limit,
         )
 
     def _update_session_title_sync(self, session_id: str, title: str) -> bool:
@@ -1785,29 +1790,90 @@ class SQLiteSessionStore:
         }
 
     def _canonical_trace_preview_sync(
-        self, conn: sqlite3.Connection, turn_id: str
+        self,
+        conn: sqlite3.Connection,
+        turn_id: str,
+        session_id: str,
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-        turn = conn.execute(
-            "SELECT session_id FROM turns WHERE id = ?", (turn_id,)
+        stats = conn.execute(
+            """
+            SELECT COUNT(*) AS total, COALESCE(MAX(seq), 0) AS last_seq
+            FROM turn_events WHERE turn_id = ?
+            """,
+            (turn_id,),
         ).fetchone()
+        # Preview queries stay bounded even for a very long agentic turn. The
+        # critical query reserves older terminal/result/ask-user state; the
+        # semantic query fills the remaining tail with tool activity.
+        columns = "turn_id, seq, type, source, stage, content, metadata_json, timestamp"
+        ask_user = """
+            json_extract(metadata_json, '$.ask_user') IS NOT NULL
+            OR json_extract(metadata_json, '$.ask_user_resolved') IS NOT NULL
+            OR json_extract(metadata_json, '$.tool_metadata.ask_user') IS NOT NULL
+        """
+        conditions = (
+            f"type IN ('done', 'error', 'cancelled', 'result') OR {ask_user}",
+            f"type IN ('done', 'error', 'cancelled', 'result', 'tool_call', 'tool_result') OR {ask_user}",
+        )
+        rows_by_seq: dict[int, sqlite3.Row] = {}
+        for condition in conditions:
+            rows = conn.execute(
+                f"""
+                SELECT {columns}
+                FROM turn_events
+                WHERE turn_id = ? AND ({condition})
+                ORDER BY seq DESC
+                LIMIT ?
+                """,
+                (turn_id, MAX_TRACE_PREVIEW_EVENTS),
+            ).fetchall()
+            rows_by_seq.update({int(row["seq"]): row for row in rows})
+        events = [self._turn_event_row_to_payload(rows_by_seq[seq]) for seq in sorted(rows_by_seq)]
+        for event in events:
+            event["session_id"] = session_id
+        preview, compacted = compact_trace_preview(events)
+        total = int(stats["total"])
+        metadata = {
+            "turn_id": turn_id,
+            "total": total,
+            "last_seq": int(stats["last_seq"]),
+            "truncated": compacted or total != len(preview),
+        }
+        return preview, metadata
+
+    def _legacy_trace_preview_sync(
+        self, events: list[dict[str, Any]]
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        preview, omitted = compact_trace_preview(events)
+        return preview, {
+            "turn_id": None,
+            "total": len(events),
+            "last_seq": max([int(event.get("seq") or 0) for event in events] or [0]),
+            "truncated": omitted,
+        }
+
+    def _ask_user_events_sync(
+        self, conn: sqlite3.Connection, turn_id: str, session_id: str
+    ) -> list[dict[str, Any]]:
         rows = conn.execute(
             """
             SELECT turn_id, seq, type, source, stage, content, metadata_json, timestamp
-            FROM turn_events WHERE turn_id = ? ORDER BY seq ASC
+            FROM turn_events
+            WHERE turn_id = ?
+              AND (
+                json_extract(metadata_json, '$.ask_user') IS NOT NULL
+                OR json_extract(metadata_json, '$.ask_user_resolved') IS NOT NULL
+                OR json_extract(metadata_json, '$.tool_metadata.ask_user') IS NOT NULL
+              )
+            ORDER BY seq DESC
+            LIMIT ?
             """,
-            (turn_id,),
+            (turn_id, MAX_TRACE_PREVIEW_EVENTS),
         ).fetchall()
-        events = [self._turn_event_row_to_payload(row) for row in rows]
+        events = [self._turn_event_row_to_payload(row) for row in reversed(rows)]
         for event in events:
-            event["session_id"] = turn["session_id"] if turn else ""
-        preview, omitted = compact_trace_preview(events)
-        metadata = {
-            "turn_id": turn_id,
-            "total": len(events),
-            "last_seq": events[-1]["seq"] if events else 0,
-            "truncated": omitted,
-        }
-        return preview, metadata
+            event["session_id"] = session_id
+        return events
 
     def _get_messages_sync(self, session_id: str) -> list[dict[str, Any]]:
         with self._connect() as conn:
@@ -1827,25 +1893,17 @@ class SQLiteSessionStore:
             for row in rows:
                 turn_id = row["trace_turn_id"]
                 if row["role"] == "assistant" and turn_id is not None:
-                    events, trace = self._canonical_trace_preview_sync(conn, turn_id)
+                    events, trace = self._canonical_trace_preview_sync(conn, turn_id, session_id)
                     result.append(self._serialize_message(row, events=events, trace=trace))
                     continue
                 legacy_events = _json_loads(row["events_json"], [])
                 if row["role"] == "assistant" and isinstance(legacy_events, list):
-                    events, omitted = compact_trace_preview(legacy_events)
+                    events, trace = self._legacy_trace_preview_sync(legacy_events)
                     result.append(
                         self._serialize_message(
                             row,
                             events=events,
-                            trace={
-                                "turn_id": None,
-                                "total": len(legacy_events),
-                                "last_seq": max(
-                                    [int(event.get("seq") or 0) for event in legacy_events]
-                                    or [0]
-                                ),
-                                "truncated": omitted,
-                            },
+                            trace=trace,
                         )
                     )
                     continue
@@ -1912,9 +1970,7 @@ class SQLiteSessionStore:
                         "role": row["role"],
                         "content": row["content"] or "",
                         "events": (
-                            filter_ask_user_events(
-                                self._get_turn_events_sync(row["turn_id"])
-                            )
+                            self._ask_user_events_sync(conn, row["turn_id"], session_id)
                             if row["turn_id"] is not None
                             else select_ask_user_events(row["events_json"])
                         ),
@@ -1947,9 +2003,7 @@ class SQLiteSessionStore:
                         "role": row["role"],
                         "content": row["content"] or "",
                         "events": (
-                            filter_ask_user_events(
-                                self._get_turn_events_sync(row["turn_id"])
-                            )
+                            self._ask_user_events_sync(conn, row["turn_id"], session_id)
                             if row["turn_id"] is not None
                             else select_ask_user_events(row["events_json"])
                         ),

--- a/deeptutor/services/session/turns/executor.py
+++ b/deeptutor/services/session/turns/executor.py
@@ -996,7 +996,7 @@ class TurnExecutor:
             if partial_content or generated_attachments or assistant_events:
                 with contextlib.suppress(Exception):
                     await asyncio.shield(
-                        assistant_message_id = await self.store.add_message(
+                        assistant_message_id=await self.store.add_message(
                             session_id=session_id,
                             role="assistant",
                             content=partial_content,

--- a/deeptutor/services/session/turns/executor.py
+++ b/deeptutor/services/session/turns/executor.py
@@ -856,7 +856,7 @@ class TurnExecutor:
                     role="assistant",
                     content=assistant_content,
                     capability=capability_name,
-                    events=assistant_events,
+                    events=[],
                     attachments=generated_attachments or None,
                     parent_message_id=new_user_message_id,
                     metadata=assistant_provider_metadata,
@@ -867,7 +867,7 @@ class TurnExecutor:
                     role="assistant",
                     content=assistant_content,
                     capability=capability_name,
-                    events=assistant_events,
+                    events=[],
                     attachments=generated_attachments or None,
                     parent_message_id=branch_parent_id,
                     metadata=assistant_provider_metadata,
@@ -878,10 +878,11 @@ class TurnExecutor:
                     role="assistant",
                     content=assistant_content,
                     capability=capability_name,
-                    events=assistant_events,
+                    events=[],
                     attachments=generated_attachments or None,
                     metadata=assistant_provider_metadata,
                 )
+            await self.store.link_turn_message(turn_id, assistant_message_id)
             turn_status, turn_error = _resolve_turn_outcome(
                 assistant_events,
                 pending_done_event,
@@ -995,12 +996,12 @@ class TurnExecutor:
             if partial_content or generated_attachments or assistant_events:
                 with contextlib.suppress(Exception):
                     await asyncio.shield(
-                        self.store.add_message(
+                        assistant_message_id = await self.store.add_message(
                             session_id=session_id,
                             role="assistant",
                             content=partial_content,
                             capability=capability_name,
-                            events=assistant_events,
+                            events=[],
                             attachments=generated_attachments or None,
                             metadata=(
                                 {"provider_response_state": provider_response_state}
@@ -1009,6 +1010,10 @@ class TurnExecutor:
                             ),
                         )
                     )
+                    with contextlib.suppress(Exception):
+                        await asyncio.shield(
+                            self.store.link_turn_message(turn_id, assistant_message_id)
+                        )
             transitioned = False
             with contextlib.suppress(Exception):
                 transitioned = await self._transition_execution(

--- a/scripts/pb_setup.py
+++ b/scripts/pb_setup.py
@@ -227,7 +227,7 @@ def main():
                 "CREATE UNIQUE INDEX idx_turns_turn_id ON turns (turn_id)",
                 "CREATE UNIQUE INDEX idx_turns_one_active_session ON turns (session_id) "
                 "WHERE status IN ('queued', 'running', 'waiting_input')",
-                "CREATE INDEX idx_turns_assistant_message ON turns (assistant_message_id)",
+                "CREATE UNIQUE INDEX idx_turns_assistant_message ON turns (assistant_message_id)",
             ],
             "listRule": "",
             "viewRule": "",

--- a/scripts/pb_setup.py
+++ b/scripts/pb_setup.py
@@ -221,11 +221,13 @@ def main():
                 {"name": "state_version", "type": "number", "required": False},
                 {"name": "failure_code", "type": "text", "required": False},
                 {"name": "retryable", "type": "bool", "required": False},
+                {"name": "assistant_message_id", "type": "text", "required": False},
             ],
             "indexes": [
                 "CREATE UNIQUE INDEX idx_turns_turn_id ON turns (turn_id)",
                 "CREATE UNIQUE INDEX idx_turns_one_active_session ON turns (session_id) "
                 "WHERE status IN ('queued', 'running', 'waiting_input')",
+                "CREATE INDEX idx_turns_assistant_message ON turns (assistant_message_id)",
             ],
             "listRule": "",
             "viewRule": "",

--- a/tests/api/test_sessions_trace.py
+++ b/tests/api/test_sessions_trace.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from deeptutor.api.routers import sessions as sessions_router
+from deeptutor.services.session.sqlite_store import SQLiteSessionStore
+
+
+def test_message_trace_is_paginated_and_session_scoped(tmp_path, monkeypatch) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat.db")
+    session = asyncio.run(store.ensure_session(None))
+    other = asyncio.run(store.ensure_session(None))
+    turn = asyncio.run(store.begin_turn(session["id"], capability="chat"))
+    message_id = asyncio.run(store.add_message(session["id"], "assistant", "answer"))
+    asyncio.run(
+        store.append_turn_events(
+            turn["id"],
+            [
+                {"type": "tool_call", "content": "lookup", "metadata": {}},
+                {"type": "done", "metadata": {"assistant_message_id": message_id}},
+            ],
+        )
+    )
+    assert asyncio.run(store.link_turn_message(turn["id"], message_id)) is True
+
+    monkeypatch.setattr(sessions_router, "get_session_store", lambda: store)
+    app = FastAPI()
+    app.include_router(sessions_router.router, prefix="/api/sessions")
+
+    with TestClient(app) as client:
+        page = client.get(
+            f"/api/sessions/{session['id']}/messages/{message_id}/events?limit=1"
+        )
+        assert page.status_code == 200
+        body = page.json()
+        assert body["turn_id"] == turn["id"]
+        assert body["total"] == 2
+        assert body["events"][0]["seq"] == 1
+        assert body["next_seq"] == 1
+        assert body["complete"] is False
+
+        denied = client.get(
+            f"/api/sessions/{other['id']}/messages/{message_id}/events"
+        )
+        assert denied.status_code == 404
+
+    detail = asyncio.run(store.get_session_with_messages(session["id"]))
+    assert detail is not None
+    message = detail["messages"][0]
+    assert message["events"][0]["type"] == "tool_call"
+    assert message["events"][-1]["type"] == "done"
+    assert message["trace"] == {
+        "turn_id": turn["id"],
+        "total": 2,
+        "last_seq": 2,
+        "truncated": False,
+    }

--- a/tests/api/test_sessions_trace.py
+++ b/tests/api/test_sessions_trace.py
@@ -31,9 +31,7 @@ def test_message_trace_is_paginated_and_session_scoped(tmp_path, monkeypatch) ->
     app.include_router(sessions_router.router, prefix="/api/sessions")
 
     with TestClient(app) as client:
-        page = client.get(
-            f"/api/sessions/{session['id']}/messages/{message_id}/events?limit=1"
-        )
+        page = client.get(f"/api/sessions/{session['id']}/messages/{message_id}/events?limit=1")
         assert page.status_code == 200
         body = page.json()
         assert body["turn_id"] == turn["id"]
@@ -42,10 +40,11 @@ def test_message_trace_is_paginated_and_session_scoped(tmp_path, monkeypatch) ->
         assert body["next_seq"] == 1
         assert body["complete"] is False
 
-        denied = client.get(
-            f"/api/sessions/{other['id']}/messages/{message_id}/events"
-        )
+        denied = client.get(f"/api/sessions/{other['id']}/messages/{message_id}/events")
         assert denied.status_code == 404
+
+        malformed = client.get(f"/api/sessions/{session['id']}/messages/not-a-sqlite-id/events")
+        assert malformed.status_code == 404
 
     detail = asyncio.run(store.get_session_with_messages(session["id"]))
     assert detail is not None

--- a/tests/services/session/test_trace_memory.py
+++ b/tests/services/session/test_trace_memory.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import asyncio
 import json
 import sqlite3
+from types import SimpleNamespace
 
 from deeptutor.services.session.event_preview import (
     MAX_LEGACY_EVENT_PAYLOAD_CHARS,
     compact_trace_preview,
 )
+from deeptutor.services.session.pocketbase_store import PocketBaseSessionStore
 from deeptutor.services.session.sqlite_store import SQLiteSessionStore
 
 
@@ -26,6 +28,7 @@ def test_preview_keeps_semantic_events_and_bounds_legacy_payloads() -> None:
     preview, truncated = compact_trace_preview(events)
 
     assert truncated is True
+    assert events[1]["content"] == "x" * (MAX_LEGACY_EVENT_PAYLOAD_CHARS + 10)
     assert [event["type"] for event in preview] == ["tool_result", "result", "done"]
     assert len(preview[0]["content"]) == MAX_LEGACY_EVENT_PAYLOAD_CHARS + len("...[truncated]")
 
@@ -121,3 +124,108 @@ def test_context_rehydrates_ask_user_from_canonical_turn_events(tmp_path) -> Non
         "tool_result",
         "progress",
     ]
+
+
+def test_session_preview_reads_a_bounded_number_of_canonical_rows(tmp_path, monkeypatch) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat.db")
+    session = asyncio.run(store.ensure_session(None))
+    turn = asyncio.run(store.begin_turn(session["id"], capability="chat"))
+    message_id = asyncio.run(store.add_message(session["id"], "assistant", "answer"))
+    asyncio.run(
+        store.append_turn_events(
+            turn["id"],
+            [
+                {"type": "tool_call", "content": f"call-{index}", "metadata": {}}
+                for index in range(1_000)
+            ],
+        )
+    )
+    asyncio.run(store.link_turn_message(turn["id"], message_id))
+
+    converted = 0
+    original = store._turn_event_row_to_payload
+
+    def count_conversion(row):
+        nonlocal converted
+        converted += 1
+        return original(row)
+
+    monkeypatch.setattr(store, "_turn_event_row_to_payload", count_conversion)
+    detail = asyncio.run(store.get_session_with_messages(session["id"]))
+
+    assert detail is not None
+    message = detail["messages"][0]
+    assert message["trace"]["total"] == 1_000
+    assert message["trace"]["truncated"] is True
+    assert len(message["events"]) == 200
+    assert converted == 200
+
+
+def test_pocketbase_trace_uses_server_side_pagination(monkeypatch) -> None:
+    events = [
+        SimpleNamespace(
+            id=f"event-{seq}",
+            turn_id="turn-1",
+            seq=seq,
+            type="tool_call",
+            source="chat",
+            stage="",
+            content=f"call-{seq}",
+            metadata_json={},
+            event_timestamp=float(seq),
+        )
+        for seq in range(1, 1_201)
+    ]
+    records = {
+        "sessions": [SimpleNamespace(id="pb-session", session_id="session-1", user_id="u_ada")],
+        "messages": [SimpleNamespace(id="message-1", session_id="session-1", role="assistant")],
+        "turns": [
+            SimpleNamespace(id="pb-turn", turn_id="turn-1", assistant_message_id="message-1")
+        ],
+        "turn_events": events,
+    }
+    full_event_reads = 0
+
+    class Collection:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def get_full_list(self, query_params=None):
+            nonlocal full_event_reads
+            if self.name == "turn_events":
+                full_event_reads += 1
+            return list(records[self.name])
+
+        def get_list(self, page, per_page, query_params=None):
+            rows = list(records[self.name])
+            params = query_params or {}
+            if self.name == "turn_events":
+                marker = "seq>"
+                filter_value = str(params.get("filter") or "")
+                if marker in filter_value:
+                    after_seq = int(filter_value.rsplit(marker, 1)[1])
+                    rows = [row for row in rows if row.seq > after_seq]
+                rows.sort(key=lambda row: row.seq, reverse=params.get("sort") == "-seq")
+            start = (page - 1) * per_page
+            return SimpleNamespace(items=rows[start : start + per_page], total_items=len(rows))
+
+    class Client:
+        def collection(self, name: str) -> Collection:
+            return Collection(name)
+
+    monkeypatch.setattr(
+        "deeptutor.services.session.pocketbase_store._current_user_id",
+        lambda: "u_ada",
+    )
+    monkeypatch.setattr("deeptutor.services.session.pocketbase_store._pb", lambda: Client())
+    store = PocketBaseSessionStore()
+
+    page = asyncio.run(store.get_message_trace("session-1", "message-1", after_seq=100, limit=50))
+
+    assert page is not None
+    assert [event["seq"] for event in page["events"]] == list(range(101, 151))
+    assert page["total"] == 1_200
+    assert page["last_seq"] == 1_200
+    assert page["next_seq"] == 150
+    assert page["complete"] is False
+    assert full_event_reads == 0

--- a/tests/services/session/test_trace_memory.py
+++ b/tests/services/session/test_trace_memory.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+
+from deeptutor.services.session.event_preview import (
+    MAX_LEGACY_EVENT_PAYLOAD_CHARS,
+    compact_trace_preview,
+)
+from deeptutor.services.session.sqlite_store import SQLiteSessionStore
+
+
+def test_preview_keeps_semantic_events_and_bounds_legacy_payloads() -> None:
+    events = [
+        {"type": "content", "content": "delta"},
+        {
+            "type": "tool_result",
+            "content": "x" * (MAX_LEGACY_EVENT_PAYLOAD_CHARS + 10),
+            "metadata": {},
+        },
+        {"type": "result", "metadata": {"summary": "ok"}},
+        {"type": "done", "metadata": {"status": "completed"}},
+    ]
+
+    preview, truncated = compact_trace_preview(events)
+
+    assert truncated is True
+    assert [event["type"] for event in preview] == ["tool_result", "result", "done"]
+    assert len(preview[0]["content"]) == MAX_LEGACY_EVENT_PAYLOAD_CHARS + len("...[truncated]")
+
+
+def test_preview_prioritizes_the_terminal_tail() -> None:
+    events = [{"type": "tool_call", "content": str(i)} for i in range(250)]
+    events.append({"type": "done", "metadata": {"status": "completed"}})
+
+    preview, truncated = compact_trace_preview(events)
+
+    assert truncated is True
+    assert len(preview) == 200
+    assert preview[-1]["type"] == "done"
+
+
+def test_migration_backfills_assistant_message_link_from_legacy_done(tmp_path) -> None:
+    path = tmp_path / "chat.db"
+    store = SQLiteSessionStore(path)
+    session = asyncio.run(store.ensure_session(None))
+    turn = asyncio.run(store.begin_turn(session["id"], capability="chat"))
+    asyncio.run(store.transition_turn(turn["id"], "completed"))
+    second_turn = asyncio.run(store.begin_turn(session["id"], capability="chat"))
+    message_id = asyncio.run(store.add_message(session["id"], "assistant", "answer"))
+    second_message_id = asyncio.run(store.add_message(session["id"], "assistant", "second"))
+
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "UPDATE messages SET events_json = ? WHERE id = ?",
+            (
+                json.dumps(
+                    [
+                        {
+                            "type": "done",
+                            "turn_id": turn["id"],
+                            "metadata": {"assistant_message_id": message_id},
+                        }
+                    ]
+                ),
+                message_id,
+            ),
+        )
+        conn.execute(
+            "UPDATE messages SET events_json = ? WHERE id = ?",
+            (
+                json.dumps(
+                    [
+                        {
+                            "type": "done",
+                            "turn_id": second_turn["id"],
+                            "metadata": {"assistant_message_id": second_message_id},
+                        }
+                    ]
+                ),
+                second_message_id,
+            ),
+        )
+        conn.execute("UPDATE turns SET assistant_message_id = NULL")
+        conn.execute("DROP INDEX idx_turns_assistant_message")
+        conn.execute("ALTER TABLE turns DROP COLUMN assistant_message_id")
+
+    reopened = SQLiteSessionStore(path)
+    linked = asyncio.run(reopened.get_turn(turn["id"]))
+    assert linked is not None
+    assert linked["assistant_message_id"] == message_id
+    second_linked = asyncio.run(reopened.get_turn(second_turn["id"]))
+    assert second_linked is not None
+    assert second_linked["assistant_message_id"] == second_message_id
+
+
+def test_context_rehydrates_ask_user_from_canonical_turn_events(tmp_path) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat.db")
+    session = asyncio.run(store.ensure_session(None))
+    turn = asyncio.run(store.begin_turn(session["id"], capability="chat"))
+    message_id = asyncio.run(store.add_message(session["id"], "assistant", "answer"))
+    asyncio.run(
+        store.append_turn_events(
+            turn["id"],
+            [
+                {"type": "content", "content": "delta", "metadata": {}},
+                {
+                    "type": "tool_result",
+                    "metadata": {"tool_metadata": {"ask_user": {"questions": []}}},
+                },
+                {"type": "progress", "metadata": {"ask_user_resolved": True}},
+            ],
+        )
+    )
+    asyncio.run(store.link_turn_message(turn["id"], message_id))
+
+    context = asyncio.run(store.get_messages_for_context(session["id"]))
+
+    assert [event["type"] for event in context[-1]["events"]] == [
+        "tool_result",
+        "progress",
+    ]

--- a/web/features/chat/ChatStateAdapter.tsx
+++ b/web/features/chat/ChatStateAdapter.tsx
@@ -1298,6 +1298,7 @@ export function ChatStateAdapterProvider({
   // or ``nothing_to_regenerate``). Keyed by session entry key.
   const pendingRegenerateRef = useRef<Map<string, MessageItem>>(new Map());
   const traceCacheRef = useRef<TraceCache>(new TraceCache());
+  const traceRequestsRef = useRef<Map<string, AbortController>>(new Map());
   // Forward-declared so ``handleRunnerEvent`` (created above
   // ``loadSession`` in source order) can trigger a server refresh after
   // a turn finishes without taking a stale closure of ``loadSession``.
@@ -1311,6 +1312,11 @@ export function ChatStateAdapterProvider({
 
   useEffect(() => {
     if (!state.selectedKey) return;
+    for (const [key, controller] of traceRequestsRef.current) {
+      if (key.startsWith(`${state.selectedKey}:`)) continue;
+      controller.abort();
+      traceRequestsRef.current.delete(key);
+    }
     const released = traceCacheRef.current.releaseExcept(state.selectedKey);
     for (const [key, snapshot] of released) {
       const [sessionId, messageId] = key.split(":");
@@ -1330,6 +1336,8 @@ export function ChatStateAdapterProvider({
       runnersRef.current.clear();
       retryTimersRef.current.forEach((id) => clearTimeout(id));
       retryTimersRef.current.clear();
+      traceRequestsRef.current.forEach((controller) => controller.abort());
+      traceRequestsRef.current.clear();
     },
     [],
   );
@@ -1695,6 +1703,8 @@ export function ChatStateAdapterProvider({
 
   const releaseMessageTrace = useCallback((sessionId: string, messageId: number) => {
     const key = `${sessionId}:${messageId}`;
+    traceRequestsRef.current.get(key)?.abort();
+    traceRequestsRef.current.delete(key);
     const preview = traceCacheRef.current.release(key);
     if (!preview) return;
     dispatch({
@@ -1709,7 +1719,7 @@ export function ChatStateAdapterProvider({
   const loadMessageTrace = useCallback(
     async (sessionId: string, messageId: number) => {
       const key = `${sessionId}:${messageId}`;
-      if (traceCacheRef.current.has(key)) return;
+      if (traceCacheRef.current.has(key) || traceRequestsRef.current.has(key)) return;
       const session = stateRef.current.sessions[sessionId];
       if (!session || session.isStreaming || session.status === "running") return;
       const message = session.messages.find(
@@ -1717,44 +1727,62 @@ export function ChatStateAdapterProvider({
       );
       if (!message?.trace?.turn_id) return;
 
-      const events: StreamEvent[] = [];
-      let afterSeq = 0;
-      let page: MessageTracePage | null = null;
-      for (let page_count = 0; page_count < 1000; page_count += 1) {
-        page = await getMessageTrace(sessionId, messageId, afterSeq);
-        events.push(...page.events);
-        if (page.complete || page.next_seq == null) break;
-        afterSeq = page.next_seq;
-      }
-      if (!page) return;
-      const metadata: MessageTraceMetadata = {
-        turn_id: page.turn_id,
-        total: page.total,
-        last_seq: page.last_seq,
-        truncated: false,
-      };
-      const preview = compactTracePreview(message.events ?? []);
-      const evicted = traceCacheRef.current.retain(key, {
-        events: preview.events,
-        metadata: message.trace,
-      });
-      for (const [evictedKey, snapshot] of evicted) {
-        const [evictedSession, evictedMessage] = evictedKey.split(":");
+      const controller = new AbortController();
+      traceRequestsRef.current.set(key, controller);
+      try {
+        const events: StreamEvent[] = [];
+        let afterSeq = 0;
+        let page: MessageTracePage | null = null;
+        for (let pageCount = 0; pageCount < 1000; pageCount += 1) {
+          page = await getMessageTrace(
+            sessionId,
+            messageId,
+            afterSeq,
+            controller.signal,
+          );
+          events.push(...page.events);
+          if (page.complete || page.next_seq == null) break;
+          if (page.next_seq <= afterSeq) return;
+          afterSeq = page.next_seq;
+        }
+        if (!page || controller.signal.aborted) return;
+        const metadata: MessageTraceMetadata = {
+          turn_id: page.turn_id,
+          total: page.total,
+          last_seq: page.last_seq,
+          truncated: false,
+        };
+        const preview = compactTracePreview(message.events ?? []);
+        const evicted = traceCacheRef.current.retain(key, {
+          events: preview.events,
+          metadata: message.trace,
+        });
+        for (const [evictedKey, snapshot] of evicted) {
+          const [evictedSession, evictedMessage] = evictedKey.split(":");
+          dispatch({
+            type: "SET_MESSAGE_TRACE",
+            key: evictedSession,
+            messageId: Number(evictedMessage),
+            events: snapshot.events,
+            trace: snapshot.metadata ?? {},
+          });
+        }
         dispatch({
           type: "SET_MESSAGE_TRACE",
-          key: evictedSession,
-          messageId: Number(evictedMessage),
-          events: snapshot.events,
-          trace: snapshot.metadata ?? {},
+          key: sessionId,
+          messageId,
+          events,
+          trace: metadata,
         });
+      } catch (reason) {
+        if (!(reason instanceof DOMException && reason.name === "AbortError")) {
+          console.warn("Failed to load message trace", reason);
+        }
+      } finally {
+        if (traceRequestsRef.current.get(key) === controller) {
+          traceRequestsRef.current.delete(key);
+        }
       }
-      dispatch({
-        type: "SET_MESSAGE_TRACE",
-        key: sessionId,
-        messageId,
-        events,
-        trace: metadata,
-      });
     },
     [],
   );

--- a/web/features/chat/ChatStateAdapter.tsx
+++ b/web/features/chat/ChatStateAdapter.tsx
@@ -28,11 +28,18 @@ import { UnifiedTurnClient } from "@/features/chat/transport/UnifiedTurnClient";
 import { buildStartTurnInput } from "@/features/chat/controllers/buildStartTurnInput";
 import {
   getSession,
+  getMessageTrace,
   deleteMessage,
   updateBranchSelection,
   updateSessionTitle,
+  type MessageTracePage,
   type SessionMessage,
 } from "@/lib/session-api";
+import {
+  TraceCache,
+  compactTracePreview,
+  type MessageTraceMetadata,
+} from "@/features/chat/trace/memory";
 import {
   normalizeMarkdownForDisplay,
   repairChineseEmphasis,
@@ -215,6 +222,7 @@ export interface MessageItem {
   events?: StreamEvent[];
   attachments?: MessageAttachment[];
   requestSnapshot?: MessageRequestSnapshot;
+  trace?: MessageTraceMetadata;
   /** Edit-branching: id of the message this row continues. */
   parentMessageId?: number | null;
 }
@@ -306,6 +314,13 @@ type Action =
       turnId?: string | null;
       userMessageId?: number | null;
       assistantMessageId?: number | null;
+    }
+  | {
+      type: "SET_MESSAGE_TRACE";
+      key: string;
+      messageId: number;
+      events: StreamEvent[];
+      trace: MessageTraceMetadata;
     }
   | { type: "DELETE_TURN"; key: string; messageId: number }
   | {
@@ -868,6 +883,22 @@ function reducer(state: ProviderState, action: Action): ProviderState {
         },
       };
     }
+    case "SET_MESSAGE_TRACE": {
+      const session = state.sessions[action.key];
+      if (!session) return state;
+      const messages = session.messages.map((message) =>
+        message.id === action.messageId && message.role === "assistant"
+          ? { ...message, events: action.events, trace: action.trace }
+          : message,
+      );
+      return {
+        ...state,
+        sessions: {
+          ...state.sessions,
+          [action.key]: { ...session, messages, updatedAt: Date.now() },
+        },
+      };
+    }
     case "SET_SELECTED_BRANCH": {
       const session = state.sessions[action.key];
       if (!session) return state;
@@ -1067,6 +1098,10 @@ interface ChatContextValue {
   /** Select an already-loaded session without fetching. Returns false when
    *  it isn't in memory, i.e. the caller must load it. */
   showCachedSession: (sessionId: string) => boolean;
+  /** Lazily fetch one persisted turn trace and retain its compact preview. */
+  loadMessageTrace: (sessionId: string, messageId: number) => Promise<void>;
+  /** Restore the compact preview when a full trace is collapsed. */
+  releaseMessageTrace: (sessionId: string, messageId: number) => void;
   selectedSessionId: string | null;
   sessionStatuses: Record<string, SessionStatusSnapshot>;
   sidebarRefreshToken: number;
@@ -1262,6 +1297,7 @@ export function ChatStateAdapterProvider({
   // assistant message if the server rejects the request (e.g. ``regenerate_busy``
   // or ``nothing_to_regenerate``). Keyed by session entry key.
   const pendingRegenerateRef = useRef<Map<string, MessageItem>>(new Map());
+  const traceCacheRef = useRef<TraceCache>(new TraceCache());
   // Forward-declared so ``handleRunnerEvent`` (created above
   // ``loadSession`` in source order) can trigger a server refresh after
   // a turn finishes without taking a stale closure of ``loadSession``.
@@ -1272,6 +1308,21 @@ export function ChatStateAdapterProvider({
   useLayoutEffect(() => {
     stateRef.current = state;
   }, [state]);
+
+  useEffect(() => {
+    if (!state.selectedKey) return;
+    const released = traceCacheRef.current.releaseExcept(state.selectedKey);
+    for (const [key, snapshot] of released) {
+      const [sessionId, messageId] = key.split(":");
+      dispatch({
+        type: "SET_MESSAGE_TRACE",
+        key: sessionId,
+        messageId: Number(messageId),
+        events: snapshot.events,
+        trace: snapshot.metadata ?? {},
+      });
+    }
+  }, [state.selectedKey]);
 
   useEffect(
     () => () => {
@@ -1324,6 +1375,7 @@ export function ChatStateAdapterProvider({
             capability: message.capability || "",
             events: Array.isArray(message.events) ? message.events : [],
             attachments,
+            trace: message.trace,
             parentMessageId:
               message.parent_message_id === undefined
                 ? null
@@ -1456,6 +1508,26 @@ export function ChatStateAdapterProvider({
               userMessageId: doneMeta?.user_message_id ?? null,
               assistantMessageId,
             });
+            const finished = stateRef.current.sessions[effectiveKey];
+            const finishedMessage = [...(finished?.messages ?? [])].reverse().find(
+              (item) => item.role === "assistant",
+            );
+            if (finishedMessage) {
+              const sourceEvents = finishedMessage.events ?? [];
+              const preview = compactTracePreview(sourceEvents);
+              dispatch({
+                type: "SET_MESSAGE_TRACE",
+                key: effectiveKey,
+                messageId: assistantMessageId,
+                events: preview.events,
+                trace: {
+                  turn_id: event.turn_id || null,
+                  total: sourceEvents.length,
+                  last_seq: Math.max(0, ...sourceEvents.map((item) => item.seq ?? 0)),
+                  truncated: preview.truncated,
+                },
+              });
+            }
           } else {
             // Older backend without ids on ``done`` — fall back to the
             // full session refetch.
@@ -1621,6 +1693,72 @@ export function ChatStateAdapterProvider({
     return true;
   }, []);
 
+  const releaseMessageTrace = useCallback((sessionId: string, messageId: number) => {
+    const key = `${sessionId}:${messageId}`;
+    const preview = traceCacheRef.current.release(key);
+    if (!preview) return;
+    dispatch({
+      type: "SET_MESSAGE_TRACE",
+      key: sessionId,
+      messageId,
+      events: preview.events,
+      trace: preview.metadata ?? {},
+    });
+  }, []);
+
+  const loadMessageTrace = useCallback(
+    async (sessionId: string, messageId: number) => {
+      const key = `${sessionId}:${messageId}`;
+      if (traceCacheRef.current.has(key)) return;
+      const session = stateRef.current.sessions[sessionId];
+      if (!session || session.isStreaming || session.status === "running") return;
+      const message = session.messages.find(
+        (item) => item.id === messageId && item.role === "assistant",
+      );
+      if (!message?.trace?.turn_id) return;
+
+      const events: StreamEvent[] = [];
+      let afterSeq = 0;
+      let page: MessageTracePage | null = null;
+      for (let page_count = 0; page_count < 1000; page_count += 1) {
+        page = await getMessageTrace(sessionId, messageId, afterSeq);
+        events.push(...page.events);
+        if (page.complete || page.next_seq == null) break;
+        afterSeq = page.next_seq;
+      }
+      if (!page) return;
+      const metadata: MessageTraceMetadata = {
+        turn_id: page.turn_id,
+        total: page.total,
+        last_seq: page.last_seq,
+        truncated: false,
+      };
+      const preview = compactTracePreview(message.events ?? []);
+      const evicted = traceCacheRef.current.retain(key, {
+        events: preview.events,
+        metadata: message.trace,
+      });
+      for (const [evictedKey, snapshot] of evicted) {
+        const [evictedSession, evictedMessage] = evictedKey.split(":");
+        dispatch({
+          type: "SET_MESSAGE_TRACE",
+          key: evictedSession,
+          messageId: Number(evictedMessage),
+          events: snapshot.events,
+          trace: snapshot.metadata ?? {},
+        });
+      }
+      dispatch({
+        type: "SET_MESSAGE_TRACE",
+        key: sessionId,
+        messageId,
+        events,
+        trace: metadata,
+      });
+    },
+    [],
+  );
+
   const loadSession = useCallback(
     async (
       sessionId: string,
@@ -1640,6 +1778,7 @@ export function ChatStateAdapterProvider({
         const local = stateRef.current.sessions[key];
         if (!local || local.isStreaming || local.status === "running") return;
       }
+      traceCacheRef.current.clear();
       const messages = hydrateMessages(session.messages ?? []);
       const loadedWorkspaceMode = normalizeWorkspaceMode(
         session.preferences?.workspace_mode,
@@ -2408,6 +2547,8 @@ export function ChatStateAdapterProvider({
       configureSession,
       loadSession,
       showCachedSession,
+      loadMessageTrace,
+      releaseMessageTrace,
       selectedSessionId: derivedState.sessionId,
       sessionStatuses,
       sidebarRefreshToken: state.sidebarRefreshToken,
@@ -2434,6 +2575,8 @@ export function ChatStateAdapterProvider({
       configureSession,
       loadSession,
       showCachedSession,
+      loadMessageTrace,
+      releaseMessageTrace,
       sessionStatuses,
       state.sidebarRefreshToken,
     ],

--- a/web/features/chat/components/ChatWorkspace.tsx
+++ b/web/features/chat/components/ChatWorkspace.tsx
@@ -287,6 +287,8 @@ export default function ChatWorkspace() {
     newSession,
     loadSession,
     showCachedSession,
+    loadMessageTrace,
+    releaseMessageTrace,
     renameSessionTitle,
     setCourseId,
   } = useChatStateAdapter();
@@ -2406,6 +2408,16 @@ export default function ChatWorkspace() {
                         onEditMessage={editMessage}
                         onSwitchBranch={switchBranch}
                         onSubmitUserReply={submitUserReply}
+                        onLoadMessageTrace={(messageId) =>
+                          state.sessionId
+                            ? loadMessageTrace(state.sessionId, messageId)
+                            : Promise.resolve()
+                        }
+                        onReleaseMessageTrace={(messageId) => {
+                          if (state.sessionId) {
+                            releaseMessageTrace(state.sessionId, messageId);
+                          }
+                        }}
                         availableKbNames={
                           knowledgeBasesLoaded ? availableKbNames : undefined
                         }

--- a/web/features/chat/messages/ChatMessageList.tsx
+++ b/web/features/chat/messages/ChatMessageList.tsx
@@ -81,6 +81,7 @@ import {
   AssistantActivity,
   NestedTraceFlow,
 } from "@/features/chat/trace/TracePresentation";
+import type { MessageTraceMetadata } from "@/features/chat/trace/memory";
 import { agentGlyph } from "@/components/agents/agent-icons";
 import { useConnectedAgentKinds } from "@/hooks/useConnectedAgentKinds";
 import {
@@ -112,6 +113,7 @@ interface ChatMessageItem {
   content: string;
   capability?: string;
   events?: StreamEvent[];
+  trace?: MessageTraceMetadata;
   attachments?: MessageAttachment[];
   requestSnapshot?: MessageRequestSnapshot;
   parentMessageId?: number | null;
@@ -325,13 +327,21 @@ export const AssistantMessage = memo(function AssistantMessage({
   onConfirmOutline,
   onSubmitUserReply,
   researchRequestSnapshot,
+  onTraceToggle,
 }: {
-  msg: { content: string; capability?: string; events?: StreamEvent[] };
+  msg: {
+    id?: number;
+    content: string;
+    capability?: string;
+    events?: StreamEvent[];
+    trace?: MessageTraceMetadata;
+  };
   isStreaming?: boolean;
   outlineStatus?: "editing" | "researching" | "done" | "failed";
   sessionId?: string | null;
   language?: string;
   researchRequestSnapshot?: MessageRequestSnapshot | null;
+  onTraceToggle?: (open: boolean) => void;
   onConfirmOutline?: (
     outline: Array<{ title: string; overview: string }>,
     topic: string,
@@ -507,6 +517,11 @@ export const AssistantMessage = memo(function AssistantMessage({
         isStreaming={isStreaming}
         content={msg.content}
         className="mb-3"
+        onTraceToggle={
+          msg.id != null && msg.trace?.turn_id
+            ? (open) => onTraceToggle?.(open)
+            : undefined
+        }
       />
       {outlinePreview && outlinePreview.sub_topics.length > 0 ? (
         <>
@@ -1308,6 +1323,8 @@ export const ChatMessageList = memo(function ChatMessageList({
   availableKbNames,
   onSubmitUserReply,
   showModeBadge = true,
+  onLoadMessageTrace,
+  onReleaseMessageTrace,
 }: {
   messages: ChatMessageItem[];
   isStreaming: boolean;
@@ -1348,6 +1365,8 @@ export const ChatMessageList = memo(function ChatMessageList({
   /** Label each user bubble with its capability. Off on surfaces that run a
    *  single capability and already name it in their own chrome. */
   showModeBadge?: boolean;
+  onLoadMessageTrace?: (messageId: number) => Promise<void>;
+  onReleaseMessageTrace?: (messageId: number) => void;
 }) {
   const { t } = useTranslation();
   // Visible path: when no branching has happened the result is identical
@@ -1603,6 +1622,14 @@ export const ChatMessageList = memo(function ChatMessageList({
                 researchRequestSnapshot={
                   pairedUserMessage?.requestSnapshot ?? null
                 }
+                onTraceToggle={(open) => {
+                  if (msg.id == null) return;
+                  if (open) {
+                    void onLoadMessageTrace?.(msg.id);
+                  } else {
+                    onReleaseMessageTrace?.(msg.id);
+                  }
+                }}
               />
             </InlineFileCardProvider>
             <GeneratedFileCards

--- a/web/features/chat/trace/TracePresentation.tsx
+++ b/web/features/chat/trace/TracePresentation.tsx
@@ -1733,6 +1733,7 @@ export function AssistantActivity({
   agentName,
   showMark = true,
   headerClassName = "",
+  onTraceToggle,
 }: {
   events: StreamEvent[];
   /**
@@ -1754,6 +1755,8 @@ export function AssistantActivity({
   /** Extra classes on the status header row (e.g. a min-height so the row
    *  vertically centers against an adjacent avatar). */
   headerClassName?: string;
+  /** Notified when a persisted trace is opened or collapsed. */
+  onTraceToggle?: (open: boolean) => void;
 }) {
   const shownTraceEvents = traceEvents ?? events;
   const hasTrace = useMemo(
@@ -1782,7 +1785,11 @@ export function AssistantActivity({
         content={content}
         expandable={hasTrace}
         expanded={open}
-        onToggle={() => setUserOpen(!open)}
+        onToggle={() => {
+          const next = !open;
+          setUserOpen(next);
+          onTraceToggle?.(next);
+        }}
         agentName={agentName}
         showMark={showMark}
         className={headerClassName}

--- a/web/features/chat/trace/memory.ts
+++ b/web/features/chat/trace/memory.ts
@@ -1,0 +1,186 @@
+import type { StreamEvent } from "@/features/chat/model/protocol";
+
+export const MAX_PREVIEW_EVENTS = 200;
+export const MAX_PREVIEW_BYTES = 128 * 1024;
+export const MAX_LEGACY_PAYLOAD_CHARS = 16 * 1024;
+
+const TERMINAL_TYPES = new Set(["done", "error", "cancelled"]);
+const utf8Encoder = new TextEncoder();
+const SEMANTIC_TYPES = new Set([
+  "done",
+  "error",
+  "cancelled",
+  "result",
+  "tool_call",
+  "tool_result",
+]);
+
+function metadata(event: StreamEvent): Record<string, unknown> {
+  return (event.metadata ?? {}) as Record<string, unknown>;
+}
+
+function isSemantic(event: StreamEvent): boolean {
+  if (SEMANTIC_TYPES.has(String(event.type ?? ""))) return true;
+  const meta = metadata(event);
+  const toolMetadata = meta.tool_metadata;
+  return Boolean(
+    meta.ask_user ||
+      meta.ask_user_resolved ||
+      (typeof toolMetadata === "object" &&
+        toolMetadata !== null &&
+        "ask_user" in toolMetadata),
+  );
+}
+
+function isCritical(event: StreamEvent): boolean {
+  if (TERMINAL_TYPES.has(String(event.type ?? "")) || String(event.type ?? "") === "result") {
+    return true;
+  }
+  const meta = metadata(event);
+  const toolMetadata = meta.tool_metadata;
+  return Boolean(
+    meta.ask_user ||
+      meta.ask_user_resolved ||
+      (typeof toolMetadata === "object" &&
+        toolMetadata !== null &&
+        "ask_user" in toolMetadata),
+  );
+}
+
+function boundLegacyPayload(event: StreamEvent): StreamEvent {
+  let changed = false;
+  const next = { ...event } as StreamEvent & { _truncated?: boolean };
+  if (typeof event.content === "string" && event.content.length > MAX_LEGACY_PAYLOAD_CHARS) {
+    next.content = `${event.content.slice(0, MAX_LEGACY_PAYLOAD_CHARS)}...[truncated]`;
+    changed = true;
+  }
+  const meta = metadata(event);
+  const toolMetadata = meta.tool_metadata;
+  if (typeof toolMetadata === "object" && toolMetadata !== null) {
+    const boundedToolMetadata = { ...(toolMetadata as Record<string, unknown>) };
+    for (const field of ["content", "answer"] as const) {
+      const value = boundedToolMetadata[field];
+      if (typeof value === "string" && value.length > MAX_LEGACY_PAYLOAD_CHARS) {
+        boundedToolMetadata[field] = `${value.slice(0, MAX_LEGACY_PAYLOAD_CHARS)}...[truncated]`;
+        changed = true;
+      }
+    }
+    if (changed) next.metadata = { ...meta, tool_metadata: boundedToolMetadata };
+  }
+  return (changed ? next : event) as StreamEvent;
+}
+
+export function compactTracePreview(
+  events: StreamEvent[],
+  maxEvents = MAX_PREVIEW_EVENTS,
+  maxBytes = MAX_PREVIEW_BYTES,
+): { events: StreamEvent[]; truncated: boolean } {
+  const semantic = events.filter(isSemantic);
+  let criticalIndices = semantic.reduce<number[]>((indices, event, index) => {
+    if (isCritical(event)) indices.push(index);
+    return indices;
+  }, []);
+  if (criticalIndices.length > maxEvents) {
+    criticalIndices = criticalIndices.slice(-maxEvents);
+  }
+  const selectedIndices = new Set(criticalIndices);
+  for (let index = semantic.length - 1; index >= 0; index -= 1) {
+    if (selectedIndices.size >= maxEvents) break;
+    selectedIndices.add(index);
+  }
+  const selected = semantic.filter((_, index) => selectedIndices.has(index));
+  const result: StreamEvent[] = [];
+  let usedBytes = 0;
+  for (const source of selected) {
+    const event = boundLegacyPayload(source);
+    let size = utf8Encoder.encode(JSON.stringify(event)).length;
+    if (result.length > 0 && usedBytes + size > maxBytes) continue;
+    if (result.length === 0 && size > maxBytes) {
+      const bounded = {
+        type: event.type,
+        source: "",
+        stage: "",
+        metadata: {},
+        turn_id: event.turn_id,
+        session_id: event.session_id,
+        seq: event.seq,
+        timestamp: event.timestamp,
+        content: "...[truncated]",
+        _truncated: true,
+      };
+      size = utf8Encoder.encode(JSON.stringify(bounded)).length;
+      result.push(bounded as StreamEvent);
+      usedBytes += size;
+      continue;
+    }
+    result.push(event);
+    usedBytes += size;
+  }
+  if (!result.some((event) => TERMINAL_TYPES.has(String(event.type ?? "")))) {
+    const terminal = [...events].reverse().find((event) => TERMINAL_TYPES.has(String(event.type ?? "")));
+    if (terminal) result.push(terminal);
+  }
+  return {
+    events: result,
+    truncated: events.length !== result.length || selected.length !== result.length,
+  };
+}
+
+export interface TraceSnapshot {
+  events: StreamEvent[];
+  metadata?: MessageTraceMetadata;
+}
+
+export interface MessageTraceMetadata {
+  turn_id?: string | null;
+  total?: number;
+  last_seq?: number;
+  truncated?: boolean;
+}
+
+export class TraceCache {
+  private readonly entries = new Map<string, TraceSnapshot>();
+
+  constructor(private readonly capacity = 5) {}
+
+  retain(key: string, snapshot: TraceSnapshot): Array<[string, TraceSnapshot]> {
+    this.entries.delete(key);
+    this.entries.set(key, snapshot);
+    const evicted: Array<[string, TraceSnapshot]> = [];
+    while (this.entries.size > this.capacity) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      const released = this.release(oldest);
+      if (released) evicted.push([oldest, released]);
+    }
+    return evicted;
+  }
+
+  release(key: string): TraceSnapshot | undefined {
+    const snapshot = this.entries.get(key);
+    this.entries.delete(key);
+    return snapshot;
+  }
+
+  has(key: string): boolean {
+    return this.entries.has(key);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  releaseExcept(keyPrefix: string): Array<[string, TraceSnapshot]> {
+    const released: Array<[string, TraceSnapshot]> = [];
+    for (const [key, snapshot] of this.entries) {
+      if (key.startsWith(`${keyPrefix}:`)) continue;
+      released.push([key, snapshot]);
+      this.entries.delete(key);
+    }
+    return released;
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+}

--- a/web/lib/session-api.ts
+++ b/web/lib/session-api.ts
@@ -22,10 +22,29 @@ export interface SessionMessage {
     size_bytes?: number;
   }>;
   metadata?: Record<string, unknown>;
+  trace?: MessageTraceMetadata;
   created_at: number;
   /** Edit-branching: id of the message this row continues. `null` for the
    *  first message in a session. Siblings share the same parent. */
   parent_message_id?: number | null;
+}
+
+export interface MessageTraceMetadata {
+  turn_id?: string | null;
+  total?: number;
+  last_seq?: number;
+  truncated?: boolean;
+}
+
+export interface MessageTracePage {
+  session_id: string;
+  message_id: number;
+  turn_id?: string | null;
+  events: StreamEvent[];
+  total: number;
+  last_seq: number;
+  next_seq: number | null;
+  complete: boolean;
 }
 
 export interface SessionPreferences {
@@ -219,6 +238,21 @@ export async function updateSessionTitle(
   const data = await expectJson<{ session: SessionDetail }>(response);
   invalidateClientCache("sessions:");
   return data.session;
+}
+
+export async function getMessageTrace(
+  sessionId: string,
+  messageId: number,
+  afterSeq = 0,
+  signal?: AbortSignal,
+): Promise<MessageTracePage> {
+  const response = await apiFetch(
+    apiUrl(
+      `/api/sessions/${sessionId}/messages/${messageId}/events?after_seq=${afterSeq}&limit=500`,
+    ),
+    { cache: "no-store", signal },
+  );
+  return expectJson<MessageTracePage>(response);
 }
 
 export type SessionOrganizationPatch = Partial<{

--- a/web/tests/trace-memory.test.ts
+++ b/web/tests/trace-memory.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { StreamEvent } from "../features/chat/model/protocol";
+import {
+  MAX_LEGACY_PAYLOAD_CHARS,
+  TraceCache,
+  compactTracePreview,
+} from "../features/chat/trace/memory";
+
+function event(
+  type: StreamEvent["type"],
+  content = "",
+  metadata: Record<string, unknown> = {},
+): StreamEvent {
+  return {
+    type,
+    source: "chat",
+    stage: "",
+    content,
+    metadata,
+    timestamp: 1,
+  };
+}
+
+test("trace previews keep semantic state and bound legacy payloads", () => {
+  const preview = compactTracePreview([
+    event("content", "delta"),
+    event("tool_result", "x".repeat(MAX_LEGACY_PAYLOAD_CHARS + 2)),
+    event("result", "", { summary: "ok" }),
+    event("done", "", { status: "completed" }),
+  ]);
+
+  assert.equal(preview.truncated, true);
+  assert.deepEqual(
+    preview.events.map((item) => item.type),
+    ["tool_result", "result", "done"],
+  );
+  const bounded = preview.events[0].content ?? "";
+  assert.equal(
+    bounded.length,
+    MAX_LEGACY_PAYLOAD_CHARS + "...[truncated]".length,
+  );
+});
+
+test("expanded trace cache evicts the oldest message beyond five entries", () => {
+  const cache = new TraceCache(5);
+  for (let index = 0; index < 6; index += 1) {
+    cache.retain(`session:${index}`, { events: [event("done")] });
+  }
+
+  const evicted = cache.release("session:0");
+  assert.equal(evicted, undefined);
+  assert.equal(cache.has("session:1"), true);
+  assert.equal(cache.has("session:5"), true);
+  assert.equal(cache.size, 5);
+});
+
+test("trace previews preserve early critical state before the event cap", () => {
+  const preview = compactTracePreview(
+    [
+      event("content", "", { ask_user: true }),
+      event("tool_result"),
+      event("tool_result"),
+      event("done"),
+    ],
+    2,
+  );
+
+  assert.deepEqual(
+    preview.events.map((item) => item.type),
+    ["content", "done"],
+  );
+});


### PR DESCRIPTION
## Summary

- Keep `turn_events` as the authoritative full trace and return bounded semantic previews from session-detail responses.
- Stop duplicating the full event trace into new assistant `messages.events_json`; link assistant messages to their turns instead.
- Add a paginated, session-scoped message trace API so the UI can load full traces only when a trace is expanded.
- Compact local traces after a completed turn and retain at most five expanded traces, restoring previews on collapse or session switch.
- Preserve early `ask_user`, result, error, and terminal events when previews hit the event cap.
- Keep route-surface contract tests compatible with FastAPI 0.141 nested included routers, stabilize the Windows UTF-8 import check, and align the sequential-reader audit with the canonical route and post-turn event ordering.

Fixes #1190

## Compatibility

- Existing `messages.events_json` and workspace `events.jsonl` are preserved; no destructive migration or data clearing is included.
- SQLite adds a nullable, indexed `turns.assistant_message_id` and backfills links from legacy DONE metadata by both session and turn ID.
- PocketBase adds the corresponding nullable schema field and index via `scripts/pb_setup.py`.
- Legacy or unlinked assistant messages continue to use `events_json`; canonical `turn_events` are used when a turn link exists.
- Ask-user context recovery prefers canonical turn events and falls back to the legacy embedded trace.

## Verification

- PASS: `python -m pytest tests/services/session tests/api/test_session_organization.py tests/api/test_sessions_trace.py tests/api/test_sessions_truncation.py tests/multi_user/test_session_cleanup.py` — 261 passed, 7 warnings.
- PASS: `python -m pytest -q tests/api` — 538 passed, 3 warnings.
- PASS: `python -m pytest -q tests/app/test_multiworker_turn_application.py` — 2 passed, 2 warnings.
- PASS: `python -m ruff check` and `ruff format --check` on touched Python source and test files.
- PASS: `npm run typecheck`.
- PASS: `npm run test:node` — 964 passed.
- PASS: `npm run test:unit` — 34 passed.
- PASS: `npm run contracts:check`.
- PASS: `npm run lint` — 0 errors, 57 warnings; all warnings are pre-existing, including the existing `ChatWorkspace` `<img>` warning.
- PASS: `npm run build`.
- PASS: `npm run perf:check` — all route budgets within limits.
- PASS: required GitHub checks at `0e3e0ee6`, including Python 3.11-3.14 matrices, Web Node Tests, Lint and Format, repository hygiene, and cross-platform import checks.
- BLOCKED: `npm run test:e2e:critical` — command exits successfully but all 3 tests are skipped because the branch does not provide the required deterministic backend fixture enabled by `DEEPTUTOR_TURN_E2E_FIXTURE=1`.
