### PR TITLE
fix(agents): retry empty structured JSON in math animator

### DIFF
--- a/deeptutor/agents/_shared/json_output.py
+++ b/deeptutor/agents/_shared/json_output.py
@@ -8,7 +8,12 @@ from typing import Any
 
 
 def extract_json_object(text: str) -> dict[str, Any]:
-    """Extract the first usable JSON object from raw model output."""
+    """Extract the first usable JSON object from raw model output.
+
+    Empty input returns ``{}`` for backward-compatible soft callers. Prefer
+    :func:`require_json_object` when a stage must fail closed on blank LLM
+    content (``content: null`` / reasoning-only replies).
+    """
     raw = (text or "").strip()
     if not raw:
         return {}
@@ -38,6 +43,18 @@ def extract_json_object(text: str) -> dict[str, Any]:
     raise json.JSONDecodeError("No JSON object found", raw, 0)
 
 
+def require_json_object(text: str) -> dict[str, Any]:
+    """Like :func:`extract_json_object`, but empty / null content is an error."""
+    raw = (text or "").strip()
+    if not raw:
+        raise json.JSONDecodeError(
+            "Empty model content; expected a JSON object",
+            text or "",
+            0,
+        )
+    return extract_json_object(raw)
+
+
 def _decode_first_json_object(text: str) -> dict[str, Any] | None:
     decoder = json.JSONDecoder()
     stripped = (text or "").lstrip()
@@ -59,4 +76,4 @@ def _decode_first_json_object(text: str) -> dict[str, Any] | None:
     return None
 
 
-__all__ = ["extract_json_object"]
+__all__ = ["extract_json_object", "require_json_object"]

