### PR TITLE
fix(cli): give reasoning models room in the init connectivity probe

### DIFF
--- a/deeptutor_cli/init_wizard.py
+++ b/deeptutor_cli/init_wizard.py
@@ -30,7 +30,7 @@ from deeptutor.services.config.embedding_endpoint import (
     is_gemini_native_embedding_endpoint,
     redact_embedding_endpoint_for_display,
 )
-from deeptutor.services.llm.config import get_token_limit_kwargs
+from deeptutor.services.llm.config import get_token_limit_kwargs, uses_max_completion_tokens
 from deeptutor.services.provider_registry import PROVIDERS, ProviderSpec, find_by_name
 
 # --- Featured selection ------------------------------------------------------
@@ -852,9 +852,20 @@ def select_model(
 
 # --- Connectivity probe --------------------------------------------------------
 
+# One token is enough to prove credentials work on a classic chat model, and
+# keeps the probe as cheap as possible.
+PROBE_MAX_TOKENS = 1
+# Reasoning models (the same families that require ``max_completion_tokens``)
+# spend the budget on hidden thinking tokens before emitting any content, so a
+# 1-token cap never reaches the answer. OpenAI rejects that outright with
+# HTTP 400 "Could not finish the message because max_tokens or model output
+# limit was reached", which reads as a credential failure even though the
+# endpoint and key are fine. Give them room for one short reasoning pass.
+PROBE_REASONING_MAX_TOKENS = 1024
+
 
 def probe_llm(*, base_url: str, api_key: str, binding: str, model: str) -> tuple[bool, int, str]:
-    """Send a single-token completion to verify credentials.
+    """Send a tiny completion to verify credentials.
 
     Returns ``(ok, elapsed_ms, error_or_empty)``. Network failures, auth
     failures, 4xx, 5xx all surface as ``ok=False`` with a short error string.
@@ -873,7 +884,7 @@ def probe_llm(*, base_url: str, api_key: str, binding: str, model: str) -> tuple
             }
             body = {
                 "model": model,
-                "max_tokens": 1,
+                "max_tokens": PROBE_MAX_TOKENS,
                 "messages": [{"role": "user", "content": "ping"}],
             }
         else:
@@ -882,9 +893,14 @@ def probe_llm(*, base_url: str, api_key: str, binding: str, model: str) -> tuple
                 "Authorization": f"Bearer {api_key or 'sk-no-key-required'}",
                 "Content-Type": "application/json",
             }
+            budget = (
+                PROBE_REASONING_MAX_TOKENS
+                if uses_max_completion_tokens(model)
+                else PROBE_MAX_TOKENS
+            )
             body = {
                 "model": model,
-                **get_token_limit_kwargs(model, 1),
+                **get_token_limit_kwargs(model, budget),
                 "messages": [{"role": "user", "content": "ping"}],
             }
 

--- a/tests/cli/test_init_wizard_probe.py
+++ b/tests/cli/test_init_wizard_probe.py
@@ -259,8 +259,28 @@ def test_probe_llm_uses_max_completion_tokens_for_gpt5(monkeypatch) -> None:
     assert ok is True
     assert error == ""
     body = _FakeClient.captured[0]["json"]
-    assert body["max_completion_tokens"] == 1
+    # Reasoning models burn hidden thinking tokens first, so a 1-token cap
+    # makes OpenAI answer HTTP 400 ("max_tokens ... reached") instead of a 200.
+    assert body["max_completion_tokens"] == init_wizard.PROBE_REASONING_MAX_TOKENS
+    assert body["max_completion_tokens"] > 1
     assert "max_tokens" not in body
+
+
+def test_probe_llm_gives_gpt56_room_for_a_reasoning_pass(monkeypatch) -> None:
+    from deeptutor_cli import init_wizard
+
+    _FakeClient.captured = []
+    monkeypatch.setattr(init_wizard.httpx, "Client", _FakeClient)
+
+    init_wizard.probe_llm(
+        base_url="https://example.test/v1",
+        api_key="sk-test",
+        binding="openai",
+        model="gpt-5.6-terra",
+    )
+
+    body = _FakeClient.captured[0]["json"]
+    assert body["max_completion_tokens"] == init_wizard.PROBE_REASONING_MAX_TOKENS
 
 
 def test_probe_llm_keeps_max_tokens_for_legacy_chat_models(monkeypatch) -> None:


