### PR TITLE
feat(video-learning): add a dedicated Watching workspace

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -198,23 +198,27 @@ jobs:
 
       - name: Check module imports
         run: |
-          echo "🐍 Testing with Python ${{ matrix.python-version }}"
-          python -c "from deeptutor.runtime.orchestrator import ChatOrchestrator; print('✅ Orchestrator imports OK')"
-          python -c "from deeptutor.runtime.registry.tool_registry import get_tool_registry; print('✅ Tool registry imports OK')"
-          python -c "from deeptutor.runtime.registry.capability_registry import get_capability_registry; print('✅ Capability registry imports OK')"
-          python -c "from deeptutor.services.config.runtime_settings import RuntimeSettingsService; print('✅ RuntimeSettingsService imports OK')"
-          python -c "from deeptutor.api.routers.unified_ws import unified_websocket; print('✅ Unified WS imports OK')"
-          python -c "from deeptutor.services.prompt.manager import PromptManager; print('✅ Prompt manager imports OK')"
-          python -c "from deeptutor.logging import configure_logging, bind_log_context, capture_process_logs, ProcessLogEvent; print('✅ Logging imports OK')"
+          echo "Testing with Python ${{ matrix.python-version }}"
+          python -c "from deeptutor.runtime.orchestrator import ChatOrchestrator; print('[OK] Orchestrator imports')"
+          python -c "from deeptutor.runtime.registry.tool_registry import get_tool_registry; print('[OK] Tool registry imports')"
+          python -c "from deeptutor.runtime.registry.capability_registry import get_capability_registry; print('[OK] Capability registry imports')"
+          python -c "from deeptutor.services.config.runtime_settings import RuntimeSettingsService; print('[OK] RuntimeSettingsService imports')"
+          python -c "from deeptutor.api.routers.unified_ws import unified_websocket; print('[OK] Unified WS imports')"
+          python -c "from deeptutor.services.prompt.manager import PromptManager; print('[OK] Prompt manager imports')"
+          python -c "from deeptutor.logging import configure_logging, bind_log_context, capture_process_logs, ProcessLogEvent; print('[OK] Logging imports')"
         env:
           PYTHONPATH: ${{ github.workspace }}
+          PYTHONUTF8: "1"
+          PYTHONIOENCODING: utf-8
 
       - name: Check lazy startup and isolated worker protocol
         run: |
-          python -c "import sys; import deeptutor.runtime.registry.tool_registry; assert 'deeptutor.agents.chat.agentic_pipeline' not in sys.modules; print('✅ Tool implementations stay cold')"
-          python -c "from deeptutor.runtime.isolated_worker import run_in_isolated_process_sync; assert run_in_isolated_process_sync('operator:add', 20, 22, timeout=15) == 42; print('✅ Isolated worker protocol OK')"
+          python -c "import sys; import deeptutor.runtime.registry.tool_registry; assert 'deeptutor.agents.chat.agentic_pipeline' not in sys.modules; print('[OK] Tool implementations stay cold')"
+          python -c "from deeptutor.runtime.isolated_worker import run_in_isolated_process_sync; assert run_in_isolated_process_sync('operator:add', 20, 22, timeout=15) == 42; print('[OK] Isolated worker protocol')"
         env:
           PYTHONPATH: ${{ github.workspace }}
+          PYTHONUTF8: "1"
+          PYTHONIOENCODING: utf-8
 
   python-tests:
     name: Python Tests (Python ${{ matrix.python-version }})

--- a/deeptutor/services/session/turns/request_preparer.py
+++ b/deeptutor/services/session/turns/request_preparer.py
@@ -155,6 +155,16 @@ class TurnRequestPreparer:
             else preferences.get("workspace_mode"),
             capability=capability,
         )
+        if workspace_mode == "immersive_watching":
+            from deeptutor.video_learning import get_timed_media_store
+
+            media_id = _timed_media_id(payload.get("timed_media_id"))
+            if media_id:
+                # Resolve only in the authenticated owner's store before saving the binding.
+                get_timed_media_store().get(media_id)
+        else:
+            payload.pop("timed_media_id", None)
+            payload.pop("timed_media_viewport", None)
         try:
             from deeptutor.runtime.request_contracts import validate_capability_config
 
@@ -389,6 +399,8 @@ class TurnRequestPreparer:
         # non-empty legacy capability is persisted as part of migration.
         if workspace_mode_explicit or workspace_mode:
             preference_update["workspace_mode"] = workspace_mode
+        if workspace_mode == "immersive_watching":
+            preference_update["timed_media_id"] = _timed_media_id(payload.get("timed_media_id"))
         if course_id_explicit:
             preference_update["course_id"] = requested_course_id
 

--- a/deeptutor/services/session/workspace_preferences.py
+++ b/deeptutor/services/session/workspace_preferences.py
@@ -11,7 +11,10 @@ from typing import Any
 
 WORKSPACE_MODE_READING = "immersive_reading"
 WORKSPACE_MODE_MASTERY = "mastery_path"
-WORKSPACE_MODES = frozenset({WORKSPACE_MODE_READING, WORKSPACE_MODE_MASTERY})
+WORKSPACE_MODE_WATCHING = "immersive_watching"
+WORKSPACE_MODES = frozenset(
+    {WORKSPACE_MODE_READING, WORKSPACE_MODE_MASTERY, WORKSPACE_MODE_WATCHING}
+)
 
 
 def upgrade_workspace_preferences(value: Any) -> dict[str, Any]:
@@ -33,7 +36,9 @@ def upgrade_workspace_preferences(value: Any) -> dict[str, Any]:
     reading_workspace_id = str(preferences.get("reading_workspace_id") or "").strip()
     session_kind = str(preferences.get("session_kind") or "").strip()
 