--- a/deeptutor/agents/_shared/structured_llm.py
+++ b/deeptutor/agents/_shared/structured_llm.py
@@ -1,0 +1,99 @@
+"""Retry helpers for agents that need a JSON object from the LLM.
+
+Thinking models sometimes return ``content: null`` (or empty streamed text)
+while emitting reasoning. Structured stages must not treat that as a valid
+``{}`` payload — they should nudge and retry a bounded number of times.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+import json
+import logging
+from typing import Any, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+from deeptutor.agents._shared.json_output import require_json_object
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+DEFAULT_STRUCTURED_ATTEMPTS = 3
+
+_JSON_RETRY_NUDGE = (
+    "\n\nIMPORTANT: Your previous reply was empty or not a valid JSON object "
+    "(reasoning-only / null content fails this step). "
+    "Reply with ONE JSON object only. No markdown fences, no prose outside JSON."
+)
+
+
+async def stream_and_validate_json(
+    *,
+    stream: Callable[..., AsyncIterator[str]],
+    user_prompt: str,
+    model_type: type[T],
+    stream_kwargs: dict[str, Any] | None = None,
+    build_messages: Callable[[str], list[dict[str, Any]]] | None = None,
+    is_complete: Callable[[T], bool] | None = None,
+    max_attempts: int = DEFAULT_STRUCTURED_ATTEMPTS,
+) -> T:
+    """Stream an LLM reply, parse a JSON object, and validate into *model_type*.
+
+    On empty content, non-JSON text, validation failure, or an incomplete
+    payload (``is_complete``), append a nudge and retry up to *max_attempts*.
+    """
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be >= 1")
+
+    base_kwargs = dict(stream_kwargs or {})
+    last_error: Exception | None = None
+    prompt = user_prompt
+
+    for attempt in range(1, max_attempts + 1):
+        kwargs = dict(base_kwargs)
+        kwargs["user_prompt"] = prompt
+        if build_messages is not None:
+            kwargs["messages"] = build_messages(prompt)
+
+        chunks: list[str] = []
+        async for chunk in stream(**kwargs):
+            chunks.append(chunk)
+        raw = "".join(chunks)
+
+        try:
+            payload = require_json_object(raw)
+            parsed = model_type.model_validate(payload)
+            if is_complete is not None and not is_complete(parsed):
+                raise ValueError(f"{model_type.__name__} missing required fields after parse")
+            if attempt > 1:
+                logger.info(
+                    "structured JSON recovered on attempt %s/%s for %s",
+                    attempt,
+                    max_attempts,
+                    model_type.__name__,
+                )
+            return parsed
+        except (json.JSONDecodeError, ValidationError, ValueError, TypeError) as exc:
+            last_error = exc
+            logger.warning(
+                "structured JSON attempt %s/%s for %s failed: %s",
+                attempt,
+                max_attempts,
+                model_type.__name__,
+                exc,
+            )
+            prompt = user_prompt + _JSON_RETRY_NUDGE
+
+    assert last_error is not None
+    raise ValueError(
+        f"LLM returned unusable structured output for {model_type.__name__} "
+        f"after {max_attempts} attempt(s)"
+    ) from last_error
+
+
+__all__ = [
+    "DEFAULT_STRUCTURED_ATTEMPTS",
+    "stream_and_validate_json",
+]

--- a/deeptutor/agents/math_animator/agents/concept_analysis_agent.py
+++ b/deeptutor/agents/math_animator/agents/concept_analysis_agent.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+from deeptutor.agents._shared.structured_llm import stream_and_validate_json
 from deeptutor.agents.base_agent import BaseAgent
 from deeptutor.core.context import Attachment
 from deeptutor.core.trace import build_trace_metadata, new_call_id
 from deeptutor.services.prompt import get_prompt_manager
 
 from ..models import ConceptAnalysis
-from ..utils import extract_json_object
 
 
 class ConceptAnalysisAgent(BaseAgent):
@@ -62,27 +62,36 @@ class ConceptAnalysisAgent(BaseAgent):
             style_hint=style_hint.strip() or "(none)",
             reference_count=reference_count,
         )
-        messages = [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt},
-        ]
-        _chunks: list[str] = []
-        async for _c in self.stream_llm(
+
+        def _messages(prompt: str) -> list[dict[str, str]]:
+            return [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ]
+
+        return await stream_and_validate_json(
+            stream=self.stream_llm,
             user_prompt=user_prompt,
-            system_prompt=system_prompt,
-            messages=messages,
-            attachments=attachments,
-            response_format={"type": "json_object"},
-            stage="concept_analysis",
-            trace_meta=build_trace_metadata(
-                call_id=new_call_id("math-analysis"),
-                phase="concept_analysis",
-                label="Concept analysis",
-                call_kind="math_concept_analysis",
-                trace_role="analyze",
-                trace_kind="llm_output",
+            model_type=ConceptAnalysis,
+            build_messages=_messages,
+            stream_kwargs={
+                "system_prompt": system_prompt,
+                "attachments": attachments,
+                "response_format": {"type": "json_object"},
+                "stage": "concept_analysis",
+                "trace_meta": build_trace_metadata(
+                    call_id=new_call_id("math-analysis"),
+                    phase="concept_analysis",
+                    label="Concept analysis",
+                    call_kind="math_concept_analysis",
+                    trace_role="analyze",
+                    trace_kind="llm_output",
+                ),
+            },
+            is_complete=lambda payload: bool(
+                payload.learning_goal.strip()
+                or payload.math_focus
+                or payload.narrative_steps
+                or payload.visual_targets
             ),
-        ):
-            _chunks.append(_c)
-        response = "".join(_chunks)
-        return ConceptAnalysis.model_validate(extract_json_object(response))
+        )

--- a/deeptutor/agents/math_animator/agents/concept_design_agent.py
+++ b/deeptutor/agents/math_animator/agents/concept_design_agent.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import json
 
+from deeptutor.agents._shared.structured_llm import stream_and_validate_json
 from deeptutor.agents.base_agent import BaseAgent
 from deeptutor.core.trace import build_trace_metadata, new_call_id
 
 from ..models import ConceptAnalysis, SceneDesign
-from ..utils import extract_json_object
 
 
 class ConceptDesignAgent(BaseAgent):
@@ -47,21 +47,24 @@ class ConceptDesignAgent(BaseAgent):
             style_hint=style_hint.strip() or "(none)",
             analysis_json=json.dumps(analysis.model_dump(), ensure_ascii=False, indent=2),
         )
-        _chunks: list[str] = []
-        async for _c in self.stream_llm(
+        return await stream_and_validate_json(
+            stream=self.stream_llm,
             user_prompt=user_prompt,
-            system_prompt=system_prompt,
-            response_format={"type": "json_object"},
-            stage="concept_design",
-            trace_meta=build_trace_metadata(
-                call_id=new_call_id("math-design"),
-                phase="concept_design",
-                label="Concept design",
-                call_kind="math_concept_design",
-                trace_role="design",
-                trace_kind="llm_output",
+            model_type=SceneDesign,
+            stream_kwargs={
+                "system_prompt": system_prompt,
+                "response_format": {"type": "json_object"},
+                "stage": "concept_design",
+                "trace_meta": build_trace_metadata(
+                    call_id=new_call_id("math-design"),
+                    phase="concept_design",
+                    label="Concept design",
+                    call_kind="math_concept_design",
+                    trace_role="design",
+                    trace_kind="llm_output",
+                ),
+            },
+            is_complete=lambda payload: bool(
+                payload.title.strip() or payload.scene_outline or payload.animation_notes
             ),
-        ):
-            _chunks.append(_c)
-        response = "".join(_chunks)
-        return SceneDesign.model_validate(extract_json_object(response))
+        )

--- a/deeptutor/agents/math_animator/agents/summary_agent.py
+++ b/deeptutor/agents/math_animator/agents/summary_agent.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import json
 
+from deeptutor.agents._shared.structured_llm import stream_and_validate_json
 from deeptutor.agents.base_agent import BaseAgent
 from deeptutor.core.trace import build_trace_metadata, new_call_id
 
 from ..models import ConceptAnalysis, RenderResult, SceneDesign, SummaryPayload
-from ..utils import extract_json_object
 
 
 class SummaryAgent(BaseAgent):
@@ -49,21 +49,34 @@ class SummaryAgent(BaseAgent):
             design_json=json.dumps(design.model_dump(), ensure_ascii=False, indent=2),
             render_json=json.dumps(render_result.model_dump(), ensure_ascii=False, indent=2),
         )
-        _chunks: list[str] = []
-        async for _c in self.stream_llm(
-            user_prompt=user_prompt,
-            system_prompt=system_prompt,
-            response_format={"type": "json_object"},
-            stage="summary",
-            trace_meta=build_trace_metadata(
-                call_id=new_call_id("math-summary"),
-                phase="summary",
-                label="Summarize result",
-                call_kind="math_summary",
-                trace_role="summarize",
-                trace_kind="llm_output",
-            ),
-        ):
-            _chunks.append(_c)
-        response = "".join(_chunks)
-        return SummaryPayload.model_validate(extract_json_object(response))
+        try:
+            return await stream_and_validate_json(
+                stream=self.stream_llm,
+                user_prompt=user_prompt,
+                model_type=SummaryPayload,
+                stream_kwargs={
+                    "system_prompt": system_prompt,
+                    "response_format": {"type": "json_object"},
+                    "stage": "summary",
+                    "trace_meta": build_trace_metadata(
+                        call_id=new_call_id("math-summary"),
+                        phase="summary",
+                        label="Summarize result",
+                        call_kind="math_summary",
+                        trace_role="summarize",
+                        trace_kind="llm_output",
+                    ),
+                },
+                is_complete=lambda payload: bool(payload.summary_text.strip()),
+            )
+        except ValueError:
+            # The render already succeeded, so an unusable summary must not
+            # discard it. Fall back to the localized text earlier stages did
+            # produce instead of leaving the turn with a blank caption.
+            self.logger.warning("Summary stage returned no usable JSON; using fallback text")
+            return SummaryPayload(
+                user_request=user_input.strip(),
+                summary_text=(
+                    analysis.learning_goal.strip() or design.title.strip() or user_input.strip()
+                ),
+            )

--- a/deeptutor/agents/math_animator/agents/visual_review_agent.py
+++ b/deeptutor/agents/math_animator/agents/visual_review_agent.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import json
 
+from deeptutor.agents._shared.structured_llm import stream_and_validate_json
 from deeptutor.agents.base_agent import BaseAgent
 from deeptutor.core.context import Attachment
 from deeptutor.core.trace import build_trace_metadata, new_call_id
 from deeptutor.services.llm import supports_vision
 
 from ..models import RenderResult, VisualReviewResult
-from ..utils import extract_json_object
 
 
 class VisualReviewAgent(BaseAgent):
@@ -68,33 +68,52 @@ class VisualReviewAgent(BaseAgent):
             ),
             current_code=current_code,
         )
-        messages = [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt},
-        ]
-        _chunks: list[str] = []
-        async for _c in self.stream_llm(
-            user_prompt=user_prompt,
-            system_prompt=system_prompt,
-            messages=messages,
-            attachments=attachments,
-            response_format={"type": "json_object"},
-            model=model,
-            stage="render_output",
-            trace_meta=build_trace_metadata(
-                call_id=new_call_id("math-visual-review"),
-                phase="render_output",
-                label="Visual quality review",
-                call_kind="math_visual_review",
-                trace_role="review",
-                trace_kind="llm_output",
-            ),
-        ):
-            _chunks.append(_c)
-        response = "".join(_chunks)
-        payload = extract_json_object(response)
-        payload.setdefault("reviewed_frames", len(attachments))
-        return VisualReviewResult.model_validate(payload)
+
+        def _messages(prompt: str) -> list[dict[str, str]]:
+            return [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ]
+
+        try:
+            result = await stream_and_validate_json(
+                stream=self.stream_llm,
+                user_prompt=user_prompt,
+                model_type=VisualReviewResult,
+                build_messages=_messages,
+                stream_kwargs={
+                    "system_prompt": system_prompt,
+                    "attachments": attachments,
+                    "response_format": {"type": "json_object"},
+                    "model": model,
+                    "stage": "render_output",
+                    "trace_meta": build_trace_metadata(
+                        call_id=new_call_id("math-visual-review"),
+                        phase="render_output",
+                        label="Visual quality review",
+                        call_kind="math_visual_review",
+                        trace_role="review",
+                        trace_kind="llm_output",
+                    ),
+                },
+                is_complete=lambda payload: bool(payload.summary.strip()),
+                # The whole review call sits inside retry_manager's
+                # review_timeout_seconds; a third attempt risks turning a
+                # slow reviewer into a timeout that re-renders a good result.
+                max_attempts=2,
+            )
+        except ValueError:
+            # An unreadable verdict must not destroy the render it judged —
+            # same "cannot judge, keep the result" policy as the skip paths.
+            self.logger.warning("Visual review returned no usable JSON; keeping the current render")
+            return VisualReviewResult(
+                passed=True,
+                summary="Visual review skipped because the reviewer returned no readable verdict.",
+                reviewed_frames=len(attachments),
+            )
+        if not result.reviewed_frames:
+            result.reviewed_frames = len(attachments)
+        return result
 
 
 __all__ = ["VisualReviewAgent"]

--- a/tests/agents/math_animator/test_post_render_fail_soft.py
+++ b/tests/agents/math_animator/test_post_render_fail_soft.py
@@ -1,0 +1,157 @@
+"""Post-render stages must degrade instead of discarding a finished render.
+
+``summary`` and ``visual_review`` both run *after* Manim produced an artifact,
+so a thinking model that streams ``content: null`` there must not take the
+video down with it (issue #1202).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from deeptutor.agents.math_animator.agents import visual_review_agent
+from deeptutor.agents.math_animator.agents.summary_agent import SummaryAgent
+from deeptutor.agents.math_animator.agents.visual_review_agent import VisualReviewAgent
+from deeptutor.agents.math_animator.models import (
+    ConceptAnalysis,
+    RenderedArtifact,
+    RenderResult,
+    SceneDesign,
+)
+from deeptutor.core.context import Attachment
+
+
+@pytest.fixture(autouse=True)
+def _no_runtime_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the test independent of ``data/user/settings/agents.yaml``."""
+    monkeypatch.setattr("deeptutor.agents.base_agent.get_agent_params", lambda _module: {})
+
+
+def _replay_stream(replies: list[str]) -> tuple[Any, list[str]]:
+    """Build a ``stream_llm`` stub that replays *replies*, one per call.
+
+    An empty string models a reasoning-only reply: the stream yields nothing,
+    so the caller joins an empty response.
+    """
+    prompts: list[str] = []
+
+    async def _stream(*, user_prompt: str, **_kwargs: Any) -> AsyncIterator[str]:
+        prompts.append(user_prompt)
+        reply = replies[min(len(prompts) - 1, len(replies) - 1)]
+        if reply:
+            yield reply
+
+    return _stream, prompts
+
+
+def _summary_agent(replies: list[str]) -> tuple[SummaryAgent, list[str]]:
+    agent = SummaryAgent(language="en")
+    agent.prompts = {
+        "system": "Summarize the render.",
+        "user_template": "Request: {user_input}",
+    }
+    stream, prompts = _replay_stream(replies)
+    agent.stream_llm = stream
+    return agent, prompts
+
+
+def _review_agent(
+    replies: list[str], monkeypatch: pytest.MonkeyPatch
+) -> tuple[VisualReviewAgent, list[str]]:
+    agent = VisualReviewAgent(language="en")
+    agent.prompts = {
+        "system": "Review the rendered frames.",
+        "user_template": "Request: {user_input}, frames: {reviewed_frames}",
+    }
+    agent.get_model = lambda: "vision-model"
+    monkeypatch.setattr(visual_review_agent, "supports_vision", lambda _binding, _model: True)
+    stream, prompts = _replay_stream(replies)
+    agent.stream_llm = stream
+    return agent, prompts
+
+
+def _render_result() -> RenderResult:
+    return RenderResult(
+        output_mode="video",
+        artifacts=[RenderedArtifact(type="video", url="/f/v.mp4", filename="v.mp4")],
+    )
+
+
+def _attachments(count: int) -> list[Attachment]:
+    return [Attachment(type="image", url=f"/f/frame-{i}.png") for i in range(count)]
+
+
+async def _summarize(agent: SummaryAgent) -> Any:
+    return await agent.process(
+        user_input="Animate a sine wave",
+        output_mode="video",
+        analysis=ConceptAnalysis(learning_goal="Wave basics"),
+        design=SceneDesign(title="Sine"),
+        render_result=_render_result(),
+    )
+
+
+async def _review(agent: VisualReviewAgent, frame_count: int) -> Any:
+    return await agent.process(
+        user_input="Animate a sine wave",
+        output_mode="video",
+        current_code="class MainScene(Scene): pass",
+        render_result=_render_result(),
+        attachments=_attachments(frame_count),
+    )
+
+
+@pytest.mark.asyncio
+async def test_summary_recovers_from_null_content() -> None:
+    agent, prompts = _summary_agent(["", '{"summary_text": "Sine wave rendered."}'])
+
+    payload = await _summarize(agent)
+
+    assert payload.summary_text == "Sine wave rendered."
+    assert len(prompts) == 2
+    assert "IMPORTANT" in prompts[1]
+
+
+@pytest.mark.asyncio
+async def test_summary_falls_back_on_text_that_earlier_stages_produced() -> None:
+    agent, prompts = _summary_agent([""])
+
+    payload = await _summarize(agent)
+
+    assert len(prompts) == 3
+    assert payload.summary_text == "Wave basics"
+    assert payload.user_request == "Animate a sine wave"
+
+
+@pytest.mark.asyncio
+async def test_visual_review_recovers_and_backfills_frame_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent, prompts = _review_agent(
+        ["", '{"passed": false, "summary": "Labels overlap the curve."}'],
+        monkeypatch,
+    )
+
+    result = await _review(agent, 3)
+
+    assert result.passed is False
+    assert result.summary == "Labels overlap the curve."
+    assert result.reviewed_frames == 3
+    assert len(prompts) == 2
+
+
+@pytest.mark.asyncio
+async def test_visual_review_keeps_the_render_when_no_verdict_arrives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent, prompts = _review_agent([""], monkeypatch)
+
+    result = await _review(agent, 2)
+
+    assert result.passed is True
+    assert result.summary
+    assert result.reviewed_frames == 2
+    assert len(prompts) == 2

--- a/tests/agents/test_shared_json_output.py
+++ b/tests/agents/test_shared_json_output.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 import json
 
+from pydantic import BaseModel, ConfigDict
 import pytest
 
-from deeptutor.agents._shared.json_output import extract_json_object
+from deeptutor.agents._shared.json_output import extract_json_object, require_json_object
+from deeptutor.agents._shared.structured_llm import stream_and_validate_json
 
 
 @pytest.mark.parametrize(
@@ -24,3 +27,83 @@ def test_extract_json_object(text: str, expected: dict[str, int]) -> None:
 def test_extract_json_object_rejects_output_without_an_object() -> None:
     with pytest.raises(json.JSONDecodeError, match="No JSON object found"):
         extract_json_object("No structured output")
+
+
+def test_require_json_object_rejects_empty_content() -> None:
+    with pytest.raises(json.JSONDecodeError, match="Empty model content"):
+        require_json_object("")
+    with pytest.raises(json.JSONDecodeError, match="Empty model content"):
+        require_json_object("   ")
+
+
+def test_require_json_object_parses_valid_payload() -> None:
+    assert require_json_object('{"code": "pass"}') == {"code": "pass"}
+
+
+class _ToyPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    code: str = ""
+
+
+@pytest.mark.asyncio
+async def test_stream_and_validate_json_retries_after_null_content() -> None:
+    calls: list[str] = []
+
+    async def _stream(*, user_prompt: str, **_kwargs: object) -> AsyncIterator[str]:
+        calls.append(user_prompt)
+        if len(calls) == 1:
+            # Simulate content: null → empty stream (reasoning-only reply).
+            if False:  # pragma: no cover - keep this an async generator
+                yield ""
+            return
+        yield '{"code": "from manim import *\\n"}'
+
+    result = await stream_and_validate_json(
+        stream=_stream,
+        user_prompt="generate code",
+        model_type=_ToyPayload,
+        is_complete=lambda payload: bool(payload.code.strip()),
+        max_attempts=3,
+    )
+
+    assert result.code.startswith("from manim")
+    assert len(calls) == 2
+    assert "IMPORTANT" in calls[1]
+
+
+@pytest.mark.asyncio
+async def test_stream_and_validate_json_retries_incomplete_payload() -> None:
+    calls = 0
+
+    async def _stream(*, user_prompt: str, **_kwargs: object) -> AsyncIterator[str]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            yield '{"code": ""}'
+            return
+        yield '{"code": "class MainScene(Scene):\\n    pass\\n"}'
+
+    result = await stream_and_validate_json(
+        stream=_stream,
+        user_prompt="generate",
+        model_type=_ToyPayload,
+        is_complete=lambda payload: bool(payload.code.strip()),
+    )
+    assert "MainScene" in result.code
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_stream_and_validate_json_fails_soft_after_exhausted_retries() -> None:
+    async def _stream(*, user_prompt: str, **_kwargs: object) -> AsyncIterator[str]:
+        return
+        yield ""  # pragma: no cover
+
+    with pytest.raises(ValueError, match="unusable structured output"):
+        await stream_and_validate_json(
+            stream=_stream,
+            user_prompt="generate",
+            model_type=_ToyPayload,
+            is_complete=lambda payload: bool(payload.code.strip()),
+            max_attempts=2,
+        )


### PR DESCRIPTION
﻿## Summary

- Add `require_json_object` + `stream_and_validate_json` so empty/`content: null` LLM replies are treated as structured-output failures (not silent `{}`)
- Wire the shared helper into the math-animator stages upstream still parses blindly: **concept analysis** and **concept design** now nudge and retry a bounded number of times, rejecting incomplete payloads (e.g. empty `code`)
- **Code generation / code repair are already covered upstream**: the v1.6.5 reconcile (`42fab3cf`) brought the maintainers' own equivalent retry (`_request_generated_code` + `GeneratedCodeOutputError`) into `code_generator_agent.py`, so this branch keeps that implementation instead of installing a second mechanism — the helper covers the stages the reconcile left unguarded
- Extend the same retry to the two **post-render** stages (`summary`, and the visual review of rendered frames), but **degrade instead of raising** there. By then the video is already on disk, so raising would throw away a good render just because its caption came back unreadable — and the old behavior was worse than a crash: a blank reply parsed as `{}`, leaving the turn with an empty response and letting the reviewer rubber-stamp frames it never read. Summary falls back to localized text that earlier successful stages already produced; the reviewer falls back to the same "cannot judge, keep the result" policy as its existing skip paths. Review retries are capped at 2 attempts because the whole call sits inside `retry_manager`'s 120 s render timeout, where a third attempt can turn a slow reviewer into a timeout that re-renders a good result.

**Rebased for the v1.6.5 reconcile (2026-09-06):** `dev` was reconciled with `main` (`42fab3cf`); branch is now 3 commits on top of it. The earlier tip's route-budget web lazy-chunks were dropped (the release sync superseded them).

Fixes #1202

## Test plan

- [x] `pytest tests/agents/test_shared_json_output.py tests/agents/math_animator -q` (27 passed; the 3 failures reproduced identically on pristine v1.6.5 `dev` — no-LLM-config/env, unrelated)
- [x] `tests/agents/math_animator/test_post_render_fail_soft.py` covers null-content recovery, the exhausted-retry fallback, and the `reviewed_frames` backfill for both stages
- [x] `ruff check` + `ruff format --check` (0.16.0, as CI runs) clean on the changed files
- [x] CI on the rebased head (`7ef83b8c`): `Lint and Format`, `Check tracked generated files`, all Import Checks, and `Python Tests 3.11/3.13/3.14` pass — `Web Node Tests` (route budget) and `Python Tests 3.12` are red on base `dev` itself (pre-existing since 09-03; see the CI note below)
- [ ] Trigger math_animator with a thinking model that sometimes returns null content; confirm a retry recovers instead of a hard stack trace — cannot be run here: needs manim and a live thinking-model key



> **CI note (2026-09-06):** 
A follow-up style commit also runs `ruff format` over the two `deeptutor/skills/builtin/*/SKILL.md` files the v1.6.5 reconcile shipped unformatted — the repo-wide `Lint and Format` gate (ruff format --check) fails on the base for every PR without it.

