### PR TITLE
fix(partners): restore generated artifact downloads (#1267)

### DIFF
--- a/deeptutor/services/path_service.py
+++ b/deeptutor/services/path_service.py
@@ -166,6 +166,16 @@ class PathService:
         if parts[:3] == ("workspace", "co-writer", "audio"):
             return candidate
 
+        # Content-workspace runtimes write chat outputs beneath their selected
+        # workspace. Partner execution scopes therefore materialize the legacy
+        # chat shapes as ``workspace/outputs/chat/<session>/<turn>/<kind>/...``.
+        if (
+            len(parts) >= 6
+            and parts[:3] == ("workspace", "outputs", "chat")
+            and parts[5] in {"exec", "media", "cli"}
+        ):
+            return candidate
+
         if (
             len(parts) >= 5
             and parts[:3] == ("workspace", "chat", "deep_solve")

--- a/deeptutor/services/workspace/service.py
+++ b/deeptutor/services/workspace/service.py
@@ -380,12 +380,17 @@ class ContentWorkspaceService:
                 raise WorkspaceError(f"The {operation} path cannot contain symbolic links.")
 
     @staticmethod
-    def _presentation_root(binding: WorkspaceBinding, *, create: bool = False) -> Path:
+    def _presentation_root(
+        binding: WorkspaceBinding,
+        *,
+        create: bool = False,
+        runtime_state_dir: Path | None = None,
+    ) -> Path:
         """Return private snapshot storage for one user-scoped workspace id."""
 
         if not re.fullmatch(r"ws_[0-9a-f]{32}", binding.workspace_id):
             raise WorkspaceError("Invalid workspace id.")
-        base = get_path_service().get_runtime_state_dir()
+        base = runtime_state_dir or get_path_service().get_runtime_state_dir()
         presentations = base / "workspace_presentations"
         root = presentations / binding.workspace_id
         if create:
@@ -769,25 +774,75 @@ class ContentWorkspaceService:
             temporary.unlink(missing_ok=True)
         return request
 
-    def resolve_published_item(
-        self, workspace_id: str, workspace_item_id: str
-    ) -> tuple[Path, WorkspaceItem]:
-        if not re.fullmatch(r"wsi_[0-9a-f]{32}", workspace_item_id):
-            raise WorkspaceError("Invalid workspace item id.")
-        binding = self.binding_by_id(workspace_id)
-        root = self._presentation_root(binding)
+    @staticmethod
+    def _binding_for_partner_scope(partner_id: str) -> tuple[WorkspaceBinding, Path]:
+        """Build a visible partner's default binding and runtime-state root."""
+        from deeptutor.multi_user.paths import get_path_service_for_scope
+        from deeptutor.services.partners.scope import partner_scope
+
+        scope = partner_scope(partner_id)
+        path_service = get_path_service_for_scope(scope)
+        workspace_root = path_service.get_workspace_dir().resolve()
+        runtime_state_dir = path_service.get_runtime_state_dir().resolve()
+        return WorkspaceBinding(
+            workspace_id=_workspace_id(scope.user_id, workspace_root),
+            root=workspace_root,
+            display_name=partner_id,
+            is_default=True,
+            locked=True,
+        ), runtime_state_dir
+
+    def _published_item_roots(self, workspace_id: str) -> list[tuple[WorkspaceBinding, Path]]:
+        """Return readable presentation roots for the current principal.
+
+        Human chats publish into the current user's own runtime state. Partner
+        chats execute in synthetic partner scopes, so their snapshots live in
+        those scopes even though the human later opens the resulting URL.
+        """
+        candidates: list[tuple[WorkspaceBinding, Path]] = []
+        try:
+            binding = self.binding_by_id(workspace_id)
+        except WorkspaceError as exc:
+            if str(exc) != "The workspace is no longer registered for this user.":
+                raise
+        else:
+            candidates.append((binding, self._presentation_root(binding)))
+
+        from deeptutor.multi_user.partner_access import visible_partners
+
+        for row in visible_partners():
+            partner_id = _safe_component(row.get("partner_id"), "")
+            if not partner_id:
+                continue
+            binding, runtime_state_dir = self._binding_for_partner_scope(partner_id)
+            if binding.workspace_id != workspace_id:
+                continue
+            candidates.append(
+                (
+                    binding,
+                    self._presentation_root(binding, runtime_state_dir=runtime_state_dir),
+                )
+            )
+        return candidates
+
+    @staticmethod
+    def _load_published_item(
+        binding: WorkspaceBinding, root: Path, workspace_item_id: str
+    ) -> tuple[Path, WorkspaceItem] | None:
         for directory in (root / "items", root / "blobs"):
             if directory.is_symlink():
                 raise WorkspaceError(
                     "The private workspace presentation path cannot contain symbolic links."
                 )
         manifest_path = root / "items" / f"{workspace_item_id}.json"
+        if not manifest_path.is_file():
+            return None
         try:
             payload = json.loads(manifest_path.read_text(encoding="utf-8"))
             item = WorkspaceItem(**payload)
         except (OSError, json.JSONDecodeError, TypeError) as exc:
             raise WorkspaceError("The presented workspace item is unavailable.") from exc
-        if item.workspace_id != workspace_id or item.workspace_item_id != workspace_item_id:
+        if item.workspace_id != binding.workspace_id or item.workspace_item_id != workspace_item_id:
             raise WorkspaceError("The workspace item manifest is invalid.")
         blob = (root / "blobs" / item.sha256).resolve()
         try:
@@ -797,6 +852,25 @@ class ContentWorkspaceService:
         if not blob.is_file():
             raise WorkspaceError("The presented workspace item is unavailable.")
         return blob, item
+
+    def resolve_published_item(
+        self, workspace_id: str, workspace_item_id: str
+    ) -> tuple[Path, WorkspaceItem]:
+        if not re.fullmatch(r"wsi_[0-9a-f]{32}", workspace_item_id):
+            raise WorkspaceError("Invalid workspace item id.")
+        candidates = self._published_item_roots(workspace_id)
+        if not candidates:
+            raise WorkspaceError("The workspace is no longer registered for this user.")
+        matches: list[tuple[Path, WorkspaceItem]] = []
+        for binding, root in candidates:
+            match = self._load_published_item(binding, root, workspace_item_id)
+            if match is not None:
+                matches.append(match)
+                if len(matches) > 1:
+                    raise WorkspaceError("The presented workspace item is unavailable.")
+        if not matches:
+            raise WorkspaceError("The presented workspace item is unavailable.")
+        return matches[0]
 
 
 _service = ContentWorkspaceService()

--- a/tests/api/test_output_files.py
+++ b/tests/api/test_output_files.py
@@ -123,7 +123,7 @@ def test_auth_disabled_reads_local_admin_output(output_app) -> None:
 
 
 def test_authenticated_user_downloads_visible_partner_output(output_app, monkeypatch) -> None:
-    relative_path = "workspace/chat/chat/session-1/code_runs/chart.png"
+    relative_path = "workspace/outputs/chat/session-1/turn-1/media/chart.png"
     alice = TokenPayload(username="alice", role="user", user_id="u_alice")
     client, admin_root, _users_root = output_app({"alice-token": alice})
 
@@ -144,6 +144,31 @@ def test_authenticated_user_downloads_visible_partner_output(output_app, monkeyp
     assert response.status_code == 200
     assert response.content.startswith(b"\x89PNG\r\n\x1a\n")
     assert response.headers["content-type"] == "image/png"
+
+
+@pytest.mark.parametrize("kind", ["exec", "media", "cli"])
+def test_workspace_output_chat_kinds_are_public(tmp_path: Path, kind: str) -> None:
+    workspace_root = tmp_path / "workspace"
+    service = PathService(workspace_root=workspace_root)
+    output = _write_output(
+        workspace_root,
+        f"workspace/outputs/chat/session-1/turn-1/{kind}/report.pdf",
+        b"generated output",
+    )
+
+    assert service.resolve_public_output_path(output) == output
+
+
+def test_arbitrary_workspace_output_file_is_not_public(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    service = PathService(workspace_root=workspace_root)
+    output = _write_output(
+        workspace_root,
+        "workspace/outputs/chat/session-1/turn-1/other/report.pdf",
+        b"private workspace file",
+    )
+
+    assert service.resolve_public_output_path(output) is None
 
 
 def test_private_suffix_is_rejected(output_app) -> None:

--- a/tests/services/workspace/test_content_workspace.py
+++ b/tests/services/workspace/test_content_workspace.py
@@ -131,6 +131,84 @@ def test_presentation_is_a_fixed_content_addressed_version(workspace_service) ->
     assert not (binding.root / "outputs" / ".deeptutor").exists()
 
 
+def test_human_resolves_a_visible_partner_presentation(
+    workspace_service,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, paths = workspace_service
+    from deeptutor.multi_user import partner_access
+    from deeptutor.multi_user import paths as multi_user_paths
+    from deeptutor.multi_user.context import get_current_user
+    from deeptutor.multi_user.paths import (
+        ensure_scope_workspace,
+        get_path_service_for_scope,
+        user_context,
+    )
+    from deeptutor.services.partners.scope import partner_user
+    from deeptutor.services.workspace import service as service_module
+
+    admin_root = tmp_path / "admin-data"
+    monkeypatch.setattr(multi_user_paths, "ADMIN_WORKSPACE_ROOT", admin_root)
+    monkeypatch.setattr(multi_user_paths, "USERS_ROOT", admin_root / "users")
+    monkeypatch.setattr(multi_user_paths, "_path_services", {})
+    monkeypatch.setattr(
+        partner_access,
+        "visible_partners",
+        lambda: [{"partner_id": "math-bot", "can_manage": True}],
+    )
+    monkeypatch.setattr(
+        service_module,
+        "get_path_service",
+        lambda: get_path_service_for_scope(get_current_user().scope),
+    )
+
+    human = CurrentUser(
+        id="u_alice",
+        username="alice",
+        role="user",
+        scope=UserScope(kind="user", user_id="u_alice", root=paths.workspace_root),
+    )
+    partner = partner_user("math-bot", name="Math Bot")
+    with user_context(partner):
+        ensure_scope_workspace(partner.scope)
+        partner_binding = service.current_binding(ensure_output=True)
+        source = partner_binding.root / "outputs" / "chat" / "s" / "t" / "exec" / "report.pdf"
+        source.parent.mkdir(parents=True)
+        source.write_bytes(b"partner report")
+        item = service.publish(partner_binding, [{"path": "outputs/chat/s/t/exec/report.pdf"}])[0]
+
+    with user_context(human):
+        blob, loaded = service.resolve_published_item(item.workspace_id, item.workspace_item_id)
+
+        assert blob.read_bytes() == b"partner report"
+        assert loaded.workspace_id == item.workspace_id
+        assert loaded.relative_path == "outputs/chat/s/t/exec/report.pdf"
+
+        monkeypatch.setattr(partner_access, "visible_partners", lambda: [])
+        with pytest.raises(WorkspaceError, match="no longer registered|unavailable"):
+            service.resolve_published_item(item.workspace_id, item.workspace_item_id)
+
+
+def test_ambiguous_presentation_roots_fail_closed(workspace_service) -> None:
+    service, _paths = workspace_service
+    binding = service.current_binding(ensure_output=True)
+    source = binding.root / "lesson.pdf"
+    source.write_bytes(b"lesson")
+    item = service.publish(binding, [{"path": "lesson.pdf"}])[0]
+    root = service._presentation_root(binding)
+    monkeypatch_targets = [(binding, root), (binding, root)]
+
+    class ServiceWithAmbiguousRoots(ContentWorkspaceService):
+        def _published_item_roots(self, workspace_id: str):
+            return monkeypatch_targets
+
+    with pytest.raises(WorkspaceError, match="presented workspace item is unavailable"):
+        ServiceWithAmbiguousRoots().resolve_published_item(
+            item.workspace_id, item.workspace_item_id
+        )
+
+
 def test_private_presentation_store_rejects_symlink_redirection(
     workspace_service, tmp_path: Path
 ) -> None:

--- a/web/components/common/InlineFileCard.tsx
+++ b/web/components/common/InlineFileCard.tsx
@@ -42,30 +42,58 @@ export function parseAttachmentHref(href?: string): string | null {
 // ---------------------------------------------------------------------------
 // Generated-file collection (shared by the provider and the message's card
 // block). Persisted ``generated`` attachments merged with artifacts streamed
-// live in ``tool_result`` events, deduped by URL.
+// live in ``tool_result`` and ``sources`` events, deduped by URL.
 // ---------------------------------------------------------------------------
+
+type WorkspaceItemMetadata = {
+  workspace_id?: string;
+  workspace_item_id?: string;
+  relative_path?: string;
+  filename?: string;
+  url?: string;
+  mime_type?: string;
+  size_bytes?: number;
+  sha256?: string;
+  title?: string;
+  caption?: string;
+  generated?: boolean;
+};
+
+function workspaceAttachment(item: WorkspaceItemMetadata): MessageAttachment | null {
+  if (!item?.url || !item.workspace_item_id) return null;
+  return {
+    type: item.mime_type?.startsWith("image/") ? "image" : "document",
+    filename: item.filename,
+    url: item.url,
+    mime_type: item.mime_type,
+    size_bytes: item.size_bytes,
+    generated: item.generated ?? true,
+    origin: "workspace",
+    workspace_id: item.workspace_id,
+    workspace_item_id: item.workspace_item_id,
+    relative_path: item.relative_path,
+    sha256: item.sha256,
+    title: item.title,
+    caption: item.caption,
+  };
+}
 
 export function extractStreamedArtifacts(
   events?: StreamEvent[],
 ): MessageAttachment[] {
   const out: MessageAttachment[] = [];
+  const seen = new Set<string>();
+  const push = (attachment: MessageAttachment) => {
+    if (attachment.url && seen.has(attachment.url)) return;
+    if (attachment.url) seen.add(attachment.url);
+    out.push(attachment);
+  };
+
   for (const ev of events ?? []) {
-    if (ev.type !== "tool_result") continue;
+    if (ev.type !== "tool_result" && ev.type !== "sources") continue;
     const meta = (ev.metadata ?? {}) as {
       tool_metadata?: {
-        workspace_items?: Array<{
-          workspace_id?: string;
-          workspace_item_id?: string;
-          relative_path?: string;
-          filename?: string;
-          url?: string;
-          mime_type?: string;
-          size_bytes?: number;
-          sha256?: string;
-          title?: string;
-          caption?: string;
-          generated?: boolean;
-        }>;
+        workspace_items?: WorkspaceItemMetadata[];
         artifacts?: Array<{
           filename?: string;
           url?: string;
@@ -73,30 +101,27 @@ export function extractStreamedArtifacts(
           size_bytes?: number;
         }>;
       };
+      sources?: Array<WorkspaceItemMetadata & { type?: string }>;
     };
+
+    if (ev.type === "sources") {
+      for (const source of meta.sources ?? []) {
+        if (source?.type !== "workspace_item") continue;
+        const attachment = workspaceAttachment(source);
+        if (attachment) push(attachment);
+      }
+      continue;
+    }
+
     const workspaceItems = meta.tool_metadata?.workspace_items ?? [];
     for (const item of workspaceItems) {
-      if (!item?.url || !item.workspace_item_id) continue;
-      out.push({
-        type: item.mime_type?.startsWith("image/") ? "image" : "document",
-        filename: item.filename,
-        url: item.url,
-        mime_type: item.mime_type,
-        size_bytes: item.size_bytes,
-        generated: item.generated ?? true,
-        origin: "workspace",
-        workspace_id: item.workspace_id,
-        workspace_item_id: item.workspace_item_id,
-        relative_path: item.relative_path,
-        sha256: item.sha256,
-        title: item.title,
-        caption: item.caption,
-      });
+      const attachment = workspaceAttachment(item);
+      if (attachment) push(attachment);
     }
     if (workspaceItems.length) continue;
     for (const a of meta.tool_metadata?.artifacts ?? []) {
       if (!a?.url) continue;
-      out.push({
+      push({
         type: a.mime_type?.startsWith("image/") ? "image" : "document",
         filename: a.filename,
         url: a.url,

--- a/web/tests/workspace-present.test.ts
+++ b/web/tests/workspace-present.test.ts
@@ -118,6 +118,29 @@ test('streamed workspace items win over legacy artifacts and dedupe by URL', () 
   assert.equal(merged.length, 1)
 })
 
+test('workspace items streamed as sources become generated attachments', () => {
+  const item = {
+    type: 'workspace_item',
+    workspace_id: 'ws_partner',
+    workspace_item_id: 'wsi_partner',
+    relative_path: 'outputs/chat/s/t/exec/report.pdf',
+    filename: 'report.pdf',
+    url: '/files/workspace-items/ws_partner/wsi_partner',
+    mime_type: 'application/pdf',
+  }
+  const sources = {
+    type: 'sources' as const,
+    metadata: {
+      sources: [item],
+    },
+  }
+
+  const extracted = extractStreamedArtifacts([sources] as never)
+  assert.equal(extracted.length, 1)
+  assert.equal(extracted[0]?.origin, 'workspace')
+  assert.equal(extracted[0]?.workspace_item_id, 'wsi_partner')
+})
+
 test('persisted workspace presentation metadata survives session hydration', () => {
   const hydrated = hydrateMessageAttachments([
     {


### PR DESCRIPTION
## Summary
- resolve published workspace snapshots from only the caller-visible partner scopes, using each partner scope runtime store and failing closed on ambiguous matches
- allow only the generated content-workspace chat output shapes under `workspace/outputs/chat/.../{exec,media,cli}` through `/files/outputs`
- extract workspace item attachments from both `tool_result` and `sources` stream events, with URL deduplication
- add backend path, service, API, ambiguity, visibility, and frontend regressions

## Testing
- `python -m pytest tests/services/workspace/test_content_workspace.py tests/api/test_output_files.py -q` (41 passed)
- `python -m pytest tests/services/workspace/test_content_workspace.py tests/api/test_output_files.py tests/api/test_workspace_router.py tests/services/session/test_artifact_attachments.py tests/tools/test_office_artifact_execution.py -q` (66 passed)
- `npm run typecheck`
- `npm run test:node` (1100 passed)
- `npx eslint components/common/InlineFileCard.tsx tests/workspace-present.test.ts`
- `ruff format --check` and `ruff check` on touched Python files
- `git diff --check`

## CI note
The full-repository failures are unchanged baseline issues outside this diff: `ruff format --check` reports two untouched builtin `SKILL.md` files, and the web route-budget gate reports `/`, `/co-writer`, and `/co-writer/[docId]`. The remote web job otherwise passes contracts, architecture, typecheck, node tests, unit tests, lint, i18n, and production build.

Fixes #1267