### PR TITLE
fix: support Moonshot k3-256k temperature override

### DIFF
--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -420,12 +420,14 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         # Moonshot's own recommendation. The tunable moonshot-v1-* series does
         # not contain "kimi" and keeps the caller's temperature. The Kimi
         # coding endpoint (api.kimi.com/coding/v1) addresses these models by
-        # bare ids ("k3", ...) without the "kimi-" prefix, so match those too.
+        # bare ids ("k3", "k3-256k", ...) without the "kimi-" prefix, so
+        # match those too.
         model_overrides=(
             ("kimi", {"temperature": None}),
             ("=k3", {"temperature": None}),
+            ("=k3-256k", {"temperature": None}),
         ),
-        exact_model_ids=("k3",),
+        exact_model_ids=("k3", "k3-256k"),
     ),
     # MiniMax runs two separate platforms: global (platform.minimax.io /
     # api.minimax.io) and mainland China (platform.minimaxi.com /

--- a/tests/services/llm/test_model_overrides.py
+++ b/tests/services/llm/test_model_overrides.py
@@ -88,7 +88,10 @@ def test_vendor_prefixed_routing_still_finds_the_model() -> None:
 def test_bare_k3_is_exact_and_does_not_capture_unrelated_short_ids() -> None:
     moonshot = find_by_name("moonshot")
     assert model_overrides_for("k3", moonshot) == {"temperature": None}
+    assert model_overrides_for("k3-256k", moonshot) == {"temperature": None}
     assert model_overrides_for("sk3", moonshot) == {}
     assert model_overrides_for("k30", moonshot) == {}
+    assert model_overrides_for("k3-256kx", moonshot) == {}
     assert find_by_model("k3") is moonshot
+    assert find_by_model("k3-256k") is moonshot
     assert find_by_model("sk3") is None


### PR DESCRIPTION
Fixes #1227.

Adds `k3-256k` to Moonshot's exact model IDs and drops the explicit temperature for it, matching the existing behavior for bare `k3`. The regression test also confirms that similar unrelated IDs remain untouched.

Validation: `28 passed` across the provider-registry and model-override tests; Ruff check and format check passed.
