### PR TITLE
fix(codex): recover Docker OAuth callbacks in settings

### DIFF
--- a/CONTAINERIZATION.md
+++ b/CONTAINERIZATION.md
@@ -90,6 +90,14 @@ Notes:
   the name. The `deeptutor-data` volume keeps your settings and workspace
   across restarts.
 
+### Complete Codex sign-in without a callback port bridge
+
+If the browser cannot open `http://localhost:1455/auth/callback` (or port `1457`), return to the same DeepTutor account's Codex settings while the login is still waiting. Copy the complete address from the failed callback page into **Callback URL**, then choose **Complete sign-in**. This works for local containers and remote deployments without publishing callback ports or restarting the service.
+
+The address is submitted to the authenticated account's existing login operation. The server parses it without fetching it, validates OAuth state, and retains the original redirect URI and PKCE exchange. The input is cleared after submission and is not saved in browser storage. Do not share the callback address in issues or logs. If the login expired, start again; a callback from another account's login is rejected.
+
+The temporary bridge below remains available when automatic browser return is preferred.
+
 ### Temporary local Codex OAuth bridge
 
 OpenAI Codex redirects the browser to fixed loopback ports `1455` or `1457`.

--- a/deeptutor/api/routers/settings.py
+++ b/deeptutor/api/routers/settings.py
@@ -770,6 +770,24 @@ async def start_openai_codex_oauth() -> dict[str, Any]:
         raise _codex_http_exception(exc) from None
 
 
+@router.post("/providers/openai-codex/oauth/complete")
+async def complete_openai_codex_oauth(request: Request) -> dict[str, bool]:
+    _require_codex_oauth_actor()
+    try:
+        payload = await request.json()
+    except ValueError:
+        payload = None
+    if not isinstance(payload, dict) or not isinstance(payload.get("callback_url"), str):
+        raise HTTPException(
+            400, detail={"code": "invalid_callback_url", "message": "Invalid callback URL."}
+        )
+    try:
+        await get_codex_oauth_service().submit_callback_url(payload["callback_url"])
+    except CodexAuthError as exc:
+        raise _codex_http_exception(exc) from None
+    return {"accepted": True}
+
+
 @router.get("/providers/openai-codex/oauth/status")
 async def get_openai_codex_oauth_status() -> dict[str, Any]:
     _require_codex_oauth_actor()

--- a/deeptutor/services/codex_auth/service.py
+++ b/deeptutor/services/codex_auth/service.py
@@ -14,6 +14,7 @@ import secrets
 import shutil
 import time
 from typing import Any
+from urllib.parse import parse_qs, urlsplit
 
 import httpx
 
@@ -445,6 +446,45 @@ class CodexOAuthService:
     def awaits_callback(self) -> bool:
         """Whether this instance has a login waiting for a browser callback."""
         return self._operation is not None and self._operation_is_active()
