### PR TITLE
fix(codex): expose eligible GPT-6 Astra in refreshed catalogs

### DIFF
--- a/deeptutor/services/codex_auth/constants.py
+++ b/deeptutor/services/codex_auth/constants.py
@@ -1,7 +1,10 @@
 """Audited OpenAI Codex compatibility constants."""
 
 CODEX_UPSTREAM_COMMIT = "81da9deb065d7adb283816b19b40f89bcc484276"
-CODEX_CLIENT_VERSION = "0.145.0"
+# Catalog compatibility: rust-v0.153.4, commit
+# 3d2ee51ca2d5db578f328aa75e20aa22c0197c9a. Older versions omit eligible models.
+# This request version is independent of the installed CLI and OAuth audit above.
+CODEX_CLIENT_VERSION = "0.153.4"
 CODEX_OAUTH_ISSUER = "https://auth.openai.com"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_SCOPE = "openid profile email offline_access api.connectors.read api.connectors.invoke"

--- a/tests/services/codex_auth/fixtures/astra-model.json
+++ b/tests/services/codex_auth/fixtures/astra-model.json
@@ -1,0 +1,39 @@
+{
+  "slug": "gpt-6-astra",
+  "display_name": "GPT-6-Astra",
+  "visibility": "list",
+  "priority": 1,
+  "default_reasoning_level": "medium",
+  "supported_reasoning_levels": [
+    {
+      "effort": "low",
+      "description": "Fast responses with lighter reasoning"
+    },
+    {
+      "effort": "medium",
+      "description": "Balances speed and reasoning depth for everyday tasks"
+    },
+    {
+      "effort": "high",
+      "description": "Greater reasoning depth for complex problems"
+    },
+    {
+      "effort": "xhigh",
+      "description": "Extra high reasoning depth for complex problems"
+    },
+    {
+      "effort": "max",
+      "description": "Maximum reasoning depth for the hardest problems"
+    },
+    {
+      "effort": "ultra",
+      "description": "Maximum reasoning with automatic task delegation"
+    }
+  ],
+  "supports_reasoning_summary_parameter": true,
+  "supports_reasoning_summaries": true,
+  "supports_parallel_tool_calls": true,
+  "use_responses_lite": true,
+  "context_window": 272000,
+  "max_context_window": 872000
+}

