### PR TITLE
fix: persist notebook answer images

### DIFF
--- a/deeptutor/services/session/sqlite_store.py
+++ b/deeptutor/services/session/sqlite_store.py
@@ -2320,7 +2320,7 @@ class SQLiteSessionStore:
                             material_title, section_id, section_title, score_trend,
                             is_correct, resolved, bookmarked, followup_session_id,
                             created_at, updated_at
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, '', ?, ?)
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, '', ?, ?)
                         ON CONFLICT(session_id, turn_id, question_id) DO UPDATE SET
                             question = excluded.question,
                             question_type = excluded.question_type,

--- a/tests/api/test_notebook_router.py
+++ b/tests/api/test_notebook_router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import importlib
 from pathlib import Path
 
@@ -14,6 +15,7 @@ notebook_router = importlib.import_module("deeptutor.api.routers.question_notebo
 sessions_router = importlib.import_module("deeptutor.api.routers.sessions").router
 
 from deeptutor.services.session.sqlite_store import SQLiteSessionStore
+from deeptutor.services.storage.attachment_store import LocalDiskAttachmentStore
 
 
 def _build_app(store: SQLiteSessionStore) -> FastAPI:
@@ -105,6 +107,52 @@ def test_list_entries_empty(store: SQLiteSessionStore) -> None:
         resp = client.get("/api/question-notebook/entries")
         assert resp.status_code == 200
         assert resp.json() == {"items": [], "total": 0}
+
+
+def test_upsert_entry_persists_base64_answer_image(
+    store: SQLiteSessionStore, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session = asyncio.run(store.create_session(title="Image answer"))
+    attachment_store = LocalDiskAttachmentStore(root=tmp_path / "attachments")
+    monkeypatch.setattr(
+        "deeptutor.api.routers.question_notebook.get_attachment_store",
+        lambda: attachment_store,
+    )
+
+    with TestClient(_build_app(store)) as client:
+        response = client.post(
+            "/api/question-notebook/entries/upsert",
+            json={
+                "session_id": session["id"],
+                "question_id": "image-question",
+                "question": "Identify the diagram.",
+                "user_answer_images": [
+                    {
+                        "id": "answer-image-1",
+                        "base64": base64.b64encode(b"image-bytes").decode("ascii"),
+                        "filename": "answer.png",
+                        "mime_type": "image/png",
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["user_answer_images"] == [
+        {
+            "id": "answer-image-1",
+            "url": (f"/files/attachments/{session['id']}/answer-image-1/answer.png"),
+            "filename": "answer.png",
+            "mime_type": "image/png",
+        }
+    ]
+    stored_path = attachment_store.resolve_path(
+        session_id=session["id"],
+        attachment_id="answer-image-1",
+        filename="answer.png",
+    )
+    assert stored_path is not None
+    assert stored_path.read_bytes() == b"image-bytes"
 
 
 def test_list_entries_filters_by_course_and_total(


### PR DESCRIPTION
## Summary

- add the missing `resolved` value placeholder to the image-bearing notebook entry upsert
- cover the `/entries/upsert` base64 image path end to end
- verify persisted image metadata and attachment bytes

Fixes #1245

## Testing

- `pytest tests/api/test_notebook_router.py -q` (16 passed)
- `pytest tests/services/session/test_sqlite_store.py -q -k "not sqlite_store_migrates_legacy_chat_history_db"` (30 passed, 1 deselected; the deselected legacy migration assertion is an existing Windows-specific failure)
- `ruff check deeptutor/services/session/sqlite_store.py tests/api/test_notebook_router.py`
- `ruff format --check deeptutor/services/session/sqlite_store.py tests/api/test_notebook_router.py`
- `python scripts/check_repo_hygiene.py`

## AI assistance

AI assistance was used to investigate and prepare this change. I manually reviewed the diff and ran the tests above.