+
+    async def submit_callback_url(self, callback_url: str) -> None:
+        """Recover a loopback redirect via the authenticated owner's Web session.
+
+        Parse only; never fetch the supplied URL or expose its query in errors.
+        The existing receiver still validates state and the exchange retains PKCE.
+        """
+        try:
+            if not isinstance(callback_url, str) or not 1 <= len(callback_url) <= 16384:
+                raise ValueError
+            parsed = urlsplit(callback_url.strip())
+            query = parse_qs(parsed.query, keep_blank_values=True, max_num_fields=20)
+            if (
+                parsed.scheme != "http"
+                or parsed.hostname not in {"localhost", "127.0.0.1", "::1"}
+                or parsed.port not in CODEX_CALLBACK_PORTS
+                or parsed.path != CODEX_CALLBACK_PATH
+                or parsed.username is not None
+                or parsed.password is not None
+                or parsed.fragment
+                or len(query.get("state", [])) != 1
+                or not query["state"][0]
+                or ("code" in query) == ("error" in query)
+                or any(
+                    len(query[key]) != 1 or not query[key][0]
+                    for key in ("code", "error")
+                    if key in query
+                )
+            ):
+                raise ValueError
+        except (ValueError, TypeError):
+            raise CodexAuthError(
+                "invalid_callback_url",
+                "Paste the complete localhost callback URL from this sign-in.",
+                400,
+            ) from None
+        await self.receive_callback(
+            query.get("code", [None])[0], query["state"][0], query.get("error", [None])[0]
+        )
 
     async def receive_callback(
         self,

--- a/tests/api/test_codex_oauth_scope.py
+++ b/tests/api/test_codex_oauth_scope.py
@@ -136,3 +136,37 @@ def test_a_partner_cannot_change_their_owners_reasoning_effort(client, tmp_path)
 
     assert response.status_code == 403
     assert service.calls == []
+
+
+def test_callback_completion_uses_own_service_and_hides_payload(client, monkeypatch):
+    test_client, service, _ = client
+
+    async def submit(value):
+        assert value == "private-callback"
+        service.calls.append("complete")
+
+    monkeypatch.setattr(service, "submit_callback_url", submit, raising=False)
+    response = test_client.post(
+        "/api/settings/providers/openai-codex/oauth/complete",
+        json={"callback_url": "private-callback"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"accepted": True}
+    assert service.calls == ["complete"]
+    for value in [{"callback_url": 123}, ["private-callback"]]:
+        response = test_client.post(
+            "/api/settings/providers/openai-codex/oauth/complete", json=value
+        )
+        assert response.status_code == 400
+        assert "private-callback" not in response.text
+
+
+def test_partner_cannot_submit_callback(client, tmp_path):
+    test_client, service, current = client
+    current["user"] = _user(f"{PARTNER_USER_PREFIX}ada", role="user", root=tmp_path / "partner")
+    response = test_client.post(
+        "/api/settings/providers/openai-codex/oauth/complete",
+        json={"callback_url": "private-callback"},
+    )
+    assert response.status_code == 403
+    assert service.calls == []

--- a/tests/services/codex_auth/test_service.py
+++ b/tests/services/codex_auth/test_service.py
@@ -1545,3 +1545,45 @@ async def test_recover_after_unauthorized_forces_refresh_for_next_request(
 
     assert oauth.refresh_calls == 1
     assert store.load_credentials().access_token == "refreshed-access"  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_pasted_callback_is_owner_scoped_and_completes(tmp_path):
+    service, *_ = await _oauth_service(tmp_path / "owner")
+    other, *_ = await _oauth_service(tmp_path / "other")
+    started = await service.start_login()
+    await other.start_login()
+    state = parse_qs(urlsplit(started["authorize_url"]).query)["state"][0]
+    url = started["redirect_uri"] + "?code=authorization-code&state=" + state
+    with pytest.raises(CodexAuthError, match="invalid state"):
+        await other.submit_callback_url(url)
+    assert other.public_status()["operation_state"] == "waiting"
+    await service.submit_callback_url(url)
+    assert (await _wait_until_terminal(service))["operation_state"] == "completed"
+    await other.cancel_login()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://evil.example/auth/callback?code=secret&state=x",
+        "http://localhost:1455/wrong?code=secret&state=x",
+        "http://localhost:8001/auth/callback?code=secret&state=x",
+        "http://localhost:1455/auth/callback?code=secret&state=x&state=y",
+        "http://localhost:1455/auth/callback?code=secret&code=other&state=x",
+        "http://localhost:1455/auth/callback?code=secret&error=denied&state=x",
+        "http://user:secret@localhost:1455/auth/callback?code=secret&state=x",
+        "http://localhost:1455/auth/callback?code=secret&state=x#secret",
+        "secret",
+    ],
+)
+async def test_pasted_callback_rejects_malformed_urls_without_echo(tmp_path, url):
+    service, *_ = await _oauth_service(tmp_path)
+    await service.start_login()
+    with pytest.raises(CodexAuthError) as error:
+        await service.submit_callback_url(url)
+    assert error.value.code == "invalid_callback_url"
+    assert "secret" not in error.value.public_message
+    assert service.public_status()["operation_state"] == "waiting"
+    await service.cancel_login()

--- a/web/components/knowledge/KnowledgePage.tsx
+++ b/web/components/knowledge/KnowledgePage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useTranslation } from "react-i18next";
@@ -9,12 +10,14 @@ import { updateRagProviderMode } from "@/features/knowledge/api/engines";
 import KnowledgeBaseDetail from "./KnowledgeBaseDetail";
 import KnowledgeHome, { type KnowledgeHomeSection } from "./KnowledgeHome";
 import EngineDetail from "@/features/knowledge/components/engines/EngineDetail";
