### PR TITLE
fix(web): redirect legacy mastery /study URLs to /sessions

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -140,6 +140,24 @@ const nextConfig = {
   // Transpile mermaid and related packages for proper ESM handling
   transpilePackages: ["mermaid"],
 
+  // v1.6.2 and earlier bookmarked Mastery Study at `/study`; tip teaches under
+  // `/sessions`. Permanent redirects keep old URLs (and issue repro links)
+  // landing on the live surface instead of a bare 404.
+  async redirects() {
+    return [
+      {
+        source: "/mastery/:pathId/study",
+        destination: "/mastery/:pathId/sessions",
+        permanent: true,
+      },
+      {
+        source: "/mastery/:pathId/study/:sessionId",
+        destination: "/mastery/:pathId/sessions/:sessionId",
+        permanent: true,
+      },
+    ];
+  },
+
   // Next.js 16 blocks cross-origin access to /_next/* dev resources (HMR
   // WebSocket, fonts, dev-only scripts) unless the request host is on this
   // allow-list. Without it, browsing http://127.0.0.1:<port>/ against a dev

--- a/web/tests/mastery-study-route.test.ts
+++ b/web/tests/mastery-study-route.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import test from "node:test";
 
 import { isMasteryDraftSessionReady } from "../lib/mastery-study-route";
@@ -48,4 +49,29 @@ test("a route or topic switch invalidates an older draft guard", () => {
 
 test("an unbound draft stays on the sessionless study route", () => {
   assert.equal(isMasteryDraftSessionReady({ ...base, sessionId: null }), false);
+});
+
+test("legacy /mastery/.../study URLs permanently redirect to /sessions", async () => {
+  const nextConfig = require(path.resolve(process.cwd(), "next.config.js")) as {
+    redirects?: () => Promise<
+      Array<{ source: string; destination: string; permanent: boolean }>
+    >;
+  };
+  assert.equal(typeof nextConfig.redirects, "function");
+  const redirects = await nextConfig.redirects!();
+  assert.deepEqual(
+    redirects.filter((entry) => entry.source.includes("/study")),
+    [
+      {
+        source: "/mastery/:pathId/study",
+        destination: "/mastery/:pathId/sessions",
+        permanent: true,
+      },
+      {
+        source: "/mastery/:pathId/study/:sessionId",
+        destination: "/mastery/:pathId/sessions/:sessionId",
+        permanent: true,
+      },
+    ],
+  );
 });


### PR DESCRIPTION
## Summary
- Redirect legacy mastery `/study` bookmarks to the current `/sessions` route.
- Preserve path identifiers through the compatibility redirect.
- Rebased onto the latest `dev` after the v1.6.4 CI repair.

## Verification
- `npm run test:node` — passed
- `npm run typecheck` — passed
- Earlier clean-base validation: full `npm run check:fast` passed.