--- a/tests/services/codex_auth/test_catalog_refresh.py
+++ b/tests/services/codex_auth/test_catalog_refresh.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from deeptutor.services.codex_auth.catalog import CodexModelCatalog, parse_models_response
+from deeptutor.services.codex_auth.contracts import CatalogSnapshot, CodexCredentials
+from deeptutor.services.codex_auth.oauth import CodexOAuthClient
+from deeptutor.services.codex_auth.service import (
+    CODEX_PROFILE_ID,
+    CodexOAuthService,
+    codex_model_id,
+    sync_codex_catalog,
+)
+from deeptutor.services.codex_auth.storage import CodexCredentialStore
+from deeptutor.services.config.model_catalog import ModelCatalogService
+from deeptutor.services.config.provider_runtime import resolve_llm_runtime_config
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.mark.asyncio
+async def test_refresh_discovers_version_gated_model_and_preserves_selection(
+    tmp_path: Path,
+) -> None:
+    # Same-account live comparison on 2026-09-06: 0.145.0 omits Astra;
+    # official rust-v0.153.4 exposes it. Only model metadata is retained.
+    old_payload = json.loads((FIXTURES / "models-response.json").read_text())
+    astra = json.loads((FIXTURES / "astra-model.json").read_text())
+    new_payload = {"models": [astra, *old_payload["models"]]}
+    requests: list[httpx.Request] = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        version = request.url.params["client_version"]
+        assert version in {"0.145.0", "0.153.4"}
+        payload = old_payload if version == "0.145.0" else new_payload
+        return httpx.Response(200, json=payload, headers={"etag": '"new-catalog"'})
+
+    store = CodexCredentialStore(tmp_path)
+    credentials = store.commit_credentials(
+        CodexCredentials(
+            schema_version=1,
+            access_token="test-access",
+            refresh_token="test-refresh",
+            id_token="test-id",
+            account_id="test-account",
+            expires_at=2_000_000_000,
+            generation=0,
+        ),
+        expected_generation=0,
+    )
+    model_catalog = ModelCatalogService(tmp_path / "model_catalog.json")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as http:
+        catalog = CodexModelCatalog(store, http=http, clock=lambda: 1_000)
+        # Seed a still-fresh pre-upgrade cache and a user's selected model.
+        previous = CatalogSnapshot(
+            models=parse_models_response(old_payload),
+            source="live",
+            fetched_at=1_000,
+            etag='"old-catalog"',
+            generation=credentials.generation,
+            account_hash=hashlib.sha256(credentials.account_id.encode()).hexdigest(),
+        )
+        store.save_catalog_cache(previous.to_dict())
+        sync_codex_catalog(model_catalog, previous, account_id=credentials.account_id)
+        service = CodexOAuthService(
+            store, catalog, model_catalog, oauth_client=CodexOAuthClient(http), clock=lambda: 1_000
+        )
+        await service.set_reasoning_effort("gpt-5.6-sol", "high")
+        before = model_catalog.load()
+        status = await service.refresh_models()
+
+        assert requests[0].headers["if-none-match"] == '"old-catalog"'
+        assert [m["model"] for m in status["models"]].count("gpt-6-astra") == 1
+        refreshed = model_catalog.load()
+        llm = refreshed["services"]["llm"]
+        assert llm["active_model_id"] == before["services"]["llm"]["active_model_id"]
+        profile = next(p for p in llm["profiles"] if p["id"] == CODEX_PROFILE_ID)
+        assert {m["model"] for m in profile["models"]} == {"gpt-6-astra", "gpt-5.6-sol"}
+        existing = next(m for m in profile["models"] if m["model"] == "gpt-5.6-sol")
+        assert existing["reasoning_effort"] == "high"
+        selected = next(m for m in profile["models"] if m["model"] == "gpt-6-astra")
+        assert selected["name"] == astra["display_name"]
+        assert selected["context_window"] == str(astra["context_window"])
+        assert selected["codex_supported_reasoning_levels"] == [
+            level["effort"] for level in astra["supported_reasoning_levels"]
+        ]
+        assert selected["codex_use_responses_lite"] is astra["use_responses_lite"]
+
+        # The settings model card persists these two IDs when the user selects it.
+        llm["active_profile_id"] = CODEX_PROFILE_ID
+        llm["active_model_id"] = codex_model_id("gpt-6-astra")
+        model_catalog.save(refreshed)
+        await service.refresh_models()
+        reopened = ModelCatalogService(model_catalog.path)
+        loaded = reopened.load()
+        resolved = resolve_llm_runtime_config(loaded, service=reopened)
+        assert resolved.model == "gpt-6-astra"
+        service.validate_runtime_profile(await service.get_token(), resolved.model)
+        assert service.public_status()["active_model"] == "gpt-6-astra"
+        assert [m["model"] for m in service.public_status()["models"]].count("gpt-6-astra") == 1

--- a/tests/services/codex_auth/test_contracts.py
+++ b/tests/services/codex_auth/test_contracts.py
@@ -47,7 +47,7 @@ def _model() -> CodexModel:
 def test_codex_upstream_contract_is_pinned() -> None:
     assert CODEX_OAUTH_CLIENT_ID == "app_EMoamEEZ73f0CkXaXp7hrann"
     assert CODEX_CALLBACK_PORTS == (1455, 1457)
-    assert CODEX_CLIENT_VERSION == "0.145.0"
+    assert CODEX_CLIENT_VERSION == "0.153.4"
     assert CODEX_MODELS_URL.endswith("/backend-api/codex/models")
     assert CODEX_DEFAULT_MODEL == "gpt-5.6-sol"
 


### PR DESCRIPTION
### Description

Refreshing the managed OpenAI Codex catalog can omit GPT-6 Astra because the request advertises `client_version=0.145.0`. A controlled same-account comparison returned no Astra with that version and a visible `gpt-6-astra` with `0.153.4`; repeating both requests reproduced the result.

