### PR TITLE
fix(cron): support migration locks on Windows

### DIFF
--- a/deeptutor/services/cron/repository.py
+++ b/deeptutor/services/cron/repository.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 import contextlib
-import fcntl
 import json
+import os
 from pathlib import Path
 import sqlite3
+import sys
 import time
 from typing import Any, Protocol
 
@@ -49,11 +50,27 @@ class SQLiteCronRepository:
     def _migration_lock(self):
         self._migration_lock_path.parent.mkdir(parents=True, exist_ok=True)
         with self._migration_lock_path.open("a+b") as handle:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"\0")
+                handle.flush()
+            handle.seek(0)
+            if sys.platform == "win32":
+                import msvcrt
+
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
             try:
                 yield
             finally:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                handle.seek(0)
+                if sys.platform == "win32":
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
     @staticmethod
     def _is_sqlite(path: Path) -> bool:

--- a/tests/services/cron/test_cron_service.py
+++ b/tests/services/cron/test_cron_service.py
@@ -8,6 +8,7 @@ import time
 
 import pytest
 
+import deeptutor.services.cron.repository as repository
 from deeptutor.services.cron.service import (
     CronOwner,
     CronSchedule,
@@ -64,6 +65,9 @@ class TestValidateSchedule:
 
 
 class TestJobManagement:
+    def test_repository_does_not_bind_posix_lock_at_import(self):
+        assert "fcntl" not in repository.__dict__
+
     def test_add_list_cancel_persist(self, tmp_path):
         store = tmp_path / "jobs.json"
         service = CronService(store_path=store)


### PR DESCRIPTION
## Summary

- avoid importing the POSIX-only `fcntl` module at repository import time
- use a one-byte `msvcrt.locking` range on Windows and `fcntl.flock` elsewhere
- retain exclusive migration-lock semantics and guaranteed release
- add a Windows-facing import regression

Fixes #1183

## Test plan

- `python -m pytest tests/services/cron -q` (`28 passed`)
- `python -m ruff check deeptutor/services/cron/repository.py tests/services/cron/test_cron_service.py`
- `python -m compileall deeptutor/services/cron/repository.py tests/services/cron/test_cron_service.py`
- `git diff --check`

## Boundary

This changes only the migration lock implementation. It does not change the
cron schema, persistence format, scheduling API, or migration behavior. The
implementation follows the cross-platform file-lock pattern already used by a
neighboring DeepTutor service.
