### PR TITLE
feat(llm): allow any model reply language independently of the UI locale

### DIFF
--- a/deeptutor/agents/loop/pipeline.py
+++ b/deeptutor/agents/loop/pipeline.py
@@ -82,7 +82,7 @@ from deeptutor.services.llm import (
     supports_tools,  # noqa: F401  (re-exported for tests)
 )
 from deeptutor.services.llm.context_window import resolve_effective_context_window
-from deeptutor.services.prompt import get_prompt_manager
+from deeptutor.services.prompt import get_prompt_manager, prompt_locale
 from deeptutor.services.prompt.lookup import prompt_text as _prompt_text
 from deeptutor.tools.builtin import PARTNER_BUILTIN_TOOL_NAMES
 
@@ -232,7 +232,9 @@ class AgenticLoopPipeline:
         event_stage: str = "responding",
         emit_result: bool = True,
     ) -> None:
-        self.language = "zh" if language.lower().startswith("zh") else "en"
+        requested = (language or "en").strip() or "en"
+        self.output_language = requested
+        self.language = prompt_locale(requested)
         self.llm_config = get_llm_config()
         self.binding = getattr(self.llm_config, "binding", None) or "openai"
         self.model = getattr(self.llm_config, "model", None)
@@ -293,7 +295,7 @@ class AgenticLoopPipeline:
         self._prompts: dict[str, Any] = self._load_prompt_pack()
         self._prompt_assembler = self.prompt_assembler_class(
             prompts=self._prompts,
-            language=self.language,
+            language=self.output_language,
         )
         self._client_config = LLMClientConfig(
             binding=self.binding,

--- a/deeptutor/agents/loop/prompt_blocks.py
+++ b/deeptutor/agents/loop/prompt_blocks.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from deeptutor.capabilities.protocol import PromptBlock
 from deeptutor.core.context import UnifiedContext
-from deeptutor.services.prompt.language import append_language_directive
+from deeptutor.services.prompt.language import append_language_directive, prompt_locale
 
 
 class LoopPromptAssembler:
@@ -26,7 +26,8 @@ class LoopPromptAssembler:
 
     def __init__(self, *, prompts: dict[str, Any], language: str) -> None:
         self.prompts = prompts
-        self.language = "zh" if language.lower().startswith("zh") else "en"
+        self.output_language = language or "en"
+        self.language = prompt_locale(self.output_language)
 
     def system_prompt(
         self,
@@ -68,7 +69,9 @@ class LoopPromptAssembler:
         # different language mid-conversation, and the strict directive plus
         # the runtime policy above it otherwise make the model refuse them.
         # Books, quizzes and research keep the strict form — nobody is asking.
-        return append_language_directive(joined, self.language, allow_user_override=True)
+        # The reply language rides in verbatim (any BCP-47 code); the directive
+        # itself still normalizes zh/en for the prompt-file locale.
+        return append_language_directive(joined, self.output_language, allow_user_override=True)
 
     def blocks(
         self,

--- a/deeptutor/api/routers/settings.py
+++ b/deeptutor/api/routers/settings.py
@@ -16,7 +16,7 @@ from typing import Any, List, Literal, Optional
 
 from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +59,7 @@ from deeptutor.services.settings.interface_settings import (
     atomic_update,
     resolve_languages,
     sanitize_enabled_tools,
+    try_parse_response_language,
 )
 from deeptutor.services.settings.interface_settings import (
     get_enabled_optional_tools as _get_enabled_optional_tools,
@@ -134,15 +135,29 @@ class SidebarNavOrder(BaseModel):
     learnResearch: List[str]
 
 
+def _require_response_language(value: Any) -> str:
+    parsed = try_parse_response_language(value)
+    if parsed is None:
+        raise ValueError("must be a BCP-47 language code (for example ja, pl, zh-tw)")
+    return parsed
+
+
 class UISettings(BaseModel):
     theme: Literal["light", "dark", "glass", "snow"] = "snow"
     language: Literal["zh", "en"] = "en"
-    response_language: Literal["zh", "en"] = "en"
+    response_language: str = "en"
     sidebar_description: Optional[str] = None
     sidebar_nav_order: Optional[SidebarNavOrder] = None
     code_block_theme: Optional[str] = None
     code_block_show_line_numbers: Optional[bool] = None
     code_block_wrap_long_lines: Optional[bool] = None
+
+    @field_validator("response_language", mode="before")
+    @classmethod
+    def _normalize_response_language(cls, value: Any) -> str:
+        if value is None or value == "":
+            return "en"
+        return _require_response_language(value)
 
 
 class UISettingsUpdate(BaseModel):
@@ -155,17 +170,23 @@ class UISettingsUpdate(BaseModel):
     from the frontend.
     """
 
-    # Same Literal domains as UISettings — a None default keeps them optional
-    # for exclude_unset partial merges, but an explicit value is still validated
-    # so PUT /ui cannot persist a theme/language the app can't render.
+    # Theme and interface language stay closed enumerations the app can render.
+    # Reply language is open-ended: listed codes plus any compact BCP-47 tag.
     theme: Literal["light", "dark", "glass", "snow"] | None = None
     language: Literal["zh", "en"] | None = None
-    response_language: Literal["zh", "en"] | None = None
+    response_language: str | None = None
     sidebar_description: str | None = None
     sidebar_nav_order: SidebarNavOrder | None = None
     code_block_theme: str | None = None
     code_block_show_line_numbers: bool | None = None
     code_block_wrap_long_lines: bool | None = None
+
+    @field_validator("response_language", mode="before")
+    @classmethod
+    def _normalize_response_language(cls, value: Any) -> str | None:
+        if value is None:
+            return None
+        return _require_response_language(value)
 
 
 class VoiceAutoplayUpdate(BaseModel):

--- a/deeptutor/capabilities/partner_authoring/tools.py
+++ b/deeptutor/capabilities/partner_authoring/tools.py
@@ -38,7 +38,7 @@ class ProposePartnerTool(BaseTool):
                     },
                     "language": {
                         "type": "string",
-                        "description": "Preferred response language, normally en or zh.",
+                        "description": "Preferred response language as a BCP-47 code (en, zh, ja, pl, …).",
                     },
                     "emoji": {"type": "string", "description": "One representative emoji."},
                     "color": {

--- a/deeptutor/capabilities/setup/apply.py
+++ b/deeptutor/capabilities/setup/apply.py
@@ -133,19 +133,24 @@ def _diff_neighbours(
 
 def _choice_error(spec: SettingSpec, value: str) -> str | None:
     choices = spec.choices()
+    match = next((choice for choice in choices if choice.value == value), None)
+    if match is not None and not match.available:
+        return (
+            f"'{match.label}' is listed but not usable yet: "
+            f"{match.description or 'it needs setup first'}"
+        )
+    if spec.open_ended:
+        return None
     if not choices:
         return (
             f"'{spec.label}' has no configured options yet, so there is nothing to select. "
             "It has to be set up in Settings first."
         )
-    match = next((choice for choice in choices if choice.value == value), None)
     if match is None:
         offered = ", ".join(choice.value for choice in choices)
         return (
             f"'{value}' is not one of the available options for {spec.label}. Options: {offered}."
         )
-    if not match.available:
-        return f"'{match.label}' is listed but not usable yet: {match.description or 'it needs setup first'}"
     return None
 
 

--- a/deeptutor/core/context.py
+++ b/deeptutor/core/context.py
@@ -96,7 +96,7 @@ class UnifiedContext:
         knowledge_bases: KB names to use for RAG.
         attachments: Images / files sent with the message.
         config_overrides: Per-request config tweaks (e.g. temperature).
-        language: UI / response language ("en" | "zh").
+        language: Reader-facing reply language (BCP-47 code, e.g. "en", "zh", "ja").
         memory_context: Memory snapshot text injected into the system prompt.
         persona_context: Selected persona's instructions, eagerly injected
             into the system prompt (a persona must shape the voice from the

--- a/deeptutor/services/config/settings_spec.py
+++ b/deeptutor/services/config/settings_spec.py
@@ -106,6 +106,11 @@ class SettingSpec:
     # Optional extra validation beyond "the value is one of ``choices``".
     # Returns an error message, or None when the value is acceptable.
     validate: Callable[[str], str | None] | None = None
+    # When True, a value that is not in ``choices`` may still be written if
+    # ``validate`` accepts it (reply language: listed endonyms plus any
+    # compact BCP-47 code). Secrets still cannot land here: validate must
+    # refuse free-form text.
+    open_ended: bool = False
     # Pre-commit connectivity check against a candidate that is not on disk.
     probe: Callable[[str], Awaitable[ProbeResult]] | None = None
     # Human-readable consequence, surfaced verbatim by the agent alongside the
@@ -126,8 +131,8 @@ class SettingSpec:
 # --------------------------------------------------------------------------
 
 _LANGUAGE_CHOICES: tuple[tuple[str, str, str], ...] = (
-    ("en", "English", "Interface and replies in English."),
-    ("zh", "简体中文", "Interface and replies in Simplified Chinese."),
+    ("en", "English", "Interface in English."),
+    ("zh", "简体中文", "Interface in Simplified Chinese."),
 )
 
 _THEME_CHOICES: tuple[tuple[str, str, str], ...] = (
@@ -171,6 +176,46 @@ def _static_choices(
     return _choices
 
 
+def _response_language_choices(
+    current: Callable[[], str],
+) -> Callable[[], tuple[SettingChoice, ...]]:
+    def _choices() -> tuple[SettingChoice, ...]:
+        from deeptutor.services.prompt.language import (
+            RESPONSE_LANGUAGE_CHOICES,
+            language_label,
+        )
+
+        active = current()
+        return tuple(
+            SettingChoice(
+                value=code,
+                label=language_label(code),
+                description=f"Replies in {language_label(code)}.",
+                current=code == active,
+            )
+            for code in RESPONSE_LANGUAGE_CHOICES
+        )
+
+    return _choices
+
+
+def _validate_response_language(value: str) -> str | None:
+    from deeptutor.services.settings.interface_settings import try_parse_response_language
+
+    if try_parse_response_language(value) is None:
+        return "Reply language must be a BCP-47 code such as en, ja, or pl."
+    return None
+
+
+def _write_response_language(value: str) -> None:
+    from deeptutor.services.settings.interface_settings import (
+        normalize_response_language,
+        set_ui_setting,
+    )
+
+    set_ui_setting("response_language", normalize_response_language(value))
+
+
 def _interface_specs() -> list[SettingSpec]:
     language_read = _read_ui("language", "en")
     response_read = _read_ui("response_language", "en")
@@ -193,10 +238,15 @@ def _interface_specs() -> list[SettingSpec]:
             scope="personal",
             effect="instant",
             label="Reply language",
-            summary="Language the assistant writes its answers in.",
+            summary=(
+                "Language the assistant writes its answers in. Listed options plus "
+                "any compact language code (for example pl, ar)."
+            ),
             read=response_read,
-            choices=_static_choices(_LANGUAGE_CHOICES, response_read),
-            write=_write_ui("response_language"),
+            choices=_response_language_choices(response_read),
+            write=_write_response_language,
+            validate=_validate_response_language,
+            open_ended=True,
             effect_detail="Applies from the next turn onwards.",
         ),
         SettingSpec(

--- a/deeptutor/services/prompt/__init__.py
+++ b/deeptutor/services/prompt/__init__.py
@@ -18,22 +18,28 @@ Usage:
 """
 
 from .language import (
+    RESPONSE_LANGUAGE_CHOICES,
     append_language_directive,
     is_chinese,
+    is_response_language_code,
     language_directive,
     language_label,
     normalize_language,
+    prompt_locale,
 )
 from .lookup import prompt_text
 from .manager import PromptManager, get_prompt_manager
 
 __all__ = [
     "PromptManager",
+    "RESPONSE_LANGUAGE_CHOICES",
     "append_language_directive",
     "get_prompt_manager",
     "is_chinese",
+    "is_response_language_code",
     "language_directive",
     "language_label",
     "normalize_language",
+    "prompt_locale",
     "prompt_text",
 ]

--- a/deeptutor/services/prompt/language.py
+++ b/deeptutor/services/prompt/language.py
@@ -7,6 +7,8 @@ utilities.
 
 from __future__ import annotations
 
+import re
+
 _LANGUAGE_LABELS: dict[str, str] = {
     "zh": "中文（简体）",
     "zh-cn": "中文（简体）",
@@ -22,9 +24,44 @@ _LANGUAGE_LABELS: dict[str, str] = {
     "it": "Italiano",
 }
 
+# Picker order for reply language. ``zh-cn`` is an alias of ``zh``, not a
+# separate option. Any other BCP-47-shaped code is still accepted at write time.
+RESPONSE_LANGUAGE_CHOICES: tuple[str, ...] = (
+    "en",
+    "zh",
+    "zh-tw",
+    "ja",
+    "ko",
+    "es",
+    "fr",
+    "de",
+    "ru",
+    "pt",
+    "it",
+)
+
+_RESPONSE_LANGUAGE_CODE_RE = re.compile(r"^[a-z]{2,3}(-[a-z0-9]{2,8}){0,2}$")
+_RESPONSE_LANGUAGE_CODE_MAX_LEN = 16
+
+
+def is_response_language_code(language: str | None) -> bool:
+    """True for a compact BCP-47-like code the reply-language setting can store."""
+    if not isinstance(language, str):
+        return False
+    code = language.strip().lower()
+    if not code or len(code) > _RESPONSE_LANGUAGE_CODE_MAX_LEN:
+        return False
+    return _RESPONSE_LANGUAGE_CODE_RE.fullmatch(code) is not None
+
 
 def normalize_language(language: str | None) -> str:
     return (language or "en").strip().lower() or "en"
+
+
+def prompt_locale(language: str | None) -> str:
+    """Return the prompt-file locale (en/zh). Other codes reuse English YAML."""
+    code = normalize_language(language)
+    return "zh" if code.startswith("zh") else "en"
 
 
 def is_chinese(language: str | None) -> bool:
@@ -114,9 +151,12 @@ def append_language_directive(
 
 
 __all__ = [
+    "RESPONSE_LANGUAGE_CHOICES",
     "append_language_directive",
     "is_chinese",
+    "is_response_language_code",
     "language_directive",
     "language_label",
     "normalize_language",
+    "prompt_locale",
 ]

--- a/deeptutor/services/session/turns/request_preparer.py
+++ b/deeptutor/services/session/turns/request_preparer.py
@@ -98,12 +98,16 @@ class TurnRequestPreparer:
             {key: value for key, value in payload.items() if key != "type"}
         ).to_payload()
         persona_explicit = "persona" in payload
-        if not payload.get("language"):
-            from deeptutor.services.settings.interface_settings import (
-                get_response_language,
-            )
+        from deeptutor.services.settings.interface_settings import (
+            get_response_language,
+        )
 
-            payload = {**payload, "language": get_response_language(default="en")}
+        # Account reply language wins over a stale client default (the web
+        # used to send "en" even after the user picked Japanese).
+        payload = {
+            **payload,
+            "language": get_response_language(default=str(payload.get("language") or "en")),
+        }
         raw_config = dict(payload.get("config", {}) or {})
         per_turn_auto_route = payload.get("auto_route")
         if per_turn_auto_route is None:

--- a/deeptutor/services/settings/interface_settings.py
+++ b/deeptutor/services/settings/interface_settings.py
@@ -53,26 +53,57 @@ def _interface_settings_file():
     return get_path_service().get_settings_file("interface")
 
 
-def _normalize_language(language: Any, default: str = "en") -> str:
-    """
-    Normalize language codes:
-    - en/english -> en
-    - zh/chinese/cn -> zh
-    """
-    if language is None or language == "":
-        language = default
+def _parse_ui_language(language: Any) -> str | None:
+    if not isinstance(language, str):
+        return None
+    s = language.lower().strip()
+    if s in {"en", "english"}:
+        return "en"
+    if s in {"zh", "chinese", "cn"}:
+        return "zh"
+    return None
 
-    if isinstance(language, str):
-        s = language.lower().strip()
-        if s in {"en", "english"}:
-            return "en"
-        if s in {"zh", "chinese", "cn"}:
-            return "zh"
 
-    # Fall back to default
-    if isinstance(default, str):
-        return _normalize_language(default, "en")
-    return "en"
+def normalize_ui_language(language: Any, default: str = "en") -> str:
+    """Collapse the interface locale to the two shipped UI catalogs (en/zh)."""
+    parsed = _parse_ui_language(language)
+    if parsed is not None:
+        return parsed
+    fallback = _parse_ui_language(default)
+    return fallback if fallback is not None else "en"
+
+
+def try_parse_response_language(language: Any) -> str | None:
+    """Return a stored reply-language code, or None when the value is unusable.
+
+    Accepts the historical en/zh aliases plus any compact BCP-47-like code
+    (``ja``, ``pl``, ``zh-tw``). Junk, blank and non-strings are None so the
+    caller can inherit a default instead of inventing one here.
+    """
+    if not isinstance(language, str):
+        return None
+    s = language.lower().strip()
+    if not s:
+        return None
+    ui = _parse_ui_language(s)
+    if ui is not None:
+        return ui
+    from deeptutor.services.prompt.language import is_response_language_code
+
+    return s if is_response_language_code(s) else None
+
+
+def normalize_response_language(language: Any, default: str = "en") -> str:
+    """Normalize the reader-facing model output language."""
+    parsed = try_parse_response_language(language)
+    if parsed is not None:
+        return parsed
+    fallback = try_parse_response_language(default)
+    return fallback if fallback is not None else "en"
+
+
+# Historical name used when UI and reply language were the same field.
+_normalize_language = normalize_ui_language
 
 
 def resolve_languages(saved: Mapping[str, Any]) -> dict[str, str]:
@@ -86,14 +117,14 @@ def resolve_languages(saved: Mapping[str, Any]) -> dict[str, str]:
     own superset of defaults on top) go through this one function so they can
     never disagree about what a legacy file means.
 
-    ``_normalize_language`` already falls back to its ``default`` for a value
-    that is missing, blank or unrecognized, so absence, ``null`` and junk all
-    land on the interface language without a separate key-presence check.
+    ``normalize_response_language`` already falls back to its ``default`` for a
+    value that is missing, blank or unrecognized, so absence, ``null`` and junk
+    all land on the interface language without a separate key-presence check.
     """
-    language = _normalize_language(saved.get("language"), DEFAULT_UI_SETTINGS["language"])
+    language = normalize_ui_language(saved.get("language"), DEFAULT_UI_SETTINGS["language"])
     return {
         "language": language,
-        "response_language": _normalize_language(saved.get("response_language"), language),
+        "response_language": normalize_response_language(saved.get("response_language"), language),
     }
 
 
@@ -237,10 +268,10 @@ def get_ui_language(default: str = "en") -> str:
     3) 'en'
     """
     settings = get_ui_settings()
-    return _normalize_language(settings.get("language"), default)
+    return normalize_ui_language(settings.get("language"), default)
 
 
 def get_response_language(default: str = "en") -> str:
     """Get the preferred reader-facing model output language."""
     settings = get_ui_settings()
-    return _normalize_language(settings.get("response_language"), default)
+    return normalize_response_language(settings.get("response_language"), default)

--- a/tests/agents/chat/test_language_prompts.py
+++ b/tests/agents/chat/test_language_prompts.py
@@ -52,6 +52,46 @@ def test_agentic_chat_final_prompt_uses_selected_language(
     assert "You are DeepTutor" in en_prompt
 
 
+def test_agentic_chat_prompt_keeps_japanese_as_reply_language(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeRegistry:
+        def build_prompt_text(self, *_args, **_kwargs) -> str:
+            return "- tool"
+
+    monkeypatch.setattr(
+        "deeptutor.agents.loop.pipeline.get_tool_registry",
+        lambda: FakeRegistry(),
+    )
+
+    from deeptutor.core.context import UnifiedContext
+
+    ctx = UnifiedContext()
+    ja_prompt = AgenticChatPipeline(language="ja")._build_system_prompt([], ctx)
+
+    # The saved reply language reaches the directive verbatim instead of
+    # collapsing to English, while the en/zh prompt pack is still selected by
+    # the locale derived from it (English here, since there is no "ja" pack).
+    assert "Write ALL reader-facing text strictly in 日本語" in ja_prompt
+    assert "Write ALL reader-facing text (titles, prose" not in ja_prompt
+    assert "You are DeepTutor" in ja_prompt
+
+
+def test_chat_assembler_keeps_requested_reply_language_for_directive() -> None:
+    from deeptutor.capabilities.protocol import PromptBlock
+
+    assembler = ChatPromptAssembler(
+        prompts={"general": "You are DeepTutor"},
+        language="ja",
+    )
+
+    prompt = assembler.render([PromptBlock("general", "You are DeepTutor")])
+
+    assert "Write ALL reader-facing text strictly in 日本語" in prompt
+    assert "请严格使用中文" not in prompt
+    assert "Write ALL reader-facing text (titles, prose" not in prompt
+
+
 def test_mastery_plugin_system_prompt_uses_localized_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/api/test_settings_router.py
+++ b/tests/api/test_settings_router.py
@@ -74,6 +74,30 @@ async def test_ui_languages_are_persisted_independently(
     assert response["response_language"] == "zh"
 
 
+@pytest.mark.asyncio
+async def test_ui_response_language_accepts_any_compact_code(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    settings_file = tmp_path / "interface.json"
+    monkeypatch.setattr(settings_router, "_settings_file", lambda: settings_file)
+
+    response = await settings_router.update_ui_settings(
+        settings_router.UISettingsUpdate(theme="snow", language="en", response_language="JA")
+    )
+
+    assert response["language"] == "en"
+    assert response["response_language"] == "ja"
+    stored = json.loads(settings_file.read_text(encoding="utf-8"))
+    assert stored["response_language"] == "ja"
+
+
+def test_ui_response_language_rejects_free_form_text() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        settings_router.UISettingsUpdate(response_language="not a language")
+
+
 class _FakeEmbeddingAdapter:
     def __init__(self, config: dict[str, Any]):
         self.config = config

--- a/tests/capabilities/test_setup_capability.py
+++ b/tests/capabilities/test_setup_capability.py
@@ -181,6 +181,32 @@ async def test_apply_rejects_a_value_outside_the_offered_choices(
 
 
 @pytest.mark.asyncio
+async def test_apply_accepts_an_unlisted_reply_language(
+    isolated_settings: Path,
+) -> None:
+    from deeptutor.services.settings.interface_settings import get_response_language
+
+    outcome = await apply_setting("interface.response_language", "pl")
+
+    assert outcome.ok
+    assert outcome.value == "pl"
+    assert get_response_language() == "pl"
+
+
+@pytest.mark.asyncio
+async def test_apply_rejects_a_free_form_reply_language(
+    isolated_settings: Path,
+) -> None:
+    from deeptutor.services.settings.interface_settings import get_response_language
+
+    outcome = await apply_setting("interface.response_language", "klingon")
+
+    assert not outcome.ok
+    assert "BCP-47" in outcome.error
+    assert get_response_language() == "en"
+
+
+@pytest.mark.asyncio
 async def test_apply_rejects_an_unknown_key(isolated_settings: Path) -> None:
     outcome = await apply_setting("nope.nope", "x")
 

--- a/tests/services/test_interface_settings.py
+++ b/tests/services/test_interface_settings.py
@@ -1,0 +1,90 @@
+"""Reply language is independent of the two UI locales."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from deeptutor.services.settings.interface_settings import (
+    get_response_language,
+    get_ui_language,
+    get_ui_settings,
+    normalize_response_language,
+    normalize_ui_language,
+    resolve_languages,
+    try_parse_response_language,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("en", "en"),
+        ("english", "en"),
+        ("zh", "zh"),
+        ("Chinese", "zh"),
+        ("ja", "ja"),
+        ("JA", "ja"),
+        ("pl", "pl"),
+        ("zh-tw", "zh-tw"),
+        ("pt-BR", "pt-br"),
+        ("ar", "ar"),
+    ],
+)
+def test_response_language_codes_are_kept(value: str, expected: str) -> None:
+    assert try_parse_response_language(value) == expected
+    assert normalize_response_language(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value", ["", None, "klingon", "en_US", "toolongcode-xx", "sk-arbitrary-key"]
+)
+def test_unusable_response_language_falls_back(value: object) -> None:
+    assert try_parse_response_language(value) is None
+    assert normalize_response_language(value, "ja") == "ja"
+    assert normalize_response_language(value, "not-a-code") == "en"
+
+
+def test_ui_language_still_collapses_to_en_or_zh() -> None:
+    assert normalize_ui_language("ja") == "en"
+    assert normalize_ui_language("pl", "zh") == "zh"
+    assert normalize_ui_language("zh") == "zh"
+
+
+def test_legacy_file_inherits_interface_language_for_replies(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    settings_file = tmp_path / "interface.json"
+    settings_file.write_text('{"theme": "snow", "language": "zh"}', encoding="utf-8")
+    monkeypatch.setattr(
+        "deeptutor.services.settings.interface_settings._interface_settings_file",
+        lambda: settings_file,
+    )
+
+    assert resolve_languages(json.loads(settings_file.read_text(encoding="utf-8"))) == {
+        "language": "zh",
+        "response_language": "zh",
+    }
+    assert get_ui_language() == "zh"
+    assert get_response_language() == "zh"
+
+
+def test_stored_japanese_replies_survive_english_ui(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    settings_file = tmp_path / "interface.json"
+    settings_file.write_text(
+        '{"theme": "snow", "language": "en", "response_language": "ja"}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "deeptutor.services.settings.interface_settings._interface_settings_file",
+        lambda: settings_file,
+    )
+
+    settings = get_ui_settings()
+    assert settings["language"] == "en"
+    assert settings["response_language"] == "ja"
+    assert get_response_language() == "ja"


### PR DESCRIPTION
## Summary

Decouple the **model reply language** from the UI locale, and allow **any** language (not just en/zh):

- `UISettings` gains `response_language`. `settings_spec` models it as an open-ended, strictly validated setting with a curated pick-list (en, zh, zh-tw, ja, ko, es, fr, de, ru, pt, it) plus full compact-BCP-47 validation — free-form text is rejected so junk or secrets can't land in the setting.
- `services/prompt/language.py` adds `RESPONSE_LANGUAGE_CHOICES`, `is_response_language_code`, and splits `normalize_ui_language` from response-language normalization. UI locale still resolves to en/zh so prompt packages keep loading their existing en/zh YAML — but the chat **reply directive** ("answer in X") is now driven by the requested reply language, not the derived locale. Non-en/zh codes (pl, ar, …) no longer silently degrade to English answers.
- `request_preparer` prefers the account's stored reply language over a stale client-sent `en`, mirroring how other account preferences win over the wire.
- Ported onto the v1.6.5-reconciled layout (`prompt_blocks`/`pipeline` now live under `agents/loop/`).

## Relation to #1179

[#1179](https://github.com/HKUDS/DeepTutor/pull/1179) (KryptonGao) targets the same feature but sits on the pre-reconcile `dev` (base before `42fab3cf`) and is currently `CONFLICTING`/`DIRTY`. This PR is that feature re-based and adapted to the current `dev` layout (15 files, Python-only, tests green locally against pristine `42fab3cf`). If the maintainers prefer to refresh #1179 instead, say the word and I'll close this one — flagging both so whoever merges first wins cleanly.

## Test plan

- [x] `pytest tests/agents/chat/test_language_prompts.py tests/api/test_settings_router.py tests/capabilities/test_setup_capability.py tests/services/test_interface_settings.py tests/services/session/test_regenerate.py tests/services/session/test_capability_routing.py tests/services/test_parse_language.py tests/services/test_prompt_manager.py` → **193 passed** on this branch vs **168 passed** on pristine `42fab3cf` (same 8 files). The single failure on both trees is `test_concurrent_preference_writes_do_not_lose_updates` — a 12-thread `interface.json` write race that fails deterministically on the unmodified baseline in this Windows sandbox (pre-existing, unrelated). All 25 new tests pass.
- [x] `uvx ruff@0.16.0 check deeptutor tests` + `format --check` clean on changed files (repo-wide drift is only the pre-existing SKILL.md pair)
- [ ] Real LLM end-to-end: set reply language to Japanese and confirm the answer actually comes back in Japanese (needs a live model key)
- [ ] Web Appearance picker for `response_language` — intentionally out of scope for this Python-only port; #1179 carried a web selector if that's the preferred surface

**Collision update (2026-09-11):** [#1345](https://github.com/HKUDS/DeepTutor/pull/1345) (opened 09-09) also addresses #1176, from the settings/web side: a fixed 13-language picker enum, no model-side wiring. The two are complementary — this PR's open-ended BCP-47 storage can adopt #1345's list as the picker's recommended choices, while the `agents/loop` reply-directive and `request_preparer` wiring here stays exclusive to #1270. Both touch `services/prompt/language.py`, so a maintainer call is needed on the storage shape; coordination note posted [on #1345](https://github.com/HKUDS/DeepTutor/pull/1345#issuecomment-5618171589). Happy to rebase this onto #1345 if that order is preferred.

Fixes #1176

