### PR TITLE
feat(rag): show LlamaIndex source figures in chat

### DIFF
--- a/deeptutor/api/routers/knowledge.py
+++ b/deeptutor/api/routers/knowledge.py
@@ -2641,6 +2641,75 @@ def _resolve_kb_raw_file_or_404(kb_name: str, filename: str) -> Path:
     return target
 
 
+def _resolve_kb_index_asset_or_404(kb_name: str, asset_path: str) -> Path:
+    """Resolve a LlamaIndex frozen figure while preventing traversal."""
+    from deeptutor.services.rag.embedding_signature import signature_from_embedding_config
+    from deeptutor.services.rag.index_versioning import resolve_storage_dir_for_read
+    from deeptutor.services.rag.pipelines.llamaindex.assets import (
+        assets_dir,
+        is_image_asset_filename,
+    )
+
+    manager = _overridden_kb_manager()
+    if manager is not None:
+        resolved_name = _resolve_registered_kb_name(manager, kb_name)
+    else:
+        resource = resolve_kb(kb_name)
+        manager = manager_for_resource(resource)
+        resolved_name = resource.name
+
+    kb_entry = _load_kb_entry_or_404(manager, resolved_name)
+    provider = str(kb_entry.get("rag_provider") or DEFAULT_PROVIDER).strip().lower()
+    if provider != DEFAULT_PROVIDER:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    kb_dir = Path(manager.get_knowledge_base_path(resolved_name))
+    storage_dir = resolve_storage_dir_for_read(kb_dir, signature_from_embedding_config())
+    if storage_dir is None:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    root = assets_dir(storage_dir)
+    if not root.is_dir():
+        raise HTTPException(status_code=404, detail="File not found")
+
+    relative = Path(asset_path)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise HTTPException(status_code=403, detail="Access denied")
+    if not is_image_asset_filename(relative.name):
+        raise HTTPException(status_code=404, detail="File not found")
+
+    root_resolved = root.resolve()
+    target = (root / relative).resolve()
+    try:
+        target.relative_to(root_resolved)
+    except ValueError:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    if not target.exists() or not target.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+    return target
+
+
+@router.get("/knowledge-bases/{kb_name}/index-assets/{asset_path:path}")
+async def serve_kb_index_asset(kb_name: str, asset_path: str):
+    """Serve a figure frozen into the current LlamaIndex version's assets dir.
+
+    Resolution is sandboxed to ``version-N/assets/``; traversal and non-image
+    files yield 403/404. Used by chat RAG citations — never expose parse-cache
+    or raw filesystem paths to the browser.
+    """
+    target = _resolve_kb_index_asset_or_404(kb_name, asset_path)
+    media_type, _ = mimetypes.guess_type(target.name)
+    if not (media_type or "").startswith("image/"):
+        raise HTTPException(status_code=404, detail="File not found")
+    return FileResponse(
+        target,
+        media_type=media_type,
+        filename=target.name,
+        content_disposition_type="inline",
+    )
+
+
 @router.get("/knowledge-bases/{kb_name}/files")
 async def list_kb_raw_files(kb_name: str):
     """List raw documents under <kb>/raw/, recursing into folders.

--- a/deeptutor/services/rag/pipelines/llamaindex/assets.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/assets.py
@@ -1,0 +1,322 @@
+"""Freeze extracted document figures into a LlamaIndex version directory.
+
+Parse engines write images under ``parse_cache/.../images/``. Retrieval and
+the chat UI cannot serve those cache paths, so indexing copies them into
+``version-N/assets/<origin>/<file>`` and records a small manifest used to
+attach figures to text hits (even when multimodal ImageNode indexing is off).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import mimetypes
+from pathlib import Path
+import re
+import shutil
+from typing import Any
+from urllib.parse import quote
+
+from deeptutor.services.file_io import atomic_write_json
+from deeptutor.services.rag.file_routing import FileTypeRouter
+
+ASSETS_DIRNAME = "assets"
+MANIFEST_FILENAME = "manifest.json"
+TEXT_IMAGE_CAP = 3
+
+_PAGE_PATTERNS = (
+    re.compile(r"(?:^|[-_])page[-_]?(\d+)", re.I),
+    re.compile(r"(?:^|[-_])pg[-_]?(\d+)", re.I),
+    re.compile(r"(?:^|[-_])p(\d+)(?:[-_.]|$)", re.I),
+)
+_UNSAFE_NAME = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+@dataclass(frozen=True)
+class ImageAssetSource:
+    """An extracted (or standalone) image plus the document it belongs to."""
+
+    path: Path
+    origin: Path
+    page: str = ""
+
+
+def normalize_page(value: object) -> str:
+    """Canonical page token for matching chunk metadata to asset records."""
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    try:
+        return str(int(float(text)))
+    except (TypeError, ValueError):
+        return text
+
+
+def page_from_filename(name: str) -> str:
+    """Best-effort page number from common parser export names (e.g. page-3.png)."""
+    for pattern in _PAGE_PATTERNS:
+        match = pattern.search(name)
+        if match:
+            return match.group(1)
+    return ""
+
+
+def page_from_blocks(blocks: list[dict[str, Any]] | None, filename: str) -> str:
+    """Look up a figure's page in parser IR blocks (MinerU ``content_list`` shape)."""
+    if not blocks:
+        return ""
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        img = str(block.get("img_path") or block.get("image_path") or block.get("path") or "")
+        if Path(img).name != filename:
+            continue
+        if "page_idx" in block and block.get("page_idx") is not None:
+            try:
+                return str(int(block["page_idx"]) + 1)
+            except (TypeError, ValueError):
+                pass
+        for key in ("page_label", "page"):
+            page = normalize_page(block.get(key))
+            if page:
+                return page
+    return ""
+
+
+def assets_dir(storage_dir: Path) -> Path:
+    return Path(storage_dir) / ASSETS_DIRNAME
+
+
+def manifest_path(storage_dir: Path) -> Path:
+    return assets_dir(storage_dir) / MANIFEST_FILENAME
+
+
+def asset_rel_path(origin_name: str, image_name: str) -> str:
+    origin = _UNSAFE_NAME.sub("_", Path(origin_name).name) or "document"
+    image = Path(image_name).name
+    if not image or image in {".", ".."}:
+        raise ValueError(f"invalid image name: {image_name!r}")
+    return f"{origin}/{image}"
+
+
+def index_asset_url(kb_name: str, rel_path: str) -> str:
+    """HTTP path the web client can pass to ``apiUrl`` / ``<img src>``."""
+    encoded_kb = quote(str(kb_name), safe="")
+    encoded_rel = "/".join(quote(part, safe="") for part in Path(rel_path).parts)
+    return f"/api/knowledge-bases/{encoded_kb}/index-assets/{encoded_rel}"
+
+
+def load_asset_manifest(storage_dir: Path | None) -> dict[str, Any]:
+    if storage_dir is None:
+        return {"assets": []}
+    path = manifest_path(storage_dir)
+    if not path.is_file():
+        return {"assets": []}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"assets": []}
+    if not isinstance(payload, dict):
+        return {"assets": []}
+    records = payload.get("assets")
+    if not isinstance(records, list):
+        payload["assets"] = []
+    return payload
+
+
+def image_ref(record: dict[str, Any], kb_name: str) -> dict[str, Any]:
+    rel = str(record.get("rel_path") or "")
+    mime = str(record.get("mime") or "")
+    if not mime:
+        mime = mimetypes.guess_type(Path(rel).name)[0] or "application/octet-stream"
+    ref: dict[str, Any] = {
+        "image_url": index_asset_url(kb_name, rel),
+        "mime_type": mime,
+    }
+    description = str(record.get("description") or "").strip()
+    if description:
+        ref["image_description"] = description
+    page = normalize_page(record.get("page"))
+    if page:
+        ref["page"] = page
+    return ref
+
+
+def match_images_for_source(
+    manifest: dict[str, Any],
+    *,
+    origin_name: str,
+    page: object = "",
+    kb_name: str,
+    cap: int = TEXT_IMAGE_CAP,
+) -> list[dict[str, Any]]:
+    """Pick figures to attach to a retrieved text chunk.
+
+    Same-origin + same-page wins. If the chunk has no page, return the first
+    ``cap`` figures from that origin so STEM PDFs still show nearby diagrams.
+    """
+    origin = Path(str(origin_name or "")).name
+    if not origin:
+        return []
+    entries = [
+        item
+        for item in (manifest.get("assets") or [])
+        if isinstance(item, dict) and Path(str(item.get("origin_name") or "")).name == origin
+    ]
+    page_key = normalize_page(page)
+    if page_key:
+        matched = [item for item in entries if normalize_page(item.get("page")) == page_key]
+        entries = matched
+    return [image_ref(item, kb_name) for item in entries[: max(0, cap)] if item.get("rel_path")]
+
+
+def freeze_image_assets(
+    storage_dir: Path,
+    sources: list[ImageAssetSource],
+    documents: list[Any] | None = None,
+) -> dict[str, Any]:
+    """Copy ``sources`` into ``storage_dir/assets`` and merge the manifest.
+
+    Stamps ``asset_rel_path`` (and frozen ``image_path``) onto matching image
+    documents so the persisted LlamaIndex docstore never points at parse cache.
+    """
+    storage = Path(storage_dir)
+    storage.mkdir(parents=True, exist_ok=True)
+    root = assets_dir(storage)
+    root.mkdir(parents=True, exist_ok=True)
+
+    existing = load_asset_manifest(storage)
+    by_rel: dict[str, dict[str, Any]] = {}
+    for item in existing.get("assets") or []:
+        if isinstance(item, dict) and item.get("rel_path"):
+            by_rel[str(item["rel_path"])] = item
+
+    for source in sources:
+        rel = asset_rel_path(source.origin.name, source.path.name)
+        dest = root / Path(rel)
+        _copy_under_assets(source.path, dest, allowed_root=root)
+        mime = mimetypes.guess_type(source.path.name)[0] or "application/octet-stream"
+        record = {
+            "origin_name": source.origin.name,
+            "page": normalize_page(source.page) or page_from_filename(source.path.name),
+            "rel_path": rel,
+            "mime": mime,
+        }
+        previous = by_rel.get(rel) or {}
+        if previous.get("description") and not record.get("description"):
+            record["description"] = previous["description"]
+        by_rel[rel] = record
+        _stamp_image_documents(documents or [], source, rel, dest, record)
+
+    payload = {"assets": list(by_rel.values())}
+    atomic_write_json(manifest_path(storage), payload)
+    return payload
+
+
+def _copy_under_assets(source: Path, dest: Path, *, allowed_root: Path) -> None:
+    if source.is_symlink() or not source.is_file():
+        raise OSError(f"Source is not an ordinary file: {source}")
+    resolved_source = source.resolve(strict=True)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        dest.unlink()
+    shutil.copyfile(resolved_source, dest)
+    resolved_dest = dest.resolve(strict=True)
+    resolved_root = allowed_root.resolve(strict=True)
+    try:
+        resolved_dest.relative_to(resolved_root)
+    except ValueError as exc:
+        dest.unlink(missing_ok=True)
+        raise OSError(f"Frozen asset escaped assets dir: {dest}") from exc
+
+
+def _stamp_image_documents(
+    documents: list[Any],
+    source: ImageAssetSource,
+    rel: str,
+    dest: Path,
+    record: dict[str, Any],
+) -> None:
+    origin_name = source.origin.name
+    image_name = source.path.name
+    for doc in documents:
+        meta = getattr(doc, "metadata", None)
+        if not isinstance(meta, dict):
+            continue
+        if meta.get("content_type") != "image":
+            continue
+        if meta.get("file_name") not in {origin_name, image_name}:
+            continue
+        current_path = Path(str(getattr(doc, "image_path", "") or ""))
+        if current_path.name and current_path.name != image_name:
+            continue
+        meta["asset_rel_path"] = rel
+        if record.get("page") and not meta.get("page"):
+            meta["page"] = record["page"]
+        description = str(meta.get("image_description") or "").strip()
+        if description:
+            record["description"] = description
+        if hasattr(doc, "image_path"):
+            doc.image_path = str(dest)
+        if hasattr(doc, "image_mimetype") and record.get("mime"):
+            doc.image_mimetype = record["mime"]
+
+
+def attach_figure_fields(
+    item: dict[str, Any],
+    *,
+    meta: dict[str, Any],
+    kb_name: str,
+    manifest: dict[str, Any],
+    image_mimetype: str = "",
+) -> dict[str, Any]:
+    """Add ``image_url`` / ``images`` to a retrieval source without filesystem paths."""
+    content_type = str(item.get("content_type") or meta.get("content_type") or "text")
+    item["content_type"] = content_type
+    if not kb_name:
+        return item
+    if content_type == "image":
+        rel = str(meta.get("asset_rel_path") or "")
+        if rel:
+            item["image_url"] = index_asset_url(kb_name, rel)
+        description = str(meta.get("image_description") or "").strip()
+        if description:
+            item["image_description"] = description
+        mime = str(meta.get("image_mimetype") or image_mimetype or "").strip()
+        if not mime and rel:
+            mime = mimetypes.guess_type(Path(rel).name)[0] or ""
+        if mime:
+            item["mime_type"] = mime
+        return item
+    origin = str(meta.get("asset_origin") or meta.get("file_name") or "")
+    related = match_images_for_source(
+        manifest, origin_name=origin, page=item.get("page"), kb_name=kb_name
+    )
+    if related:
+        item["images"] = related
+    return item
+
+
+def is_image_asset_filename(name: str) -> bool:
+    return Path(name).suffix.lower() in FileTypeRouter.IMAGE_EXTENSIONS
+
+
+__all__ = [
+    "ASSETS_DIRNAME",
+    "ImageAssetSource",
+    "TEXT_IMAGE_CAP",
+    "asset_rel_path",
+    "assets_dir",
+    "attach_figure_fields",
+    "freeze_image_assets",
+    "image_ref",
+    "index_asset_url",
+    "is_image_asset_filename",
+    "load_asset_manifest",
+    "match_images_for_source",
+    "normalize_page",
+    "page_from_blocks",
+    "page_from_filename",
+]

