### PR TITLE
fix(cli): expose knowledge-base progress events

### DIFF
--- a/deeptutor/knowledge/initializer.py
+++ b/deeptutor/knowledge/initializer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from collections.abc import Callable
 from datetime import datetime
 import json
 import logging
@@ -262,16 +263,23 @@ async def initialize_knowledge_base(
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
     rag_provider: Optional[str] = None,
+    *,
+    progress_callback: Callable[[dict[str, object]], None] | None = None,
 ) -> bool:
     """Convenience initializer used by CLI wrappers."""
     from deeptutor.knowledge.manager import KnowledgeBaseManager
 
     manager = KnowledgeBaseManager(base_dir=base_dir)
+    progress_tracker = ProgressTracker(kb_name, Path(base_dir))
+    if progress_callback is not None:
+        progress_tracker.set_callback(progress_callback)
+
     initializer = KnowledgeBaseInitializer(
         kb_name=kb_name,
         base_dir=base_dir,
         api_key=api_key,
         base_url=base_url,
+        progress_tracker=progress_tracker,
         rag_provider=rag_provider,
     )
     try:

--- a/deeptutor_cli/kb.py
+++ b/deeptutor_cli/kb.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+import sys
 from typing import Optional
 
 from rich.console import Console
@@ -23,6 +24,18 @@ from deeptutor.services.rag.factory import DEFAULT_PROVIDER
 from deeptutor.services.rag.file_routing import FileTypeRouter
 
 console = Console()
+
+
+def _cli_progress(progress: dict[str, object]) -> None:
+    """Render one progress-tracker event for a synchronous CLI user."""
+    stage = str(progress.get("stage") or "?")
+    message = str(progress.get("message") or "")
+    percent = progress.get("progress_percent")
+    if isinstance(percent, (int, float)):
+        prefix = f"[{stage}] {percent:5.1f}%"
+    else:
+        prefix = f"[{stage}]"
+    print(f"{prefix} {message}".rstrip(), file=sys.stderr, flush=True)
 
 
 def _get_kb_manager() -> KnowledgeBaseManager:
@@ -175,6 +188,7 @@ def register(app: typer.Typer) -> None:
                     kb_name=name,
                     source_files=doc_paths,
                     base_dir=str(mgr.base_dir),
+                    progress_callback=_cli_progress,
                 )
             )
         except Exception as exc:

--- a/tests/cli/test_kb_cli.py
+++ b/tests/cli/test_kb_cli.py
@@ -18,3 +18,19 @@ def test_collect_documents_from_directory_matches_uppercase_extensions(tmp_path:
     collected = [Path(path).name for path in _collect_documents([], str(docs_dir))]
 
     assert collected == ["README.MD", "报告.PDF"]
+
+
+def test_cli_progress_formats_tracker_payload(capsys) -> None:
+    from deeptutor_cli.kb import _cli_progress
+
+    _cli_progress(
+        {
+            "stage": "processing_documents",
+            "message": "Embedding batches: 1/4 complete",
+            "progress_percent": 25,
+        }
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ("[processing_documents]  25.0% Embedding batches: 1/4 complete\n")

--- a/tests/knowledge/test_initializer_progress_callback.py
+++ b/tests/knowledge/test_initializer_progress_callback.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import deeptutor.knowledge.initializer as initializer_module
+from deeptutor.knowledge.progress_tracker import ProgressStage
+
+
+@pytest.mark.asyncio
+async def test_initialize_knowledge_base_forwards_progress_callback(
+    monkeypatch, tmp_path: Path
+) -> None:
+    seen: list[dict[str, object]] = []
+
+    class FakeInitializer:
+        def __init__(self, *, kb_name, base_dir, progress_tracker, **kwargs):
+            self.kb_name = kb_name
+            self.base_dir = Path(base_dir)
+            self.progress_tracker = progress_tracker
+            self.raw_dir = self.base_dir / kb_name / "raw"
+
+        def create_directory_structure(self) -> None:
+            self.raw_dir.mkdir(parents=True, exist_ok=True)
+
+        def copy_documents(self, source_files: list[str]) -> list[str]:
+            return list(source_files)
+
+        async def process_documents(self) -> bool:
+            self.progress_tracker.update(
+                ProgressStage.PROCESSING_DOCUMENTS,
+                "sentinel progress",
+                current=1,
+                total=2,
+            )
+            return True
+
+    monkeypatch.setattr(initializer_module, "KnowledgeBaseInitializer", FakeInitializer)
+
+    result = await initializer_module.initialize_knowledge_base(
+        kb_name="callback-kb",
+        source_files=["/tmp/sentinel.md"],
+        base_dir=str(tmp_path),
+        progress_callback=seen.append,
+    )
+
+    assert result is True
+    assert seen
+    assert seen[-1]["stage"] == "processing_documents"
+    assert seen[-1]["message"] == "sentinel progress"


### PR DESCRIPTION
## Summary

The standalone `deeptutor kb create` command previously called
`initialize_knowledge_base()` without a way to observe the `ProgressTracker`
events it already generated. As a result, CLI users saw the initial creation
line and then had no structured progress output.

This change adds an optional synchronous callback to the convenience initializer
and renders those events to stderr from the CLI.

## Root cause

`ProgressTracker` already supports synchronous consumer callbacks through
`set_callback()`. The CLI path did not attach one; the server-only progress
ports are intentionally no-ops in CLI mode and are not the CLI interface.

## Changes

- Add keyword-only `progress_callback` to
  `initialize_knowledge_base()`.
- Attach the callback to the initializer's existing `ProgressTracker`.
- Add `_cli_progress()` to render stage, percentage, and message to stderr.
- Add tests for callback forwarding and CLI formatting.

The callback consumes the tracker payload's `progress_percent` field and remains
synchronous, matching `ProgressTracker._notify()`.

## Validation

```text
10 focused Python tests passed (one existing warning)
Ruff passed
pre-commit passed: repository hygiene, Ruff, formatting, secret scan, Bandit, mypy
1,013 frontend Node tests passed
frontend typecheck passed
frontend lint passed with existing warnings and zero errors
source Docker image built successfully: deeptutor:cli-progress-2026-09-02
```

Commands:

```bash
DEEPTUTOR_HOME=/Users/greggonzales/deeptutor .venv/bin/python -m pytest -q \
  tests/cli/test_kb_cli.py \
  tests/knowledge/test_progress_tracker.py \
  tests/knowledge/test_initializer_progress_callback.py \
  tests/api/test_knowledge_progress_ws.py

.venv/bin/python -m ruff check \
  deeptutor/knowledge/initializer.py \
  deeptutor_cli/kb.py \
  tests/cli/test_kb_cli.py \
  tests/knowledge/test_initializer_progress_callback.py

cd web
npm run test:node
npm run typecheck
npm run lint
```

## Scope limitation

This change makes existing progress events visible to CLI consumers. It does
not claim to add a heartbeat during a blocking LlamaIndex persistence call.
That separate behavior should be addressed only after an evidence-backed
reproduction identifies whether the process is alive in persistence or has
actually failed.

The frontend WebSocket retry guard and API indexing failure capture are already
present in the v1.6.4 baseline and are intentionally not duplicated here.
