### PR TITLE
fix: normalize Codex named-function tool choice for Responses

### DIFF
--- a/deeptutor/services/llm/provider_core/openai_codex_provider.py
+++ b/deeptutor/services/llm/provider_core/openai_codex_provider.py
@@ -54,6 +54,7 @@ class OpenAICodexProvider(LLMProvider):
         model_name = model or self.default_model
         model_slug = _strip_model_prefix(model_name)
         system_prompt, input_items = convert_messages(messages)
+        responses_tool_choice = _convert_tool_choice(tool_choice)
 
         body: dict[str, Any] = {
             "model": model_slug,
@@ -64,7 +65,7 @@ class OpenAICodexProvider(LLMProvider):
             "text": {"verbosity": "medium"},
             "include": ["reasoning.encrypted_content"],
             "prompt_cache_key": _prompt_cache_key(messages),
-            "tool_choice": tool_choice or "auto",
+            "tool_choice": responses_tool_choice or "auto",
             "parallel_tool_calls": True,
         }
         if reasoning_effort:
@@ -173,6 +174,24 @@ def _strip_model_prefix(model: str) -> str:
     if model.startswith("openai-codex/") or model.startswith("openai_codex/"):
         return model.split("/", 1)[1]
     return model
+
+
+def _convert_tool_choice(
+    tool_choice: str | dict[str, Any] | None,
+) -> str | dict[str, Any] | None:
+    """Flatten a named Chat Completions function choice for Responses."""
+    if not isinstance(tool_choice, dict) or tool_choice.get("type") != "function":
+        return tool_choice
+
+    function = tool_choice.get("function")
+    if not isinstance(function, dict):
+        return tool_choice
+
+    name = function.get("name")
+    if not isinstance(name, str) or not name:
+        return tool_choice
+
+    return {"type": "function", "name": name}
 
 
 def _build_headers(account_id: str, token: str) -> dict[str, str]:

--- a/tests/services/llm/test_codex_tool_choice_conversion.py
+++ b/tests/services/llm/test_codex_tool_choice_conversion.py
@@ -1,0 +1,161 @@
+"""Verify named tool choices at the Codex provider request boundary."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from copy import deepcopy
+from typing import Any, Literal
+
+import pytest
+
+from deeptutor.services.codex_auth.contracts import CodexToken
+import deeptutor.services.llm.provider_core.openai_codex_provider as codex_provider
+
+pytestmark = pytest.mark.asyncio
+
+ChatMethod = Literal["chat", "chat_stream"]
+ToolChoice = str | dict[str, Any] | None
+
+
+class _FakeCodexService:
+    """Supply synthetic credentials without reading the user's OAuth state."""
+
+    @asynccontextmanager
+    async def inference_guard(self) -> AsyncIterator[None]:
+        """Keep the provider's normal inference-guard path in the test."""
+        yield
+
+    async def get_token(self) -> CodexToken:
+        """Return a synthetic token; no real account or network is needed."""
+        return CodexToken(
+            access_token="test-token",
+            account_id="test-account",
+            expires_at=2_000_000_000,
+            generation=1,
+        )
+
+    def validate_runtime_profile(
+        self,
+        token: CodexToken,
+        model: str,
+        reasoning_effort: str | None,
+    ) -> None:
+        """Avoid fetching a model catalog in a request-shape regression."""
+        del token, model, reasoning_effort
+
+
+@pytest.fixture
+def captured_requests(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Capture outgoing bodies and emulate one successful content delta."""
+    captured: list[dict[str, Any]] = []
+    service = _FakeCodexService()
+
+    async def _fake_request(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        *,
+        verify: bool,
+        on_content_delta: Callable[[str], Awaitable[None]] | None = None,
+    ) -> tuple[str, list[codex_provider.ToolCallRequest], str]:
+        del url, headers, verify
+        captured.append(body)
+        if on_content_delta is not None:
+            await on_content_delta("ok")
+        return "ok", [], "stop"
+
+    monkeypatch.setattr(codex_provider, "get_codex_oauth_service", lambda: service)
+    monkeypatch.setattr(codex_provider, "_request_codex", _fake_request)
+    return captured
+
+
+@pytest.mark.parametrize("method", ["chat", "chat_stream"])
+@pytest.mark.parametrize("tool_name", ["ask_user", "read_source"])
+async def test_named_function_choice(
+    captured_requests: list[dict[str, Any]],
+    method: ChatMethod,
+    tool_name: str,
+) -> None:
+    """Both public entry points flatten names without mutating caller input."""
+    choice = {"type": "function", "function": {"name": tool_name}}
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": tool_name,
+                "description": "A test function",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    original_choice = deepcopy(choice)
+    original_tools = deepcopy(tools)
+    deltas: list[str] = []
+
+    async def on_content_delta(text: str) -> None:
+        deltas.append(text)
+
+    provider = codex_provider.OpenAICodexProvider()
+    result = await getattr(provider, method)(
+        messages=[{"role": "user", "content": "Use the selected tool."}],
+        tools=tools,
+        tool_choice=choice,
+        on_content_delta=on_content_delta,
+    )
+
+    assert result.content == "ok"
+    assert result.finish_reason == "stop"
+    assert len(captured_requests) == 1
+    body = captured_requests[0]
+    assert body["tool_choice"] == {"type": "function", "name": tool_name}
+    assert body["tools"][0]["name"] == tool_name
+    assert "function" not in body["tools"][0]
+    assert choice == original_choice
+    assert tools == original_tools
+    assert deltas == (["ok"] if method == "chat_stream" else [])
+
+
+@pytest.mark.parametrize("method", ["chat", "chat_stream"])
+@pytest.mark.parametrize(
+    ("choice", "expected"),
+    [
+        pytest.param(None, "auto", id="default"),
+        pytest.param("auto", "auto", id="auto"),
+        pytest.param("required", "required", id="required"),
+        pytest.param("none", "none", id="none"),
+        pytest.param(
+            {"type": "function", "name": "ask_user"},
+            {"type": "function", "name": "ask_user"},
+            id="already-flat",
+        ),
+    ],
+)
+async def test_other_choices_keep_existing_behavior(
+    captured_requests: list[dict[str, Any]],
+    method: ChatMethod,
+    choice: ToolChoice,
+    expected: ToolChoice,
+) -> None:
+    """Defaults, strings, and already-flat choices must not be rewritten."""
+    original_choice = deepcopy(choice)
+    provider = codex_provider.OpenAICodexProvider()
+
+    result = await getattr(provider, method)(
+        messages=[{"role": "user", "content": "Hello"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "ask_user",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        tool_choice=choice,
+    )
+
+    assert result.finish_reason == "stop"
+    assert len(captured_requests) == 1
+    assert captured_requests[0]["tool_choice"] == expected
+    assert choice == original_choice


### PR DESCRIPTION
### Description

Convert Chat Completions-style forced function selections at the Codex provider request boundary:

```text
{"type": "function", "function": {"name": "ask_user"}}
→
{"type": "function", "name": "ask_user"}
```

The provider already converts messages and tool definitions, but previously forwarded `tool_choice` unchanged. The shared chat loop produces the nested format when it forces a named tool, including `ask_user`.

This change:

- Adds a small typed conversion helper and uses its result in the outgoing request body.
- Converts only a function choice with a nested dictionary containing a nonempty string name.
- Passes string choices, already-flat choices, and unrecognized shapes through unchanged, retaining the existing `"auto"` default for unspecified choices.
- Adds 14 provider-level cases across `chat()` and `chat_stream()`, capturing outgoing bodies with authentication and transport stubbed.
- Verifies two function names independently (one tool per request), preserves caller-owned input, and exercises the streaming content callback.
- Covers the existing default, `auto`, `required`, `none`, and already-flat single-function choices. Multi-tool choice conversion is explicitly out of scope.

Scope is limited to the Codex provider and its regression test. No restart-recovery changes, frontend changes, dependencies, settings, or authentication behavior are included.

### Related Issues

- Closes #1250.

### Module(s) Affected

- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
  No documentation changes are needed for this internal request-format fix; it introduces no new public feature or configuration.
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

Target branch: `dev`.
Head commit: `c1d2a2639ce1cc08433bc2b5de82904d6b9fbe58`.

Local validation was performed in an isolated worktree at `dev` commit
`269f65deded7380f324486c543f2ed96ae09945f`, with only the provider patch and its
new test file applied. A separate unmodified worktree is used to compare
baseline failures.

- Unmodified provider with the new tests: **4 failed, 10 passed**. All four named-function cases fail on the expected request-shape mismatch.
- Patched provider with the same tests: **14 passed**.
- `python -m pytest tests/services/llm tests/services/codex_auth tests/agents/chat -q`: **570 passed**, using the repository's synthetic CI model catalog on Linux / Python 3.14.6.
- `python -m pytest -q tests deeptutor/learning/tests -rs --maxfail=5`: **6,489 passed, 47 skipped, 15 warnings**, completed in 265.15 seconds. Skips cover optional RAG/parser dependencies, unconfigured Redis/integration fixtures, and the public-DNS-dependent case; no Codex regression case is skipped.
- `ruff check .` and `ruff format --check .`: **passed** with the CI-pinned Ruff 0.16.0.
- `lint-imports`: **3 contracts kept, 0 broken**.
- `python scripts/check_architecture.py` and `python scripts/check_repo_hygiene.py`: **passed**.
- `python3 scripts/check_workspace_hygiene.py`: **passed** after committing the two-file patch in the isolated worktree.
- CI import, lazy-startup, and isolated-worker checks: **passed** on Linux / Python 3.14.6.
- `pre-commit run --files deeptutor/services/llm/provider_core/openai_codex_provider.py tests/services/llm/test_codex_tool_choice_conversion.py`: **all applicable hooks passed**, including Bandit and Mypy, using an isolated Python 3.12 hook environment and the unchanged repository configuration.
- `git diff --check`: **passed**.

The initial Python 3.14 hook environment could not load some rules in the
repository-pinned Bandit 1.8.0 (`Str is not a valid node type in AST`). This was
addressed by running the unchanged hooks in an independent Python 3.12
environment, not by disabling rules or changing the hook versions.

`pre-commit run --all-files` was also run on both the patch and an unmodified
checkout using the same clean Python 3.12 hook environment. Both runs report
the same existing findings:

- End-of-file fixer: extra trailing blank line in `web/tests/auth-status-singleflight.spec.ts`.
- JSON validation: duplicate `Unavailable` keys in both `web/locales/en/app.json` and `web/locales/zh/app.json`.
- Bandit: B310 at `deeptutor/services/search/source_filter.py:235` and B608 at `deeptutor/services/session/sqlite_store.py:1821`.
- Mypy: the `asyncio.shield()` call at `deeptutor/services/session/turns/executor.py:998` and the session-store protocol return type at `deeptutor/services/session/__init__.py:37`.

No unrelated fixes or hook-rule changes are included. The full pre-commit
checkbox intentionally remains unchecked: the command ran, but these baseline
findings are not fixed in this PR.

Optional Slack/Telegram/QR test packages were installed only into a temporary
test dependency directory. No project dependency files or existing project
virtual-environment packages were changed. A live Codex API test, the frontend
build/browser gates, and the full cross-platform/Python-version CI matrix have
not been run locally.

#### Remote CI and upstream baseline comparison (2026-09-05)

For head `c1d2a2639ce1cc08433bc2b5de82904d6b9fbe58`, the completed checks report **12 passed, 2 failed, and 1 skipped**:

- **Passed:** Python tests on 3.11, 3.12, 3.13, and 3.14; all six Linux/macOS/Windows import-check jobs; Ruff lint/format and dependency-boundary checks; repository hygiene.
- **Failed:** Web Node Tests, specifically `npm run perf:check` within `npm run check`. Test Summary fails because of that frontend result; it is not a separate underlying failure.
- **Skipped:** Four-worker browser acceptance, which is gated by `vars.DEEPTUTOR_MULTI_WORKER_E2E_URL != ''`.

The frontend job completed **1,036 Node tests and 22 unit tests successfully**, passed TypeScript checking and the production build, and reported **0 ESLint errors / 72 warnings**. It then failed these route JavaScript size budgets:

| Route | Unmodified upstream base | This PR | Budget |
| --- | --- | --- | --- |
| `/knowledge-bases` | 564 KB | 564 KB | 550 KB |
| `/co-writer/[docId]` | 519 KB | 519 KB | 515 KB |

The exact upstream base `269f65deded7380f324486c543f2ed96ae09945f` already failed on the same routes and values on **2026-09-03**, before this PR. All nine route-budget output rows are identical between the two runs:

- [Unmodified upstream baseline log](https://github.com/HKUDS/DeepTutor/actions/runs/33733193470/job/100577628648)
- [This PR's frontend log](https://github.com/HKUDS/DeepTutor/actions/runs/33957084556/job/101282251165)
- [This PR's complete Tests workflow](https://github.com/HKUDS/DeepTutor/actions/runs/33957084556)

The diff against that base contains only the provider fix and its regression test; `web/` and workflow files are unchanged. These frontend budget failures are pre-existing, not introduced by this PR. Frontend optimization is intentionally kept out of this focused fix, and no budgets, checks, or failure handling have been relaxed. The frontend job's subsequent Playwright/browser audits were skipped after the budget failure, so this is **not** a claim that all CI or browser validation passed.