--- a/deeptutor/services/rag/pipelines/llamaindex/document_loader.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/document_loader.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import asyncio
 import base64
-from dataclasses import dataclass
 import logging
 import mimetypes
 from pathlib import Path
@@ -27,6 +26,7 @@ from deeptutor.services.llm.client import get_llm_client
 from deeptutor.services.rag.file_routing import FileTypeRouter
 from deeptutor.utils.document_validator import DocumentValidator
 
+from .assets import ImageAssetSource, page_from_blocks, page_from_filename
 from .config import image_description_limits
 
 IMAGE_DESCRIPTION_SYSTEM_PROMPT = (
@@ -42,26 +42,19 @@ IMAGE_DESCRIPTION_PROMPT = (
 )
 
 
-@dataclass(frozen=True)
-class _ImageSource:
-    """An image to embed as an ``ImageNode``, plus the document it came from.
-
-    ``path`` is the image file on disk (what gets embedded and served).
-    ``origin`` is the document it belongs to: the image itself for a standalone
-    image file, or the source PDF/e-book for an image extracted during parsing —
-    so retrieval cites the source document rather than an opaque cache asset.
-    """
-
-    path: Path
-    origin: Path
-
-
 class LlamaIndexDocumentLoader:
     """Convert source files into LlamaIndex ``Document`` / ``ImageNode`` objects."""
 
     def __init__(self, logger=None, image_concurrency: int = 6) -> None:
         self.logger = logger or logging.getLogger(__name__)
         self.image_concurrency = max(1, int(image_concurrency))
+        self._pending_image_sources: list[ImageAssetSource] = []
+
+    def take_pending_image_sources(self) -> list[ImageAssetSource]:
+        """Images discovered during the last ``load``, including skipped ImageNodes."""
+        sources = self._pending_image_sources
+        self._pending_image_sources = []
+        return sources
 
     async def load(
         self,
@@ -69,7 +62,8 @@ class LlamaIndexDocumentLoader:
         image_progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[Any]:
         documents: list[Any] = []
-        image_sources: list[_ImageSource] = []
+        image_sources: list[ImageAssetSource] = []
+        self._pending_image_sources = []
         classification = FileTypeRouter.classify_files(list(file_paths))
 
         for file_path_str in classification.parser_files:
@@ -120,10 +114,11 @@ class LlamaIndexDocumentLoader:
                 else:
                     # Preserve the pre-parser behavior when an image-capable
                     # engine fails or yields no usable IR.
-                    image_sources.append(_ImageSource(path=path, origin=path))
+                    image_sources.append(ImageAssetSource(path=path, origin=path))
             else:
-                image_sources.append(_ImageSource(path=path, origin=path))
+                image_sources.append(ImageAssetSource(path=path, origin=path))
 
+        self._pending_image_sources = list(image_sources)
         if image_sources:
             documents.extend(
                 await self._load_image_nodes(
@@ -140,7 +135,7 @@ class LlamaIndexDocumentLoader:
         self,
         file_path: Path,
         parse_service=None,  # noqa: ANN001
-    ) -> tuple[str, list[_ImageSource], str]:
+    ) -> tuple[str, list[ImageAssetSource], str]:
         """Parse a document through the shared, engine-pluggable parse layer.
 
         Returns ``(text, extracted_images, engine)``. A parse failure (engine
@@ -160,7 +155,9 @@ class LlamaIndexDocumentLoader:
             return "", [], ""
 
         text = parsed.markdown.strip() or self._text_from_blocks(parsed.blocks)
-        images = self._collect_asset_images(parsed.asset_dir, origin=file_path)
+        images = self._collect_asset_images(
+            parsed.asset_dir, origin=file_path, blocks=parsed.blocks
+        )
         return text, images, str(parsed.engine or "")
 
     @staticmethod
@@ -175,7 +172,13 @@ class LlamaIndexDocumentLoader:
         ]
         return "\n\n".join(part for part in parts if part)
 
-    def _collect_asset_images(self, asset_dir: Path | None, *, origin: Path) -> list[_ImageSource]:
+    def _collect_asset_images(
+        self,
+        asset_dir: Path | None,
+        *,
+        origin: Path,
+        blocks: list[dict] | None = None,
+    ) -> list[ImageAssetSource]:
         """Gather images the parse engine extracted into ``asset_dir``.
 
         Engines that don't extract images (text-only, markitdown) leave
@@ -185,7 +188,11 @@ class LlamaIndexDocumentLoader:
         if not asset_dir or not Path(asset_dir).is_dir():
             return []
         images = [
-            _ImageSource(path=child, origin=origin)
+            ImageAssetSource(
+                path=child,
+                origin=origin,
+                page=page_from_blocks(blocks, child.name) or page_from_filename(child.name),
+            )
             for child in sorted(Path(asset_dir).iterdir())
             if child.is_file() and child.suffix.lower() in FileTypeRouter.IMAGE_EXTENSIONS
         ]
@@ -197,7 +204,7 @@ class LlamaIndexDocumentLoader:
 
     async def _load_image_nodes(
         self,
-        sources: list[_ImageSource],
+        sources: list[ImageAssetSource],
         *,
         image_progress_callback: Callable[[int, int], None] | None = None,
     ) -> list[ImageNode]:
@@ -231,7 +238,7 @@ class LlamaIndexDocumentLoader:
             )
             return []
 
-        embedded: list[_ImageSource] = []
+        embedded: list[ImageAssetSource] = []
         descriptions: list[str] = []
         contents: list[dict[str, str]] = []
         completed = 0
@@ -240,10 +247,10 @@ class LlamaIndexDocumentLoader:
         semaphore = asyncio.Semaphore(concurrency)
 
         async def _describe_one(
-            source: _ImageSource,
-        ) -> tuple[_ImageSource, str, dict[str, str]] | None:
+            source: ImageAssetSource,
+        ) -> tuple[ImageAssetSource, str, dict[str, str]] | None:
             nonlocal completed