Update the catalog compatibility version to `0.153.4`, justified by the official [Codex release](https://github.com/openai/codex/releases/tag/rust-v0.153.4) at `3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`. Model eligibility and metadata still come from the signed-in account's response. The existing OAuth audit pin and authentication constants are unchanged, and no installed CLI dependency is introduced.

The regression starts with an old catalog cache, verifies that refresh adds the eligible model without replacing the user's selection or reasoning override, then selects Astra and verifies its identity after another refresh and configuration reload. The new fixture contains only sanitized upstream model metadata.

### Related Issues

No public issue linked.

### Module(s) Affected

- [x] `services`
- [x] `tests`

### Validation

Exact head: `6cfbbe93dcc7ebbb87d0809e37b844e702f69391`, based on `dev` at `42fab3cf429a1fbf36b257ab8d116a3814964202`.

Environment: Ubuntu ARM64, Python 3.11.16, pytest 9.1.1, pytest-asyncio 1.4.0, with the v1.6.5 dependency set and isolated application state. The new regression fails with the original request version because Astra is absent, then passes with this change.

```bash
python -m pytest tests/services/codex_auth tests/services/llm/test_openai_codex_oauth_provider.py tests/multi_user/test_personal_codex_models.py -q
```

Result: **141 passed**. Focused Ruff lint/format and mypy checks also pass. Frontend node-test TypeScript compilation and the 30 existing Codex client/settings contract tests pass with Node 22.23.2.

`pre-commit run --all-files` was run in a clean checkout of the exact head. Every hook passed except the full mypy hook, which reported two errors outside the changed files:

- `deeptutor/services/workspace/service.py:686`: cannot infer type of lambda.
- `deeptutor/services/config/readiness.py:786`: incompatible import of `verify_remote`.

The checkout remained clean. These errors were not modified by this PR. A subsequent matched base/head pre-commit run reproduced exactly these two errors; see the contribution-check follow-up below. The focused `python -m mypy deeptutor/services/codex_auth/constants.py` check passes.

### Checklist

- [x] Read and followed the contribution guidelines; targets `dev`.
- [x] Added focused regression coverage.
- [ ] All pre-commit hooks pass (full mypy errors recorded above).
- [x] Reviewed the exact code and sanitized fixture independently; no findings.
- [x] Documented the compatibility-version provenance in source.

### Additional Notes

An isolated replay of the full captured response also verified unique Astra catalog membership, persisted selection, runtime-profile validation, and actual ModelCard DOM rendering and selection. These are replay/component checks, not a full browser end-to-end test or live inference. No model generation was performed. Availability for other accounts and the minimum supporting client version were not established.

PR CI has reported a Ruff formatting failure in `deeptutor/skills/builtin/docx/SKILL.md` and `deeptutor/skills/builtin/xlsx/SKILL.md`, both unchanged here. The [PR job](https://github.com/HKUDS/DeepTutor/actions/runs/34025125660/job/101464617960) and the [base-commit job](https://github.com/HKUDS/DeepTutor/actions/runs/34015350623/job/101438037224) report the same missing-blank-line formatting changes with Python 3.11.16, Ruff 0.16.0 and `ruff format --check .`. The new Python regression adds one formatted file; this is not a claim of identical full test universes. CI has now completed; see the contribution-check follow-up below. This PR is not reported as CI-green.

### Contribution-check follow-up

`pre-commit run --all-files` was run on this exact head and on `dev` at `42fab3cf429a1fbf36b257ab8d116a3814964202`, using the same Ubuntu ARM64 environment, Python 3.11 tooling, task-owned Node 22.23.2, and identical pinned hook configuration. Fourteen hooks passed. Full mypy failed only on the same two baseline errors:

- `deeptutor/services/workspace/service.py:686`: cannot infer the lambda type.
- `deeptutor/services/config/readiness.py:786`: incompatible `verify_remote` import types.

The checks introduced no tracked-file changes. No unrelated baseline repair is included, and full pre-commit is not reported as passing.

Completed remote CI for this exact head has three substantive failures plus the derived Test Summary: Lint and Format, Web Node Tests, and Python 3.12. Direct comparison with [the exact dev-base run](https://github.com/HKUDS/DeepTutor/actions/runs/34015350623) found identical failure signals: the same DOCX/XLSX Markdown formatting findings; the same three route-budget overruns (305/300 KB, 324/320 KB, 525/515 KB); and the same three mastery tests failing on the missing Chinese prompt file. All other executed jobs passed; four-worker browser acceptance was skipped.