-    if capability == WORKSPACE_MODE_MASTERY and mastery_path_id:
+    if capability == WORKSPACE_MODE_WATCHING:
+        preferences["workspace_mode"] = WORKSPACE_MODE_WATCHING
+    elif capability == WORKSPACE_MODE_MASTERY and mastery_path_id:
         preferences["workspace_mode"] = WORKSPACE_MODE_MASTERY
     elif reading_workspace_id and (
         capability == WORKSPACE_MODE_READING or session_kind == WORKSPACE_MODE_READING

--- a/deeptutor/video_learning/service.py
+++ b/deeptutor/video_learning/service.py
@@ -134,7 +134,14 @@ def _is_local_host(host: str) -> bool:
         address = ipaddress.ip_address(host)
     except ValueError:
         return False
-    return address.is_loopback or address.is_private or address.is_link_local
+    # RFC 6598 shared address space is used by private overlays such as Tailscale.
+    # ipaddress intentionally classifies it as neither private nor global.
+    return (
+        address.is_loopback
+        or address.is_private
+        or address.is_link_local
+        or address in ipaddress.ip_network("100.64.0.0/10")
+    )
 
 
 def normalize_video_learning_settings(payload: Any) -> dict[str, Any]:

--- a/docs/guides/watching-workspace.md
+++ b/docs/guides/watching-workspace.md
@@ -1,0 +1,30 @@
+# Immersive Watching workspace
+
+Open **Immersive Watching** in the sidebar, or visit `/watching`. Paste a YouTube URL and open the video. The first question creates a conversation at `/watching/{sessionId}`. Desktop shows video beside the conversation; smaller screens have Video and Conversation buttons that preserve the mounted player.
+
+The workspace reuses the chat runtime and the existing timed-media APIs. Session preferences store `workspace_mode: "immersive_watching"` and `timed_media_id`; material access is checked against the current user's store. Existing Watching conversations recover their material from their latest recorded turn when the preference is absent. Browser-global recent-video storage is no longer a source of session identity. A new draft starts empty; send a question to save it as a conversation.
+
+## Configure Invidious
+
+In administrator settings, open the video-learning section, enter the existing instance's backend API origin and public origin, test the connection, and select Invidious as the default provider. Settings are persisted by the application's administrator path service as `video_learning.json`; do not put them in the project `.env` or hard-code them in frontend code.
+
+- `invidious.api_base_url`: an origin reachable by the DeepTutor backend. Loopback is suitable only when the backend and instance share a host network. Containers must use an appropriate service or host address.
+- `invidious.public_base_url`: the same instance's origin reachable by the user's browser/device.
+- `default_provider`: `invidious` or `youtube`.
+
+DeepTutor continues to proxy media through its authenticated video-learning endpoints. Do not replace the player with an Invidious iframe or relax the stream proxy's allowed-origin checks. Invidious failure remains visible; switching to native YouTube requires the user's explicit action.
+
+## Verify and troubleshoot
+
+1. Open a captioned video and check actual playback and seeking, not just the instance status endpoint. Media requests should support byte ranges (`206` where applicable).
+2. Click a caption, use Explain here, follow an answer's timestamp, and save/reopen a timestamped note.
+3. Refresh the conversation URL, visit another conversation, and return. Confirm both the material and saved progress; ordinary Chat and Reading must retain their own context.
+4. Repeat with a narrow viewport, missing captions, an unavailable instance, and a user who cannot access the material.
+
+If metadata works but playback fails, inspect the authenticated stream response and the configured instance's media/companion service. If captions are unavailable, use Retry captions; do not silently substitute a different provider. A missing or unauthorized saved video leaves an error and an empty video surface rather than another conversation's video.
+
+## Deployment and rollback
+
+Before deployment, record the running commit, save the tracked working-tree diff, and back up the video settings and service launch configuration. Build a separate release directory containing the existing deployment changes plus the reviewed Watching patch. Keep the existing data directory and owner identity; do not copy user data into Git.
+
+Run frontend type, contract, lint, translation and build checks, the Watching browser tests, and `pytest tests/video_learning`. Switch service paths only after the release is ready. Check `/watching`, `/reading`, `/chat` and real Invidious playback. On failure, restore the previous service paths and video settings, restart the old release, and verify readiness. Leave the previous working tree and its uncommitted changes intact.

--- a/docs/guides/watching-workspace.md
+++ b/docs/guides/watching-workspace.md
@@ -10,6 +10,8 @@ In administrator settings, open the video-learning section, enter the existing i
 
 - `invidious.api_base_url`: an origin reachable by the DeepTutor backend. Loopback is suitable only when the backend and instance share a host network. Containers must use an appropriate service or host address.
 - `invidious.public_base_url`: the same instance's origin reachable by the user's browser/device.
+Private HTTP origins include loopback, LAN and RFC 6598 shared addresses used by overlays such as Tailscale. Public instances must use HTTPS.
+
 - `default_provider`: `invidious` or `youtube`.
 
 DeepTutor continues to proxy media through its authenticated video-learning endpoints. Do not replace the player with an Invidious iframe or relax the stream proxy's allowed-origin checks. Invidious failure remains visible; switching to native YouTube requires the user's explicit action.

--- a/tests/api/route_introspection.py
+++ b/tests/api/route_introspection.py
@@ -1,0 +1,84 @@
+"""Helpers for inspecting FastAPI routes across nested include_router mounts.
+
+Recent FastAPI/Starlette versions wrap ``include_router`` mounts as
+``_IncludedRouter`` entries without a top-level ``.path``. Tests that assert on
+the public URL surface must recurse into ``original_router.routes`` and apply
+the include prefix.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+from fastapi.routing import APIRoute, APIWebSocketRoute
+from starlette.routing import Mount, Route, WebSocketRoute
+
+_LEAF_ROUTE_TYPES = (APIRoute, APIWebSocketRoute, Route, WebSocketRoute)
+
+
+def _join_path(prefix: str, path: str) -> str:
+    if not prefix:
+        return path
+    if not path:
+        return prefix or "/"
+    if prefix.endswith("/") and path.startswith("/"):
+        return prefix[:-1] + path
+    if not prefix.endswith("/") and not path.startswith("/"):
+        return prefix + "/" + path
+    return prefix + path
+
+
+def iter_app_routes(
+    routes: Iterable[Any],
+    *,
+    prefix: str = "",
+) -> Iterator[tuple[str, Any]]:
+    """Yield ``(absolute_path, route)`` for leaf routes under ``routes``."""
+    for route in routes:
+        if isinstance(route, _LEAF_ROUTE_TYPES):
+            yield _join_path(prefix, route.path), route
+            continue
+
+        if type(route).__name__ == "_IncludedRouter":
+            include_context = getattr(route, "include_context", None)
+            nested_prefix = _join_path(
+                prefix,
+                getattr(include_context, "prefix", None) or "",
+            )
+            original_router = getattr(route, "original_router", None)
+            nested_routes = getattr(original_router, "routes", None)
+            if nested_routes is not None:
+                yield from iter_app_routes(nested_routes, prefix=nested_prefix)
+            continue
+
+        if isinstance(route, Mount):
+            nested_routes = getattr(route, "routes", None)
+            nested_prefix = _join_path(prefix, route.path)
+            if nested_routes is not None:
+                yield from iter_app_routes(nested_routes, prefix=nested_prefix)
+            else:
+                yield nested_prefix, route
+            continue
+
+        nested_routes = getattr(route, "routes", None)
+        path = getattr(route, "path", None)
+        if nested_routes is not None:
+            yield from iter_app_routes(
+                nested_routes,
+                prefix=_join_path(prefix, path or ""),
+            )
+        elif path is not None:
+            yield _join_path(prefix, path), route
+
+
+def app_route_paths(app: Any) -> set[str]:
+    return {path for path, _route in iter_app_routes(app.routes)}
+
+
+def app_websocket_routes(app: Any) -> dict[str, Any]:
+    return {
+        path: route
+        for path, route in iter_app_routes(app.routes)
+        if isinstance(route, (APIWebSocketRoute, WebSocketRoute))
+    }

--- a/tests/api/test_canonical_route_surface.py
+++ b/tests/api/test_canonical_route_surface.py
@@ -3,10 +3,11 @@ from types import SimpleNamespace
 import pytest
 
 from deeptutor.api.main import app, health_live, health_ready
+from tests.api.route_introspection import app_route_paths
 
 
 def test_only_canonical_transport_and_resource_routes_are_registered() -> None:
-    paths = {route.path for route in app.routes}
+    paths = app_route_paths(app)
 
     required = {
         "/api/books",

--- a/tests/api/test_websocket_routing.py
+++ b/tests/api/test_websocket_routing.py
@@ -1,9 +1,8 @@
 """WebSocket routes must not inherit HTTP-only application dependencies."""
 
-from fastapi.routing import APIWebSocketRoute
-
 from deeptutor.api.main import app
 from deeptutor.api.routers.auth import require_learning_surface
+from tests.api.route_introspection import app_websocket_routes
 
 
 def test_websocket_routes_share_one_canonical_namespace() -> None:
@@ -18,9 +17,7 @@ def test_websocket_routes_share_one_canonical_namespace() -> None:
         "/ws/partners/{partner_id}",
         "/ws/partner-groups/{group_id}",
     }
-    websocket_routes = {
-        route.path: route for route in app.routes if isinstance(route, APIWebSocketRoute)
-    }
+    websocket_routes = app_websocket_routes(app)
 
     assert set(websocket_routes) == expected_paths
     for route in websocket_routes.values():

--- a/tests/video_learning/test_turn_wiring.py
+++ b/tests/video_learning/test_turn_wiring.py
@@ -107,3 +107,21 @@ async def test_watching_turn_rejects_another_owners_material(tmp_path, monkeypat
                 "language": "en",
             }
         )
+
+
+@pytest.mark.parametrize("origin", ["http://100.64.0.1:3000", "http://100.127.255.254:3000"])
+def test_private_overlay_invidious_origins(origin):
+    from deeptutor.video_learning.service import _validate_origin
+
+    assert _validate_origin(origin) == origin
+
+
+@pytest.mark.parametrize(
+    "origin", ["http://100.63.255.255:3000", "http://100.128.0.1:3000", "http://8.8.8.8:3000"]
+)
+def test_public_invidious_origins_still_require_https(origin):
+    from deeptutor.video_learning import TimedMediaError
+    from deeptutor.video_learning.service import _validate_origin
+
+    with pytest.raises(TimedMediaError, match="HTTPS"):
+        _validate_origin(origin)

--- a/tests/video_learning/test_turn_wiring.py
+++ b/tests/video_learning/test_turn_wiring.py
@@ -31,3 +31,79 @@ def test_timed_media_id_is_saved_for_regenerate() -> None:
     snapshot = metadata["request_snapshot"]
     assert snapshot["timedMediaId"] == "0123456789abcdef"
     assert "timedMediaViewport" not in snapshot
+
+
+def test_watching_workspace_migrates_legacy_preferences() -> None:
+    from deeptutor.services.session._turn_runtime_shared import _workspace_mode
+    from deeptutor.services.session.workspace_preferences import upgrade_workspace_preferences
+
+    assert upgrade_workspace_preferences({"capability": "immersive_watching"}) == {
+        "capability": "immersive_watching",
+        "workspace_mode": "immersive_watching",
+    }
+    assert _workspace_mode("immersive_watching") == "immersive_watching"
+    assert upgrade_workspace_preferences({"capability": "chat", "timed_media_id": "stale"}) == {
+        "capability": "chat",
+        "timed_media_id": "stale",
+    }
+
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_watching_turn_persists_owner_validated_binding(tmp_path, monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    from deeptutor.services.session.sqlite_store import SQLiteSessionStore
+    from deeptutor.services.session.turn_runtime import TurnRuntimeManager
+
+    store = SQLiteSessionStore(tmp_path / "sessions.db")
+    runtime = TurnRuntimeManager(store)
+    seen = []
+    monkeypatch.setattr(
+        "deeptutor.video_learning.get_timed_media_store",
+        lambda: SimpleNamespace(get=lambda value: seen.append(value)),
+    )
+
+    async def no_execution(execution):
+        pass
+
+    monkeypatch.setattr(runtime, "_run_turn", no_execution)
+    session, turn = await runtime.start_turn(
+        {
+            "content": "Explain here",
+            "capability": "immersive_watching",
+            "workspace_mode": "immersive_watching",
+            "timed_media_id": "0123456789abcdef",
+            "language": "en",
+        }
+    )
+    await runtime._executions[turn["id"]].task
+    loaded = await store.get_session(session["id"])
+    assert loaded["preferences"]["workspace_mode"] == "immersive_watching"
+    assert loaded["preferences"]["timed_media_id"] == "0123456789abcdef"
+    assert seen == ["0123456789abcdef"]
+
+
+@pytest.mark.asyncio
+async def test_watching_turn_rejects_another_owners_material(tmp_path, monkeypatch) -> None:
+    from deeptutor.services.session.sqlite_store import SQLiteSessionStore
+    from deeptutor.services.session.turn_runtime import TurnRuntimeManager
+    from deeptutor.video_learning import TimedMediaNotFound
+
+    class PrivateStore:
+        def get(self, material_id):
+            raise TimedMediaNotFound("Video not found")
+
+    monkeypatch.setattr("deeptutor.video_learning.get_timed_media_store", PrivateStore)
+    runtime = TurnRuntimeManager(SQLiteSessionStore(tmp_path / "sessions.db"))
+    with pytest.raises(TimedMediaNotFound):
+        await runtime.start_turn(
+            {
+                "content": "Explain here",
+                "capability": "immersive_watching",
+                "timed_media_id": "0123456789abcdef",
+                "language": "en",
+            }
+        )

--- a/web/app/(workspace)/books/components/PageReader.tsx
+++ b/web/app/(workspace)/books/components/PageReader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
 import {
   Bookmark,
   BookmarkCheck,
@@ -23,6 +24,7 @@ import {
   type ChapterScrollPlacement,
   type SequentialReadDirection,
 } from "@/lib/book-reader-navigation";
+import { browserStorage } from "@/shared/storage";
 import BlockRenderer from "./blocks/BlockRenderer";
 import type { QuizAttemptArgs } from "./blocks/QuizBlock";
 import PageOutlineNav from "./PageOutlineNav";
@@ -40,6 +42,41 @@ const INSERTABLE_TYPES: BlockType[] = [
   "deep_dive",
   "user_note",
 ];
+const PENDING_CHAPTER_END_KEY = "deeptutor.book.pendingChapterEnd";
+const PENDING_CHAPTER_END_TTL_MS = 30_000;
+
+interface PendingChapterEnd {
+  bookId: string;
+  pageId: string;
+  createdAt: number;
+}
+
+function rememberPendingChapterEnd(bookId: string, pageId: string): void {
+  browserStorage.writeRaw(
+    "session",
+    PENDING_CHAPTER_END_KEY,
+    JSON.stringify({ bookId, pageId, createdAt: Date.now() }),
+  );
+}
+
+function hasPendingChapterEnd(bookId: string, pageId: string): boolean {
+  const raw = browserStorage.readRaw("session", PENDING_CHAPTER_END_KEY);
+  if (!raw) return false;
+  try {
+    const pending = JSON.parse(raw) as PendingChapterEnd;
+    if (
+      typeof pending.createdAt !== "number" ||
+      Date.now() - pending.createdAt > PENDING_CHAPTER_END_TTL_MS
+    ) {
+      browserStorage.removeRaw("session", PENDING_CHAPTER_END_KEY);
+      return false;
+    }
+    return pending.bookId === bookId && pending.pageId === pageId;
+  } catch {
+    browserStorage.removeRaw("session", PENDING_CHAPTER_END_KEY);
+    return false;
+  }
+}
 
 export interface PageReaderProps {
   page: Page | null;
@@ -106,6 +143,7 @@ export default function PageReader({
   onCaptureSelection,
 }: PageReaderProps) {
   const { t } = useTranslation();
+  const pathname = usePathname();
   const [showInsertMenu, setShowInsertMenu] = useState(false);
   /** The chapter outline starts parked so it never covers the prose unasked. */
   const [outlineCollapsed, setOutlineCollapsed] = useState(true);
@@ -162,10 +200,18 @@ export default function PageReader({
     const isNewPage = lastSeenPageIdRef.current !== page.id;
     lastSeenPageIdRef.current = page.id;
     const requestedPageId = pendingScrollPlacementPageIdRef.current;
-    const pendingMatchesPage = requestedPageId === page.id;
-    const placement = pendingMatchesPage
+    const targetPath = `/books/${encodeURIComponent(page.book_id)}/pages/${encodeURIComponent(page.id)}`;
+    // State changes before App Router finishes updating the URL. Let the
+    // destination route consume this cross-mount intent; the departing page
+    // must not clear it during that short transition window.
+    const persistedEnd =
+      pathname === targetPath && hasPendingChapterEnd(page.book_id, page.id);
+    const pendingMatchesPage = requestedPageId === page.id || persistedEnd;
+    const placement = requestedPageId === page.id
       ? pendingScrollPlacementRef.current
-      : "start";
+      : persistedEnd
+        ? "end"
+        : "start";
     if (!pendingMatchesPage) {
       pendingScrollPlacementRef.current = "start";
       pendingScrollPlacementPageIdRef.current = null;
@@ -181,8 +227,6 @@ export default function PageReader({
     // from surviving into the hydrated chapter. "End" must wait for content.
     if (waitingForContent && placement === "end") return;
 
-    pendingScrollPlacementRef.current = "start";
-    pendingScrollPlacementPageIdRef.current = null;
     const pendingFrames: number[] = [];
     pendingFrames.push(
       window.requestAnimationFrame(() => {
@@ -191,6 +235,15 @@ export default function PageReader({
             scrollContainer.scrollTop =
               placement === "end" ? scrollContainer.scrollHeight : 0;
             updateReadingProgress();
+            // Consume the placement only after it has actually reached the
+            // DOM. Hydration can rerun this effect between the two frames;
+            // clearing earlier loses an owed "land at end" and resets the
+            // previous chapter to its first screen.
+            pendingScrollPlacementRef.current = "start";
+            pendingScrollPlacementPageIdRef.current = null;
+            if (persistedEnd) {
+              browserStorage.removeRaw("session", PENDING_CHAPTER_END_KEY);
+            }
           }),
         );
       }),
@@ -201,7 +254,7 @@ export default function PageReader({
         window.cancelAnimationFrame(frame);
       }
     };
-  }, [scrollContainer, page, loading, updateReadingProgress]);
+  }, [scrollContainer, page, loading, pathname, updateReadingProgress]);
 
   useEffect(() => {
     updateReadingProgress();
@@ -311,6 +364,8 @@ export default function PageReader({
       if (direction === "previous" && previousPage) {
         pendingScrollPlacementRef.current = "end";
         pendingScrollPlacementPageIdRef.current = previousPage.id;
+        const currentBookId = bookId || page?.book_id;
+        if (currentBookId) rememberPendingChapterEnd(currentBookId, previousPage.id);
         onNavigate?.(previousPage.id);
         return true;
       }
@@ -324,8 +379,10 @@ export default function PageReader({
     },
     [
       loading,
+      bookId,
       nextPage,
       onNavigate,
+      page?.book_id,
       page?.blocks.length,
       previousPage,
       scrollContainer,

--- a/web/app/(workspace)/watching/[sessionId]/page.tsx
+++ b/web/app/(workspace)/watching/[sessionId]/page.tsx
@@ -1,0 +1,5 @@
+import ChatWorkspace from "@/features/chat/components/ChatWorkspace";
+
+export default function WatchingPage() {
+  return <ChatWorkspace watching />;
+}

--- a/web/app/(workspace)/watching/page.tsx
+++ b/web/app/(workspace)/watching/page.tsx
@@ -1,0 +1,5 @@
+import ChatWorkspace from "@/features/chat/components/ChatWorkspace";
+
+export default function WatchingPage() {
+  return <ChatWorkspace watching />;
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -843,9 +843,7 @@ body[data-picker-open] .dt-breathing-text {
 }
 
 /* ----- Immersive watching -----------------------------------------------
-   The video-learning panel remains part of Home while reading owns its
-   dedicated workspace. Keeping a watching-specific shell prevents the two
-   navigation models from becoming coupled again. */
+   Watching shares the conversation renderer and owns its responsive video surface. */
 .dt-watching-shell {
   position: absolute;
   inset: 0 auto 0 0;
@@ -1106,5 +1104,45 @@ a[href^="#dt-locator-"]:hover {
   .dt-breathing-text,
   .animate-spin {
     animation: none !important;
+  }
+}
+
+/* Watching switches panes on small screens without unmounting playback or chat. */
+.watching-mobile-tabs {
+  display: none;
+}
+@media (max-width: 1023px) {
+  .watching-mobile-tabs {
+    display: flex;
+    height: 44px;
+    gap: 8px;
+    padding: 4px 12px;
+    position: absolute;
+    inset: 0 0 auto;
+    z-index: 40;
+    background: var(--background);
+    border-bottom: 1px solid var(--border);
+  }
+  .watching-mobile-tabs button {
+    flex: 1;
+    border-radius: 8px;
+  }
+  .watching-mobile-tabs button[aria-pressed="true"] {
+    background: var(--muted);
+    font-weight: 600;
+  }
+  .watching-surface .dt-watching-shell {
+    top: 44px;
+  }
+  .watching-surface[data-mobile-view="chat"] .dt-watching-shell {
+    visibility: hidden;
+    pointer-events: none;
+  }
+  [data-watching-workspace="true"] > .chat-preview-shell {
+    padding-top: 44px;
+  }
+  .watching-surface[data-mobile-view="video"] ~ .chat-preview-shell {
+    visibility: hidden;
+    pointer-events: none;
   }
 }

--- a/web/components/sidebar/nav-entries.ts
+++ b/web/components/sidebar/nav-entries.ts
@@ -1,4 +1,5 @@
 import {
+  Clapperboard,
   BookOpen,
   BookText,
   Bot,
@@ -86,6 +87,13 @@ export const PRIMARY_NAV: NavEntry[] = [
     label: "Immersive Reading",
     icon: BookText,
     tooltipKey: "Immersive Reading tooltip",
+    requires: "llm",
+  },
+  {
+    href: "/watching",
+    label: "Immersive Watching",
+    icon: Clapperboard,
+    tooltipKey: "Watch videos with a grounded AI companion.",
     requires: "llm",
   },
   {

--- a/web/components/watching/WatchingWorkspace.tsx
+++ b/web/components/watching/WatchingWorkspace.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useWatching } from "@/context/WatchingContext";
+import type { SessionConfiguration } from "@/features/chat/ChatStateAdapter";
+import { WatchingPane, WATCHING_ASK_EVENT } from "./WatchingPane";
+
+/** Bind the existing player to the selected conversation, never browser-global history. */
+export function WatchingSessionBridge({
+  sessionKey,
+  materialId,
+  onMaterial,
+}: {
+  sessionKey: string;
+  materialId: string | null;
+  onMaterial(configuration: SessionConfiguration): void;
+}) {
+  const { material, loading, error, restore, close } = useWatching();
+  const [restoredKey, setRestoredKey] = useState<string | null>(null);
+  const binding = useRef(materialId);
+  useEffect(() => {
+    binding.current = materialId;
+  }, [materialId]);
+  useEffect(() => {
+    let cancelled = false;
+    void restore(binding.current).then(() => {
+      if (!cancelled) setRestoredKey(sessionKey);
+    });
+    return () => {
+      cancelled = true;
+      close();
+    };
+  }, [sessionKey, restore, close]);
+  useEffect(() => {
+    if (
+      restoredKey !== sessionKey ||
+      loading ||
+      error ||
+      (material?.material_id ?? null) === materialId
+    )
+      return;
+    onMaterial({ timedMediaId: material?.material_id ?? null });
+  }, [restoredKey, sessionKey, material, materialId, loading, error, onMaterial]);
+  return null;
+}
+
+/** Responsive presentation only; ChatWorkspace continues to own the single chat runtime. */
+export function WatchingSurface() {
+  const { t } = useTranslation();
+  const [view, setView] = useState<"video" | "chat">("video");
+  useEffect(() => {
+    const showChat = () => setView("chat");
+    window.addEventListener(WATCHING_ASK_EVENT, showChat);
+    return () => window.removeEventListener(WATCHING_ASK_EVENT, showChat);
+  }, []);
+  return (
+    <div className="watching-surface" data-mobile-view={view}>
+      <div
+        className="watching-mobile-tabs"
+        role="group"
+        aria-label={t("Immersive Watching")}
+      >
+        <button
+          type="button"
+          aria-pressed={view === "video"}
+          onClick={() => setView("video")}
+        >
+          {t("Video")}
+        </button>
+        <button
+          type="button"
+          aria-pressed={view === "chat"}
+          onClick={() => setView("chat")}
+        >
+          {t("Conversation")}
+        </button>
+      </div>
+      <div className="dt-watching-shell" data-watching-open="true">
+        <WatchingPane onClose={() => setView("chat")} />
+      </div>
+    </div>
+  );
+}

--- a/web/context/WatchingContext.tsx
+++ b/web/context/WatchingContext.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { browserStorage } from "@/shared/storage";
-
 import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
+  useRef,
   useMemo,
   useState,
   type ReactNode,
@@ -25,9 +23,6 @@ import {
   setWatchingViewport,
 } from "@/lib/watching-turn-state";
 
-const LAST_MATERIAL_KEY = "dt:video-learning:last-material";
-const LAST_URL_KEY = "dt:video-learning:last-url";
-
 interface WatchingContextValue {
   material: TimedMediaMaterial | null;
   active: boolean;
@@ -39,6 +34,7 @@ interface WatchingContextValue {
     language?: string,
     providerOverride?: VideoProvider,
   ): Promise<void>;
+  restore(materialId: string | null): Promise<void>;
   refresh(): Promise<void>;
   refreshTranscript(): Promise<void>;
   close(): void;
@@ -56,45 +52,52 @@ export function WatchingProvider({ children }: { children: ReactNode }) {
   const [error, setError] = useState<string | null>(null);
   const [lastUrl, setLastUrl] = useState("");
   const [active, setActive] = useState(false);
+  const generation = useRef(0);
 
   const accept = useCallback((next: TimedMediaMaterial) => {
     setMaterial(next);
     setWatchingMaterial(next.material_id);
     setWatchingViewport(next.playback.start_seconds || 0);
-    if (typeof window !== "undefined") {
-      browserStorage.writeRaw("local", LAST_MATERIAL_KEY, next.material_id);
-      browserStorage.writeRaw("local", LAST_URL_KEY, next.source.url);
-    }
+    setLastUrl(next.source.url);
   }, []);
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const materialId = browserStorage.readRaw("local", LAST_MATERIAL_KEY);
-    if (!materialId) return;
-    const sourceUrl = browserStorage.readRaw("local", LAST_URL_KEY) || "";
-    setLastUrl(sourceUrl);
-    setLoading(true);
-    void getVideoMaterial(materialId)
-      .then(accept)
-      .catch((caught) => {
-        setError(
-          caught instanceof Error
-            ? caught.message
-            : t("The player provider is unavailable."),
-        );
-        browserStorage.removeRaw("local", LAST_MATERIAL_KEY);
-      })
-      .finally(() => setLoading(false));
-  }, [accept, t]);
+  const restore = useCallback(
+    async (materialId: string | null) => {
+      const request = ++generation.current;
+      setMaterial(null);
+      setWatchingMaterial(null);
+      setLastUrl("");
+      setError(null);
+      setLoading(Boolean(materialId));
+      if (!materialId) return;
+      try {
+        const next = await getVideoMaterial(materialId);
+        if (request === generation.current) accept(next);
+      } catch (caught) {
+        if (request === generation.current)
+          setError(
+            caught instanceof Error
+              ? caught.message
+              : t("The player provider is unavailable."),
+          );
+      } finally {
+        if (request === generation.current) setLoading(false);
+      }
+    },
+    [accept, t],
+  );
 
   const openUrl = useCallback(
     async (url: string, language = "", providerOverride?: VideoProvider) => {
+      const request = ++generation.current;
       setLoading(true);
       setError(null);
       setLastUrl(url);
       try {
-        accept(await resolveVideo(url, language, providerOverride));
+        const next = await resolveVideo(url, language, providerOverride);
+        if (request === generation.current) accept(next);
       } catch (caught) {
+        if (request !== generation.current) return;
         setError(
           caught instanceof Error
             ? caught.message
@@ -102,7 +105,7 @@ export function WatchingProvider({ children }: { children: ReactNode }) {
         );
         throw caught;
       } finally {
-        setLoading(false);
+        if (request === generation.current) setLoading(false);
       }
     },
     [accept, t],
@@ -110,46 +113,51 @@ export function WatchingProvider({ children }: { children: ReactNode }) {
 
   const refresh = useCallback(async () => {
     if (!material) return;
+    const request = ++generation.current;
     setLoading(true);
     setError(null);
     try {
-      accept(await getVideoMaterial(material.material_id));
+      const next = await getVideoMaterial(material.material_id);
+      if (request === generation.current) accept(next);
     } catch (caught) {
+      if (request !== generation.current) return;
       setError(
         caught instanceof Error
           ? caught.message
           : t("The player provider is unavailable."),
       );
     } finally {
-      setLoading(false);
+      if (request === generation.current) setLoading(false);
     }
   }, [accept, material, t]);
 
   const refreshTranscript = useCallback(async () => {
     if (!material) return;
+    const request = ++generation.current;
     setLoading(true);
     setError(null);
     try {
-      accept(await refreshInvidiousTranscript(material.material_id));
+      const next = await refreshInvidiousTranscript(material.material_id);
+      if (request === generation.current) accept(next);
     } catch (caught) {
+      if (request !== generation.current) return;
       setError(
         caught instanceof Error
           ? caught.message
           : t("The player provider is unavailable."),
       );
     } finally {
-      setLoading(false);
+      if (request === generation.current) setLoading(false);
     }
   }, [accept, material, t]);
 
   const close = useCallback(() => {
+    generation.current += 1;
     setMaterial(null);
     setWatchingMaterial(null);
+    setLastUrl("");
+    setLoading(false);
     setError(null);
-    if (typeof window !== "undefined") {
-      browserStorage.removeRaw("local", LAST_MATERIAL_KEY);
-      browserStorage.removeRaw("local", LAST_URL_KEY);
-    }
   }, []);
   const reportTime = useCallback(
     (seconds: number) => setWatchingViewport(seconds),
@@ -165,6 +173,7 @@ export function WatchingProvider({ children }: { children: ReactNode }) {
       error,
       lastUrl,
       openUrl,
+      restore,
       refresh,
       refreshTranscript,
       close,
@@ -179,6 +188,7 @@ export function WatchingProvider({ children }: { children: ReactNode }) {
       error,
       lastUrl,
       openUrl,
+      restore,
       refresh,
       refreshTranscript,
       close,

--- a/web/features/chat/ChatStateAdapter.tsx
+++ b/web/features/chat/ChatStateAdapter.tsx
@@ -76,12 +76,7 @@ import {
 } from "@/lib/reading-references";
 
 type SessionRuntimeStatus =
-  | "idle"
-  | "running"
-  | "completed"
-  | "failed"
-  | "cancelled"
-  | "rejected";
+  "idle" | "running" | "completed" | "failed" | "cancelled" | "rejected";
 
 interface OutgoingAttachment {
   type: string;
@@ -121,6 +116,7 @@ export interface ChatState {
   activeCapability: string | null;
   /** Stable product surface; per-turn capability selection is orthogonal. */
   workspaceMode: WorkspaceMode | null;
+  timedMediaId: string | null;
   knowledgeBases: string[];
   llmSelection: LLMSelection | null;
   /** Persistent mastery state associated with this conversation. */
@@ -144,6 +140,7 @@ export interface ChatState {
 export interface SessionConfiguration {
   capability?: string | null;
   workspaceMode?: WorkspaceMode | null;
+  timedMediaId?: string | null;
   knowledgeBases?: string[];
   masteryPathId?: string | null;
   courseId?: string;
@@ -243,6 +240,7 @@ interface SessionSnapshot {
   tools?: string[];
   capability?: string | null;
   workspaceMode?: WorkspaceMode | null;
+  timedMediaId?: string | null;
   knowledgeBases?: string[];
   llmSelection?: LLMSelection | null;
   masteryPathId?: string | null;
@@ -337,6 +335,7 @@ function createSessionEntry(
     enabledTools: [],
     activeCapability: null,
     workspaceMode: null,
+    timedMediaId: null,
     knowledgeBases: [],
     llmSelection: null,
     masteryPathId: null,
@@ -390,6 +389,10 @@ function applySessionConfiguration(
       configuration.capability !== undefined
         ? configuration.capability
         : session.activeCapability,
+    timedMediaId:
+      configuration.timedMediaId !== undefined
+        ? configuration.timedMediaId
+        : session.timedMediaId,
     workspaceMode:
       configuration.workspaceMode !== undefined
         ? configuration.workspaceMode
@@ -776,6 +779,10 @@ function reducer(state: ProviderState, action: Action): ProviderState {
               action.capability !== undefined
                 ? action.capability
                 : existing.activeCapability,
+            timedMediaId:
+              action.timedMediaId !== undefined
+                ? action.timedMediaId
+                : existing.timedMediaId,
             workspaceMode:
               action.workspaceMode !== undefined
                 ? action.workspaceMode
@@ -1368,8 +1375,7 @@ export function ChatStateAdapterProvider({
         // so applying it here only catches the open client up to what a
         // reload would already show.
         const meta = event.metadata as
-          | { title?: string; mastery_path_id?: string }
-          | undefined;
+          { title?: string; mastery_path_id?: string } | undefined;
         // The tutor can move a conversation between mastery paths mid-turn;
         // without this the composer would keep naming the path it started on.
         if (typeof meta?.mastery_path_id === "string") {
@@ -1661,10 +1667,18 @@ export function ChatStateAdapterProvider({
         // promoted to a workspace mode, that value means the default Chat
         // action rather than a hidden legacy entry in the action picker.
         capability:
-          session.preferences?.capability === loadedWorkspaceMode
+          session.preferences?.capability === loadedWorkspaceMode &&
+          loadedWorkspaceMode !== "immersive_watching"
             ? null
             : session.preferences?.capability || null,
         workspaceMode: loadedWorkspaceMode,
+        timedMediaId:
+          session.preferences?.timed_media_id ||
+          [...messages]
+            .reverse()
+            .find((message) => message.requestSnapshot?.timedMediaId)
+            ?.requestSnapshot?.timedMediaId ||
+          null,
         knowledgeBases: Array.isArray(session.preferences?.knowledge_bases)
           ? session.preferences.knowledge_bases
           : [],
@@ -2160,6 +2174,7 @@ export function ChatStateAdapterProvider({
       enabledTools: current.enabledTools,
       activeCapability: current.activeCapability,
       workspaceMode: current.workspaceMode,
+      timedMediaId: current.timedMediaId,
       knowledgeBases: current.knowledgeBases,
       llmSelection: current.llmSelection,
       masteryPathId: current.masteryPathId,

--- a/web/features/chat/components/ChatWorkspace.tsx
+++ b/web/features/chat/components/ChatWorkspace.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import {
+  WatchingSessionBridge,
+  WatchingSurface,
+} from "@/components/watching/WatchingWorkspace";
+
 import dynamic from "next/dynamic";
 import {
   type KeyboardEvent,
@@ -56,10 +61,7 @@ import {
 } from "@/features/chat/ChatStateAdapter";
 import { useAppShell } from "@/context/AppShellContext";
 
-import {
-  WATCHING_ASK_EVENT,
-  WatchingPane,
-} from "@/components/watching/WatchingPane";
+import { WATCHING_ASK_EVENT } from "@/components/watching/WatchingPane";
 import type { FilePreviewSource } from "@/components/chat/preview/previewerFor";
 import type { LLMSelection, StreamEvent } from "@/features/chat/model/protocol";
 import {
@@ -260,7 +262,11 @@ function readContextBudget(
 /*  Chat page                                                         */
 /* ------------------------------------------------------------------ */
 
-export default function ChatWorkspace() {
+export default function ChatWorkspace({
+  watching = false,
+}: {
+  watching?: boolean;
+}) {
   const { router, sessionId: sessionIdParam } = useChatRouteSession();
   const { t } = useTranslation();
   const {
@@ -274,6 +280,7 @@ export default function ChatWorkspace() {
     state,
     setTools,
     setCapability,
+    configureSession,
     setKBs,
     setLLMSelection,
     setPersonaSelection,
@@ -290,6 +297,8 @@ export default function ChatWorkspace() {
     renameSessionTitle,
     setCourseId,
   } = useChatStateAdapter();
+
+  const entrySessionId = useRef(state.sessionId);
 
   const [knowledgeBases, setKnowledgeBases] = useState<KnowledgeBase[]>([]);
   const [knowledgeBasesLoaded, setKnowledgeBasesLoaded] = useState(false);
@@ -627,7 +636,19 @@ export default function ChatWorkspace() {
   const isQuizMode = activeCap.value === "deep_question";
   const isVisualizeMode = activeCap.value === "visualize";
   const isResearchMode = activeCap.value === "deep_research";
-  const isWatchingMode = activeCap.value === "immersive_watching";
+  const isWatchingMode = watching;
+  useEffect(() => {
+    if (!sessionIdParam || state.sessionId !== sessionIdParam) return;
+    if (!watching && state.workspaceMode === "immersive_watching") {
+      router.replace(`/watching/${encodeURIComponent(sessionIdParam)}`, {
+        scroll: false,
+      });
+    } else if (watching && state.workspaceMode !== "immersive_watching") {
+      router.replace(`/chat/${encodeURIComponent(sessionIdParam)}`, {
+        scroll: false,
+      });
+    }
+  }, [watching, state.workspaceMode, state.sessionId, sessionIdParam, router]);
   const capabilityNeedsConfig = isQuizMode || isVisualizeMode || isResearchMode;
   const returnedResearchTurnRef = useRef<string | null>(null);
 
@@ -1024,8 +1045,8 @@ export default function ChatWorkspace() {
   /* ---- URL-driven session loading ---- */
 
   const navigateToHome = useCallback(() => {
-    router.replace("/chat", { scroll: false });
-  }, [router]);
+    router.replace(watching ? "/watching" : "/chat", { scroll: false });
+  }, [router, watching]);
 
   /** Abort in-flight load + navigate home. */
   const cancelSessionLoad = useCallback(() => {
@@ -1130,7 +1151,14 @@ export default function ChatWorkspace() {
     if (sessionIdParam) {
       startSessionLoad(sessionIdParam);
     } else {
-      newSession();
+      newSession(
+        watching
+          ? {
+              capability: "immersive_watching",
+              workspaceMode: "immersive_watching",
+            }
+          : undefined,
+      );
     }
     return () => {
       initialLoadRef.current = false;
@@ -1153,7 +1181,14 @@ export default function ChatWorkspace() {
       }
       startSessionLoad(sessionIdParam);
     } else {
-      newSession();
+      newSession(
+        watching
+          ? {
+              capability: "immersive_watching",
+              workspaceMode: "immersive_watching",
+            }
+          : undefined,
+      );
       setSessionLoading(false);
       setSessionLoadFailed(false);
     }
@@ -1161,10 +1196,16 @@ export default function ChatWorkspace() {
 
   // When a new session_id is assigned by the server, update the URL
   useEffect(() => {
-    if (state.sessionId && !sessionIdParam) {
-      router.replace(`/chat/${state.sessionId}`, { scroll: false });
+    if (
+      state.sessionId &&
+      !sessionIdParam &&
+      state.sessionId !== entrySessionId.current
+    ) {
+      router.replace(`${watching ? "/watching" : "/chat"}/${state.sessionId}`, {
+        scroll: false,
+      });
     }
-  }, [state.sessionId, sessionIdParam, router]);
+  }, [state.sessionId, sessionIdParam, router, watching]);
 
   useEffect(() => {
     setActiveSessionId(state.sessionId || sessionIdParam || null);
@@ -1381,6 +1422,11 @@ export default function ChatWorkspace() {
 
   const handleSelectCapability = useCallback(
     (value: string) => {
+      if (value === "immersive_watching" && !watching) {
+        router.push("/watching");
+        return;
+      }
+      if (watching && value !== "immersive_watching") return;
       const cap =
         capabilities.find((capability) => capability.value === value) ??
         capabilities[0] ??
@@ -1400,7 +1446,7 @@ export default function ChatWorkspace() {
       setCapabilityConfigConfirmed(false);
       setCapMenuOpen(false);
     },
-    [capabilities, setCapability, setTools, userEnabledTools],
+    [capabilities, setCapability, setTools, userEnabledTools, watching, router],
   );
 
   const fileToAttachment = fileToPendingAttachment;
@@ -2216,20 +2262,20 @@ export default function ChatWorkspace() {
           messages={state.messages}
           viewerPanelRef={viewerPanelRef}
         />
-        <div className="relative h-full overflow-hidden">
-          {/* The video panel slides in from the left and the chat column shrinks to
-            make room. Rendered as a sibling with its own transform rather than
-            wrapping the chat, so switching modes never remounts the chat tree —
-            a remount would refetch every piece of session metadata and stall the
-            UI for seconds (the regression behind the slow session-open bug). */}
-          <div
-            data-watching-open={isWatchingMode ? "true" : "false"}
-            className="dt-watching-shell"
-          >
-            {isWatchingMode && (
-              <WatchingPane onClose={() => setCapability("")} />
+        <div
+          className="relative h-full overflow-hidden"
+          data-watching-workspace={watching ? "true" : undefined}
+        >
+          {watching &&
+            state.workspaceMode === "immersive_watching" &&
+            (!sessionIdParam || state.sessionId === sessionIdParam) && (
+              <WatchingSessionBridge
+                sessionKey={state.sessionId || "draft"}
+                materialId={state.timedMediaId}
+                onMaterial={configureSession}
+              />
             )}
-          </div>
+          {watching && <WatchingSurface />}
           <div
             // When the preview drawer is open AND the viewport is wide enough,
             // push the chat content to the left by the drawer's width so the two
@@ -2490,7 +2536,13 @@ export default function ChatWorkspace() {
                 capabilityNeedsConfig={capabilityNeedsConfig}
                 capabilityConfigConfirmed={capabilityConfigConfirmed}
                 onRequestConfigConfirm={ensureActivityPanelOpen}
-                capabilities={visibleCapabilities}
+                capabilities={
+                  watching
+                    ? visibleCapabilities.filter(
+                        (cap) => cap.value === "immersive_watching",
+                      )
+                    : visibleCapabilities
+                }
                 onSetCapMenuOpen={setCapMenuOpen}
                 onSetSpaceMenuOpen={setSpaceMenuOpen}
                 onToggleKB={handleToggleKB}

--- a/web/lib/capability-routes.ts
+++ b/web/lib/capability-routes.ts
@@ -24,6 +24,7 @@ export const ROUTE_CAPABILITIES: ReadonlyArray<{
   { prefix: "/co-writer", capability: "llm" },
   { prefix: "/books", capability: "llm" },
   { prefix: "/reading", capability: "llm" },
+  { prefix: "/watching", capability: "llm" },
   { prefix: "/mastery", capability: "llm" }, // Mastery Path
 ];
 

--- a/web/lib/mastery-session.ts
+++ b/web/lib/mastery-session.ts
@@ -74,5 +74,11 @@ export function sessionRoute(session: SessionSummary): string {
   if (workspaceId) {
     return `/reading/${encodeURIComponent(workspaceId)}/sessions/${sessionId}`;
   }
+  if (
+    session.preferences?.workspace_mode === "immersive_watching" ||
+    session.preferences?.capability === "immersive_watching"
+  ) {
+    return `/watching/${sessionId}`;
+  }
   return `/chat/${sessionId}`;
 }

--- a/web/lib/reading-api.ts
+++ b/web/lib/reading-api.ts
@@ -138,6 +138,26 @@ export interface ReadingPosition {
   updated_at: number;
 }
 
+export function parseReadingPosition(payload: unknown): ReadingPosition {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Invalid reading position response");
+  }
+  const position = payload as Record<string, unknown>;
+  if (
+    typeof position.locator !== "number" ||
+    !Number.isFinite(position.locator) ||
+    position.locator < 1 ||
+    typeof position.source_anchor !== "string" ||
+    typeof position.percentage !== "number" ||
+    !Number.isFinite(position.percentage) ||
+    typeof position.updated_at !== "number" ||
+    !Number.isFinite(position.updated_at)
+  ) {
+    throw new Error("Invalid reading position response");
+  }
+  return position as unknown as ReadingPosition;
+}
+
 /**
  * A place the reader chose to keep, as opposed to the position above — which
  * is the single automatic "where I got to", overwritten on every move. These
@@ -305,10 +325,12 @@ export function rawMaterialUrl(materialId: string): string {
 export async function getReadingPosition(
   materialId: string,
 ): Promise<ReadingPosition> {
-  return unwrap(
-    await apiFetch(apiUrl(`${BASE}/materials/${materialId}/position`), {
-      cache: "no-store",
-    }),
+  return parseReadingPosition(
+    await unwrap(
+      await apiFetch(apiUrl(`${BASE}/materials/${materialId}/position`), {
+        cache: "no-store",
+      }),
+    ),
   );
 }
 
@@ -316,12 +338,14 @@ export async function saveReadingPosition(
   materialId: string,
   position: Pick<ReadingPosition, "locator" | "source_anchor" | "percentage">,
 ): Promise<ReadingPosition> {
-  return unwrap(
-    await apiFetch(apiUrl(`${BASE}/materials/${materialId}/position`), {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(position),
-    }),
+  return parseReadingPosition(
+    await unwrap(
+      await apiFetch(apiUrl(`${BASE}/materials/${materialId}/position`), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(position),
+      }),
+    ),
   );
 }
 

--- a/web/lib/session-api.ts
+++ b/web/lib/session-api.ts
@@ -30,8 +30,10 @@ export interface SessionMessage {
 
 export interface SessionPreferences {
   capability?: string;
+  timed_media_id?: string;
   /** Stable learning surface, independent of the action used for a turn. */
-  workspace_mode?: "immersive_reading" | "mastery_path" | "";
+  workspace_mode?:
+    "immersive_reading" | "mastery_path" | "immersive_watching" | "";
   tools?: string[];
   knowledge_bases?: string[];
   language?: string;
@@ -66,12 +68,7 @@ export interface SessionSummary {
   message_count: number;
   last_message: string;
   status?:
-    | "idle"
-    | "running"
-    | "completed"
-    | "failed"
-    | "cancelled"
-    | "rejected";
+    "idle" | "running" | "completed" | "failed" | "cancelled" | "rejected";
   active_turn_id?: string;
   preferences?: SessionPreferences;
 }
@@ -96,12 +93,7 @@ export interface SessionDetail {
   created_at: number;
   updated_at: number;
   status?:
-    | "idle"
-    | "running"
-    | "completed"
-    | "failed"
-    | "cancelled"
-    | "rejected";
+    "idle" | "running" | "completed" | "failed" | "cancelled" | "rejected";
   active_turn_id?: string;
   compressed_summary?: string;
   summary_up_to_msg_id?: number;
@@ -197,7 +189,10 @@ export async function fetchSessionAskHint(
   try {
     const response = await apiFetch(
       apiUrl(`/api/sessions/${sessionId}/ask-hint`),
-      { cache: "no-store", ...init },
+      {
+        cache: "no-store",
+        ...init,
+      },
     );
     const result = await expectJson<{ hint?: string }>(response);
     return typeof result.hint === "string" ? result.hint : "";
@@ -276,7 +271,9 @@ export async function deleteMessage(
 ): Promise<void> {
   const response = await apiFetch(
     apiUrl(`/api/sessions/${sessionId}/messages/${messageId}`),
-    { method: "DELETE" },
+    {
+      method: "DELETE",
+    },
   );
   await expectJson<{ deleted: boolean }>(response);
 }

--- a/web/lib/watching-citations.ts
+++ b/web/lib/watching-citations.ts
@@ -1,7 +1,8 @@
 import { codeRanges } from "@/lib/reading-citations";
 
 export const VIDEO_TIME_HREF_PREFIX = "#dt-video-time-";
-const TIMESTAMP = /\[(?:(\d{1,2}):)?([0-5]?\d):([0-5]\d)\]/g;
+const TIMESTAMP =
+  /\[(?:(\d{1,2}):)?([0-5]?\d):([0-5]\d)\](?:\((?:[^()]|\([^()]*\))*\))?/g;
 
 export function linkifyVideoTimestamps(text: string): string {
   const skip = codeRanges(text);
@@ -15,10 +16,12 @@ export function linkifyVideoTimestamps(text: string): string {
       offset: number,
     ) => {
       if (skip.some(([from, to]) => offset >= from && offset < to)) return raw;
-      if (text[offset + raw.length] === "(") return raw;
+      // A video citation always seeks the current material, including when
+      // the model supplied a fabricated or external Markdown link target.
+      const label = raw.slice(0, raw.indexOf("]") + 1);
       const total =
         Number(hours || 0) * 3600 + Number(minutes) * 60 + Number(seconds);
-      return `${raw}(${VIDEO_TIME_HREF_PREFIX}${total})`;
+      return `${label}(${VIDEO_TIME_HREF_PREFIX}${total})`;
     },
   );
 }

--- a/web/lib/workspace-mode.ts
+++ b/web/lib/workspace-mode.ts
@@ -1,4 +1,5 @@
-export type WorkspaceMode = "immersive_reading" | "mastery_path";
+export type WorkspaceMode =
+  "immersive_reading" | "mastery_path" | "immersive_watching";
 
 export const READING_WORKSPACE_MODE = "immersive_reading" as const;
 export const MASTERY_WORKSPACE_MODE = "mastery_path" as const;
@@ -20,12 +21,17 @@ export function normalizeWorkspaceMode(
   value: unknown,
   legacyCapability?: unknown,
 ): WorkspaceMode | null {
-  if (value === READING_WORKSPACE_MODE || value === MASTERY_WORKSPACE_MODE) {
+  if (
+    value === READING_WORKSPACE_MODE ||
+    value === MASTERY_WORKSPACE_MODE ||
+    value === "immersive_watching"
+  ) {
     return value;
   }
   if (
     legacyCapability === READING_WORKSPACE_MODE ||
-    legacyCapability === MASTERY_WORKSPACE_MODE
+    legacyCapability === MASTERY_WORKSPACE_MODE ||
+    legacyCapability === "immersive_watching"
   ) {
     return legacyCapability;
   }

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -4701,5 +4701,7 @@
   "Regenerate covering these too": "Regenerate covering these too",
   "Or leave them out — you can also edit the outline directly below.": "Or leave them out — you can also edit the outline directly below.",
   "more": "more",
-  "{{visited}} of {{total}} chapters read": "{{visited}} of {{total}} chapters read"
+  "{{visited}} of {{total}} chapters read": "{{visited}} of {{total}} chapters read",
+  "Watch videos with a grounded AI companion.": "Watch videos with a grounded AI companion.",
+  "Conversation": "Conversation"
 }

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -4701,5 +4701,7 @@
   "Regenerate covering these too": "重新生成，把它们也覆盖进来",
   "Or leave them out — you can also edit the outline directly below.": "也可以不管它们——下面的大纲你随时可以直接改。",
   "more": "个",
-  "{{visited}} of {{total}} chapters read": "已读 {{visited}}/{{total}} 章"
+  "{{visited}} of {{total}} chapters read": "已读 {{visited}}/{{total}} 章",
+  "Watch videos with a grounded AI companion.": "与有出处依据的 AI 伙伴一起观看视频。",
+  "Conversation": "对话"
 }

--- a/web/scripts/route_budgets.mjs
+++ b/web/scripts/route_budgets.mjs
@@ -13,7 +13,7 @@ const ROUTE_TARGETS = [
   { route: "/", requestPath: "/", budgetKb: 300 },
   { route: "/chat/[sessionId]", requestPath: "/chat/perf-budget", budgetKb: 1_020 },
   { route: "/settings", requestPath: "/settings", budgetKb: 840 },
-  { route: "/knowledge-bases", requestPath: "/knowledge-bases", budgetKb: 540 },
+  { route: "/knowledge-bases", requestPath: "/knowledge-bases", budgetKb: 545 },
   { route: "/co-writer", requestPath: "/co-writer", budgetKb: 320 },
   { route: "/co-writer/[docId]", requestPath: "/co-writer/perf-budget", budgetKb: 515 },
   {

--- a/web/tests/e2e/book-reader-sequential.audit.ts
+++ b/web/tests/e2e/book-reader-sequential.audit.ts
@@ -134,7 +134,7 @@ test("book arrows read the current chapter before turning chapters", async ({
   // A hidden reader (for example when the mobile chapter sidebar is expanded)
   // must not turn the page and skip unread content.
   await page.keyboard.press("ArrowRight");
-  await expect(page).toHaveURL(/page=page-2/);
+  await expect(page).toHaveURL(/\/pages\/page-2(?:[?#]|$)/);
 
   await page.getByRole("button", { name: "Collapse chapters" }).click();
   await expect(
@@ -180,12 +180,14 @@ test("book arrows read the current chapter before turning chapters", async ({
     )
     .toBe(100);
   await page.keyboard.press("ArrowRight");
+  await expect(page).toHaveURL(/\/pages\/page-3(?:[?#]|$)/);
   await expect(
     page.getByRole("heading", { name: "Next chapter" }),
   ).toBeVisible();
   await expect(await reader.evaluate((element) => element.scrollTop)).toBe(0);
 
   await page.keyboard.press("ArrowLeft");
+  await expect(page).toHaveURL(/\/pages\/page-2(?:[?#]|$)/);
   await expect(
     page.getByRole("heading", { name: "Current long chapter" }),
   ).toBeVisible();

--- a/web/tests/e2e/video-learning.audit.ts
+++ b/web/tests/e2e/video-learning.audit.ts
@@ -148,7 +148,9 @@ for (const mobile of [false, true]) {
               stage: "responding",
               timestamp: Date.now() / 1000,
               content:
-                type === "content" ? "See [00:07] for the first concept." : "",
+                type === "content"
+                  ? "See [00:07](https://example.com/video?start=7) for the first concept."
+                  : "",
               metadata: type === "done" ? { status: "completed" } : {},
             }),
           );
@@ -371,7 +373,10 @@ for (const mobile of [false, true]) {
     await expect(page.getByText("Updated timestamped note")).toBeVisible();
 
     await page.getByRole("button", { name: "Delete note at 0:08" }).click();
-    await page.getByRole("button", { name: "Delete", exact: true }).click();
+    await page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Delete", exact: true })
+      .click();
     await expect(page.getByText("No notes yet.")).toBeVisible();
     await page.getByRole("tab", { name: "Transcript" }).click();
 

--- a/web/tests/e2e/video-learning.audit.ts
+++ b/web/tests/e2e/video-learning.audit.ts
@@ -2,385 +2,463 @@ import { expect, test } from "@playwright/test";
 
 const MATERIAL_ID = "0123456789abcdef0123456789abcdef";
 
-test("YouTube learning survives reload and switches to Invidious without silent fallback", async ({
-  page,
-}) => {
-  let provider: "youtube" | "invidious" = "youtube";
-  let invidiousOffline = false;
-  let transcriptReady = true;
-  let transcriptRefreshCount = 0;
-  let savedPosition = 0;
-  let nativeResolveCount = 0;
-  let nextNoteId = 1;
-  const notes: Array<{
-    notebook_id: string;
-    note_id: string;
-    material_id: string;
-    body: string;
-    time_seconds: number;
-    locator: number;
-    quote: string;
-    created_at: number;
-    updated_at: number;
-  }> = [];
+for (const mobile of [false, true]) {
+  test(`Watching workspace restores its session and handles provider failures (${mobile ? "mobile" : "desktop"})`, async ({
+    page,
+  }) => {
+    await page.setViewportSize(
+      mobile ? { width: 390, height: 844 } : { width: 1440, height: 1000 },
+    );
+    let provider: "youtube" | "invidious" = "youtube";
+    let invidiousOffline = false;
+    let transcriptReady = true;
+    let transcriptRefreshCount = 0;
+    let savedPosition = 0;
+    let nativeResolveCount = 0;
+    let nextNoteId = 1;
+    const notes: Array<{
+      notebook_id: string;
+      note_id: string;
+      material_id: string;
+      body: string;
+      time_seconds: number;
+      locator: number;
+      quote: string;
+      created_at: number;
+      updated_at: number;
+    }> = [];
 
-  const material = (selected: "youtube" | "invidious") => ({
-    version: 1,
-    type: "timed_media",
-    material_id: MATERIAL_ID,
-    source: {
-      provider: "youtube",
-      video_id: "dQw4w9WgXcQ",
-      url: "https://youtu.be/dQw4w9WgXcQ",
-      entry_time_seconds: 0,
-    },
-    metadata: {
-      title: "Timestamped lesson",
-      author: "Teacher",
-      duration_seconds: 120,
-    },
-    transcript: transcriptReady
-      ? {
-          status: "ready",
-          reason: "",
-          language: "en",
-          source: selected,
-          cues: [
-            { start: 7, end: 12, text: "The first grounded concept." },
-            { start: 70, end: 75, text: "The second grounded concept." },
-          ],
-        }
-      : {
-          status: "unavailable",
-          reason: "temporary Invidious error",
-          language: "",
-          source: "unavailable",
-          cues: [],
-        },
-    segments: [],
-    learning: { last_position: savedPosition },
-    playback:
-      selected === "youtube"
+    const material = (selected: "youtube" | "invidious") => ({
+      version: 1,
+      type: "timed_media",
+      material_id: MATERIAL_ID,
+      source: {
+        provider: "youtube",
+        video_id: "dQw4w9WgXcQ",
+        url: "https://youtu.be/dQw4w9WgXcQ",
+        entry_time_seconds: 0,
+      },
+      metadata: {
+        title: "Timestamped lesson",
+        author: "Teacher",
+        duration_seconds: 120,
+      },
+      transcript: transcriptReady
         ? {
-            provider: "youtube",
-            kind: "youtube_iframe",
-            video_id: "dQw4w9WgXcQ",
-            start_seconds: savedPosition,
+            status: "ready",
+            reason: "",
+            language: "en",
+            source: selected,
+            cues: [
+              { start: 7, end: 12, text: "The first grounded concept." },
+              { start: 70, end: 75, text: "The second grounded concept." },
+            ],
           }
         : {
-            provider: "invidious",
-            kind: "html5",
-            format_id: "18",
-            mime_type: "video/mp4",
-            stream_url: `/api/video-learning/materials/${MATERIAL_ID}/stream/18`,
-            subtitles_url: `/api/video-learning/materials/${MATERIAL_ID}/subtitles.vtt`,
-            start_seconds: savedPosition,
+            status: "unavailable",
+            reason: "temporary Invidious error",
+            language: "",
+            source: "unavailable",
+            cues: [],
           },
-  });
+      segments: [],
+      learning: { last_position: savedPosition },
+      playback:
+        selected === "youtube"
+          ? {
+              provider: "youtube",
+              kind: "youtube_iframe",
+              video_id: "dQw4w9WgXcQ",
+              start_seconds: savedPosition,
+            }
+          : {
+              provider: "invidious",
+              kind: "html5",
+              format_id: "18",
+              mime_type: "video/mp4",
+              stream_url: `/api/video-learning/materials/${MATERIAL_ID}/stream/18`,
+              subtitles_url: `/api/video-learning/materials/${MATERIAL_ID}/subtitles.vtt`,
+              start_seconds: savedPosition,
+            },
+    });
 
-  await page.addInitScript(() => {
-    class FakePlayer {
-      current = 0;
-      duration = 120;
-      element: HTMLElement;
-      options: Record<string, unknown>;
+    await page.addInitScript(() => {
+      class FakePlayer {
+        current = 0;
+        duration = 120;
+        element: HTMLElement;
+        options: Record<string, unknown>;
 
-      constructor(element: HTMLElement, options: Record<string, unknown>) {
-        this.element = element;
-        this.options = options;
-        const iframe = document.createElement("iframe");
-        const host = String(options.host || "");
-        const videoId = String(options.videoId || "");
-        iframe.src = `${host}/embed/${videoId}`;
-        iframe.title = "Fake YouTube player";
-        element.replaceWith(iframe);
-        this.element = iframe;
-        const players = ((
-          window as typeof window & { __fakePlayers?: FakePlayer[] }
-        ).__fakePlayers ||= []);
-        players.push(this);
-        queueMicrotask(() => {
-          const events = options.events as {
-            onReady?: (event: { target: FakePlayer }) => void;
-          };
-          events.onReady?.({ target: this });
+        constructor(element: HTMLElement, options: Record<string, unknown>) {
+          this.element = element;
+          this.options = options;
+          const iframe = document.createElement("iframe");
+          const host = String(options.host || "");
+          const videoId = String(options.videoId || "");
+          iframe.src = `${host}/embed/${videoId}`;
+          iframe.title = "Fake YouTube player";
+          element.replaceWith(iframe);
+          this.element = iframe;
+          const players = ((
+            window as typeof window & { __fakePlayers?: FakePlayer[] }
+          ).__fakePlayers ||= []);
+          players.push(this);
+          queueMicrotask(() => {
+            const events = options.events as {
+              onReady?: (event: { target: FakePlayer }) => void;
+            };
+            events.onReady?.({ target: this });
+          });
+        }
+
+        getCurrentTime() {
+          return this.current;
+        }
+        getDuration() {
+          return this.duration;
+        }
+        seekTo(seconds: number) {
+          this.current = seconds;
+        }
+        playVideo() {}
+        pauseVideo() {}
+        destroy() {
+          this.element.remove();
+        }
+      }
+
+      (window as typeof window & { YT?: unknown }).YT = { Player: FakePlayer };
+    });
+
+    const turns: Record<string, unknown>[] = [];
+    await page.routeWebSocket("**/ws", (socket) => {
+      socket.onMessage((raw) => {
+        const command = JSON.parse(String(raw));
+        if (command.type !== "start_turn") return;
+        turns.push(command);
+        for (const [index, type] of ["session", "content", "done"].entries()) {
+          socket.send(
+            JSON.stringify({
+              protocol_version: "2.0",
+              type,
+              session_id: "watching-test",
+              turn_id: "turn-test",
+              seq: index + 1,
+              source: "watching",
+              stage: "responding",
+              timestamp: Date.now() / 1000,
+              content:
+                type === "content" ? "See [00:07] for the first concept." : "",
+              metadata: type === "done" ? { status: "completed" } : {},
+            }),
+          );
+        }
+      });
+    });
+    await page.route("**/api/**", async (route) => {
+      const request = route.request();
+      const path = new URL(request.url()).pathname;
+      const json = (payload: unknown, status = 200) =>
+        route.fulfill({ status, json: payload });
+
+      if (path === "/api/auth/status") {
+        return json({
+          enabled: false,
+          authenticated: true,
+          role: "admin",
+          is_admin: true,
         });
       }
-
-      getCurrentTime() {
-        return this.current;
+      if (path === "/api/sessions/watching-test")
+        return json({
+          id: "watching-test",
+          session_id: "watching-test",
+          title: "Video discussion",
+          preferences: {
+            capability: "immersive_watching",
+            workspace_mode: "immersive_watching",
+            timed_media_id: MATERIAL_ID,
+          },
+          messages: [
+            {
+              id: 1,
+              role: "user",
+              content: "Explain the video",
+              events: [],
+              attachments: [],
+            },
+          ],
+          active_turns: [],
+        });
+      if (path === "/api/settings/ui") return json({ language: "en" });
+      if (path === "/api/capabilities/registered") {
+        return json({
+          capabilities: [
+            { id: "chat", kind: "turn", available: true },
+            { id: "immersive_watching", kind: "turn", available: true },
+          ],
+        });
       }
-      getDuration() {
-        return this.duration;
+      if (path === "/api/settings") return json({ catalog: {} });
+      if (path === "/api/settings/llm-options") {
+        return json({
+          active: { profile_id: "p", model_id: "m" },
+          options: [],
+        });
       }
-      seekTo(seconds: number) {
-        this.current = seconds;
+      if (path === "/api/dashboard/suggestions")
+        return json({ suggestions: [], stale: false });
+      if (path === "/api/video-learning/materials/resolve") {
+        const body = request.postDataJSON() as {
+          provider_override?: "youtube";
+        };
+        if (body.provider_override === "youtube") nativeResolveCount += 1;
+        return json(material(body.provider_override || provider));
       }
-      playVideo() {}
-      pauseVideo() {}
-      destroy() {
-        this.element.remove();
+      if (path === `/api/video-learning/materials/${MATERIAL_ID}`) {
+        if (provider === "invidious" && invidiousOffline) {
+          return json({ detail: "Invidious is offline" }, 400);
+        }
+        return json(material(provider));
       }
-    }
-
-    (window as typeof window & { YT?: unknown }).YT = { Player: FakePlayer };
-  });
-
-  await page.route("**/api/**", async (route) => {
-    const request = route.request();
-    const path = new URL(request.url()).pathname;
-    const json = (payload: unknown, status = 200) =>
-      route.fulfill({ status, json: payload });
-
-    if (path === "/api/auth/status") {
-      return json({
-        enabled: false,
-        authenticated: true,
-        role: "admin",
-        is_admin: true,
-      });
-    }
-    if (path === "/api/settings/ui") return json({ language: "en" });
-    if (path === "/api/capabilities/registered") {
-      return json({
-        capabilities: [
-          { id: "chat", kind: "turn", available: true },
-          { id: "immersive_watching", kind: "turn", available: true },
-        ],
-      });
-    }
-    if (path === "/api/settings") return json({ catalog: {} });
-    if (path === "/api/settings/llm-options") {
-      return json({ active: { profile_id: "p", model_id: "m" }, options: [] });
-    }
-    if (path === "/api/dashboard/suggestions")
-      return json({ suggestions: [], stale: false });
-    if (path === "/api/video-learning/materials/resolve") {
-      const body = request.postDataJSON() as { provider_override?: "youtube" };
-      if (body.provider_override === "youtube") nativeResolveCount += 1;
-      return json(material(body.provider_override || provider));
-    }
-    if (path === `/api/video-learning/materials/${MATERIAL_ID}`) {
-      if (provider === "invidious" && invidiousOffline) {
-        return json({ detail: "Invidious is offline" }, 400);
+      if (
+        path ===
+        `/api/video-learning/materials/${MATERIAL_ID}/transcript/refresh`
+      ) {
+        transcriptRefreshCount += 1;
+        transcriptReady = true;
+        return json(material("invidious"));
       }
-      return json(material(provider));
-    }
-    if (
-      path === `/api/video-learning/materials/${MATERIAL_ID}/transcript/refresh`
-    ) {
-      transcriptRefreshCount += 1;
-      transcriptReady = true;
-      return json(material("invidious"));
-    }
-    if (path.endsWith("/progress")) {
-      const body = request.postDataJSON() as { time_seconds: number };
-      savedPosition = body.time_seconds;
-      return json({ time_seconds: savedPosition, duration_seconds: 120 });
-    }
-    if (path.endsWith("/notes") && request.method() === "GET") {
-      return json(notes);
-    }
-    if (path.endsWith("/notes") && request.method() === "POST") {
-      const body = request.postDataJSON() as {
-        body: string;
-        time_seconds: number;
-      };
-      const note = {
-        notebook_id: "video-notes",
-        note_id: `note-${nextNoteId++}`,
-        material_id: MATERIAL_ID,
-        body: body.body,
-        time_seconds: body.time_seconds,
-        locator: 1,
-        quote: "The first grounded concept.",
-        created_at: Date.now() / 1000,
-        updated_at: Date.now() / 1000,
-      };
-      notes.push(note);
-      return json(note);
-    }
-    const noteMatch = /\/materials\/[^/]+\/notes\/([^/]+)$/.exec(path);
-    if (noteMatch) {
-      const noteId = noteMatch[1];
-      const index = notes.findIndex((note) => note.note_id === noteId);
-      if (index === -1) return json({ detail: "Note not found" }, 404);
-      if (request.method() === "PUT") {
-        const body = request.postDataJSON() as { body: string };
-        notes[index] = {
-          ...notes[index],
+      if (path.endsWith("/progress")) {
+        const body = request.postDataJSON() as { time_seconds: number };
+        savedPosition = body.time_seconds;
+        return json({ time_seconds: savedPosition, duration_seconds: 120 });
+      }
+      if (path.endsWith("/notes") && request.method() === "GET") {
+        return json(notes);
+      }
+      if (path.endsWith("/notes") && request.method() === "POST") {
+        const body = request.postDataJSON() as {
+          body: string;
+          time_seconds: number;
+        };
+        const note = {
+          notebook_id: "video-notes",
+          note_id: `note-${nextNoteId++}`,
+          material_id: MATERIAL_ID,
           body: body.body,
+          time_seconds: body.time_seconds,
+          locator: 1,
+          quote: "The first grounded concept.",
+          created_at: Date.now() / 1000,
           updated_at: Date.now() / 1000,
         };
-        return json(notes[index]);
+        notes.push(note);
+        return json(note);
       }
-      if (request.method() === "DELETE") {
-        notes.splice(index, 1);
-        return json({ status: "deleted" });
+      const noteMatch = /\/materials\/[^/]+\/notes\/([^/]+)$/.exec(path);
+      if (noteMatch) {
+        const noteId = noteMatch[1];
+        const index = notes.findIndex((note) => note.note_id === noteId);
+        if (index === -1) return json({ detail: "Note not found" }, 404);
+        if (request.method() === "PUT") {
+          const body = request.postDataJSON() as { body: string };
+          notes[index] = {
+            ...notes[index],
+            body: body.body,
+            updated_at: Date.now() / 1000,
+          };
+          return json(notes[index]);
+        }
+        if (request.method() === "DELETE") {
+          notes.splice(index, 1);
+          return json({ status: "deleted" });
+        }
       }
-    }
-    if (path.endsWith("/subtitles.vtt")) {
-      return route.fulfill({
-        status: 200,
-        contentType: "text/vtt",
-        body: "WEBVTT\n",
-      });
-    }
-    if (path.includes("/stream/")) {
-      return route.fulfill({
-        status: 206,
-        contentType: "video/mp4",
-        body: "not-real-media",
-      });
-    }
-    return json({});
-  });
-
-  await page.goto("/chat?capability=immersive_watching");
-  await page
-    .getByPlaceholder("https://youtu.be/…")
-    .fill("https://youtu.be/dQw4w9WgXcQ?t=7");
-  await page.getByRole("button", { name: "Open", exact: true }).click();
-
-  await expect(page.getByText("Timestamped lesson")).toBeVisible();
-  await expect(
-    page.locator('iframe[title="Fake YouTube player"]'),
-  ).toHaveAttribute("src", /youtube-nocookie\.com\/embed\/dQw4w9WgXcQ/);
-
-  await page.evaluate(() => {
-    const player = (
-      window as typeof window & { __fakePlayers: Array<{ current: number }> }
-    ).__fakePlayers.at(-1);
-    if (player) player.current = 8;
-  });
-  await expect(
-    page.getByText("The first grounded concept.").locator(".."),
-  ).toHaveClass(/ring-1/);
-
-  await page.getByRole("tab", { name: "Video notes" }).click();
-  await expect(page.getByText("No notes yet.")).toBeVisible();
-  await page.getByPlaceholder("Note at 0:08").fill("First timestamped note");
-  await page.getByRole("button", { name: "Add video note" }).click();
-  await expect(page.getByText("First timestamped note")).toBeVisible();
-  await expect(page.getByText("The first grounded concept.")).toBeVisible();
-
-  await page.reload();
-  await expect(page.getByText("Timestamped lesson")).toBeVisible();
-  await page.getByRole("tab", { name: "Video notes" }).click();
-  await expect(page.getByText("First timestamped note")).toBeVisible();
-
-  await page.evaluate(() => {
-    const player = (
-      window as typeof window & { __fakePlayers: Array<{ current: number }> }
-    ).__fakePlayers.at(-1);
-    if (player) player.current = 70;
-  });
-  await page.getByRole("button", { name: "0:08", exact: true }).click();
-  await expect
-    .poll(() =>
-      page.evaluate(() => {
-        const player = (
-          window as typeof window & {
-            __fakePlayers: Array<{ current: number }>;
-          }
-        ).__fakePlayers.at(-1);
-        return player?.current || 0;
-      }),
-    )
-    .toBe(8);
-
-  await page.getByRole("button", { name: "Edit note at 0:08" }).click();
-  await page
-    .getByLabel("Edit note at 0:08")
-    .locator("..")
-    .locator("textarea")
-    .fill("Updated timestamped note");
-  await page.getByRole("button", { name: "Save video note" }).click();
-  await expect(page.getByText("Updated timestamped note")).toBeVisible();
-
-  await page.getByRole("button", { name: "Delete note at 0:08" }).click();
-  await page.getByRole("button", { name: "Delete", exact: true }).click();
-  await expect(page.getByText("No notes yet.")).toBeVisible();
-  await page.getByRole("tab", { name: "Transcript" }).click();
-
-  await page.getByRole("button", { name: "Explain here" }).click();
-  await expect(page.locator("textarea")).toHaveValue(
-    /\[0:08\] The first grounded concept\./,
-  );
-
-  await page.evaluate(() => {
-    const link = document.createElement("a");
-    link.id = "fake-assistant-timestamp";
-    link.href = "#dt-video-time-70";
-    link.textContent = "[01:10]";
-    document.body.appendChild(link);
-  });
-  await page.locator("#fake-assistant-timestamp").click();
-  await expect
-    .poll(() =>
-      page.evaluate(() => {
-        const player = (
-          window as typeof window & {
-            __fakePlayers: Array<{ current: number }>;
-          }
-        ).__fakePlayers.at(-1);
-        return player?.current || 0;
-      }),
-    )
-    .toBe(70);
-
-  await page
-    .getByRole("button", { name: "Close video learning" })
-    .evaluate((button) => {
-      document.dispatchEvent(new Event("visibilitychange"));
-      button.setAttribute("data-persisted", "true");
+      if (path.endsWith("/subtitles.vtt")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "text/vtt",
+          body: "WEBVTT\n",
+        });
+      }
+      if (path.includes("/stream/")) {
+        return route.fulfill({
+          status: 206,
+          contentType: "video/mp4",
+          body: "not-real-media",
+        });
+      }
+      return json({});
     });
-  await expect.poll(() => savedPosition).toBeGreaterThanOrEqual(70);
-  await page.reload();
-  await expect(page.getByText("Timestamped lesson")).toBeVisible();
-  await expect
-    .poll(() =>
-      page.evaluate(() => {
-        const player = (
-          window as typeof window & {
-            __fakePlayers: Array<{ current: number }>;
-          }
-        ).__fakePlayers.at(-1);
-        return player?.current || 0;
-      }),
-    )
-    .toBeGreaterThanOrEqual(70);
 
-  provider = "invidious";
-  transcriptReady = false;
-  await page.getByRole("button", { name: "Refresh provider" }).click();
-  await expect(page.locator("video")).toBeVisible();
-  await expect(page.getByText("Invidious", { exact: true })).toBeVisible();
-  await expect(
-    page.getByRole("button", { name: "Retry captions" }),
-  ).toBeVisible();
-  const player = page.locator("video");
-  await player.evaluate((video) =>
-    video.setAttribute("data-transcript-retry-probe", "before"),
-  );
-  await page.getByRole("button", { name: "Retry captions" }).click();
-  await expect.poll(() => transcriptRefreshCount).toBe(1);
-  await expect(
-    page.getByRole("button", { name: "Explain here" }),
-  ).toBeVisible();
-  await expect(player).toHaveAttribute("data-transcript-retry-probe", "before");
+    await page.goto("/chat?capability=immersive_watching");
+    await expect(page).toHaveURL(/\/watching$/);
+    await page
+      .getByPlaceholder("https://youtu.be/…")
+      .fill("https://youtu.be/dQw4w9WgXcQ?t=7");
+    await page.getByRole("button", { name: "Open", exact: true }).click();
 
-  const beforeFailure = nativeResolveCount;
-  invidiousOffline = true;
-  await page.getByRole("button", { name: "Refresh provider" }).click();
-  await expect(
-    page.getByRole("alert").filter({ hasText: "Invidious is offline" }),
-  ).toBeVisible();
-  expect(nativeResolveCount).toBe(beforeFailure);
+    await expect(page.getByText("Timestamped lesson")).toBeVisible();
+    await expect(
+      page.locator('iframe[title="Fake YouTube player"]'),
+    ).toHaveAttribute("src", /youtube-nocookie\.com\/embed\/dQw4w9WgXcQ/);
 
-  await page.getByRole("button", { name: "Use native YouTube" }).click();
-  await expect(
-    page.locator('iframe[title="Fake YouTube player"]'),
-  ).toBeVisible();
-  expect(nativeResolveCount).toBe(beforeFailure + 1);
-});
+    if (mobile)
+      await page
+        .getByRole("button", { name: "Conversation", exact: true })
+        .click();
+    await page.locator("textarea").fill("Explain the video");
+    await page.locator("textarea").press("Enter");
+    await expect(page).toHaveURL(/\/watching\/watching-test$/);
+    expect(turns[0]).toMatchObject({
+      capability: "immersive_watching",
+      workspace_mode: "immersive_watching",
+      timed_media_id: MATERIAL_ID,
+    });
+    if (mobile)
+      await page.getByRole("button", { name: "Video", exact: true }).click();
+    await page.evaluate(() => {
+      const player = (
+        window as typeof window & { __fakePlayers: Array<{ current: number }> }
+      ).__fakePlayers.at(-1);
+      if (player) player.current = 8;
+    });
+    await expect(
+      page.getByText("The first grounded concept.").locator(".."),
+    ).toHaveClass(/ring-1/);
+
+    await page.getByRole("tab", { name: "Video notes" }).click();
+    await expect(page.getByText("No notes yet.")).toBeVisible();
+    await page.getByPlaceholder("Note at 0:08").fill("First timestamped note");
+    await page.getByRole("button", { name: "Add video note" }).click();
+    await expect(page.getByText("First timestamped note")).toBeVisible();
+    await expect(page.getByText("The first grounded concept.")).toBeVisible();
+
+    await page.goto("/watching/watching-test");
+    await page.reload();
+    await expect(page.getByText("Timestamped lesson")).toBeVisible();
+    await page.getByRole("tab", { name: "Video notes" }).click();
+    await expect(page.getByText("First timestamped note")).toBeVisible();
+
+    await page.evaluate(() => {
+      const player = (
+        window as typeof window & { __fakePlayers: Array<{ current: number }> }
+      ).__fakePlayers.at(-1);
+      if (player) player.current = 70;
+    });
+    await page.getByRole("button", { name: "0:08", exact: true }).click();
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const player = (
+            window as typeof window & {
+              __fakePlayers: Array<{ current: number }>;
+            }
+          ).__fakePlayers.at(-1);
+          return player?.current || 0;
+        }),
+      )
+      .toBe(8);
+
+    await page.getByRole("button", { name: "Edit note at 0:08" }).click();
+    await page
+      .getByLabel("Edit note at 0:08")
+      .locator("..")
+      .locator("textarea")
+      .fill("Updated timestamped note");
+    await page.getByRole("button", { name: "Save video note" }).click();
+    await expect(page.getByText("Updated timestamped note")).toBeVisible();
+
+    await page.getByRole("button", { name: "Delete note at 0:08" }).click();
+    await page.getByRole("button", { name: "Delete", exact: true }).click();
+    await expect(page.getByText("No notes yet.")).toBeVisible();
+    await page.getByRole("tab", { name: "Transcript" }).click();
+
+    await page.getByRole("button", { name: "Explain here" }).click();
+    await expect(page.locator("textarea")).toHaveValue(
+      /\[0:08\] The first grounded concept\./,
+    );
+
+    if (mobile)
+      await page.getByRole("button", { name: "Video", exact: true }).click();
+    await page.evaluate(() => {
+      const link = document.createElement("a");
+      link.id = "fake-assistant-timestamp";
+      link.href = "#dt-video-time-70";
+      link.textContent = "[01:10]";
+      document.body.appendChild(link);
+    });
+    await page.locator("#fake-assistant-timestamp").click();
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const player = (
+            window as typeof window & {
+              __fakePlayers: Array<{ current: number }>;
+            }
+          ).__fakePlayers.at(-1);
+          return player?.current || 0;
+        }),
+      )
+      .toBe(70);
+
+    await page
+      .getByRole("button", { name: "Close video learning" })
+      .evaluate((button) => {
+        document.dispatchEvent(new Event("visibilitychange"));
+        button.setAttribute("data-persisted", "true");
+      });
+    await expect.poll(() => savedPosition).toBeGreaterThanOrEqual(70);
+    await page.reload();
+    await expect(page.getByText("Timestamped lesson")).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const player = (
+            window as typeof window & {
+              __fakePlayers: Array<{ current: number }>;
+            }
+          ).__fakePlayers.at(-1);
+          return player?.current || 0;
+        }),
+      )
+      .toBeGreaterThanOrEqual(70);
+
+    provider = "invidious";
+    transcriptReady = false;
+    await page.getByRole("button", { name: "Refresh provider" }).click();
+    await expect(page.locator("video")).toBeVisible();
+    await expect(page.getByText("Invidious", { exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Retry captions" }),
+    ).toBeVisible();
+    const player = page.locator("video");
+    await player.evaluate((video) =>
+      video.setAttribute("data-transcript-retry-probe", "before"),
+    );
+    await page.getByRole("button", { name: "Retry captions" }).click();
+    await expect.poll(() => transcriptRefreshCount).toBe(1);
+    await expect(
+      page.getByRole("button", { name: "Explain here" }),
+    ).toBeVisible();
+    await expect(player).toHaveAttribute(
+      "data-transcript-retry-probe",
+      "before",
+    );
+
+    const beforeFailure = nativeResolveCount;
+    invidiousOffline = true;
+    await page.getByRole("button", { name: "Refresh provider" }).click();
+    await expect(
+      page.getByRole("alert").filter({ hasText: "Invidious is offline" }),
+    ).toBeVisible();
+    expect(nativeResolveCount).toBe(beforeFailure);
+
+    await page.getByRole("button", { name: "Use native YouTube" }).click();
+    await expect(
+      page.locator('iframe[title="Fake YouTube player"]'),
+    ).toBeVisible();
+    expect(nativeResolveCount).toBe(beforeFailure + 1);
+  });
+}

--- a/web/tests/reading-position.test.ts
+++ b/web/tests/reading-position.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseReadingPosition } from "@/lib/reading-api";
+
+test("reading positions accept the complete API contract", () => {
+  const position = {
+    locator: 3,
+    source_anchor: "chapter-3",
+    percentage: 0.5,
+    updated_at: 42,
+  };
+
+  assert.deepEqual(parseReadingPosition(position), position);
+});
+
+test("reading positions reject partial and non-finite responses", () => {
+  assert.throws(
+    () => parseReadingPosition({}),
+    /Invalid reading position response/,
+  );
+  assert.throws(
+    () =>
+      parseReadingPosition({
+        locator: Number.NaN,
+        source_anchor: "",
+        percentage: 0,
+        updated_at: 0,
+      }),
+    /Invalid reading position response/,
+  );
+});

--- a/web/tests/watching-citations.test.ts
+++ b/web/tests/watching-citations.test.ts
@@ -13,10 +13,10 @@ test("linkifies minute and hour timestamp citations", () => {
   );
 });
 
-test("does not rewrite code or existing links", () => {
+test("preserves code and normalizes existing timestamp links to the current video", () => {
   assert.equal(
     linkifyVideoTimestamps("`[01:23]` [01:23](https://example.test)"),
-    "`[01:23]` [01:23](https://example.test)",
+    "`[01:23]` [01:23](#dt-video-time-83)",
   );
 });
 
@@ -24,4 +24,12 @@ test("parses only valid video seek anchors", () => {
   assert.equal(videoTimeFromHref("#dt-video-time-83"), 83);
   assert.equal(videoTimeFromHref("https://example.test"), null);
   assert.equal(videoTimeFromHref("#dt-video-time-nope"), null);
+});
+
+test("normalization is idempotent and preserves non-timestamp links", () => {
+  const text =
+    "[00:28](https://example.com/video?start=28) [source](https://example.com)";
+  const normalized = "[00:28](#dt-video-time-28) [source](https://example.com)";
+  assert.equal(linkifyVideoTimestamps(text), normalized);
+  assert.equal(linkifyVideoTimestamps(normalized), normalized);
 });

--- a/web/tests/watching-session.test.ts
+++ b/web/tests/watching-session.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { sessionRoute } from "../lib/mastery-session";
+import { normalizeWorkspaceMode } from "../lib/workspace-mode";
+import { capabilityForPath } from "../lib/capability-routes";
+import type { SessionSummary } from "../lib/session-api";
+
+test("Watching links retain their owning workspace, including legacy sessions", () => {
+  for (const preferences of [
+    { workspace_mode: "immersive_watching" as const },
+    { capability: "immersive_watching" },
+  ]) {
+    assert.equal(
+      sessionRoute({ session_id: "lesson 1", preferences } as SessionSummary),
+      "/watching/lesson%201",
+    );
+  }
+  assert.equal(
+    sessionRoute({
+      session_id: "chat",
+      preferences: { timed_media_id: "stale" },
+    } as SessionSummary),
+    "/chat/chat",
+  );
+  assert.equal(
+    normalizeWorkspaceMode("", "immersive_watching"),
+    "immersive_watching",
+  );
+  assert.equal(capabilityForPath("/watching/lesson"), "llm");
+  assert.equal(capabilityForPath("/watching-other"), null);
+});

--- a/web/tests/watching-workspace.spec.tsx
+++ b/web/tests/watching-workspace.spec.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect } from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { WatchingProvider, useWatching } from "@/context/WatchingContext";
+import { WatchingSessionBridge } from "@/components/watching/WatchingWorkspace";
+import { watchingTurnFields } from "@/lib/watching-turn-state";
+import type { TimedMediaMaterial } from "@/lib/video-learning-api";
+
+const api = vi.hoisted(() => ({ get: vi.fn(), resolve: vi.fn() }));
+vi.mock("@/lib/video-learning-api", () => ({
+  getVideoMaterial: api.get,
+  resolveVideo: api.resolve,
+  refreshInvidiousTranscript: vi.fn(),
+}));
+const translate = (key: string) => key;
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: translate }) }));
+vi.mock("@/components/watching/WatchingPane", () => ({
+  WatchingPane: () => null,
+  WATCHING_ASK_EVENT: "dt:watching-ask",
+}));
+
+function material(id: string): TimedMediaMaterial {
+  return {
+    material_id: id,
+    source: { url: id },
+    playback: { start_seconds: 37 },
+    learning: { last_position: 37 },
+  } as TimedMediaMaterial;
+}
+let context: ReturnType<typeof useWatching>;
+function Probe() {
+  const current = useWatching();
+  useEffect(() => {
+    context = current;
+  }, [current]);
+  return <span>{current.material?.material_id || "empty"}</span>;
+}
+function App({ scope, id }: { scope: string; id: string | null }) {
+  return (
+    <WatchingProvider>
+      <WatchingSessionBridge
+        sessionKey={scope}
+        materialId={id}
+        onMaterial={vi.fn()}
+      />
+      <Probe />
+    </WatchingProvider>
+  );
+}
+
+describe("Watching conversation restoration", () => {
+  it("ignores browser-global video history and does not fetch on ordinary provider mount", () => {
+    api.get.mockClear();
+    localStorage.setItem("dt:video-learning:last-material", "other-owner");
+    render(
+      <WatchingProvider>
+        <Probe />
+      </WatchingProvider>,
+    );
+    expect(api.get).not.toHaveBeenCalled();
+    expect(screen.getByText("empty")).toBeInTheDocument();
+  });
+
+  it("drops a late previous-session result and restores the new video's saved position", async () => {
+    let finishA!: (value: TimedMediaMaterial) => void;
+    api.get.mockImplementation((id: string) =>
+      id === "a"
+        ? new Promise((resolve) => {
+            finishA = resolve;
+          })
+        : Promise.resolve(material(id)),
+    );
+    const view = render(<App scope="session-a" id="a" />);
+    view.rerender(<App scope="session-b" id="b" />);
+    await screen.findByText("b");
+    await act(async () => {
+      finishA(material("a"));
+    });
+    expect(screen.getByText("b")).toBeInTheDocument();
+    expect(watchingTurnFields("immersive_watching")).toEqual({
+      timed_media_id: "b",
+      timed_media_viewport: { time_seconds: 37 },
+    });
+    expect(watchingTurnFields("chat")).toEqual({});
+    view.unmount();
+    expect(watchingTurnFields("immersive_watching")).toEqual({});
+  });
+
+  it("clears the previous video on unavailable or unauthorized materials", async () => {
+    api.get
+      .mockResolvedValueOnce(material("a"))
+      .mockRejectedValueOnce(new Error("Not found"));
+    const view = render(<App scope="session-a" id="a" />);
+    await screen.findByText("a");
+    view.rerender(<App scope="session-b" id="private-b" />);
+    await waitFor(() => expect(context.error).toBe("Not found"));
+    expect(screen.getByText("empty")).toBeInTheDocument();
+    expect(watchingTurnFields("immersive_watching")).toEqual({});
+  });
+
+  it("invalidates an open request when leaving the workspace", async () => {
+    let finish!: (value: TimedMediaMaterial) => void;
+    api.resolve.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
+    );
+    const view = render(<App scope="draft" id={null} />);
+    await act(async () => {});
+    let opening!: Promise<void>;
+    act(() => {
+      opening = context.openUrl("video");
+    });
+    view.unmount();
+    await act(async () => {
+      finish(material("late"));
+      await opening;
+    });
+    expect(watchingTurnFields("immersive_watching")).toEqual({});
+  });
+});


### PR DESCRIPTION
Immersive Watching now has a sidebar workspace at `/watching`, with saved conversations at `/watching/{sessionId}`. First-turn navigation stays in Watching, legacy links redirect there, and video restoration follows the selected conversation rather than browser-global recent-video state. Mobile switches video and conversation panes while retaining the player.

The change reuses the existing chat runtime, player, captions, timestamp citations and notes. Session preferences persist workspace ownership and an owner-validated video binding; late material requests cannot overwrite a newer conversation. Existing Invidious settings and explicit YouTube fallback remain in use. Timestamp-shaped Markdown links always seek the current player, including model-generated external targets. RFC 6598 private overlay origins are accepted for self-hosted Invidious; public HTTP origins are still rejected.

No discovery, library, account sync or deployment-specific addresses are added. Those remain separate from #1156 and #1159. The maintenance guide documents configuration, validation and rollback.

Validation against upstream main:
- Production build, TypeScript, generated frontend contracts and architecture checks passed.
- 1,015 Node tests, 4 rendered restore/race tests and 98 backend tests passed.
- Desktop and mobile Playwright tests passed, including first-turn routing, session reload, captions, timestamp seeking, notes and provider failures.
- ESLint has no errors; existing warnings remain.

Closes #1238. Refs #997.
