### PR TITLE
fix(learner): restore course access (#1228)

### DIFF
--- a/deeptutor/api/routers/auth.py
+++ b/deeptutor/api/routers/auth.py
@@ -405,6 +405,7 @@ def _learning_surface_for_path(path: str) -> str:
     normalized = "/" + str(path or "").lstrip("/")
     for root, surface in (
         ("/api/reading", "reading"),
+        ("/api/courses", "reading"),
         ("/api/chat", "chat"),
         ("/api/question", "chat"),
         ("/api/question-notebook", "chat"),

--- a/tests/multi_user/test_account_presets.py
+++ b/tests/multi_user/test_account_presets.py
@@ -36,6 +36,7 @@ def test_learning_surface_routing_matches_complete_path_segments():
     from deeptutor.api.routers.auth import _learning_surface_for_path
 
     assert _learning_surface_for_path("/api/reading/materials") == "reading"
+    assert _learning_surface_for_path("/api/courses/course/state") == "reading"
     assert _learning_surface_for_path("/api/question-notebook/entries") == "chat"
     assert _learning_surface_for_path("/api/reading-private") == ""
     assert _learning_surface_for_path("/api/questions") == ""

--- a/web/components/courses/CoursesShelf.tsx
+++ b/web/components/courses/CoursesShelf.tsx
@@ -6,6 +6,7 @@ import {
   Archive,
   ArrowRight,
   BookOpen,
+  CircleAlert,
   Layers,
   MessagesSquare,
   Plus,
@@ -36,6 +37,7 @@ export default function CoursesShelf() {
   const [courses, setCourses] = useState<StudyCourse[]>([]);
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
 
   useEffect(() => {
@@ -48,6 +50,10 @@ export default function CoursesShelf() {
         if (cancelled) return;
         setCourses(nextCourses);
         setSessions(nextSessions);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setLoadError(error instanceof Error ? error.message : "");
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -133,6 +139,21 @@ export default function CoursesShelf() {
               className="h-32 animate-pulse rounded-xl border border-[var(--border)] bg-[var(--card)]"
             />
           ))}
+        </div>
+      ) : loadError !== null ? (
+        <div
+          role="alert"
+          className="flex min-h-32 items-center gap-3 rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 text-[12.5px] text-[var(--muted-foreground)]"
+        >
+          <CircleAlert size={16} strokeWidth={1.8} aria-hidden />
+          <span>
+            <span className="block font-medium text-[var(--foreground)]">
+              {t("Courses could not load")}
+            </span>
+            <span className="mt-1 block leading-relaxed">
+              {loadError || t("Courses could not load")}
+            </span>
+          </span>
         </div>
       ) : (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">

--- a/web/lib/courses-api.ts
+++ b/web/lib/courses-api.ts
@@ -1,5 +1,6 @@
 import { apiFetch, apiUrl } from "@/lib/api";
 import { invalidateClientCache, withClientCache } from "@/lib/client-cache";
+import { ApiError } from "@/shared/api/errors";
 
 /**
  * Kinds of resource a course may reference.
@@ -128,8 +129,24 @@ export const DEFAULT_COURSE_COLORS = [
 ];
 
 async function expectJson<T>(response: Response): Promise<T> {
-  if (!response.ok) throw new Error(`Request failed: ${response.status}`);
-  return response.json() as Promise<T>;
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const detail =
+      payload && typeof payload === "object"
+        ? String((payload as { detail?: unknown }).detail ?? "").trim()
+        : "";
+    throw new ApiError({
+      code: `http_${response.status}`,
+      message: detail || `Request failed (${response.status})`,
+      retryable:
+        response.status === 408 ||
+        response.status === 429 ||
+        response.status >= 500,
+      scope: "network",
+      status: response.status,
+    });
+  }
+  return payload as T;
 }
 
 /** Fill in fields absent from courses created before the container existed. */

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -3729,6 +3729,7 @@
   "Selected text": "Selected text",
   "Ask anything about the selected text.": "Ask anything about the selected text.",
   "My courses": "My courses",
+  "Courses could not load": "Courses could not load",
   "Create a course": "Create a course",
   "Create your first course": "Create your first course",
   "Course name": "Course name",

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -3729,6 +3729,7 @@
   "Selected text": "选中内容",
   "Ask anything about the selected text.": "可以针对这段选中内容继续提问。",
   "My courses": "我的课程",
+  "Courses could not load": "课程加载失败",
   "Create a course": "创建课程",
   "Create your first course": "创建第一门课程",
   "Course name": "课程名称",

--- a/web/tests/course-organization-api.test.ts
+++ b/web/tests/course-organization-api.test.ts
@@ -1,9 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import { listCourses } from "../lib/courses-api";
 import { listAllSessions, updateSessionOrganization } from "../lib/session-api";
 import { organizeSessionTree } from "../lib/session-organization";
 import type { SessionSummary } from "../lib/session-api";
+import { ApiError } from "../shared/api/errors";
 
 function session(
   id: string,
@@ -50,6 +52,34 @@ test("course organization fetches every session page", async () => {
     const sessions = await listAllSessions({ force: true });
     assert.equal(sessions.length, 203);
     assert.deepEqual(offsets, [0, 200]);
+  } finally {
+    (globalThis as { fetch: typeof fetch }).fetch = original;
+  }
+});
+
+test("course policy failures preserve the server denial", async () => {
+  const original = globalThis.fetch;
+  (globalThis as { fetch: typeof fetch }).fetch = async () =>
+    new Response(
+      JSON.stringify({
+        detail: "This learning account cannot use the reading surface."
+      }),
+      { status: 403, headers: { "Content-Type": "application/json" } },
+    );
+
+  try {
+    await assert.rejects(
+      listCourses({ force: true }),
+      (error: unknown) => {
+        assert.ok(error instanceof ApiError);
+        assert.equal(error.status, 403);
+        assert.equal(
+          error.message,
+          "This learning account cannot use the reading surface."
+        );
+        return true;
+      },
+    );
   } finally {
     (globalThis as { fetch: typeof fetch }).fetch = original;
   }

--- a/web/tests/courses-shelf.spec.tsx
+++ b/web/tests/courses-shelf.spec.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import CoursesShelf from "@/components/courses/CoursesShelf";
+import { initI18n } from "@/i18n/init";
+
+initI18n("en");
+
+vi.mock("@/lib/courses-api", () => ({
+  DEFAULT_COURSE_COLORS: ["#C65D2E"],
+  listCourses: vi.fn(() =>
+    Promise.reject(
+      new Error("This learning account cannot use the reading surface.")
+    )
+  ),
+  createCourse: vi.fn(),
+}));
+
+vi.mock("@/lib/session-api", () => ({
+  listAllSessions: vi.fn(() => Promise.resolve([])),
+}));
+
+describe("courses shelf", () => {
+  it("shows an authorization failure instead of an empty shelf", async () => {
+    render(<CoursesShelf />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(
+      "This learning account cannot use the reading surface."
+    );
+    expect(
+      screen.queryByRole("button", { name: "Create your first course" })
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Maps `/api/courses` to the existing `reading` learning surface so learner accounts retain their assigned course data without introducing a new policy migration.
- Preserves FastAPI `detail` in the Courses API error boundary.
- Replaces the misleading zero-course empty state with an explicit Courses load error and localized fallback.

Fixes #1228.

## Validation

- `DEEPTUTOR_TEST_REDIS_URL=redis://127.0.0.1:6379/0 python -m pytest tests/multi_user/test_account_presets.py -q` — 11 passed
- `npm run test:node` — 1037 passed
- `npm run test:unit -- tests/courses-shelf.spec.tsx` — 1 passed
- `npm run typecheck` — passed
- `npm run lint` — 0 errors, 72 pre-existing warnings
- `npm run i18n:check` — passed
- `npm run build` — passed
- `ruff check` and `ruff format --check` on touched Python files — passed

`npm run perf:check` still reports the current `dev` baseline failures on `/knowledge-bases` (565KB/550KB) and `/co-writer/[docId]` (519KB/515KB). This change does not touch those routes; #1216 is the pending baseline fix.