### PR DESCRIPTION
The `deeptutor init` wizard probed the LLM endpoint with a 1-token output budget. Reasoning models (o*, gpt-4o, gpt-5+) spend that budget on hidden thinking tokens before emitting any content, so OpenAI answered HTTP 400 ("max_tokens or model output limit was reached") and the wizard reported a perfectly valid endpoint and API key as a connection failure.

Select the probe budget per model family: reasoning models now get 1024 tokens, matching the web Settings probe in ConfigTestRunner._test_llm, while classic chat models and the Anthropic path keep the cheap 1-token cap.

Fixes #1220

<!--
Thank you for contributing to DeepTutor! 🚀
Please ensure your PR is ready for review and follows our contribution guidelines.
For more details, see our [CONTRIBUTING.md](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
-->

### Description

Users read this as "my API key is wrong" and get pushed into the
"Re-enter API key and retry?" loop, which can never succeed.

### Root cause

`probe_llm()` in `deeptutor_cli/init_wizard.py` sent a deliberately
minimal request — `get_token_limit_kwargs(model, 1)`, i.e. a 1-token
output budget — because one token is all you need to prove that
credentials and the endpoint work.

That assumption breaks for reasoning models. They spend their output
budget on hidden thinking tokens *before* emitting any visible content,
so a 1-token cap is exhausted during reasoning and the API rejects the
request with HTTP 400 instead of returning a usable 200. The probe
treats any 4xx as a failure, so a healthy configuration was reported as
broken.

The web Settings probe (`ConfigTestRunner._test_llm`) already accounts
for this and uses a 1024-token default; only the CLI wizard was left
behind.

### Fix

`probe_llm()` now picks its token budget based on the model family:

- **Reasoning models** — detected with the existing
  `uses_max_completion_tokens()` helper, which already identifies the
  `o*` / `gpt-4o` / `gpt-5+` families — get
  `PROBE_REASONING_MAX_TOKENS = 1024`, enough room for one short
  reasoning pass.
- **Classic chat models and the Anthropic path** keep
  `PROBE_MAX_TOKENS = 1`, so the probe stays as cheap as it was.

Both budgets are named module constants with a comment explaining why
they differ, so the next person doesn't "optimize" the cap back to 1.
The parameter *name* selection (`max_tokens` vs `max_completion_tokens`)
is unchanged — it still goes through `get_token_limit_kwargs()`.

### Changes

- `deeptutor_cli/init_wizard.py` — add `PROBE_MAX_TOKENS` /
  `PROBE_REASONING_MAX_TOKENS`, select the budget per model family in
  `probe_llm()`.
- `tests/cli/test_init_wizard_probe.py` — the existing gpt-5 test
  asserted the buggy `max_completion_tokens == 1`; it now asserts the
  reasoning budget. Added
  `test_probe_llm_gives_gpt56_room_for_a_reasoning_pass` as a regression
  test for the exact model from the report.

### Verification

- `pytest tests/cli/test_init_wizard_probe.py`
- Manual: `deeptutor init` with `gpt-5.6-terra` now reports a successful
  connection instead of HTTP 400.

### Notes / possible follow-up

`_probe_provider()` in `deeptutor/services/doctor.py` uses
`max_tokens=64` and then raises on an empty response, so
`deeptutor doctor --online` may hit the same class of problem with
reasoning models. Left out of this PR to keep the change focused.

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [x] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [ ] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [ x My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [ ] I have added relevant tests for my changes.
- [ ] I have updated the documentation (if necessary).
- [ ] My changes do not introduce any new security vulnerabilities.

### Additional Notes
*Add any other context or screenshots about the pull request here.*
