### PR TITLE
fix(llm): fall back on DeepSeek reasoning-replay 400s from Responses turns

### DIFF
--- a/deeptutor/services/llm/provider_core/openai_compat_provider.py
+++ b/deeptutor/services/llm/provider_core/openai_compat_provider.py
@@ -494,7 +494,7 @@ class OpenAICompatProvider(LLMProvider):
             or getattr(response, "text", None)
         )
         body_text = str(body).lower() if body is not None else ""
-        return any(
+        endpoint_unsupported = any(
             marker in body_text
             for marker in (
                 "responses",
@@ -508,6 +508,16 @@ class OpenAICompatProvider(LLMProvider):
                 "not supported",
             )
         )
+        # DeepSeek V4 reports a very specific three-part error when a
+        # Responses continuation cannot replay its prior reasoning item.  Keep
+        # these markers conjunctive: each phrase on its own is common in
+        # unrelated validation errors and must not trip the circuit breaker.
+        reasoning_replay_rejected = (
+            any(field in body_text for field in ("reasoning_text", "reasoning_content"))
+            and "thinking mode" in body_text
+            and "passed back" in body_text
+        )
+        return endpoint_unsupported or reasoning_replay_rejected
 
     @staticmethod
     def _is_response_format_error(exc: Exception) -> bool:

--- a/tests/services/llm/test_openai_compat_responses_fallback.py
+++ b/tests/services/llm/test_openai_compat_responses_fallback.py
@@ -1,0 +1,113 @@
+"""Tests for Responses-error fallback classification on the OpenAI-compatible provider."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from deeptutor.services.llm.provider_core.openai_compat_provider import (
+    OpenAICompatProvider,
+)
+from deeptutor.services.provider_registry import find_by_name
+
+
+class _FakeHTTPError(Exception):
+    def __init__(self, status_code: int, body: str) -> None:
+        super().__init__(body)
+        self.status_code = status_code
+        self.body = body
+
+
+class TestResponsesReasoningReplayFallback:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "The reasoning_text in the thinking mode must be passed back to the API.",
+            "The reasoning_content in the thinking mode must be passed back to the API.",
+        ],
+    )
+    def test_deepseek_reasoning_replay_400_falls_back(self, message: str) -> None:
+        exc = _FakeHTTPError(400, f"{{'message': '{message}', 'code': 'invalid_request_error'}}")
+        assert OpenAICompatProvider._should_fallback_from_responses_error(exc) is True
+
+    def test_unrelated_400_still_does_not_fall_back(self) -> None:
+        exc = _FakeHTTPError(
+            400, "{'message': 'Invalid model id', 'code': 'invalid_request_error'}"
+        )
+        assert OpenAICompatProvider._should_fallback_from_responses_error(exc) is False
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "reasoning_text is invalid",
+            "thinking mode is unavailable",
+            "The previous response must be passed back",
+        ],
+    )
+    def test_partial_reasoning_markers_do_not_fall_back(self, message: str) -> None:
+        exc = _FakeHTTPError(400, message)
+        assert OpenAICompatProvider._should_fallback_from_responses_error(exc) is False
+
+    def test_non_4xx_reasoning_error_does_not_fall_back(self) -> None:
+        exc = _FakeHTTPError(
+            500,
+            "The reasoning_text in the thinking mode must be passed back to the API.",
+        )
+        assert OpenAICompatProvider._should_fallback_from_responses_error(exc) is False
+
+    @pytest.mark.asyncio
+    async def test_automatic_responses_mode_retries_through_chat_completions(self) -> None:
+        calls = {"responses": 0, "chat": 0}
+
+        class FailingResponses:
+            async def create(self, **_kwargs):
+                calls["responses"] += 1
+                raise _FakeHTTPError(
+                    400,
+                    "The reasoning_text in the thinking mode must be passed back to the API.",
+                )
+
+        class SuccessfulChatCompletions:
+            async def create(self, **_kwargs):
+                calls["chat"] += 1
+                message = SimpleNamespace(
+                    content="fallback answer",
+                    reasoning_content=None,
+                    reasoning=None,
+                    tool_calls=None,
+                )
+                return SimpleNamespace(
+                    choices=[SimpleNamespace(message=message, finish_reason="stop")],
+                    usage=None,
+                )
+
+        provider = OpenAICompatProvider(
+            api_key="test-key",
+            default_model="deepseek-v4-flash",
+            spec=find_by_name("deepseek"),
+            provider_name="deepseek",
+            wire_api="auto",
+        )
+        provider._client = SimpleNamespace(
+            responses=FailingResponses(),
+            chat=SimpleNamespace(completions=SuccessfulChatCompletions()),
+        )
+
+        result = await provider.chat(
+            messages=[{"role": "user", "content": "search"}],
+            model="deepseek-v4-flash",
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "description": "Search the web",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        )
+
+        assert result.content == "fallback answer"
+        assert calls == {"responses": 1, "chat": 1}


### PR DESCRIPTION
## Summary
- Fall back from automatic Responses mode when DeepSeek reports that a prior `reasoning_text`/`reasoning_content` item was not passed back.
- Require the reasoning field, `thinking mode`, and `passed back` markers together so unrelated 4xx validation errors do not trip the circuit breaker.
- Add an end-to-end provider-path test proving that automatic Responses mode retries through Chat Completions.
- Rebased onto current `dev`.

## Verification
- 39 focused OpenAI-compatible provider tests passed.
- `ruff check` and `ruff format --check` passed.