-            result: tuple[_ImageSource, str, dict[str, str]] | None = None
+            result: tuple[ImageAssetSource, str, dict[str, str]] | None = None
             try:
                 try:
                     async with semaphore:
@@ -332,6 +339,8 @@ class LlamaIndexDocumentLoader:
                         "file_path": str(source.origin),
                         "content_type": "image",
                         "image_description": description,
+                        "asset_origin": source.origin.name,
+                        **({"page": source.page} if source.page else {}),
                     },
                     embedding=embedding,
                 )
@@ -339,7 +348,7 @@ class LlamaIndexDocumentLoader:
             self.logger.info(f"Loaded image: {source.path.name} ({len(embedding)}D vector)")
         return nodes
 
-    def _log_skipped_images(self, sources: list[_ImageSource], reason: str) -> None:
+    def _log_skipped_images(self, sources: list[ImageAssetSource], reason: str) -> None:
         for source in sources:
             self.logger.warning(
                 "Skipped image because image indexing requires both multimodal "
@@ -389,6 +398,7 @@ class LlamaIndexDocumentLoader:
                     metadata={
                         "file_name": file_path.name,
                         "file_path": str(file_path),
+                        "asset_origin": file_path.name,
                     },
                 )
             )

--- a/deeptutor/services/rag/pipelines/llamaindex/pipeline.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/pipeline.py
@@ -22,6 +22,11 @@ from deeptutor.services.rag.index_versioning import (
 from deeptutor.services.rag.kb_paths import resolve_kb_dir
 
 from . import storage
+from .assets import (
+    attach_figure_fields,
+    freeze_image_assets,
+    load_asset_manifest,
+)
 from .config import default_top_k, should_show_progress
 from .document_loader import LlamaIndexDocumentLoader
 from .embedding_adapter import (
@@ -171,6 +176,8 @@ class LlamaIndexPipeline:
                 self.logger.error("No valid documents found")
                 return False
 
+            self._freeze_loaded_assets(storage_dir, documents)
+
             self.logger.info(
                 f"Creating VectorStoreIndex with {len(documents)} documents "
                 f"(chunking + embedding)..."
@@ -239,7 +246,9 @@ class LlamaIndexPipeline:
                 lambda: storage.retrieve_nodes(storage_dir, query, top_k=top_k),
             )
 
-            result = self._nodes_to_result(query, nodes)
+            result = self._nodes_to_result(
+                query, nodes, kb_name=kb_name, storage_dir=storage_dir
+            )
             if embedding_mismatch_warning:
                 result["warning"] = embedding_mismatch_warning
             return result
@@ -274,22 +283,51 @@ class LlamaIndexPipeline:
         except Exception:
             return ""
 
-    def _nodes_to_result(self, query: str, nodes: list[Any]) -> Dict[str, Any]:
+    def _freeze_loaded_assets(self, storage_dir: Path, documents: list[Any]) -> None:
+        taker = getattr(self.document_loader, "take_pending_image_sources", None)
+        if not callable(taker):
+            return
+        sources = taker()
+        if not sources:
+            return
+        try:
+            freeze_image_assets(storage_dir, sources, documents)
+        except OSError as exc:
+            self.logger.warning("Failed to freeze extracted figures into %s: %s", storage_dir, exc)
+
+    def _nodes_to_result(
+        self,
+        query: str,
+        nodes: list[Any],
+        *,
+        kb_name: str = "",
+        storage_dir: Path | None = None,
+    ) -> Dict[str, Any]:
         context_parts: list[str] = []
         sources: list[dict[str, Any]] = []
+        manifest = load_asset_manifest(storage_dir)
         for i, node in enumerate(nodes):
             context_parts.append(node.node.text)
             meta = node.node.metadata or {}
-            sources.append(
-                {
-                    "title": meta.get("file_name", meta.get("title", f"Document {i + 1}")),
-                    "content": node.node.text[:200],
-                    "source": meta.get("file_path", meta.get("file_name", "")),
-                    "page": meta.get("page_label", meta.get("page", "")),
-                    "chunk_id": node.node.node_id or str(i),
-                    "score": round(node.score, 4) if node.score is not None else "",
-                }
+            content_type = str(meta.get("content_type") or "text")
+            page = meta.get("page_label", meta.get("page", ""))
+            item: dict[str, Any] = {
+                "title": meta.get("file_name", meta.get("title", f"Document {i + 1}")),
+                "content": node.node.text[:200],
+                "source": meta.get("file_path", meta.get("file_name", "")),
+                "page": page,
+                "chunk_id": node.node.node_id or str(i),
+                "score": round(node.score, 4) if node.score is not None else "",
+                "content_type": content_type,
+            }
+            attach_figure_fields(
+                item,
+                meta=meta,
+                kb_name=kb_name,
+                manifest=manifest,
+                image_mimetype=str(getattr(node.node, "image_mimetype", "") or ""),
             )
+            sources.append(item)
 
         content = "\n\n".join(context_parts) if context_parts else ""
         return {
@@ -320,6 +358,8 @@ class LlamaIndexPipeline:
             if not documents:
                 self.logger.warning("No valid documents to add")
                 return False
+
+            self._freeze_loaded_assets(plan.storage_dir, documents)
 
             if plan.existing_storage is not None:
                 self.logger.info(f"Loading existing index from {plan.existing_storage}...")

--- a/deeptutor/services/rag/pipelines/llamaindex/storage.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/storage.py
@@ -45,15 +45,18 @@ def _storage_path_from_version_entry(entry: dict[str, Any]) -> Path | None:
 
 
 def cleanup_failed_version_dir(storage_dir: Path) -> bool:
-    """Remove an empty flat version dir created by a failed indexing attempt."""
+    """Remove a flat version dir that never produced a usable index.
+
+    Freeze writes ``assets/`` before ``docstore.json`` exists, so a failed
+    run can leave a non-empty directory. Anything without ``docstore.json``
+    is still an unpublished attempt and is safe to drop.
+    """
     if not storage_dir.is_dir() or not storage_dir.name.startswith("version-"):
         return False
-    storage_empty = not any(child for child in storage_dir.iterdir() if child.name != "meta.json")
-    meta_path = storage_dir / "meta.json"
-    if storage_empty and not meta_path.exists():
-        shutil.rmtree(storage_dir, ignore_errors=True)
-        return True
-    return False
+    if (storage_dir / "docstore.json").exists():
+        return False
+    shutil.rmtree(storage_dir, ignore_errors=True)
+    return True
 
 
 def resolve_add_storage_plan(kb_dir: Path, signature: EmbeddingSignature | None) -> AddStoragePlan:

--- a/deeptutor/tools/builtin/__init__.py
+++ b/deeptutor/tools/builtin/__init__.py
@@ -69,7 +69,9 @@ def _rag_sources(result: dict[str, Any], *, query: str, kb_name: str) -> list[di
     """Citations for one ``rag`` call, from the retrieval's own provenance.
 
     Every pipeline normalises what it retrieved into ``result["sources"]``
-    (``{title, content, source, page, chunk_id, score}`` — see the GraphRAG and
+    (``{title, content, source, page, chunk_id, score}`` plus optional
+    ``content_type``, ``image_url``, ``image_description``, ``mime_type``,
+    and ``images`` for LlamaIndex figure hits — see the GraphRAG and
     LightRAG-server pipelines). Forward those so a grounded claim is traceable
     to the chunk / entity / report behind it; without this the tool reported
     only an echo of its own query (issue #694). ``type``/``kb_name`` are kept on

--- a/tests/api/test_knowledge_router.py
+++ b/tests/api/test_knowledge_router.py
@@ -2760,3 +2760,77 @@ def test_lightrag_config_validates_dedicated_llm_selection(monkeypatch, tmp_path
         json={"llm_profile_id": "", "llm_model_id": ""},
     )
     assert cleared.status_code == 200
+
+
+def _index_asset_kb(tmp_path: Path) -> tuple["_FakeKBManager", Path]:
+    manager = _ready_kb_manager(tmp_path)
+    storage = manager.base_dir / "kb" / "version-1"
+    asset_dir = storage / "assets" / "paper.pdf"
+    asset_dir.mkdir(parents=True)
+    figure = asset_dir / "page-1.png"
+    figure.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+    (storage / "assets" / "manifest.json").write_text("{}", encoding="utf-8")
+    (storage / "docstore.json").write_text("{}", encoding="utf-8")
+    return manager, figure
+
+
+def test_index_asset_route_serves_frozen_png(monkeypatch, tmp_path: Path) -> None:
+    manager, figure = _index_asset_kb(tmp_path)
+    monkeypatch.setattr(knowledge_router_module, "get_kb_manager", lambda: manager)
+    monkeypatch.setattr(
+        "deeptutor.services.rag.index_versioning.resolve_storage_dir_for_read",
+        lambda *_args, **_kwargs: figure.parents[2],
+    )
+    monkeypatch.setattr(
+        "deeptutor.services.rag.embedding_signature.signature_from_embedding_config",
+        lambda: None,
+    )
+
+    with TestClient(_build_app()) as client:
+        response = client.get("/api/knowledge-bases/kb/index-assets/paper.pdf/page-1.png")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("image/png")
+    assert response.content.startswith(b"\x89PNG")
+
+
+def test_index_asset_route_rejects_traversal(monkeypatch, tmp_path: Path) -> None:
+    manager, _figure = _index_asset_kb(tmp_path)
+    secret = manager.base_dir / "secret.png"
+    secret.write_bytes(b"\x89PNG\r\nsecret")
+    monkeypatch.setattr(knowledge_router_module, "get_kb_manager", lambda: manager)
+    monkeypatch.setattr(
+        "deeptutor.services.rag.index_versioning.resolve_storage_dir_for_read",
+        lambda *_args, **_kwargs: manager.base_dir / "kb" / "version-1",
+    )
+    monkeypatch.setattr(
+        "deeptutor.services.rag.embedding_signature.signature_from_embedding_config",
+        lambda: None,
+    )
+
+    with TestClient(_build_app()) as client:
+        response = client.get("/api/knowledge-bases/kb/index-assets/%2E%2E/%2E%2E/secret.png")
+
+    assert response.status_code in {403, 404}
+
+
+def test_index_asset_route_rejects_non_image(monkeypatch, tmp_path: Path) -> None:
+    manager, figure = _index_asset_kb(tmp_path)
+    (figure.parent / "notes.txt").write_text("nope", encoding="utf-8")
+    monkeypatch.setattr(knowledge_router_module, "get_kb_manager", lambda: manager)
+    monkeypatch.setattr(
+        "deeptutor.services.rag.index_versioning.resolve_storage_dir_for_read",
+        lambda *_args, **_kwargs: figure.parents[2],
+    )
+    monkeypatch.setattr(
+        "deeptutor.services.rag.embedding_signature.signature_from_embedding_config",
+        lambda: None,
+    )
+
+    with TestClient(_build_app()) as client:
+        missing = client.get("/api/knowledge-bases/kb/index-assets/paper.pdf/missing.png")
+        text = client.get("/api/knowledge-bases/kb/index-assets/paper.pdf/notes.txt")
+
+    assert missing.status_code == 404
+    assert text.status_code == 404
+

--- a/tests/services/rag/test_llamaindex_assets.py
+++ b/tests/services/rag/test_llamaindex_assets.py
@@ -1,0 +1,161 @@
+"""Tests for LlamaIndex figure freeze, retrieval sources, and page matching."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from deeptutor.services.rag.pipelines.llamaindex.assets import (
+    ImageAssetSource,
+    attach_figure_fields,
+    freeze_image_assets,
+    index_asset_url,
+    load_asset_manifest,
+    match_images_for_source,
+    page_from_filename,
+)
+
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+def test_page_from_filename_recognizes_parser_exports() -> None:
+    assert page_from_filename("page-3.png") == "3"
+    assert page_from_filename("doc_page_12_img_1.png") == "12"
+    assert page_from_filename("figure-1.png") == ""
+
+
+def test_freeze_copies_into_version_assets_and_writes_manifest(tmp_path: Path) -> None:
+    origin = tmp_path / "paper.pdf"
+    origin.write_bytes(b"%PDF")
+    cache = tmp_path / "parse_cache" / "images"
+    cache.mkdir(parents=True)
+    source_file = cache / "page-2.png"
+    source_file.write_bytes(PNG)
+
+    storage_dir = tmp_path / "kb" / "version-1"
+    node = SimpleNamespace(
+        image_path=str(source_file),
+        image_mimetype="image/png",
+        metadata={
+            "file_name": "paper.pdf",
+            "content_type": "image",
+            "image_description": "A circuit diagram",
+        },
+    )
+
+    payload = freeze_image_assets(
+        storage_dir,
+        [ImageAssetSource(path=source_file, origin=origin, page="2")],
+        [node],
+    )
+
+    frozen = storage_dir / "assets" / "paper.pdf" / "page-2.png"
+    assert frozen.is_file()
+    assert frozen.read_bytes() == PNG
+    assert node.image_path == str(frozen)
+    assert node.metadata["asset_rel_path"] == "paper.pdf/page-2.png"
+    assert "parse_cache" not in node.metadata["asset_rel_path"]
+
+    records = payload["assets"]
+    assert len(records) == 1
+    assert records[0]["origin_name"] == "paper.pdf"
+    assert records[0]["page"] == "2"
+    assert records[0]["rel_path"] == "paper.pdf/page-2.png"
+
+    reloaded = load_asset_manifest(storage_dir)
+    assert reloaded["assets"][0]["rel_path"] == "paper.pdf/page-2.png"
+
+
+def test_match_images_prefers_same_page_and_caps(tmp_path: Path) -> None:
+    storage_dir = tmp_path / "version-1"
+    origin = tmp_path / "notes.pdf"
+    origin.write_bytes(b"%PDF")
+    images = tmp_path / "imgs"
+    images.mkdir()
+    sources = []
+    for name, page in (("page-1.png", "1"), ("page-2.png", "2"), ("page-2b.png", "2")):
+        path = images / name
+        path.write_bytes(PNG)
+        sources.append(ImageAssetSource(path=path, origin=origin, page=page))
+    freeze_image_assets(storage_dir, sources, [])
+    manifest = load_asset_manifest(storage_dir)
+
+    page_two = match_images_for_source(
+        manifest, origin_name="notes.pdf", page="2", kb_name="circuits", cap=3
+    )
+    assert len(page_two) == 2
+    assert all("/api/knowledge-bases/circuits/index-assets/" in item["image_url"] for item in page_two)
+    assert all("parse_cache" not in item["image_url"] for item in page_two)
+    assert all(not str(item["image_url"]).startswith("/") or item["image_url"].startswith("/api/") for item in page_two)
+
+    no_page = match_images_for_source(
+        manifest, origin_name="notes.pdf", page="", kb_name="circuits", cap=2
+    )
+    assert len(no_page) == 2
+
+
+def test_attach_figure_fields_emits_image_url_and_related_figures(tmp_path: Path) -> None:
+    origin = tmp_path / "paper.pdf"
+    origin.write_bytes(b"%PDF")
+    cache = tmp_path / "page-1.png"
+    cache.write_bytes(PNG)
+    storage_dir = tmp_path / "version-1"
+    freeze_image_assets(
+        storage_dir,
+        [ImageAssetSource(path=cache, origin=origin, page="1")],
+        [],
+    )
+    manifest = load_asset_manifest(storage_dir)
+
+    image_item = attach_figure_fields(
+        {
+            "title": "paper.pdf",
+            "content": "[Image] paper.pdf",
+            "source": str(origin),
+            "page": "1",
+            "chunk_id": "img-1",
+            "score": 0.91,
+            "content_type": "image",
+        },
+        meta={
+            "file_name": "paper.pdf",
+            "file_path": str(origin),
+            "content_type": "image",
+            "image_description": "A gate diagram",
+            "asset_rel_path": "paper.pdf/page-1.png",
+            "page": "1",
+        },
+        kb_name="circuits",
+        manifest=manifest,
+        image_mimetype="image/png",
+    )
+    text_item = attach_figure_fields(
+        {
+            "title": "paper.pdf",
+            "content": "NAND gates are universal.",
+            "source": str(origin),
+            "page": "1",
+            "chunk_id": "txt-1",
+            "score": 0.8,
+            "content_type": "text",
+        },
+        meta={
+            "file_name": "paper.pdf",
+            "file_path": str(origin),
+            "asset_origin": "paper.pdf",
+            "page": "1",
+        },
+        kb_name="circuits",
+        manifest=manifest,
+    )
+
+    assert image_item["content_type"] == "image"
+    assert image_item["image_url"] == index_asset_url("circuits", "paper.pdf/page-1.png")
+    assert image_item["image_description"] == "A gate diagram"
+    assert "image_path" not in image_item
+    assert text_item["images"]
+    assert text_item["images"][0]["image_url"] == image_item["image_url"]
+    dumped = str(image_item) + str(text_item)
+    assert str(cache) not in dumped
+    assert "parse_cache" not in dumped

--- a/tests/services/rag/test_llamaindex_document_loader.py
+++ b/tests/services/rag/test_llamaindex_document_loader.py
@@ -172,9 +172,6 @@ def test_loader_explains_scanned_pdf_when_parser_yields_images_only(
     pytest.importorskip("llama_index.core")
     from deeptutor.services.parsing.types import ParsedDocument
     from deeptutor.services.rag.pipelines.llamaindex import document_loader as loader_module
-    from deeptutor.services.rag.pipelines.llamaindex.document_loader import (
-        LlamaIndexDocumentLoader,
-    )
 
     pdf_path = tmp_path / "scan.pdf"
     pdf_path.write_bytes(b"stub")
@@ -202,13 +199,51 @@ def test_loader_explains_scanned_pdf_when_parser_yields_images_only(
     monkeypatch.setattr(loader_module, "get_embedding_client", lambda: _TextOnlyClient())
 
     with caplog.at_level("WARNING"):
-        documents = asyncio.run(LlamaIndexDocumentLoader().load([str(pdf_path)]))
+        documents = asyncio.run(loader_module.LlamaIndexDocumentLoader().load([str(pdf_path)]))
 
     assert documents == []
     assert "pymupdf4llm engine extracted 1 image(s) but no text" in caplog.text
     assert "scanned PDF" in caplog.text
     assert "OCR-capable" in caplog.text
     assert "Settings, Document Parsing" in caplog.text
+
+
+def test_loader_keeps_extracted_images_when_multimodal_indexing_is_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("llama_index.core")
+    from deeptutor.services.parsing.types import ParsedDocument
+    from deeptutor.services.rag.pipelines.llamaindex import document_loader as loader_module
+
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"stub")
+    asset_dir = tmp_path / "assets"
+    asset_dir.mkdir()
+    (asset_dir / "page-1.png").write_bytes(b"\x89PNG\r\n")
+
+    _install_stub_parse_service(
+        monkeypatch,
+        {"paper.pdf": ParsedDocument(markdown="Body", asset_dir=asset_dir)},
+    )
+
+    class _TextOnlyClient:
+        config = type("Config", (), {"binding": "openai", "model": "text-embedding"})()
+
+        def supports_multimodal_contents(self) -> bool:
+            return False
+
+    monkeypatch.setattr(loader_module, "get_embedding_client", lambda: _TextOnlyClient())
+
+    loader = loader_module.LlamaIndexDocumentLoader()
+    documents = asyncio.run(loader.load([str(pdf_path)]))
+    pending = loader.take_pending_image_sources()
+
+    assert len(documents) == 1
+    assert documents[0].metadata["asset_origin"] == "paper.pdf"
+    assert len(pending) == 1
+    assert pending[0].path.name == "page-1.png"
+    assert pending[0].origin.name == "paper.pdf"
+    assert pending[0].page == "1"
 
 
 def test_loader_keeps_generic_empty_warning_for_non_pdf(
@@ -284,6 +319,7 @@ def test_loader_indexes_images_extracted_from_parsed_document(
 
     assert len(text_docs) == 1
     assert text_docs[0].text == "Paper body"
+    assert text_docs[0].metadata["asset_origin"] == "paper.pdf"
 
     assert len(image_nodes) == 1
     node = image_nodes[0]

--- a/web/components/chat/RagSourceFigures.tsx
+++ b/web/components/chat/RagSourceFigures.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { MessageAttachment } from "@/features/chat/ChatStateAdapter";
+import type { StreamEvent } from "@/features/chat/model/protocol";
+import { apiUrl } from "@/lib/api";
+import {
+  collectRagSourceFigures,
+  type RagSourceFigure,
+} from "@/lib/rag-source-figures";
+
+function attachmentForFigure(figure: RagSourceFigure): MessageAttachment {
+  const pathName = figure.image_url.split("?")[0]?.split("/").pop() || "figure";
+  const filename = decodeURIComponent(pathName);
+  return {
+    type: "image",
+    filename,
+    url: figure.image_url,
+    mime_type: figure.mime_type || "image/png",
+    title: figure.title || filename,
+    caption: figure.image_description,
+  };
+}
+
+export function RagSourceFigures({
+  events,
+  onOpen,
+}: {
+  events?: StreamEvent[];
+  onOpen?: (attachment: MessageAttachment) => void;
+}) {
+  const { t } = useTranslation();
+  const figures = useMemo(() => collectRagSourceFigures(events), [events]);
+  if (!figures.length) return null;
+
+  return (
+    <div className="mt-3 flex flex-wrap gap-2">
+      {figures.map((figure) => {
+        const src = apiUrl(figure.image_url);
+        const label =
+          figure.title ||
+          figure.image_description ||
+          t("Retrieved figure");
+        const attachment = attachmentForFigure(figure);
+        return (
+          <button
+            key={figure.image_url}
+            type="button"
+            onClick={onOpen ? () => onOpen(attachment) : undefined}
+            className="group max-w-[200px] overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)] text-left shadow-sm transition hover:border-[var(--foreground)]/30"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={src}
+              alt={label}
+              loading="lazy"
+              className="block h-[120px] w-full bg-[var(--background)] object-contain"
+            />
+            <span className="block truncate px-2 py-1 text-[11px] text-[var(--muted-foreground)]">
+              {label}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/features/chat/messages/ChatMessageList.tsx
+++ b/web/features/chat/messages/ChatMessageList.tsx
@@ -30,6 +30,7 @@ import { useTranslation } from "react-i18next";
 import type { SelectedHistorySession } from "@/components/chat/HistorySessionPicker";
 import type { SelectedQuestionEntry } from "@/components/chat/QuestionBankPicker";
 import AssistantResponse from "@/components/common/AssistantResponse";
+import { RagSourceFigures } from "@/components/chat/RagSourceFigures";
 import {
   InlineFileCardProvider,
   mergeGeneratedFiles,
@@ -1769,6 +1770,10 @@ export const ChatMessageList = memo(function ChatMessageList({
                 masterySkips={masterySkips}
               />
             </InlineFileCardProvider>
+            <RagSourceFigures
+              events={msg.events}
+              onOpen={onPreviewAttachment}
+            />
             <GeneratedFileCards
               attachments={msg.attachments ?? []}
               events={msg.events}

--- a/web/features/chat/trace/TracePresentation.tsx
+++ b/web/features/chat/trace/TracePresentation.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import MarkdownRenderer from "@/components/common/MarkdownRenderer";
+import { apiUrl } from "@/lib/api";
 import { formatTurnDuration, getTurnDurationSeconds } from "@/lib/trace-timing";
 import { describeProviderTool, type ToolProvider } from "@/lib/trace-tools";
 import type { StreamEvent } from "@/features/chat/model/protocol";
@@ -904,12 +905,35 @@ function TraceRowBody({
       {inlineSources.length > 0 && (
         <div className="mt-1 opacity-50">
           {t("Sources")}:{" "}
-          {inlineSources.map((source, idx) => (
-            <span key={`${callId}-source-${idx}`}>
-              {idx > 0 && " · "}
-              {String(source.title || source.query || source.type || "source")}
-            </span>
-          ))}
+          {inlineSources.map((source, idx) => {
+            const nested = Array.isArray(source.images)
+              ? (source.images as Array<Record<string, unknown>>)
+              : [];
+            const thumbUrl = String(
+              source.image_url || nested[0]?.image_url || "",
+            );
+            const title = String(
+              source.title || source.query || source.type || "source",
+            );
+            return (
+              <span
+                key={`${callId}-source-${idx}`}
+                className="inline-flex items-center gap-1"
+              >
+                {idx > 0 && " · "}
+                {thumbUrl.startsWith("/api/") ||
+                thumbUrl.startsWith("http") ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={apiUrl(thumbUrl)}
+                    alt=""
+                    className="inline-block h-4 w-4 rounded-sm object-cover align-text-bottom"
+                  />
+                ) : null}
+                {title}
+              </span>
+            );
+          })}
         </div>
       )}
 

--- a/web/features/knowledge/api/client.ts
+++ b/web/features/knowledge/api/client.ts
@@ -643,6 +643,17 @@ export function knowledgeBaseFilePath(
     .join("/")}`;
 }
 
+/** Build the `/api/...` path for a LlamaIndex frozen figure (caller can pass to apiUrl()). */
+export function knowledgeBaseIndexAssetPath(
+  kbName: string,
+  assetPath: string,
+): string {
+  return `/api/knowledge-bases/${encodeURIComponent(kbName)}/index-assets/${assetPath
+    .split("/")
+    .map(encodeURIComponent)
+    .join("/")}`;
+}
+
 /** Build the `/api/...` path for extracted plain-text preview of a raw KB file. */
 export function knowledgeBaseFilePreviewTextPath(
   kbName: string,

--- a/web/features/knowledge/api/files.ts
+++ b/web/features/knowledge/api/files.ts
@@ -3,6 +3,7 @@ export {
   deleteKbFile,
   knowledgeBaseFilePath,
   knowledgeBaseFilePreviewTextPath,
+  knowledgeBaseIndexAssetPath,
   listKnowledgeBaseFiles,
   moveKbFile,
   uploadKnowledgeBaseFiles,

--- a/web/features/settings/sections/DocumentParsingSettingsSection.tsx
+++ b/web/features/settings/sections/DocumentParsingSettingsSection.tsx
@@ -168,6 +168,11 @@ export default function DocumentParsingSettingsPage() {
                   "The active engine handles all parsing. Text-only is built in and extracts plain text; markitdown is lightweight and optional; MinerU and Docling produce richer structure, while Tika provides broad remote text extraction.",
                 )}
               </p>
+              <p className="mt-2 text-[12.5px] leading-relaxed text-[var(--muted-foreground)]">
+                {t(
+                  "To show figures from textbooks in LlamaIndex RAG answers, pick MinerU, PyMuPDF4LLM, or LiteParse with image extraction, then reindex the knowledge base. Text-only leaves images out of the index.",
+                )}
+              </p>
             </header>
             <div className="flex flex-col gap-2">
               {data.available_engines.map((engine) => {

--- a/web/lib/rag-source-figures.ts
+++ b/web/lib/rag-source-figures.ts
@@ -1,0 +1,95 @@
+/** Collect RAG citation figures from turn stream events (no React). */
+
+export type RagSourceFigure = {
+  image_url: string;
+  mime_type?: string;
+  image_description?: string;
+  title?: string;
+  page?: string;
+};
+
+function isServableImageUrl(url: string): boolean {
+  return (
+    url.startsWith("/api/") ||
+    url.startsWith("http://") ||
+    url.startsWith("https://")
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function figureFromSource(
+  source: Record<string, unknown>,
+  extra?: Partial<RagSourceFigure>,
+): RagSourceFigure | null {
+  const imageUrl = String(source.image_url || extra?.image_url || "").trim();
+  if (!isServableImageUrl(imageUrl)) return null;
+  const mime = String(source.mime_type || extra?.mime_type || "").trim();
+  const description = String(
+    source.image_description || extra?.image_description || "",
+  ).trim();
+  const title = String(source.title || extra?.title || "").trim();
+  const page = String(source.page || extra?.page || "").trim();
+  return {
+    image_url: imageUrl,
+    ...(mime ? { mime_type: mime } : {}),
+    ...(description ? { image_description: description } : {}),
+    ...(title ? { title } : {}),
+    ...(page ? { page } : {}),
+  };
+}
+
+function figuresFromSource(source: unknown): RagSourceFigure[] {
+  const record = asRecord(source);
+  if (!record) return [];
+  const found: RagSourceFigure[] = [];
+  const primary = figureFromSource(record);
+  if (primary) found.push(primary);
+  const nested = record.images;
+  if (Array.isArray(nested)) {
+    for (const item of nested) {
+      const nestedRecord = asRecord(item);
+      if (!nestedRecord) continue;
+      const figure = figureFromSource(nestedRecord, {
+        title: String(record.title || ""),
+      });
+      if (figure) found.push(figure);
+    }
+  }
+  return found;
+}
+
+function sourcesFromMetadata(metadata: unknown): unknown[] {
+  const record = asRecord(metadata);
+  if (!record) return [];
+  if (Array.isArray(record.sources)) return record.sources;
+  const nested = asRecord(record.metadata);
+  if (nested && Array.isArray(nested.sources)) return nested.sources;
+  const toolMeta = asRecord(record.tool_metadata);
+  if (toolMeta && Array.isArray(toolMeta.sources)) return toolMeta.sources;
+  return [];
+}
+
+export function collectRagSourceFigures(
+  events:
+    | Array<{ type?: string; metadata?: Record<string, unknown> | null }>
+    | undefined,
+): RagSourceFigure[] {
+  if (!events?.length) return [];
+  const seen = new Set<string>();
+  const figures: RagSourceFigure[] = [];
+  for (const event of events) {
+    for (const source of sourcesFromMetadata(event.metadata)) {
+      for (const figure of figuresFromSource(source)) {
+        if (seen.has(figure.image_url)) continue;
+        seen.add(figure.image_url);
+        figures.push(figure);
+      }
+    }
+  }
+  return figures;
+}

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -2194,6 +2194,8 @@
   "Server base URL": "Server base URL",
   "Settings are written to data/user/settings/document_parsing.json.": "Settings are written to data/user/settings/document_parsing.json.",
   "The active engine handles all parsing. Text-only is built in and extracts plain text; markitdown is lightweight and optional; MinerU and Docling produce richer structure, while Tika provides broad remote text extraction.": "The active engine handles all parsing. Text-only is built in and extracts plain text; markitdown is lightweight and optional; MinerU and Docling produce richer structure, while Tika provides broad remote text extraction.",
+  "To show figures from textbooks in LlamaIndex RAG answers, pick MinerU, PyMuPDF4LLM, or LiteParse with image extraction, then reindex the knowledge base. Text-only leaves images out of the index.": "To show figures from textbooks in LlamaIndex RAG answers, pick MinerU, PyMuPDF4LLM, or LiteParse with image extraction, then reindex the knowledge base. Text-only leaves images out of the index.",
+  "Retrieved figure": "Retrieved figure",
   "Tika": "Tika",
   "0 = unlimited. Limit pages parsed per document.": "0 = unlimited. Limit pages parsed per document.",
   "Docling remote mode has no server URL configured.": "Docling remote mode has no server URL configured.",

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -2194,6 +2194,8 @@
   "Server base URL": "服务器基础 URL",
   "Settings are written to data/user/settings/document_parsing.json.": "设置会写入 data/user/settings/document_parsing.json。",
   "The active engine handles all parsing. Text-only is built in and extracts plain text; markitdown is lightweight and optional; MinerU and Docling produce richer structure, while Tika provides broad remote text extraction.": "当前引擎负责所有解析。仅文本为内置引擎，只提取纯文本；markitdown 轻量且为可选依赖；MinerU 和 Docling 可生成更丰富的结构，而 Tika 提供广泛的远程文本提取。",
+  "To show figures from textbooks in LlamaIndex RAG answers, pick MinerU, PyMuPDF4LLM, or LiteParse with image extraction, then reindex the knowledge base. Text-only leaves images out of the index.": "若要在 LlamaIndex RAG 回答中展示教材插图，请选择 MinerU、PyMuPDF4LLM 或开启图片提取的 LiteParse，然后重新索引知识库。仅文本引擎不会把图片编入索引。",
+  "Retrieved figure": "检索到的图片",
   "Tika": "Tika",
   "0 = unlimited. Limit pages parsed per document.": "0 = 不限。限制每个文档的解析页数。",
   "Docling remote mode has no server URL configured.": "Docling 远程模式尚未配置服务器 URL。",

--- a/web/tests/rag-source-figures.test.ts
+++ b/web/tests/rag-source-figures.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { collectRagSourceFigures } from "../lib/rag-source-figures";
+
+test("collectRagSourceFigures reads image_url and nested images from sources events", () => {
+  const figures = collectRagSourceFigures([
+    {
+      type: "sources",
+      metadata: {
+        sources: [
+          {
+            title: "paper.pdf",
+            content_type: "image",
+            image_url: "/api/knowledge-bases/kb/index-assets/paper.pdf/page-1.png",
+            mime_type: "image/png",
+            image_description: "NAND gate",
+          },
+          {
+            title: "paper.pdf",
+            content_type: "text",
+            images: [
+              {
+                image_url: "/api/knowledge-bases/kb/index-assets/paper.pdf/page-1.png",
+              },
+              {
+                image_url: "/api/knowledge-bases/kb/index-assets/paper.pdf/page-2.png",
+                mime_type: "image/png",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ]);
+
+  assert.equal(figures.length, 2);
+  assert.equal(
+    figures[0].image_url,
+    "/api/knowledge-bases/kb/index-assets/paper.pdf/page-1.png",
+  );
+  assert.equal(figures[0].image_description, "NAND gate");
+  assert.equal(
+    figures[1].image_url,
+    "/api/knowledge-bases/kb/index-assets/paper.pdf/page-2.png",
+  );
+});
+
+test("collectRagSourceFigures ignores filesystem paths", () => {
+  const figures = collectRagSourceFigures([
+    {
+      type: "sources",
+      metadata: {
+        sources: [
+          {
+            image_url: "/tmp/parse_cache/figure.png",
+            title: "leaked",
+          },
+          {
+            image_path: "/Users/me/kb/version-1/assets/x.png",
+            title: "also leaked",
+          },
+        ],
+      },
+    },
+  ]);
+  assert.deepEqual(figures, []);
+});


### PR DESCRIPTION
## Summary
- Freeze parser-extracted figures into the LlamaIndex index version (`version-N/assets/`) so retrieval can cite them without parse-cache paths.
- Extend LlamaIndex sources with `content_type`, `image_url`, and page-matched `images[]`; serve files via sandboxed `GET /api/knowledge-bases/{kb}/index-assets/{path}`.
- Render citation thumbnails in chat (and small thumbs in the trace), and hint in Document Parsing settings that figure RAG needs MinerU / PyMuPDF4LLM / LiteParse plus a reindex.

Fixes #1249

## Test plan
- [ ] Index a PDF with MinerU or PyMuPDF4LLM (not text-only), then query a diagram-heavy passage and confirm figures appear under the assistant message.
- [ ] Click a thumbnail and confirm it opens in the existing file viewer.
- [ ] Confirm `GET /api/knowledge-bases/{kb}/index-assets/../secret.png` is rejected.
- [ ] `pytest tests/services/rag/test_llamaindex_assets.py tests/services/rag/test_llamaindex_document_loader.py tests/api/test_knowledge_router.py::test_index_asset_route_serves_frozen_png tests/api/test_knowledge_router.py::test_index_asset_route_rejects_traversal tests/api/test_knowledge_router.py::test_index_asset_route_rejects_non_image`
- [ ] Frontend: `web/tests/rag-source-figures.test.ts`


Made with [Cursor](https://cursor.com)