### PR TITLE
feat(video-learning): add playback speed controls (#1207)

### DIFF
--- a/web/components/watching/WatchingPane.tsx
+++ b/web/components/watching/WatchingPane.tsx
@@ -469,7 +469,7 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
       {material && (
         <div className="flex min-h-0 flex-1 flex-col">
           <WatchingPlayer
-            key={`${material.material_id}:${material.playback.provider}`}
+            key={material.material_id}
             playback={material.playback}
             transcriptLanguage={material.transcript.language || "en"}
             onController={handleController}

--- a/web/components/watching/WatchingPlayer.tsx
+++ b/web/components/watching/WatchingPlayer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { apiUrl } from "@/lib/api";
@@ -21,11 +21,66 @@ interface WatchingPlayerProps {
   onError(message: string): void;
 }
 
+const PLAYBACK_RATES = [0.75, 1, 1.25, 1.5, 1.75, 2] as const;
+
 export function WatchingPlayer(props: WatchingPlayerProps) {
-  return props.playback.kind === "youtube_iframe" ? (
-    <YouTubePlayer {...props} playback={props.playback} />
-  ) : (
-    <InvidiousPlayer {...props} playback={props.playback} />
+  const { playback, onController } = props;
+  const { t } = useTranslation();
+  const [controller, setController] = useState<PlayerController | null>(null);
+  const [playbackRate, setPlaybackRate] = useState(1);
+
+  const handleController = useCallback(
+    (nextController: PlayerController | null) => {
+      setController(nextController);
+      onController(nextController);
+    },
+    [onController],
+  );
+
+  useEffect(() => {
+    if (controller?.setPlaybackRate) {
+      controller.setPlaybackRate(playbackRate);
+    }
+  }, [controller, playbackRate]);
+
+  return (
+    <>
+      {playback.kind === "youtube_iframe" ? (
+        <YouTubePlayer
+          {...props}
+          playback={playback}
+          onController={handleController}
+        />
+      ) : (
+        <InvidiousPlayer
+          {...props}
+          playback={playback}
+          onController={handleController}
+        />
+      )}
+      <div
+        role="group"
+        aria-label={t("Playback speed")}
+        className="flex items-center gap-1 border-b border-[var(--border)] px-4 py-2"
+      >
+        {PLAYBACK_RATES.map((rate) => (
+          <button
+            key={rate}
+            type="button"
+            disabled={!controller}
+            aria-pressed={playbackRate === rate}
+            onClick={() => setPlaybackRate(rate)}
+            className={`min-w-12 rounded-md px-2 py-1 text-xs font-medium tabular-nums ${
+              playbackRate === rate
+                ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+                : "text-[var(--muted-foreground)] hover:bg-[var(--muted)]"
+            } disabled:opacity-50`}
+          >
+            {rate}x
+          </button>
+        ))}
+      </div>
+    </>
   );
 }
 

--- a/web/lib/video-player-controller.ts
+++ b/web/lib/video-player-controller.ts
@@ -1,4 +1,9 @@
-export interface PlayerController {
+export interface PlaybackRateController {
+  getPlaybackRate(): number;
+  setPlaybackRate(rate: number): void;
+}
+
+export interface PlayerController extends Partial<PlaybackRateController> {
   currentTime(): number;
   duration(): number;
   seek(seconds: number): void;
@@ -7,9 +12,14 @@ export interface PlayerController {
   destroy(): void;
 }
 
+export type PlaybackRateCapableController = PlayerController &
+  PlaybackRateController;
+
 export interface YouTubePlayerLike {
   getCurrentTime(): number;
   getDuration(): number;
+  getPlaybackRate?(): number;
+  setPlaybackRate?(rate: number): void;
   seekTo(seconds: number, allowSeekAhead: boolean): void;
   playVideo(): void;
   pauseVideo(): void;
@@ -18,10 +28,12 @@ export interface YouTubePlayerLike {
 
 export function youtubePlayerController(
   player: YouTubePlayerLike,
-): PlayerController {
+): PlaybackRateCapableController {
   return {
     currentTime: () => Number(player.getCurrentTime()) || 0,
     duration: () => Number(player.getDuration()) || 0,
+    getPlaybackRate: () => Number(player.getPlaybackRate?.()) || 1,
+    setPlaybackRate: (rate) => player.setPlaybackRate?.(rate),
     seek: (seconds) => player.seekTo(Math.max(0, seconds), true),
     play: () => player.playVideo(),
     pause: () => player.pauseVideo(),
@@ -31,10 +43,14 @@ export function youtubePlayerController(
 
 export function html5PlayerController(
   video: HTMLMediaElement,
-): PlayerController {
+): PlaybackRateCapableController {
   return {
     currentTime: () => Number(video.currentTime) || 0,
     duration: () => Number(video.duration) || 0,
+    getPlaybackRate: () => Number(video.playbackRate) || 1,
+    setPlaybackRate: (rate) => {
+      video.playbackRate = rate;
+    },
     seek: (seconds) => {
       video.currentTime = Math.max(0, seconds);
     },

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -4442,6 +4442,7 @@
   "Immersive Watching": "Immersive Watching",
   "Native YouTube learning": "Native YouTube learning",
   "Refresh provider": "Refresh provider",
+  "Playback speed": "Playback speed",
   "Close video learning": "Close video learning",
   "Open a YouTube learning video": "Open a YouTube learning video",
   "Paste a watch, Shorts, Live, Embed, or youtu.be link.": "Paste a watch, Shorts, Live, Embed, or youtu.be link.",

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -4442,6 +4442,7 @@
   "Immersive Watching": "沉浸式观看",
   "Native YouTube learning": "原生 YouTube 学习",
   "Refresh provider": "刷新播放提供方",
+  "Playback speed": "播放速度",
   "Close video learning": "关闭视频学习",
   "Open a YouTube learning video": "打开 YouTube 学习视频",
   "Paste a watch, Shorts, Live, Embed, or youtu.be link.": "粘贴 watch、Shorts、Live、Embed 或 youtu.be 链接。",

--- a/web/tests/e2e/video-learning.audit.ts
+++ b/web/tests/e2e/video-learning.audit.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "@playwright/test";
 
 const MATERIAL_ID = "0123456789abcdef0123456789abcdef";
+const SECOND_MATERIAL_ID = "fedcba9876543210fedcba9876543210";
+const SECOND_VIDEO_ID = "9bZkp7q19f0";
 
 test("YouTube learning survives reload and switches to Invidious without silent fallback", async ({
   page,
@@ -15,6 +17,9 @@ test("YouTube learning survives reload and switches to Invidious without silent 
   let exportRequestCount = 0;
   let exportShouldFail = false;
   let nextNoteId = 1;
+  let activeMaterialId = MATERIAL_ID;
+  let activeVideoId = "dQw4w9WgXcQ";
+  let activeTitle = "Timestamped lesson";
   const notes: Array<{
     notebook_id: string;
     note_id: string;
@@ -40,15 +45,15 @@ test("YouTube learning survives reload and switches to Invidious without silent 
   const material = (selected: "youtube" | "invidious") => ({
     version: 1,
     type: "timed_media",
-    material_id: MATERIAL_ID,
+    material_id: activeMaterialId,
     source: {
       provider: "youtube",
-      video_id: "dQw4w9WgXcQ",
-      url: "https://youtu.be/dQw4w9WgXcQ",
+      video_id: activeVideoId,
+      url: `https://youtu.be/${activeVideoId}`,
       entry_time_seconds: 0,
     },
     metadata: {
-      title: "Timestamped lesson",
+      title: activeTitle,
       author: "Teacher",
       duration_seconds: 120,
     },
@@ -74,7 +79,7 @@ test("YouTube learning survives reload and switches to Invidious without silent 
         ? {
             provider: "youtube",
             kind: "youtube_iframe",
-            video_id: "dQw4w9WgXcQ",
+            video_id: activeVideoId,
             start_seconds: savedPosition,
           }
         : {
@@ -82,8 +87,8 @@ test("YouTube learning survives reload and switches to Invidious without silent 
             kind: "html5",
             format_id: "18",
             mime_type: "video/mp4",
-            stream_url: `/api/video-learning/materials/${MATERIAL_ID}/stream/18`,
-            subtitles_url: `/api/video-learning/materials/${MATERIAL_ID}/subtitles.vtt`,
+            stream_url: `/api/video-learning/materials/${activeMaterialId}/stream/18`,
+            subtitles_url: `/api/video-learning/materials/${activeMaterialId}/subtitles.vtt`,
             start_seconds: savedPosition,
           },
   });
@@ -94,6 +99,7 @@ test("YouTube learning survives reload and switches to Invidious without silent 
     class FakePlayer {
       current = 0;
       duration = 120;
+      playbackRate = 1;
       element: HTMLElement;
       options: Record<string, unknown>;
 
@@ -124,6 +130,12 @@ test("YouTube learning survives reload and switches to Invidious without silent 
       }
       getDuration() {
         return this.duration;
+      }
+      getPlaybackRate() {
+        return this.playbackRate;
+      }
+      setPlaybackRate(rate: number) {
+        this.playbackRate = rate;
       }
       seekTo(seconds: number) {
         this.current = seconds;
@@ -177,7 +189,7 @@ test("YouTube learning survives reload and switches to Invidious without silent 
       if (body.provider_override === "youtube") nativeResolveCount += 1;
       return json(material(body.provider_override || provider));
     }
-    if (path === `/api/video-learning/materials/${MATERIAL_ID}`) {
+    if (path === `/api/video-learning/materials/${activeMaterialId}`) {
       materialRequestCount += 1;
       if (provider === "invidious" && invidiousOffline) {
         return json({ detail: "Invidious is offline" }, 400);
@@ -273,6 +285,30 @@ test("YouTube learning survives reload and switches to Invidious without silent 
   await expect(
     page.locator('iframe[title="Fake YouTube player"]'),
   ).toHaveAttribute("src", /youtube-nocookie\.com\/embed\/dQw4w9WgXcQ/);
+  const speedGroup = page.getByRole("group", { name: "Playback speed" });
+  const normalSpeedButton = page.getByRole("button", {
+    name: "1x",
+    exact: true,
+  });
+  const fastSpeedButton = page.getByRole("button", {
+    name: "1.5x",
+    exact: true,
+  });
+  const currentYouTubePlaybackRate = () =>
+    page.evaluate(() => {
+      const player = (
+        window as typeof window & {
+          __fakePlayers: Array<{ playbackRate: number }>;
+        }
+      ).__fakePlayers.at(-1);
+      return player?.playbackRate || 1;
+    });
+  await expect(speedGroup).toBeVisible();
+  await expect(normalSpeedButton).toBeEnabled();
+  await expect(normalSpeedButton).toHaveAttribute("aria-pressed", "true");
+  await fastSpeedButton.click();
+  await expect(fastSpeedButton).toHaveAttribute("aria-pressed", "true");
+  await expect.poll(currentYouTubePlaybackRate).toBe(1.5);
 
   await page.evaluate(() => {
     const player = (
@@ -362,6 +398,8 @@ test("YouTube learning survives reload and switches to Invidious without silent 
   await page.goto("/chat?capability=immersive_watching");
   await expect.poll(() => materialRequestCount).toBe(1);
   await expect(page.getByText("Timestamped lesson")).toBeVisible();
+  await expect(normalSpeedButton).toHaveAttribute("aria-pressed", "true");
+  await expect.poll(currentYouTubePlaybackRate).toBe(1);
   await page.getByRole("tab", { name: "Video notes" }).click();
   await expect(page.getByText("First timestamped note")).toBeVisible();
 
@@ -447,10 +485,14 @@ test("YouTube learning survives reload and switches to Invidious without silent 
     )
     .toBeGreaterThanOrEqual(70);
 
+  await fastSpeedButton.click();
+  await expect(fastSpeedButton).toHaveAttribute("aria-pressed", "true");
+
   provider = "invidious";
   transcriptReady = false;
   await page.getByRole("button", { name: "Refresh provider" }).click();
   await expect(page.locator("video")).toBeVisible();
+  await expect(page.locator("video")).toHaveJSProperty("playbackRate", 1.5);
   await expect(page.getByText("Invidious", { exact: true })).toBeVisible();
   await expect(
     page.getByRole("button", { name: "Retry captions" }),
@@ -479,4 +521,25 @@ test("YouTube learning survives reload and switches to Invidious without silent 
     page.locator('iframe[title="Fake YouTube player"]'),
   ).toBeVisible();
   expect(nativeResolveCount).toBe(beforeFailure + 1);
+
+  await page.getByRole("button", { name: "Close video learning" }).click();
+  activeMaterialId = SECOND_MATERIAL_ID;
+  activeVideoId = SECOND_VIDEO_ID;
+  activeTitle = "Second timestamped lesson";
+  savedPosition = 0;
+  await page.goto("/chat?capability=immersive_watching");
+  await page
+    .getByPlaceholder("https://youtu.be/…")
+    .fill(`https://youtu.be/${SECOND_VIDEO_ID}`);
+  await page.getByRole("button", { name: "Open", exact: true }).click();
+  await expect(page.getByText("Second timestamped lesson")).toBeVisible();
+  await page.getByRole("button", { name: "Use native YouTube" }).click();
+  await expect(
+    page.locator('iframe[title="Fake YouTube player"]'),
+  ).toHaveAttribute(
+    "src",
+    new RegExp(`youtube-nocookie\\.com/embed/${SECOND_VIDEO_ID}`),
+  );
+  await expect(normalSpeedButton).toHaveAttribute("aria-pressed", "true");
+  await expect.poll(currentYouTubePlaybackRate).toBe(1);
 });

--- a/web/tests/video-player-controller.test.ts
+++ b/web/tests/video-player-controller.test.ts
@@ -1,16 +1,24 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { youtubePlayerController } from "../lib/video-player-controller";
+import {
+  html5PlayerController,
+  youtubePlayerController,
+} from "../lib/video-player-controller";
 
 test("normalizes the YouTube IFrame API behind the shared player contract", () => {
   let seeked = -1;
+  let playbackRate = 1;
   let played = 0;
   let paused = 0;
   let destroyed = 0;
   const controller = youtubePlayerController({
     getCurrentTime: () => 12.5,
     getDuration: () => 90,
+    getPlaybackRate: () => playbackRate,
+    setPlaybackRate: (rate) => {
+      playbackRate = rate;
+    },
     seekTo: (seconds) => {
       seeked = seconds;
     },
@@ -26,10 +34,28 @@ test("normalizes the YouTube IFrame API behind the shared player contract", () =
   });
   assert.equal(controller.currentTime(), 12.5);
   assert.equal(controller.duration(), 90);
+  controller.setPlaybackRate(1.5);
+  assert.equal(controller.getPlaybackRate(), 1.5);
   controller.seek(-3);
   controller.play();
   controller.pause();
   controller.destroy();
   assert.equal(seeked, 0);
   assert.deepEqual([played, paused, destroyed], [1, 1, 1]);
+});
+
+test("maps HTML5 playback rate behind the shared player contract", () => {
+  const video = {
+    currentTime: 4,
+    duration: 48,
+    playbackRate: 1,
+    play: () => undefined,
+    pause: () => undefined,
+  } as unknown as HTMLMediaElement;
+  const controller = html5PlayerController(video);
+
+  assert.equal(controller.getPlaybackRate(), 1);
+  controller.setPlaybackRate(0.75);
+  assert.equal(video.playbackRate, 0.75);
+  assert.equal(controller.getPlaybackRate(), 0.75);
 });


### PR DESCRIPTION
## Summary
- add shared YouTube/HTML5 playback-rate controller operations
- add accessible localized speed controls to Immersive Watching
- preserve speed across provider switches and reset new materials to 1x
- extend controller and browser regression coverage

Closes #1207

## Testing
- npm run typecheck
- npm run test:node
- npm run i18n:check
- eslint components/watching/WatchingPane.tsx components/watching/WatchingPlayer.tsx lib/video-player-controller.ts tests/e2e/video-learning.audit.ts tests/video-player-controller.test.ts
- WEB_BASE_URL=http://127.0.0.1:4317 ./node_modules/.bin/playwright test tests/e2e/video-learning.audit.ts --project=ui-audit --timeout=90000