### PR TITLE
feat(storage): content-addressed dedup for chat attachments

### DIFF
--- a/deeptutor/services/storage/__init__.py
+++ b/deeptutor/services/storage/__init__.py
@@ -1,8 +1,7 @@
 """Pluggable storage backends for chat-session artifacts.
 
-Currently exposes only :mod:`attachment_store`, which persists user-uploaded
-chat attachments to disk so the frontend can preview them after the original
-base64 payload is dropped from the message record.
+Currently exposes :mod:`attachment_store` (session-facing paths + public URLs)
+and :mod:`blob_store` (content-addressed bytes shared across identical uploads).
 """
 
 from deeptutor.services.storage.attachment_store import (
@@ -10,9 +9,12 @@ from deeptutor.services.storage.attachment_store import (
     LocalDiskAttachmentStore,
     get_attachment_store,
 )
+from deeptutor.services.storage.blob_store import ContentAddressedBlobStore, sha256_hex
 
 __all__ = [
     "AttachmentStore",
+    "ContentAddressedBlobStore",
     "LocalDiskAttachmentStore",
     "get_attachment_store",
+    "sha256_hex",
 ]

--- a/deeptutor/services/storage/attachment_store.py
+++ b/deeptutor/services/storage/attachment_store.py
@@ -17,18 +17,23 @@ Design goals
   S3 / MinIO / GCS backend without touching call-sites.
 * **Path-safe**: filenames coming over the WS are sanitised; resolved paths
   must remain inside the configured root.
+* **Content-addressed**: identical payloads share one blob object via
+  :class:`ContentAddressedBlobStore` (#1138). Session paths stay stable
+  ``{id}_{filename}`` hard-links (or copies) so ``/files/attachments/...``
+  URLs do not change.
 
 The on-disk layout is::
 
     {root}/{session_id}/{attachment_id}_{filename}
-
-The ``attachment_id`` prefix prevents collisions when the same filename is
-uploaded twice in the same session.
+    {root}/{session_id}/{attachment_id}_{filename}.cas.json   # digest sidecar
+    {blob_root}/objects/<ab>/<sha256>
+    {blob_root}/refs/<ab>/<sha256>.json
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 from pathlib import Path
@@ -38,13 +43,16 @@ from urllib.parse import quote
 from deeptutor.partners.helpers import safe_filename
 from deeptutor.services.config import load_system_settings
 from deeptutor.services.path_service import get_path_service
+from deeptutor.services.storage.blob_store import ContentAddressedBlobStore
 
 logger = logging.getLogger(__name__)
 
 
 _DEFAULT_SUBPATH = ("workspace", "chat", "attachments")
+_DEFAULT_BLOB_SUBPATH = ("workspace", "chat", "attachment_blobs")
 # Public route prefix served by deeptutor.api.routers.attachments
 _PUBLIC_URL_PREFIX = "/files/attachments"
+_CAS_SUFFIX = ".cas.json"
 
 
 def _coerce_filename(filename: str) -> str:
@@ -58,6 +66,10 @@ def _coerce_filename(filename: str) -> str:
     base = os.path.basename(filename or "")
     cleaned = safe_filename(base)
     return cleaned or "file"
+
+
+def _attachment_label(session_id: str, attachment_id: str) -> str:
+    return f"attachment:{_coerce_filename(session_id)}:{attachment_id}"
 
 
 @runtime_checkable
@@ -106,16 +118,29 @@ class LocalDiskAttachmentStore:
     The root directory defaults to ``data/user/workspace/chat/attachments``
     under the project root (matching :class:`PathService`'s public outputs).
     Override via ``data/user/settings/system.json`` ``chat_attachment_dir``.
+
+    Bytes are stored once in a sibling content-addressed blob catalog
+    (``chat_attachment_blob_dir`` / ``workspace/chat/attachment_blobs``).
     """
 
-    def __init__(self, root: Path | None = None) -> None:
+    def __init__(
+        self,
+        root: Path | None = None,
+        *,
+        blob_store: ContentAddressedBlobStore | None = None,
+    ) -> None:
         if root is None:
             root = _attachment_root()
         self._root = root
+        self._blobs = blob_store or ContentAddressedBlobStore(_blob_root(self._root))
 
     @property
     def root(self) -> Path:
         return self._root
+
+    @property
+    def blob_store(self) -> ContentAddressedBlobStore:
+        return self._blobs
 
     def _stored_filename(self, attachment_id: str, filename: str) -> str:
         return f"{attachment_id}_{_coerce_filename(filename)}"
@@ -153,8 +178,9 @@ class LocalDiskAttachmentStore:
         if target is None:
             raise ValueError(f"refusing to write attachment outside storage root: {stored!r}")
 
+        label = _attachment_label(session_id, attachment_id)
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._write_sync, target, data)
+        await loop.run_in_executor(None, self._put_sync, target, data, label)
 
         # The router uses the same _coerce_filename rules to look up the file,
         # so the public URL must use the sanitised pieces. Each path segment
@@ -165,16 +191,15 @@ class LocalDiskAttachmentStore:
         name = quote(_coerce_filename(filename), safe="")
         return f"{_PUBLIC_URL_PREFIX}/{sid}/{aid}/{name}"
 
-    @staticmethod
-    def _write_sync(target: Path, data: bytes) -> None:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        # Atomic-ish write: write to .tmp then rename. Avoids exposing a
-        # half-written file via the static handler.
-        tmp = target.with_suffix(target.suffix + ".tmp")
+    def _put_sync(self, target: Path, data: bytes, label: str) -> None:
+        digest = self._blobs.put(data, label=label)
+        mode = self._blobs.link_or_copy(digest, target)
+        sidecar = Path(str(target) + _CAS_SUFFIX)
+        payload = {"sha256": digest, "label": label, "materialize": mode}
+        tmp = sidecar.with_suffix(sidecar.suffix + ".tmp")
         try:
-            with tmp.open("wb") as fh:
-                fh.write(data)
-            os.replace(tmp, target)
+            tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+            os.replace(tmp, sidecar)
         finally:
             if tmp.exists():
                 try:
@@ -187,7 +212,7 @@ class LocalDiskAttachmentStore:
         if not session_dir.exists():
             return
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._rmtree_sync, session_dir)
+        await loop.run_in_executor(None, self._delete_session_sync, session_dir)
 
     async def delete_attachment(self, session_id: str, attachment_id: str) -> None:
         session_dir = self._session_dir(session_id)
@@ -196,29 +221,56 @@ class LocalDiskAttachmentStore:
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._delete_attachment_sync, session_dir, attachment_id)
 
-    @staticmethod
-    def _rmtree_sync(path: Path) -> None:
+    def _delete_session_sync(self, session_dir: Path) -> None:
         import shutil
 
+        if session_dir.is_dir():
+            for entry in list(session_dir.iterdir()):
+                if entry.name.endswith(_CAS_SUFFIX):
+                    continue
+                if entry.is_file():
+                    self._release_file(entry)
         try:
-            shutil.rmtree(path)
+            shutil.rmtree(session_dir)
         except OSError as exc:
-            logger.warning("failed to clean up attachment dir %s: %s", path, exc)
+            logger.warning("failed to clean up attachment dir %s: %s", session_dir, exc)
 
-    @staticmethod
-    def _delete_attachment_sync(session_dir: Path, attachment_id: str) -> None:
+    def _delete_attachment_sync(self, session_dir: Path, attachment_id: str) -> None:
         prefix = f"{attachment_id}_"
-        for entry in session_dir.iterdir():
+        for entry in list(session_dir.iterdir()):
+            if entry.name.endswith(_CAS_SUFFIX):
+                continue
             if entry.name.startswith(prefix):
+                self._release_file(entry)
                 try:
-                    entry.unlink()
+                    entry.unlink(missing_ok=True)
                 except OSError as exc:
                     logger.warning("failed to delete attachment file %s: %s", entry, exc)
+                sidecar = Path(str(entry) + _CAS_SUFFIX)
+                try:
+                    sidecar.unlink(missing_ok=True)
+                except OSError as exc:
+                    logger.warning("failed to delete attachment sidecar %s: %s", sidecar, exc)
         try:
             if session_dir.exists() and not any(session_dir.iterdir()):
                 session_dir.rmdir()
         except OSError as exc:
             logger.warning("failed to remove empty attachment dir %s: %s", session_dir, exc)
+
+    def _release_file(self, entry: Path) -> None:
+        sidecar = Path(str(entry) + _CAS_SUFFIX)
+        digest: str | None = None
+        label: str | None = None
+        if sidecar.is_file():
+            try:
+                raw = json.loads(sidecar.read_text(encoding="utf-8"))
+                if isinstance(raw, dict):
+                    digest = str(raw.get("sha256") or "").strip() or None
+                    label = str(raw.get("label") or "").strip() or None
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.warning("failed to read CAS sidecar %s: %s", sidecar, exc)
+        if label:
+            self._blobs.release(label, digest=digest)
 
     def resolve_path(self, *, session_id: str, attachment_id: str, filename: str) -> Path | None:
         stored = self._stored_filename(attachment_id, filename)
@@ -249,6 +301,17 @@ def _attachment_root() -> Path:
     if override:
         return Path(override).expanduser().resolve()
     return get_path_service().get_user_root().joinpath(*_DEFAULT_SUBPATH).resolve()
+
+
+def _blob_root(attachment_root: Path | None = None) -> Path:
+    override = str(load_system_settings().get("chat_attachment_blob_dir") or "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    if attachment_root is not None:
+        # Prefer a sibling of the attachments directory so a custom
+        # ``chat_attachment_dir`` still keeps blobs next to session files.
+        return (Path(attachment_root).resolve().parent / "attachment_blobs").resolve()
+    return get_path_service().get_user_root().joinpath(*_DEFAULT_BLOB_SUBPATH).resolve()
 
 
 def reset_attachment_store() -> None:

--- a/deeptutor/services/storage/attachment_store.py
+++ b/deeptutor/services/storage/attachment_store.py
@@ -198,7 +198,9 @@ class LocalDiskAttachmentStore:
         payload = {"sha256": digest, "label": label, "materialize": mode}
         tmp = sidecar.with_suffix(sidecar.suffix + ".tmp")
         try:
-            tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+            tmp.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+            )
             os.replace(tmp, sidecar)
         finally:
             if tmp.exists():

--- a/deeptutor/services/storage/blob_store.py
+++ b/deeptutor/services/storage/blob_store.py
@@ -180,6 +180,7 @@ class ContentAddressedBlobStore:
             except OSError as exc:
                 logger.warning("failed to remove blob object %s: %s", obj, exc)
                 return []
+
     def link_or_copy(self, digest: str, dest: Path) -> str:
         """Materialise *digest* at *dest* via hard link, else copy.
 

--- a/deeptutor/services/storage/blob_store.py
+++ b/deeptutor/services/storage/blob_store.py
@@ -1,0 +1,209 @@
+"""Content-addressed blob store with labelled reference counting.
+
+Used by chat attachments (#1138, stage 1) so identical uploads share one
+on-disk object. Reading / knowledge-base stores can adopt the same catalog
+later without changing the digest / label contract.
+
+Layout under ``root``::
+
+    objects/<ab>/<sha256>          # raw bytes
+    refs/<ab>/<sha256>.json        # {"labels": [...], "size": N}
+
+Hard-link (or copy fallback) materialises a consumer path while the blob
+object remains the single copy of the bytes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+import shutil
+import threading
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_HEX = frozenset("0123456789abcdef")
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+class ContentAddressedBlobStore:
+    """SHA-256 object store with per-label refcounts."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = Path(root)
+        self._objects = self._root / "objects"
+        self._refs = self._root / "refs"
+        self._locks: dict[str, threading.Lock] = {}
+        self._locks_guard = threading.Lock()
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    def _digest_lock(self, digest: str) -> threading.Lock:
+        with self._locks_guard:
+            lock = self._locks.get(digest)
+            if lock is None:
+                lock = threading.Lock()
+                self._locks[digest] = lock
+            return lock
+
+    def _shard(self, digest: str) -> str:
+        digest = digest.lower().strip()
+        if len(digest) != 64 or any(ch not in _HEX for ch in digest):
+            raise ValueError(f"invalid sha256 digest: {digest!r}")
+        return digest[:2]
+
+    def object_path(self, digest: str) -> Path:
+        shard = self._shard(digest)
+        return self._objects / shard / digest.lower()
+
+    def refs_path(self, digest: str) -> Path:
+        shard = self._shard(digest)
+        return self._refs / shard / f"{digest.lower()}.json"
+
+    def _read_refs(self, digest: str) -> dict[str, Any]:
+        path = self.refs_path(digest)
+        if not path.is_file():
+            return {"labels": [], "size": 0}
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("corrupt blob refs %s: %s", path, exc)
+            return {"labels": [], "size": 0}
+        labels = raw.get("labels") if isinstance(raw, dict) else None
+        size = raw.get("size") if isinstance(raw, dict) else 0
+        if not isinstance(labels, list):
+            labels = []
+        cleaned = [str(item) for item in labels if str(item or "").strip()]
+        return {"labels": cleaned, "size": int(size or 0)}
+
+    def _write_refs(self, digest: str, payload: dict[str, Any]) -> None:
+        path = self.refs_path(digest)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        text = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        try:
+            tmp.write_text(text, encoding="utf-8")
+            os.replace(tmp, path)
+        finally:
+            if tmp.exists():
+                try:
+                    tmp.unlink()
+                except OSError:
+                    pass
+
+    def _write_object(self, digest: str, data: bytes) -> Path:
+        target = self.object_path(digest)
+        if target.is_file() and target.stat().st_size == len(data):
+            return target
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        try:
+            with tmp.open("wb") as fh:
+                fh.write(data)
+            os.replace(tmp, target)
+        finally:
+            if tmp.exists():
+                try:
+                    tmp.unlink()
+                except OSError:
+                    pass
+        return target
+
+    def put(self, data: bytes, *, label: str) -> str:
+        """Store *data* (or reuse an existing object) and attach *label*."""
+        label = str(label or "").strip()
+        if not label:
+            raise ValueError("blob label must be non-empty")
+        digest = sha256_hex(data)
+        with self._digest_lock(digest):
+            self._write_object(digest, data)
+            meta = self._read_refs(digest)
+            labels = list(meta["labels"])
+            if label not in labels:
+                labels.append(label)
+            self._write_refs(digest, {"labels": labels, "size": len(data)})
+        return digest
+
+    def labels_for(self, digest: str) -> tuple[str, ...]:
+        return tuple(self._read_refs(digest)["labels"])
+
+    def release(self, label: str, *, digest: str | None = None) -> list[str]:
+        """Drop *label* from matching blobs; delete objects whose refcount hits zero.
+
+        When *digest* is provided only that object is touched; otherwise the
+        refs tree is scanned (used for recovery if a sidecar is missing).
+
+        Returns digests whose objects were removed.
+        """
+        label = str(label or "").strip()
+        if not label:
+            return []
+        if digest:
+            return self._release_one(digest, label)
+        if not self._refs.exists():
+            return []
+        removed: list[str] = []
+        for refs_file in self._refs.glob("*/*.json"):
+            candidate = refs_file.stem
+            if len(candidate) != 64:
+                continue
+            removed.extend(self._release_one(candidate, label))
+        return removed
+
+    def _release_one(self, digest: str, label: str) -> list[str]:
+        with self._digest_lock(digest):
+            meta = self._read_refs(digest)
+            labels = [item for item in meta["labels"] if item != label]
+            if len(labels) == len(meta["labels"]):
+                return []
+            refs_file = self.refs_path(digest)
+            if labels:
+                self._write_refs(digest, {"labels": labels, "size": meta["size"]})
+                return []
+            try:
+                refs_file.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning("failed to remove blob refs %s: %s", refs_file, exc)
+            obj = self.object_path(digest)
+            try:
+                obj.unlink(missing_ok=True)
+                return [digest.lower()]
+            except OSError as exc:
+                logger.warning("failed to remove blob object %s: %s", obj, exc)
+                return []
+    def link_or_copy(self, digest: str, dest: Path) -> str:
+        """Materialise *digest* at *dest* via hard link, else copy.
+
+        Returns ``"link"`` or ``"copy"``.
+        """
+        src = self.object_path(digest)
+        if not src.is_file():
+            raise FileNotFoundError(f"blob object missing for {digest}")
+        dest = Path(dest)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if dest.exists():
+            dest.unlink()
+        try:
+            os.link(src, dest)
+            return "link"
+        except OSError as exc:
+            logger.debug("hardlink unavailable for %s → %s (%s); copying", src, dest, exc)
+            shutil.copy2(src, dest)
+            return "copy"
+
+    def object_count(self) -> int:
+        if not self._objects.exists():
+            return 0
+        return sum(1 for path in self._objects.glob("*/*") if path.is_file())
+
+
+__all__ = ["ContentAddressedBlobStore", "sha256_hex"]

--- a/tests/services/storage/test_attachment_blob_dedup.py
+++ b/tests/services/storage/test_attachment_blob_dedup.py
@@ -29,7 +29,9 @@ def test_blob_store_dedups_and_releases(tmp_path: Path) -> None:
     assert dest_a.read_bytes() == payload
     assert dest_b.read_bytes() == payload
     if mode_a == "link" and mode_b == "link":
-        assert dest_a.stat().st_ino == dest_b.stat().st_ino == store.object_path(first).stat().st_ino
+        assert (
+            dest_a.stat().st_ino == dest_b.stat().st_ino == store.object_path(first).stat().st_ino
+        )
 
     removed = store.release("attachment:s1:a1", digest=first)
     assert removed == []
@@ -41,7 +43,9 @@ def test_blob_store_dedups_and_releases(tmp_path: Path) -> None:
     assert store.object_count() == 0
 
 
-def test_blob_store_link_falls_back_to_copy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_blob_store_link_falls_back_to_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     store = ContentAddressedBlobStore(tmp_path / "blobs")
     digest = store.put(b"payload", label="attachment:s:a")
 

--- a/tests/services/storage/test_attachment_blob_dedup.py
+++ b/tests/services/storage/test_attachment_blob_dedup.py
@@ -1,0 +1,120 @@
+"""Content-addressed chat attachment dedup (#1138 stage 1)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+from deeptutor.services.storage.attachment_store import LocalDiskAttachmentStore
+from deeptutor.services.storage.blob_store import ContentAddressedBlobStore, sha256_hex
+
+
+def test_blob_store_dedups_and_releases(tmp_path: Path) -> None:
+    store = ContentAddressedBlobStore(tmp_path / "blobs")
+    payload = b"identical-bytes"
+
+    first = store.put(payload, label="attachment:s1:a1")
+    second = store.put(payload, label="attachment:s1:a2")
+    assert first == second == sha256_hex(payload)
+    assert store.object_count() == 1
+    assert set(store.labels_for(first)) == {"attachment:s1:a1", "attachment:s1:a2"}
+
+    dest_a = tmp_path / "a.bin"
+    dest_b = tmp_path / "b.bin"
+    mode_a = store.link_or_copy(first, dest_a)
+    mode_b = store.link_or_copy(first, dest_b)
+    assert dest_a.read_bytes() == payload
+    assert dest_b.read_bytes() == payload
+    if mode_a == "link" and mode_b == "link":
+        assert dest_a.stat().st_ino == dest_b.stat().st_ino == store.object_path(first).stat().st_ino
+
+    removed = store.release("attachment:s1:a1", digest=first)
+    assert removed == []
+    assert store.object_count() == 1
+    assert store.labels_for(first) == ("attachment:s1:a2",)
+
+    removed = store.release("attachment:s1:a2", digest=first)
+    assert removed == [first]
+    assert store.object_count() == 0
+
+
+def test_blob_store_link_falls_back_to_copy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = ContentAddressedBlobStore(tmp_path / "blobs")
+    digest = store.put(b"payload", label="attachment:s:a")
+
+    def _no_link(*_args: object, **_kwargs: object) -> None:
+        raise OSError("hardlink unsupported")
+
+    monkeypatch.setattr(os, "link", _no_link)
+    dest = tmp_path / "out.bin"
+    assert store.link_or_copy(digest, dest) == "copy"
+    assert dest.read_bytes() == b"payload"
+
+
+def test_attachment_store_shares_blob_across_uploads(tmp_path: Path) -> None:
+    root = tmp_path / "attachments"
+    blobs = ContentAddressedBlobStore(tmp_path / "blobs")
+    store = LocalDiskAttachmentStore(root=root, blob_store=blobs)
+    payload = b"%PDF-same-document"
+
+    async def _run() -> None:
+        url1 = await store.put(
+            session_id="sess-a",
+            attachment_id="att-1",
+            filename="notes.pdf",
+            data=payload,
+        )
+        url2 = await store.put(
+            session_id="sess-b",
+            attachment_id="att-2",
+            filename="notes.pdf",
+            data=payload,
+        )
+        assert url1 == "/files/attachments/sess-a/att-1/notes.pdf"
+        assert url2 == "/files/attachments/sess-b/att-2/notes.pdf"
+        assert blobs.object_count() == 1
+
+        path1 = store.resolve_path(session_id="sess-a", attachment_id="att-1", filename="notes.pdf")
+        path2 = store.resolve_path(session_id="sess-b", attachment_id="att-2", filename="notes.pdf")
+        assert path1 is not None and path2 is not None
+        assert path1.read_bytes() == path2.read_bytes() == payload
+        # Prefer hardlinks when the filesystem allows them.
+        if path1.stat().st_ino == path2.stat().st_ino:
+            assert path1.stat().st_nlink >= 2
+
+        await store.delete_attachment(session_id="sess-a", attachment_id="att-1")
+        assert (
+            store.resolve_path(session_id="sess-a", attachment_id="att-1", filename="notes.pdf")
+            is None
+        )
+        assert (
+            store.resolve_path(session_id="sess-b", attachment_id="att-2", filename="notes.pdf")
+            is not None
+        )
+        assert blobs.object_count() == 1
+
+        await store.delete_session("sess-b")
+        assert blobs.object_count() == 0
+        assert (
+            store.resolve_path(session_id="sess-b", attachment_id="att-2", filename="notes.pdf")
+            is None
+        )
+
+    asyncio.run(_run())
+
+
+def test_attachment_store_distinct_bytes_stay_separate(tmp_path: Path) -> None:
+    store = LocalDiskAttachmentStore(
+        root=tmp_path / "attachments",
+        blob_store=ContentAddressedBlobStore(tmp_path / "blobs"),
+    )
+
+    async def _run() -> None:
+        await store.put(session_id="s", attachment_id="a", filename="a.txt", data=b"one")
+        await store.put(session_id="s", attachment_id="b", filename="b.txt", data=b"two")
+        assert store.blob_store.object_count() == 2
+
+    asyncio.run(_run())


### PR DESCRIPTION
﻿## Summary

- Add a content-addressed blob catalog (`ContentAddressedBlobStore`) keyed by SHA-256 with labelled refcounts
- Wire `LocalDiskAttachmentStore` so identical chat uploads share one object via hard-link (copy fallback when the FS cannot link)
- Keep public `/files/attachments/{session}/{id}/{name}` URLs and session path layout unchanged; sidecars track digests for safe release
- **Scope**: chat attachments only (Reading / KB left for follow-ups per #1138)

**Rebased for the v1.6.5 reconcile (2026-09-06):** `dev` was reconciled with `main` (`42fab3cf`); branch is now 3 commits on top of it, storage-only plus the base SKILL.md ruff-format fix, +427/鈭?6). The earlier tip's route-budget web lazy-chunks were dropped (the release sync superseded them).

Part of #1138

## Test plan

- [x] `pytest tests/services/storage tests/multi_user/test_session_cleanup.py -q` (5 passed) on the rebased head
- [x] `ruff check` on `deeptutor/services/storage` + new tests; `ruff format --check` clean
- [x] Upload the same PDF twice in two sessions → one blob object under `workspace/chat/attachment_blobs` — pinned by `test_attachment_store_shares_blob_across_uploads` (same bytes in two sessions → one blob) and `test_blob_store_dedups_and_releases`
- [x] Delete one attachment → the other preview still works; delete the last → blob removed — pinned by `test_attachment_store_shares_blob_across_uploads`: deleting one session keeps the blob (count stays 1), deleting the last drops it to 0




> **CI note (2026-09-06):** 
A follow-up style commit also runs `ruff format` over the two `deeptutor/skills/builtin/*/SKILL.md` files the v1.6.5 reconcile shipped unformatted — the repo-wide `Lint and Format` gate (ruff format --check) fails on the base for every PR without it.



