### PR TITLE
fix(agentic): fall back for Gemini thinking tools

### DIFF
--- a/deeptutor/runtime/agentic/client.py
+++ b/deeptutor/runtime/agentic/client.py
@@ -43,10 +43,12 @@ from deeptutor.services.provider_registry import (
     wire_api_from_api_format,
 )
 
-# Providers that don't reliably support OpenAI function-calling. The loop
-# still runs without tool schemas — the model just produces prose.
+# Providers that cannot safely use the generic OpenAI function-calling path.
+# Gemini thinking models require provider-specific thought_signature replay,
+# which this path cannot retain. The loop still runs without tool schemas and
+# the model produces prose instead.
 _NATIVE_TOOL_BLOCKED_BINDINGS: frozenset[str] = frozenset(
-    {"anthropic", "claude", "ollama", "lm_studio", "vllm", "llama_cpp"}
+    {"anthropic", "claude", "gemini", "ollama", "lm_studio", "vllm", "llama_cpp"}
 )
 
 # Native provider adapters whose backends speak OpenAI-style function calling

--- a/tests/core/test_agentic_client_provider_kwargs.py
+++ b/tests/core/test_agentic_client_provider_kwargs.py
@@ -409,7 +409,6 @@ def test_registered_cloud_openai_compat_providers_enable_native_tools() -> None:
     # disabling native tools when a new cloud provider joins the registry (the
     # gap that affected SiliconFlow before #584).
     for binding in (
-        "gemini",
         "zhipu",
         "qianfan",
         "stepfun",
@@ -423,6 +422,12 @@ def test_registered_cloud_openai_compat_providers_enable_native_tools() -> None:
         "byteplus_coding_plan",
     ):
         assert can_use_native_tool_calling(binding=binding, model=None) is True, binding
+
+
+def test_gemini_openai_compat_stays_opted_out_of_native_tools() -> None:
+    # Gemini thinking models require provider-specific thought signatures to be
+    # replayed after a function call, which the generic OpenAI path cannot retain.
+    assert can_use_native_tool_calling(binding="gemini", model="gemini-3-pro") is False
 
 
 def test_openai_codex_backend_can_use_native_tool_calling() -> None:


### PR DESCRIPTION
### Description

Gemini thinking models require provider-specific `thought_signature` metadata
to be replayed after function calls. DeepTutor's generic OpenAI-compatible tool
path cannot retain that metadata, so multi-turn native tool calls enter an
invalid provider contract.

This patch opts Gemini out of that generic native-tool path and reuses the
existing prose fallback. It also adds a regression that keeps Gemini blocked
without disabling native tools for the other registered OpenAI-compatible
cloud providers.

### Related Issues

- Closes #1181

### Module(s) Affected

- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [x] Other: `runtime/agentic`

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

Validated after rebasing onto current `dev` (`93df3d4`):

- `python -m pytest tests/core/test_agentic_client_provider_kwargs.py -q`
  (`32 passed`)
- Ruff on both modified files
- `compileall` on both modified files
- `git diff --check`

The complete all-files pre-commit sweep was not claimed; the modified-file
Ruff checks and focused tests passed, and upstream CI remains authoritative.

This is a safe compatibility fallback, not a native Gemini adapter. Native
Gemini tool calling should be restored only through a provider-specific path
that captures and replays thought signatures across function-call turns.