-import CreateKbModal from "./CreateKbModal";
+
 import {
   decodeResourceSegment,
   knowledgeBaseRoute,
 } from "@/lib/resource-routes";
 import type { IndexingLLMSelection } from "@/features/knowledge/model/types";
+
+const CreateKbModal = dynamic(() => import("./CreateKbModal"), { ssr: false });
 
 export default function KnowledgePage() {
   const { t } = useTranslation();
@@ -366,7 +369,7 @@ export default function KnowledgePage() {
         </div>
       )}
 
-      <CreateKbModal
+      {createOpen && <CreateKbModal
         isOpen={createOpen}
         onClose={() => setCreateOpen(false)}
         providers={providers}
@@ -384,7 +387,7 @@ export default function KnowledgePage() {
           setCreateOpen(false);
           openEngine(providerId);
         }}
-      />
+      />}
     </div>
   );
 }

--- a/web/components/settings/CodexOAuthCard.tsx
+++ b/web/components/settings/CodexOAuthCard.tsx
@@ -10,6 +10,7 @@ import { reasoningEffortOptionsFromSupportedLevels } from "@/lib/reasoning-effor
 import {
   buildSshForwardCommand,
   cancelCodexLogin,
+  completeCodexLogin,
   codexRemoteGuidance,
   CodexOAuthApiError,
   codexErrorMessageKey,
@@ -34,6 +35,8 @@ export function CodexOAuthCard() {
     useSettings();
   const [status, setStatus] = useState<CodexOAuthStatus | null>(null);
   const [pending, setPending] = useState(false);
+  const [callbackUrl, setCallbackUrl] = useState("");
+  const [callbackErrorKey, setCallbackErrorKey] = useState<string | null>(null);
   const [errorKey, setErrorKey] = useState<string | null>(null);
   const [pollTick, setPollTick] = useState(0);
   const [loginStart, setLoginStart] = useState<CodexLoginStart | null>(null);
@@ -149,6 +152,31 @@ export function CodexOAuthCard() {
     reloadedOperation.current = status.operation_id;
     void syncCatalog();
   }, [syncCatalog, status]);
+
+  useEffect(() => {
+    setCallbackUrl("");
+    setCallbackErrorKey(null);
+  }, [status?.operation_id, status?.operation_state]);
+
+  const completeSignIn = async () => {
+    const submitted = callbackUrl;
+    setCallbackUrl("");
+    setPending(true);
+    setCallbackErrorKey(null);
+    invalidateStatusRequests();
+    try {
+      await completeCodexLogin(submitted);
+      await loadStatus();
+    } catch (error) {
+      setCallbackErrorKey(
+        codexErrorMessageKey(
+          error instanceof CodexOAuthApiError ? error.code : null,
+        ),
+      );
+    } finally {
+      setPending(false);
+    }
+  };
 
   const localSignIn = async () => {
     invalidateStatusRequests();
@@ -396,6 +424,36 @@ export function CodexOAuthCard() {
                 </div>
               </div>
             )}
+          {status?.operation_state === "waiting" && (
+            <div className="mt-4 rounded-lg border border-[var(--border)] p-3">
+              <p className="text-sm">{t("codex.oauth.callbackHelp")}</p>
+              {callbackErrorKey && (
+                <p role="alert" className="mt-2 text-sm">
+                  {t(callbackErrorKey)}
+                </p>
+              )}
+              <label className="mt-2 block text-xs">
+                {t("codex.oauth.callbackInput")}
+                <input
+                  type="password"
+                  autoComplete="off"
+                  spellCheck={false}
+                  value={callbackUrl}
+                  onChange={(event) => setCallbackUrl(event.target.value)}
+                  className="mt-1 w-full rounded border border-[var(--border)] bg-[var(--background)] p-2"
+                />
+              </label>
+              <Button
+                type="button"
+                size="sm"
+                className="mt-2"
+                disabled={pending || !callbackUrl.trim()}
+                onClick={() => void completeSignIn()}
+              >
+                {t("codex.oauth.completeLogin")}
+              </Button>
+            </div>
+          )}
           {remoteAccess && remoteGuidance && (
             <div className="mt-4 rounded-lg border border-[var(--border)] bg-[var(--background)] p-3">
               <p className="text-sm font-medium">

--- a/web/contracts/generated/api.ts
+++ b/web/contracts/generated/api.ts
@@ -6886,6 +6886,23 @@ export interface paths {
     readonly patch?: never;
     readonly trace?: never;
   };
+  readonly "/api/settings/providers/openai-codex/oauth/complete": {
+    readonly parameters: {
+      readonly query?: never;
+      readonly header?: never;
+      readonly path?: never;
+      readonly cookie?: never;
+    };
+    readonly get?: never;
+    readonly put?: never;
+    /** Complete Openai Codex Oauth */
+    readonly post: operations["complete_openai_codex_oauth_api_settings_providers_openai_codex_oauth_complete_post"];
+    readonly delete?: never;
+    readonly options?: never;
+    readonly head?: never;
+    readonly patch?: never;
+    readonly trace?: never;
+  };
   readonly "/api/settings/providers/openai-codex/oauth/logout": {
     readonly parameters: {
       readonly query?: never;
@@ -29019,6 +29036,41 @@ export interface operations {
         content: {
           readonly "application/json": {
             readonly [key: string]: unknown;
+          };
+        };
+      };
+      /** @description Validation Error */
+      readonly 422: {
+        headers: {
+          readonly [name: string]: unknown;
+        };
+        content: {
+          readonly "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  readonly complete_openai_codex_oauth_api_settings_providers_openai_codex_oauth_complete_post: {
+    readonly parameters: {
+      readonly query?: never;
+      readonly header?: {
+        readonly Authorization?: string | null;
+      };
+      readonly path?: never;
+      readonly cookie?: {
+        readonly dt_token?: string | null;
+      };
+    };
+    readonly requestBody?: never;
+    readonly responses: {
+      /** @description Successful Response */
+      readonly 200: {
+        headers: {
+          readonly [name: string]: unknown;
+        };
+        content: {
+          readonly "application/json": {
+            readonly [key: string]: boolean;
           };
         };
       };

--- a/web/contracts/schema/openapi.json
+++ b/web/contracts/schema/openapi.json
@@ -40872,6 +40872,73 @@
         "tags": ["settings"]
       }
     },
+    "/api/settings/providers/openai-codex/oauth/complete": {
+      "post": {
+        "operationId": "complete_openai_codex_oauth_api_settings_providers_openai_codex_oauth_complete_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "dt_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Dt Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "title": "Response Complete Openai Codex Oauth Api Settings Providers Openai Codex Oauth Complete Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Complete Openai Codex Oauth",
+        "tags": ["settings"]
+      }
+    },
     "/api/settings/providers/openai-codex/oauth/logout": {
       "post": {
         "operationId": "logout_openai_codex_oauth_api_settings_providers_openai_codex_oauth_logout_post",

--- a/web/features/co-writer/components/CoWriterWorkspace.tsx
+++ b/web/features/co-writer/components/CoWriterWorkspace.tsx
@@ -71,10 +71,13 @@ import { useSelectionEdit } from "@/features/co-writer/hooks/useSelectionEdit";
 import { useSplitPane } from "@/features/co-writer/hooks/useSplitPane";
 import { useSynchronizedScroll } from "@/features/co-writer/hooks/useSynchronizedScroll";
 import { useDocumentLifecycle } from "@/features/co-writer/hooks/useDocumentLifecycle";
-import SaveToNotebookModal, {
-  type NotebookSavePayload,
-} from "@/components/notebook/SaveToNotebookModal";
+import type { NotebookSavePayload } from "@/components/notebook/SaveToNotebookModal";
 import { CO_WRITER_SAMPLE_TEMPLATE } from "@/app/(workspace)/co-writer/sampleTemplate";
+
+const SaveToNotebookModal = dynamic(
+  () => import("@/components/notebook/SaveToNotebookModal"),
+  { ssr: false },
+);
 
 const MarkdownRenderer = dynamic(
   () => import("@/components/common/MarkdownRenderer"),
@@ -2410,7 +2413,7 @@ export default function CoWriterWorkspace({ docId }: CoWriterWorkspaceProps) {
         </div>
       )}
 
-      <SaveToNotebookModal
+      {notebookSavePayload !== null && <SaveToNotebookModal
         open={notebookSavePayload !== null}
         payload={notebookSavePayload}
         onClose={() => setNotebookSavePayload(null)}
@@ -2418,7 +2421,7 @@ export default function CoWriterWorkspace({ docId }: CoWriterWorkspaceProps) {
           setStatus(t("Saved to notebook."));
           setError("");
         }}
-      />
+      />}
     </div>
   );
 }

--- a/web/lib/codex-oauth.ts
+++ b/web/lib/codex-oauth.ts
@@ -26,11 +26,7 @@ export type CodexOAuthStatus = {
   redirect_uri: string | null;
   model_count: number;
   catalog_source:
-    | "live"
-    | "fresh-cache"
-    | "revalidated-cache"
-    | "stale-cache"
-    | null;
+    "live" | "fresh-cache" | "revalidated-cache" | "stale-cache" | null;
   catalog_fetched_at: number | null;
   active_model: string | null;
   models: CodexReasoningModel[];
@@ -176,6 +172,14 @@ export function startCodexLogin(): Promise<CodexLoginStart> {
   return requestCodex<CodexLoginStart>("/oauth/start", "POST");
 }
 
+export function completeCodexLogin(
+  callbackUrl: string,
+): Promise<{ accepted: boolean }> {
+  return requestCodex("/oauth/complete", "POST", apiFetch, {
+    callback_url: callbackUrl,
+  });
+}
+
 export function cancelCodexLogin(): Promise<CodexOAuthStatus> {
   return requestCodex<CodexOAuthStatus>("/oauth/cancel", "POST");
 }
@@ -216,6 +220,9 @@ export function codexErrorMessageKey(code: string | null): string {
   if (code === "inference_in_progress") {
     return "codex.oauth.inferenceActive";
   }
+  if (code === "invalid_callback_url") return "codex.oauth.invalidCallback";
+  if (code === "state_mismatch" || code === "login_not_active")
+    return "codex.oauth.callbackMismatch";
   if (code === "login_timeout") return "codex.oauth.callbackMissing";
   if (code === "callback_unavailable") {
     return "codex.oauth.callbackUnavailable";

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -4726,7 +4726,6 @@
   "Model default": "Model default",
   "VLM capability": "VLM capability",
   "Available": "Available",
-  "Unavailable": "Unavailable",
   "used for this version": "used for this version",
   "not used for this version": "not used for this version",
   "Version source": "Version source",
@@ -4753,5 +4752,10 @@
   "The LightRAG query-model setting could not be loaded. Choose an indexing model or try again.": "The LightRAG query-model setting could not be loaded. Choose an indexing model or try again.",
   "The historical indexing model is unknown. Queries remain available, but incremental uploads require a full rebuild.": "The historical indexing model is unknown. Queries remain available, but incremental uploads require a full rebuild.",
   "Unverified historical indexing model": "Unverified historical indexing model",
-  "This legacy LightRAG index remains queryable, but it must be fully rebuilt before incremental uploads.": "This legacy LightRAG index remains queryable, but it must be fully rebuilt before incremental uploads."
+  "This legacy LightRAG index remains queryable, but it must be fully rebuilt before incremental uploads.": "This legacy LightRAG index remains queryable, but it must be fully rebuilt before incremental uploads.",
+  "codex.oauth.callbackHelp": "If the localhost callback page cannot open (Docker or remote server), paste its full address here to finish signing in. No port changes are needed.",
+  "codex.oauth.callbackInput": "Callback URL (kept only until submitted)",
+  "codex.oauth.completeLogin": "Complete sign-in",
+  "codex.oauth.invalidCallback": "Paste the complete localhost callback URL from the browser address bar.",
+  "codex.oauth.callbackMismatch": "This callback does not match your active sign-in. Start again using this account."
 }

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -4726,7 +4726,6 @@
   "Model default": "模型默认值",
   "VLM capability": "VLM 能力",
   "Available": "可用",
-  "Unavailable": "不可用",
   "used for this version": "此版本已使用",
   "not used for this version": "此版本未使用",
   "Version source": "版本来源",
@@ -4753,5 +4752,10 @@
   "The LightRAG query-model setting could not be loaded. Choose an indexing model or try again.": "无法加载 LightRAG 查询模型设置。请选择索引模型或重试。",
   "The historical indexing model is unknown. Queries remain available, but incremental uploads require a full rebuild.": "历史索引模型无法确认。知识库仍可查询，但增量上传前必须完整重建。",
   "Unverified historical indexing model": "无法确认的历史索引模型",
-  "This legacy LightRAG index remains queryable, but it must be fully rebuilt before incremental uploads.": "此旧版 LightRAG 索引仍可查询，但增量上传前必须完整重建。"
+  "This legacy LightRAG index remains queryable, but it must be fully rebuilt before incremental uploads.": "此旧版 LightRAG 索引仍可查询，但增量上传前必须完整重建。",
+  "codex.oauth.callbackHelp": "如果 localhost 回调页无法打开（Docker 或远程服务器），将该页完整地址粘贴到这里完成登录，无需修改端口。",
+  "codex.oauth.callbackInput": "回调地址（仅保留到提交时）",
+  "codex.oauth.completeLogin": "完成登录",
+  "codex.oauth.invalidCallback": "请粘贴浏览器地址栏中的完整 localhost 回调地址。",
+  "codex.oauth.callbackMismatch": "该回调与当前账号的登录不匹配，请使用此账号重新发起登录。"
 }

--- a/web/tests/codex-callback-recovery.spec.tsx
+++ b/web/tests/codex-callback-recovery.spec.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { expect, test, vi } from "vitest";
+import { CodexOAuthCard } from "@/components/settings/CodexOAuthCard";
+import { completeCodexLogin } from "@/lib/codex-oauth";
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (s: string) => s }),
+}));
+vi.mock("@/features/settings/store/SettingsStore", () => ({
+  useSettings: () => ({
+    reloadSettings: vi.fn(),
+    setToast: vi.fn(),
+    hasUnsavedChanges: false,
+  }),
+}));
+vi.mock("@/lib/codex-oauth", async () => ({
+  ...(await vi.importActual("@/lib/codex-oauth")),
+  getCodexStatus: vi.fn().mockResolvedValue({
+    connection: "authorizing",
+    operation_id: "op",
+    operation_state: "waiting",
+    models: [],
+  }),
+  completeCodexLogin: vi.fn().mockResolvedValue({ accepted: true }),
+}));
+test("localhost users can submit a hidden callback and the field is cleared", async () => {
+  render(<CodexOAuthCard />);
+  const input = await screen.findByLabelText("codex.oauth.callbackInput");
+  expect(input).toHaveAttribute("type", "password");
+  const url = "http://localhost:1455/auth/callback?code=sample&state=sample";
+  fireEvent.change(input, { target: { value: url } });
+  fireEvent.click(
+    screen.getByRole("button", { name: "codex.oauth.completeLogin" }),
+  );
+  await waitFor(() => expect(completeCodexLogin).toHaveBeenCalledWith(url));
+  expect(input).toHaveValue("");
+});
+
+test("a rejected callback stays recoverable without retaining the URL", async () => {
+  const { CodexOAuthApiError } = await import("@/lib/codex-oauth");
+  vi.mocked(completeCodexLogin).mockRejectedValueOnce(
+    new CodexOAuthApiError("state_mismatch", "private details"),
+  );
+  render(<CodexOAuthCard />);
+  const input = await screen.findByLabelText("codex.oauth.callbackInput");
+  fireEvent.change(input, {
+    target: {
+      value: "http://localhost:1455/auth/callback?code=sample&state=wrong",
+    },
+  });
+  fireEvent.click(
+    screen.getByRole("button", { name: "codex.oauth.completeLogin" }),
+  );
+  expect(await screen.findByRole("alert")).toHaveTextContent(
+    "codex.oauth.callbackMismatch",
+  );
+  expect(input).toHaveValue("");
+  expect(screen.queryByText("private details")).toBeNull();
+});


### PR DESCRIPTION
### Problem and behavior

A browser accessing a local Docker deployment cannot reach the container's localhost OAuth callback listener. The standard manifests do not reserve 1455/1457, and the settings card hides remote guidance on localhost, leaving sign-in waiting after browser authorization.

Add a callback completion form whenever Codex sign-in is waiting. Users paste the failed callback page's complete address into the same account's settings and choose Complete sign-in; no port edits, published callback ports or container restart are needed. Existing native callbacks, remote SSH guidance and the optional temporary Compose bridge remain available.

The authenticated POST endpoint parses expected loopback callback URLs without fetching them, sends them only to the caller's owner-scoped service, and retains state validation, original redirect URI and PKCE exchange. Malformed/duplicate parameters and cross-account state are rejected with redacted errors. The password-style field is cleared after submission and on operation changes; neither browser storage nor URL query transport is used. Partner identities remain denied.

Include the existing closed-dialog lazy-loading prerequisite in a separate commit so the dev baseline's knowledge-base/co-writer performance failures do not block this fix. No budgets are increased.

### Validation

- 154 OAuth service/API tests passed, including loopback listeners, callback URL validation, cross-account rejection, and existing token-exchange tests.
- Two rendered recovery tests passed on localhost: completion and rejected-state feedback, with field clearing.
- Web Node tests, unit suite, contracts, architecture, typecheck, lint and i18n checks passed; production build and all performance budgets passed.
- Real account OAuth authorization has not been replayed. A fresh user login is required to verify the final account connection after deployment.

Fixes #1252. Complements the temporary bridge from #743 and per-user scope from #781.

### Local deployment

Deployed as `deeptutor-local:codex-callback-recovery` over the existing reading-fixes image, retaining data and the previous image/config for rollback. Container health and backend readiness pass; the completion endpoint rejects unauthenticated requests with HTTP 401. Full GitHub Python/Web checks are still running; import, lint and generated-file checks have passed.
