### PR TITLE
feat(subagent): add ACP client backend (Part of #1028)

### DIFF
--- a/deeptutor/services/subagent/acp.py
+++ b/deeptutor/services/subagent/acp.py
@@ -1,0 +1,773 @@
+"""ACP backend — drive any Agent Client Protocol (ACP) host as a subagent.
+
+Part of #1028 (stage 1): DeepTutor plays the *client* side of the Agent Client
+Protocol — a JSON-RPC 2.0 dialect over newline-delimited stdio — against a
+spawnable ACP *host* process. The host command is not hard-coded (ACP is a
+transport standard, not one binary): it comes from the ``DEEPTUTOR_ACP_COMMAND``
+environment variable (a JSON array of argv, or a shell-quoted string), or from
+the per-backend ``BackendConfig.extra_args`` when the env var is unset — so the
+same backend can drive ``claude --acp``-style agent CLIs, ``acp-remote``
+bridges, or any future ACP host, once those binaries exist on the machine.
+
+Wire transcript this backend drives (client → host unless noted):
+
+1. client ``initialize`` → host replies with the negotiated ``protocolVersion``
+   and its capabilities (some hosts notify ``initialize_result`` instead; both
+   shapes are accepted).
+2. client ``session/new`` (fresh) or ``session/load`` with ``session_id``
+   (resume) → the host returns the session id in the JSON-RPC result and/or
+   announces acceptance with a ``session/update`` notification
+   (``status: accepted | rejected``). Either source of the id ends the
+   handshake; ``rejected`` fails the consult.
+3. client ``prompt`` (the question plus ``tools: []``; the working directory is
+   set on the process spawn, not carried in the message) → the host streams
+   ``agent/message`` notifications whose content blocks are translated
+   one-to-one into :class:`SubagentEvent` channels: ``text``/``textDelta`` →
+   ``text`` (deltas stream as partial rows), ``tool_call`` → ``tool``,
+   ``tool_call_result`` → ``tool_result``, ``progress``/``system``/unknown →
+   ``log``, ``error`` → ``error`` (fails the run). A ``result`` content block
+   closes the turn.
+4. A host ``session/input_request`` is surfaced as a log event and auto-replied
+   with an empty input (``{"input": ""}``) so a headless run never stalls; the
+   request-reply shape and the empty-input default are the same headless
+   contract the other backends use for approval prompts.
+
+Consult waits for the host's own turn end — the ``result`` content block, an
+``error`` block, or the process exiting. Only the protocol handshake
+(initialize → session ready) is bounded by ``_HANDSHAKE_TIMEOUT_SECONDS``, so a
+non-ACP binary pointed at this backend fails fast instead of hanging the turn;
+once a turn is running, consult waits unconditionally, matching the subagent
+driver contract. After the turn ends the child is reaped within a short grace
+(``_SHUTDOWN_GRACE_SECONDS``) so a long-lived host cannot leak a process per
+consult.
+
+⚠️ Schema-verification note: this is stage 1 of #1028 and the ACP spec is still
+settling. The method names, message directions, and framing above match the
+widely deployed ACP v1 shape (``agentclientprotocol.com``), but the primary
+schema could not be fetched from this environment, so every field this module
+**emits** is deliberately minimal and each one this module **reads** is parsed
+defensively. Fields a maintainer must check against the official JSON Schema /
+TS types before wiring a real host: ``initialize`` params (``protocolVersion``
+and ``clientCapabilities``) and the host's capability reply; the
+``session/new`` vs ``session/load`` request params and whether acceptance is a
+plain result, ``initialize_result``, or a ``session/update`` notification
+(``status`` values and the ``session_id``/``sessionId`` key spellings); the
+``prompt`` params (string vs structured ``content`` prompt, and where ``tools``
+and ``cwd`` belong); the ``agent/message`` envelope (``message.content`` block
+types and delta spellings such as ``textDelta``) and how turn end is signalled
+(``result`` block vs a message-level completion flag); and the
+``session/input_request`` request/response shape. Nothing here is asserted as
+required beyond the JSON-RPC 2.0 envelope itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+import contextlib
+import json
+import logging
+import os
+import shlex
+import shutil
+from typing import Any
+
+from deeptutor.services.subagent.base import OnEvent, SubagentBackend
+from deeptutor.services.subagent.config import BackendConfig, load_subagent_settings
+from deeptutor.services.subagent.process import (
+    compact_field as _compact,
+)
+from deeptutor.services.subagent.process import (
+    resolve_cli_command,
+    truncate_field,
+)
+from deeptutor.services.subagent.types import (
+    EVENT_ERROR,
+    EVENT_LOG,
+    EVENT_RESULT,
+    EVENT_TEXT,
+    EVENT_TOOL,
+    EVENT_TOOL_RESULT,
+    ConsultResult,
+    DetectResult,
+    SubagentEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Env var naming the ACP host argv (JSON array preferred; else shell-quoted).
+ACP_COMMAND_ENV = "DEEPTUTOR_ACP_COMMAND"
+
+#: ACP v1 protocol version we negotiate. See the schema-verification note above.
+_PROTOCOL_VERSION = 1
+#: How long the initialize → session handshake may take before consult fails.
+_HANDSHAKE_TIMEOUT_SECONDS = 30.0
+#: How long to wait for the child to exit / drain after the turn ends.
+_SHUTDOWN_GRACE_SECONDS = 5.0
+
+_NOT_CONFIGURED = (
+    f"No ACP host command configured: set {ACP_COMMAND_ENV} to the host argv "
+    '(e.g. ["claude", "--acp"]) or provide it as the per-backend extra_args.'
+)
+
+#: Session id key spellings tolerated when parsing host frames.
+_SESSION_ID_KEYS = ("sessionId", "session_id", "session.id")
+#: ``session/update`` statuses that end a session attempt in failure.
+_REJECTED_STATUSES = frozenset({"rejected", "refused", "error", "denied"})
+#: ``session/update`` statuses that mean the session is usable.
+_ACCEPTED_STATUSES = frozenset({"accepted", "ready", "ok", ""})
+#: Content block types that carry assistant answer text.
+_TEXT_BLOCK_TYPES = frozenset({"text"})
+#: Content block types that close the current turn.
+_RESULT_BLOCK_TYPES = frozenset({"result"})
+#: Content block types that represent a tool invocation.
+_TOOL_CALL_TYPES = frozenset({"tool_call", "tool_use"})
+_TOOL_UPDATE_TYPES = frozenset({"tool_call_update", "tool_use_update"})
+_TOOL_RESULT_TYPES = frozenset({"tool_call_result", "tool_result"})
+
+
+class AcpHostError(Exception):
+    """The ACP host violated the protocol (or the handshake failed)."""
+
+
+class AcpBackend(SubagentBackend):
+    """Consult any ACP host process as a subagent over stdio JSON-RPC."""
+
+    kind = "acp"
+    display_name = "ACP (Agent Client Protocol)"
+    # No fixed binary — the command is configured per machine (env / settings).
+    cli_command = ""
+    local_cli = True
+    detectable = True
+
+    def __init__(
+        self,
+        host_factory: Callable[[], Awaitable[Any]] | None = None,
+    ) -> None:
+        """Optionally inject a host spawner for offline tests.
+
+        The default spawns the configured ACP host command as a subprocess with
+        its stdio piped (see :func:`_spawn_host`). ``host_factory`` — awaited
+        with no arguments and expected to return an object exposing the same
+        duck-typed surface as an :class:`asyncio.subprocess.Process` (``stdin``
+        writer, ``stdout`` reader, ``returncode``, ``wait``/``terminate``/
+        ``kill``) — is the seam tests use to drive consult against an in-process
+        fake host when OS pipes are unavailable, mirroring the transport
+        injection the remote Hermes backend already uses.
+        """
+        self._host_factory = host_factory
+
+    async def detect(self) -> DetectResult:
+        """Report whether an ACP host command is configured and resolvable.
+
+        ACP is a transport, so there is no universal ``--version`` probe and
+        none is attempted (an ACP-mode CLI would wait for the handshake and
+        time out). Availability is "a host command is configured (env or
+        per-backend extra_args) and its first token resolves on PATH".
+        """
+        command = acp_host_command(load_subagent_settings().backend(self.kind))
+        if not command:
+            return DetectResult(
+                kind=self.kind,
+                display_name=self.display_name,
+                available=False,
+                detail=_NOT_CONFIGURED,
+            )
+        if _command_resolves(command):
+            return DetectResult(
+                kind=self.kind,
+                display_name=self.display_name,
+                available=True,
+            )
+        return DetectResult(
+            kind=self.kind,
+            display_name=self.display_name,
+            available=False,
+            detail=f"configured ACP host command not found on PATH: {command[0]}",
+        )
+
+    async def consult(
+        self,
+        question: str,
+        *,
+        on_event: OnEvent,
+        cwd: str | None = None,
+        session_id: str | None = None,
+        config: BackendConfig | None = None,
+        images: list[str] | None = None,
+        partner_id: str | None = None,  # noqa: ARG002 — partner-only; ignored here
+    ) -> ConsultResult:
+        config = config or BackendConfig()
+        command = acp_host_command(config)
+        result = ConsultResult(session_id=session_id)
+
+        async def emit(
+            kind: str,
+            text: str,
+            raw: dict[str, Any] | None = None,
+            meta: dict[str, Any] | None = None,
+        ) -> None:
+            result.event_count += 1
+            await on_event(SubagentEvent(kind=kind, text=text, raw=raw or {}, meta=meta or {}))
+
+        if not command and self._host_factory is None:
+            return await _fail(result, emit, _NOT_CONFIGURED)
+
+        prompt = _build_prompt(
+            question,
+            system_prompt=config.system_prompt,
+            images=images,
+            resumed=session_id is not None,
+        )
+
+        process = None
+        reader_task = None
+        try:
+            spawn = self._host_factory or (lambda: _spawn_host(command, cwd=cwd))
+            process = await spawn()
+            session = _HostSession(process, emit)
+            reader_task = asyncio.create_task(_pump_frames(process.stdout, session.frames))
+            sid = await _handshake(session, resume=session_id)
+            result.session_id = sid
+            await emit(EVENT_LOG, f"ACP session {sid} started", {})
+            await _run_turn(session, result, emit, sid, prompt)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive: surface, don't crash the turn
+            logger.warning("acp consult failed: %s", exc, exc_info=True)
+            await _fail(result, emit, str(exc))
+        finally:
+            if process is not None:
+                await _teardown(process, reader_task)
+        return result
+
+
+# ---- command resolution ---------------------------------------------------------
+
+
+def acp_host_command(config: BackendConfig | None = None) -> list[str]:
+    """The configured ACP host argv, or ``[]`` when nothing is configured.
+
+    Precedence: the :data:`ACP_COMMAND_ENV` variable (JSON array of strings, or
+    a shell-quoted string) wins; otherwise ``config.extra_args`` is treated as
+    the full argv. When the env var supplies the command, ``extra_args`` are
+    appended as trailing flags.
+    """
+    raw = os.environ.get(ACP_COMMAND_ENV, "").strip()
+    if raw:
+        command = _parse_command(raw)
+        if command:
+            extra = list((config.extra_args or []) if config else [])
+            return [*command, *extra]
+    if config and config.extra_args:
+        return list(config.extra_args)
+    return []
+
+
+def _parse_command(raw: str) -> list[str]:
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, list) and all(isinstance(item, str) for item in parsed):
+            return parsed
+    except (ValueError, TypeError):
+        pass
+    try:
+        parts = shlex.split(raw)
+    except ValueError:
+        return []
+    return parts
+
+
+def _command_resolves(command: list[str]) -> bool:
+    head = command[0]
+    resolved = shutil.which(head, path=os.environ.get("PATH")) if head else None
+    if resolved:
+        return True
+    # An absolute path that shutil.which could not resolve may still be a file.
+    return bool(os.path.isabs(head) and os.path.isfile(head))
+
+
+# ---- prompt assembly -------------------------------------------------------------
+
+
+def _build_prompt(
+    question: str,
+    *,
+    system_prompt: str,
+    images: list[str] | None = None,
+    resumed: bool = False,
+) -> str:
+    text = question
+    # The delegate instruction rides on the session-creating consult only; a
+    # resumed session already carries it (mirrors the other CLI backends).
+    if system_prompt.strip() and not resumed:
+        text = f"{system_prompt.strip()}\n\n{text}"
+    if images:
+        listing = "\n".join(str(path) for path in images)
+        text = f"{text}\n\nAttached image files (read them from disk):\n{listing}"
+    return text
+
+
+# ---- process plumbing --------------------------------------------------------------
+
+
+async def _spawn_host(command: list[str], *, cwd: str | None) -> asyncio.subprocess.Process:
+    env = {
+        **os.environ,
+        # Whatever the host is, ask it to talk clean UTF-8 text on the pipes.
+        "PYTHONIOENCODING": "utf-8",
+        "PYTHONUNBUFFERED": "1",
+    }
+    resolved = resolve_cli_command(command, path=env.get("PATH"))
+    try:
+        return await asyncio.create_subprocess_exec(
+            *resolved,
+            cwd=cwd or None,
+            env=env,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+    except FileNotFoundError as exc:
+        raise AcpHostError(
+            f"ACP host command not found: {command[0]} (configure {ACP_COMMAND_ENV})"
+        ) from exc
+
+
+class _HostSession:
+    """One live host process plus the single queue its stdout feeds."""
+
+    def __init__(self, process: asyncio.subprocess.Process, emit: Any) -> None:
+        self.process = process
+        self.emit = emit
+        self.frames: asyncio.Queue = asyncio.Queue()
+        self._seq = 0
+
+    def next_request_id(self) -> int:
+        self._seq += 1
+        return self._seq
+
+    async def send_request(self, method: str, params: dict[str, Any]) -> int:
+        request_id = self.next_request_id()
+        await self._write({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
+        return request_id
+
+    async def send_response(self, request_id: Any, result: dict[str, Any]) -> None:
+        await self._write({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+    async def send_error(self, request_id: Any, code: int, message: str) -> None:
+        await self._write(
+            {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
+        )
+
+    async def _write(self, obj: dict[str, Any]) -> None:
+        stdin = self.process.stdin
+        if stdin is None:
+            raise AcpHostError("ACP host stdin closed unexpectedly")
+        stdin.write((json.dumps(obj, ensure_ascii=False) + "\n").encode("utf-8"))
+        await stdin.drain()
+
+
+async def _pump_frames(stream: asyncio.StreamReader | None, queue: asyncio.Queue) -> None:
+    """Read newline-delimited frames; raw lines and EOF are queue items too."""
+    if stream is None:  # pragma: no cover - defensive
+        await queue.put(("eof", None))
+        return
+    while True:
+        raw = await stream.readline()
+        if not raw:
+            await queue.put(("eof", None))
+            return
+        line = raw.decode("utf-8", "replace").strip()
+        if not line:
+            continue
+        if line[0] == "{":
+            try:
+                parsed = json.loads(line)
+            except (ValueError, TypeError):
+                parsed = None
+            if isinstance(parsed, dict):
+                await queue.put(("frame", parsed))
+                continue
+        await queue.put(("raw", line))
+
+
+# ---- handshake ---------------------------------------------------------------------
+
+
+async def _handshake(session: _HostSession, *, resume: str | None) -> str:
+    try:
+        return await asyncio.wait_for(
+            _establish_session(session, resume=resume),
+            timeout=_HANDSHAKE_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError as exc:
+        raise AcpHostError(
+            "ACP host did not complete the initialize/session handshake within "
+            f"{_HANDSHAKE_TIMEOUT_SECONDS:.0f}s — is the configured command an ACP host?"
+        ) from exc
+
+
+async def _establish_session(session: _HostSession, *, resume: str | None) -> str:
+    # 1. initialize
+    await session.send_request("initialize", {"protocolVersion": _PROTOCOL_VERSION})
+    await _await_initialize(session)
+    # 2. session/new (fresh) or session/load (resume)
+    method = "session/load" if resume else "session/new"
+    params = {"session_id": resume} if resume else {}
+    request_id = await session.send_request(method, params)
+    saw_response_without_id = False
+    while True:
+        item = await session.frames.get()
+        if item[0] == "eof":
+            raise AcpHostError(_eof_during("the session handshake", session.process))
+        if item[0] == "raw":
+            if item[1].strip():
+                await session.emit(EVENT_LOG, item[1], {"stream": "stdout"})
+            continue
+        frame: dict[str, Any] = item[1]
+        if frame.get("id") == request_id:
+            if "error" in frame:
+                raise AcpHostError(
+                    f"ACP host rejected the session request: {_rpc_error_text(frame)}"
+                )
+            sid = _pick_session_id(frame.get("result"))
+            if sid:
+                return sid
+            saw_response_without_id = True
+            continue
+        if frame.get("method") == "session/update":
+            status = _update_status(frame)
+            if status in _REJECTED_STATUSES:
+                detail = _update_detail(frame) or status
+                raise AcpHostError(f"ACP host rejected the session: {detail}")
+            if status in _ACCEPTED_STATUSES or saw_response_without_id:
+                sid = _pick_session_id(frame.get("params"))
+                if sid:
+                    return sid
+            continue
+        await _log_unknown(frame, session)
+
+
+async def _await_initialize(session: _HostSession) -> None:
+    """Wait for the initialize reply: an id-matched result or a notification."""
+    request_id = 1  # the initialize request is always the first one sent
+    while True:
+        item = await session.frames.get()
+        if item[0] == "eof":
+            raise AcpHostError(_eof_during("initialize", session.process))
+        if item[0] == "raw":
+            if item[1].strip():
+                await session.emit(EVENT_LOG, item[1], {"stream": "stdout"})
+            continue
+        frame: dict[str, Any] = item[1]
+        method = str(frame.get("method") or "")
+        if method == "initialize_result":
+            return
+        if frame.get("id") == request_id:
+            if "error" in frame:
+                raise AcpHostError(f"ACP host initialize failed: {_rpc_error_text(frame)}")
+            return
+        if method and "id" in frame:
+            # A host request before we are ready cannot be answered yet.
+            await session.send_error(frame.get("id"), -32601, "method not found")
+            continue
+        await _log_unknown(frame, session)
+
+
+def _eof_during(phase: str, process: asyncio.subprocess.Process) -> str:
+    if process.returncode is None:
+        # The pipe closed before the process was reaped; treat as an exit.
+        code = "?"
+    else:
+        code = str(process.returncode)
+    return f"ACP host closed its output during {phase} (exit {code})"
+
+
+# ---- the prompt turn ----------------------------------------------------------------
+
+
+async def _run_turn(
+    session: _HostSession,
+    result: ConsultResult,
+    emit: Any,
+    session_id: str,
+    prompt: str,
+) -> None:
+    """Send the prompt and translate the host's stream until the turn ends."""
+    request_id = await session.send_request(
+        "prompt",
+        {
+            "session_id": session_id,
+            "prompt": prompt,
+            "tools": [],
+        },
+    )
+    chunks: list[str] = []
+    result_text = ""
+    end_of_turn = False
+
+    while not end_of_turn:
+        item = await session.frames.get()
+        if item[0] == "eof":
+            break
+        if item[0] == "raw":
+            if item[1].strip():
+                await emit(EVENT_LOG, item[1], {"stream": "stdout"})
+            continue
+        frame: dict[str, Any] = item[1]
+        if frame.get("id") == request_id and "error" in frame:
+            await _fail(result, emit, f"ACP host prompt failed: {_rpc_error_text(frame)}")
+            return
+        method = str(frame.get("method") or "")
+        if method == "agent/message":
+            message = frame.get("params")
+            if not isinstance(message, dict):
+                continue
+            message = message.get("message")
+            if not isinstance(message, dict):
+                continue
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                kind, text, meta, is_error, closes_turn = _map_block(block)
+                if is_error:
+                    await _fail(result, emit, text)
+                    return
+                if kind and text:
+                    await emit(kind, text, block, meta)
+                if kind == EVENT_TEXT:
+                    chunks.append(text)
+                elif kind == EVENT_RESULT and text:
+                    result_text = text
+                if closes_turn:
+                    end_of_turn = True
+                    break
+            continue
+        if method == "session/update":
+            status = _update_status(frame)
+            if status in _REJECTED_STATUSES:
+                detail = _update_detail(frame) or status
+                await _fail(result, emit, f"ACP host ended the session: {detail}")
+                return
+            continue
+        if method == "session/input_request":
+            await _answer_input_request(session, emit, frame)
+            continue
+        await _log_unknown(frame, session)
+
+    # EOF without a clean result block: only a non-zero exit with no answer text
+    # is a failure — otherwise the streamed text stands on its own.
+    if not end_of_turn and result.success and not chunks and not result_text:
+        await session.process.wait()
+        code = session.process.returncode
+        if code not in (0, None):
+            await _fail(result, emit, f"ACP host exited with code {code} before completing")
+            return
+    result.final_text = "".join(chunks) or result_text
+
+
+async def _answer_input_request(session: _HostSession, emit: Any, frame: dict[str, Any]) -> None:
+    """Surface a host input request and auto-reply so a headless run never stalls."""
+    await emit(
+        EVENT_LOG,
+        "ACP host requested user input; auto-replied with empty input (headless consult).",
+        frame,
+    )
+    request_id = frame.get("id")
+    if request_id is not None:
+        # Accepted shapes for the empty auto-answer: see the schema note.
+        await session.send_response(request_id, {"input": ""})
+
+
+# ---- content mapping ----------------------------------------------------------------
+
+
+def _map_block(block: dict[str, Any]) -> tuple[str | None, str, dict[str, Any], bool, bool]:
+    """Map one ``agent/message`` content block to (kind, text, meta, error, end)."""
+    btype = str(block.get("type") or "")
+    if btype in _TEXT_BLOCK_TYPES:
+        delta = block.get("textDelta")
+        if isinstance(delta, str) and delta:
+            return EVENT_TEXT, delta, {"partial": True}, False, False
+        text = block.get("text")
+        if isinstance(text, str) and text:
+            return EVENT_TEXT, text, {}, False, False
+        return None, "", {}, False, False
+    if btype in _TOOL_CALL_TYPES:
+        return (
+            EVENT_TOOL,
+            _tool_header(block),
+            {"tool": str(block.get("name") or "tool")},
+            False,
+            False,
+        )
+    if btype in _TOOL_UPDATE_TYPES:
+        text = _tool_header(block)
+        return (
+            EVENT_TOOL,
+            truncate_field(text),
+            {"tool": str(block.get("name") or "tool")},
+            False,
+            False,
+        )
+    if btype in _TOOL_RESULT_TYPES:
+        return (
+            EVENT_TOOL_RESULT,
+            truncate_field(_content_text(block.get("content")) or _compact(block)),
+            {},
+            False,
+            False,
+        )
+    if btype == "progress":
+        message = block.get("message")
+        if not isinstance(message, str) or not message.strip():
+            message = block.get("text")
+        return EVENT_LOG, truncate_field(str(message or _compact(block))), {}, False, False
+    if btype == "system":
+        return (
+            EVENT_LOG,
+            truncate_field(_content_text(block.get("content")) or _compact(block)),
+            {},
+            False,
+            False,
+        )
+    if btype == "error":
+        message = block.get("message")
+        if not isinstance(message, str) or not message.strip():
+            message = block.get("text")
+        return EVENT_ERROR, str(message or "ACP agent reported an error"), {}, True, True
+    if btype in _RESULT_BLOCK_TYPES:
+        text = block.get("text")
+        text = str(text) if isinstance(text, str) and text.strip() else ""
+        # The ``result`` block closes the turn; its text is only surfaced as the
+        # answer when nothing was already streamed (avoids duplication).
+        return (EVENT_RESULT, text, {}, False, True)
+    # Unknown block: keep it visible as a log rather than dropping it.
+    return EVENT_LOG, truncate_field(_compact(block)), {}, False, False
+
+
+def _tool_header(block: dict[str, Any]) -> str:
+    name = str(block.get("name") or block.get("tool") or "tool")
+    args = block.get("arguments")
+    if args is None:
+        args = block.get("input")
+    if not isinstance(args, (dict, list)) or not args:
+        return name
+    return truncate_field(f"{name} · {_compact(args)}")
+
+
+def _content_text(content: Any) -> str:
+    """Best-effort plain text of a content field (str, block dict, or list)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict):
+        return str(content.get("text") or content.get("content") or "")
+    if isinstance(content, list):
+        parts: list[str] = []
+        for entry in content:
+            if isinstance(entry, str):
+                parts.append(entry)
+            elif isinstance(entry, dict):
+                parts.append(_content_text(entry))
+        return "\n".join(parts)
+    return ""
+
+
+# ---- small frame helpers ---------------------------------------------------------------
+
+
+def _pick_session_id(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    for key in _SESSION_ID_KEYS:
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _update_status(frame: dict[str, Any]) -> str:
+    params = frame.get("params")
+    if not isinstance(params, dict):
+        return ""
+    value = params.get("status")
+    if value is None:
+        value = params.get("state")
+    return str(value or "").lower()
+
+
+def _update_detail(frame: dict[str, Any]) -> str:
+    params = frame.get("params")
+    if not isinstance(params, dict):
+        return ""
+    for key in ("detail", "message", "reason"):
+        value = params.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _rpc_error_text(frame: dict[str, Any]) -> str:
+    error = frame.get("error")
+    if isinstance(error, dict):
+        message = error.get("message")
+        if isinstance(message, str) and message:
+            return message
+        return _compact(error)
+    return "JSON-RPC error"
+
+
+async def _log_unknown(frame: dict[str, Any], session: _HostSession) -> None:
+    """Anything not understood is kept visible (and answered) rather than dropped."""
+    if "id" in frame and "method" in frame and "result" not in frame and "error" not in frame:
+        # An unknown host request: tell the peer we cannot serve it so it can
+        # proceed instead of waiting on a reply that will never come.
+        await session.send_error(frame.get("id"), -32601, "method not found")
+    method = str(frame.get("method") or "")
+    if method:
+        await session.emit(EVENT_LOG, truncate_field(_compact(frame)), frame)
+
+
+async def _fail(result: ConsultResult, emit: Any, message: str) -> ConsultResult:
+    if not result.error:
+        result.success = False
+        result.error = message
+        await emit(EVENT_ERROR, message, {})
+    return result
+
+
+# ---- teardown ---------------------------------------------------------------------------
+
+
+async def _teardown(process: asyncio.subprocess.Process, reader_task: asyncio.Task | None) -> None:
+    """Close stdin, drain briefly, then reap the child (terminate → kill)."""
+    if process.stdin is not None:
+        with contextlib.suppress(Exception):
+            process.stdin.close()
+    if reader_task is not None and not reader_task.done():
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(reader_task, timeout=_SHUTDOWN_GRACE_SECONDS)
+        if not reader_task.done():
+            reader_task.cancel()
+            with contextlib.suppress(Exception):
+                await asyncio.gather(reader_task, return_exceptions=True)
+    if process.returncode is None:
+        try:
+            await asyncio.wait_for(process.wait(), timeout=_SHUTDOWN_GRACE_SECONDS)
+        except asyncio.TimeoutError:
+            with contextlib.suppress(ProcessLookupError):
+                process.terminate()
+            try:
+                await asyncio.wait_for(process.wait(), timeout=_SHUTDOWN_GRACE_SECONDS)
+            except (TimeoutError, asyncio.TimeoutError):
+                with contextlib.suppress(ProcessLookupError):
+                    process.kill()
+                with contextlib.suppress(Exception):
+                    await process.wait()
+
+
+__all__ = ["ACP_COMMAND_ENV", "AcpBackend"]

--- a/deeptutor/services/subagent/acp.py
+++ b/deeptutor/services/subagent/acp.py
@@ -1,63 +1,74 @@
-"""ACP backend — drive any Agent Client Protocol (ACP) host as a subagent.
+"""ACP backend — drive an Agent Client Protocol (ACP) agent as a subagent.
 
-Part of #1028 (stage 1): DeepTutor plays the *client* side of the Agent Client
-Protocol — a JSON-RPC 2.0 dialect over newline-delimited stdio — against a
-spawnable ACP *host* process. The host command is not hard-coded (ACP is a
-transport standard, not one binary): it comes from the ``DEEPTUTOR_ACP_COMMAND``
-environment variable (a JSON array of argv, or a shell-quoted string), or from
-the per-backend ``BackendConfig.extra_args`` when the env var is unset — so the
-same backend can drive ``claude --acp``-style agent CLIs, ``acp-remote``
-bridges, or any future ACP host, once those binaries exist on the machine.
+Part of #1028 (stage 1): DeepTutor plays the ACP *client* side — JSON-RPC 2.0
+over newline-delimited stdio — against a spawnable ACP *agent* process. The
+agent command is not hard-coded (ACP is a transport standard, not one binary):
+it comes from the ``DEEPTUTOR_ACP_COMMAND`` environment variable (a JSON array
+of argv, or a shell-quoted string), or from the per-backend
+``BackendConfig.extra_args`` when the env var is unset.
 
-Wire transcript this backend drives (client → host unless noted):
+Wire transcript (schema-verified against ACP v1; see the note below for what
+was and was not confirmed):
 
-1. client ``initialize`` → host replies with the negotiated ``protocolVersion``
-   and its capabilities (some hosts notify ``initialize_result`` instead; both
-   shapes are accepted).
-2. client ``session/new`` (fresh) or ``session/load`` with ``session_id``
-   (resume) → the host returns the session id in the JSON-RPC result and/or
-   announces acceptance with a ``session/update`` notification
-   (``status: accepted | rejected``). Either source of the id ends the
-   handshake; ``rejected`` fails the consult.
-3. client ``prompt`` (the question plus ``tools: []``; the working directory is
-   set on the process spawn, not carried in the message) → the host streams
-   ``agent/message`` notifications whose content blocks are translated
-   one-to-one into :class:`SubagentEvent` channels: ``text``/``textDelta`` →
-   ``text`` (deltas stream as partial rows), ``tool_call`` → ``tool``,
-   ``tool_call_result`` → ``tool_result``, ``progress``/``system``/unknown →
-   ``log``, ``error`` → ``error`` (fails the run). A ``result`` content block
-   closes the turn.
-4. A host ``session/input_request`` is surfaced as a log event and auto-replied
-   with an empty input (``{"input": ""}``) so a headless run never stalls; the
-   request-reply shape and the empty-input default are the same headless
-   contract the other backends use for approval prompts.
+1. client → agent: ``initialize`` (``protocolVersion`` + ``clientCapabilities``).
+   The agent replies with the negotiated version and its capabilities.
+2. client → agent: ``session/new`` with ``cwd`` (absolute) + ``mcpServers: []``,
+   or ``session/load`` with ``mcpServers: []`` + ``cwd`` + ``sessionId`` when
+   resuming a prior session. The agent replies with the ``sessionId`` in the
+   JSON-RPC result (a JSON-RPC error rejects the request).
+3. client → agent: ``session/prompt`` with ``sessionId`` and a ``prompt`` array
+   of content blocks (``[{"type": "text", "text": …}]``). While it works, the
+   agent streams ``session/update`` notifications whose ``update.sessionUpdate``
+   discriminator picks the shape:
+   ``agent_message_chunk`` → ``text`` (streamed text pieces),
+   ``agent_thought_chunk`` → ``reasoning``, ``tool_call`` → ``tool``,
+   ``tool_call_update`` (``completed``/``failed``) → ``tool_result`` (tool start
+   and finish share a ``merge_id`` of the ``toolCallId`` so the UI collapses
+   them), ``plan*`` / ``session_info_update`` / ``usage_update`` /
+   ``compaction*`` / mode/config/command updates → ``log``, and any unknown
+   ``sessionUpdate`` kind is kept visible as ``log`` rather than dropped.
+   The turn ends when the ``session/prompt`` request gets its JSON-RPC response
+   (``result.stopReason``); ``refusal``/``cancelled`` fail the consult, other
+   stop reasons succeed with whatever text streamed.
+4. Interactive prompts in v1 are *elicitation*, not ``input_request``: the agent
+   sends an ``elicitation/create`` **request** and the client answers with a
+   ``CreateElicitationResponse``. This backend answers ``{"action": "decline"}``
+   (no input from a headless run — a valid v1 response for any elicitation
+   mode) and surfaces a log event; the follow-up ``elicitation/complete``
+   notification is consumed. Full elicitation (form/URL/text collection) is
+   future work. ``session/request_permission`` and any other unsolicited agent
+   request (``fs/*``, ``terminal/*``, ``mcp/*``) are answered with JSON-RPC
+   method-not-found — this client advertises none of those capabilities, so a
+   conformant agent should not call them; auto-approving permissions is
+   deliberately not done.
 
-Consult waits for the host's own turn end — the ``result`` content block, an
-``error`` block, or the process exiting. Only the protocol handshake
-(initialize → session ready) is bounded by ``_HANDSHAKE_TIMEOUT_SECONDS``, so a
-non-ACP binary pointed at this backend fails fast instead of hanging the turn;
-once a turn is running, consult waits unconditionally, matching the subagent
-driver contract. After the turn ends the child is reaped within a short grace
+Consult waits for the agent's own turn end — the ``session/prompt`` response,
+or the process exiting. Only the protocol handshake (initialize → session
+ready) is bounded by ``_HANDSHAKE_TIMEOUT_SECONDS``, so a non-ACP binary
+pointed at this backend fails fast instead of hanging the turn; once a turn is
+running, consult waits unconditionally, matching the subagent driver contract.
+After the turn ends the child is reaped within a short grace
 (``_SHUTDOWN_GRACE_SECONDS``) so a long-lived host cannot leak a process per
 consult.
 
-⚠️ Schema-verification note: this is stage 1 of #1028 and the ACP spec is still
-settling. The method names, message directions, and framing above match the
-widely deployed ACP v1 shape (``agentclientprotocol.com``), but the primary
-schema could not be fetched from this environment, so every field this module
-**emits** is deliberately minimal and each one this module **reads** is parsed
-defensively. Fields a maintainer must check against the official JSON Schema /
-TS types before wiring a real host: ``initialize`` params (``protocolVersion``
-and ``clientCapabilities``) and the host's capability reply; the
-``session/new`` vs ``session/load`` request params and whether acceptance is a
-plain result, ``initialize_result``, or a ``session/update`` notification
-(``status`` values and the ``session_id``/``sessionId`` key spellings); the
-``prompt`` params (string vs structured ``content`` prompt, and where ``tools``
-and ``cwd`` belong); the ``agent/message`` envelope (``message.content`` block
-types and delta spellings such as ``textDelta``) and how turn end is signalled
-(``result`` block vs a message-level completion flag); and the
-``session/input_request`` request/response shape. Nothing here is asserted as
-required beyond the JSON-RPC 2.0 envelope itself.
+✏️ Schema-verification note (updated): stage-1 shapes were verified against the
+official ACP v1 schema — ``schema/v1/schema.json`` in
+``agentclientprotocol/agent-client-protocol``, cross-checked with the types
+generated from it in ``@agentclientprotocol/sdk`` (``InitializeRequest``,
+``NewSessionRequest`` ``{cwd, mcpServers}``, ``LoadSessionRequest``
+``{mcpServers, cwd, sessionId}``, ``PromptRequest`` ``{sessionId,
+prompt: ContentBlock[]}``, the ``session/update`` notification envelope
+``{sessionId, update}`` with the ``SessionUpdate`` variant union, the
+``elicitation/create`` request with its ``CreateElicitationResponse`` result,
+and ``session/prompt`` → ``PromptResponse.stopReason``). Fields still only
+documented, not exercised against a real agent: the full ``ClientCapabilities``
+/``AgentCapabilities`` matrices (we send an empty client-capabilities object),
+the auth flows some agents gate on ``authenticate`` (not implemented — such an
+agent will surface its own error at the handshake), the exact
+``session/request_permission`` response shape (answered method-not-found), and
+elicitation form/URL content formats (answered with a universal ``decline``).
+Nothing here is asserted as required beyond the JSON-RPC 2.0 envelope and the
+schema fields listed above.
 """
 
 from __future__ import annotations
@@ -84,7 +95,7 @@ from deeptutor.services.subagent.process import (
 from deeptutor.services.subagent.types import (
     EVENT_ERROR,
     EVENT_LOG,
-    EVENT_RESULT,
+    EVENT_REASONING,
     EVENT_TEXT,
     EVENT_TOOL,
     EVENT_TOOL_RESULT,
@@ -95,10 +106,10 @@ from deeptutor.services.subagent.types import (
 
 logger = logging.getLogger(__name__)
 
-#: Env var naming the ACP host argv (JSON array preferred; else shell-quoted).
+#: Env var naming the ACP agent argv (JSON array preferred; else shell-quoted).
 ACP_COMMAND_ENV = "DEEPTUTOR_ACP_COMMAND"
 
-#: ACP v1 protocol version we negotiate. See the schema-verification note above.
+#: ACP protocol version we negotiate (v1 — see the schema-verification note).
 _PROTOCOL_VERSION = 1
 #: How long the initialize → session handshake may take before consult fails.
 _HANDSHAKE_TIMEOUT_SECONDS = 30.0
@@ -106,32 +117,51 @@ _HANDSHAKE_TIMEOUT_SECONDS = 30.0
 _SHUTDOWN_GRACE_SECONDS = 5.0
 
 _NOT_CONFIGURED = (
-    f"No ACP host command configured: set {ACP_COMMAND_ENV} to the host argv "
+    f"No ACP agent command configured: set {ACP_COMMAND_ENV} to the agent argv "
     '(e.g. ["claude", "--acp"]) or provide it as the per-backend extra_args.'
 )
 
-#: Session id key spellings tolerated when parsing host frames.
+#: Session id key spellings tolerated when reading agent frames (v1 uses
+#: ``sessionId``; the snake_case spellings are kept defensively for forward
+#: compat with builds that leak them).
 _SESSION_ID_KEYS = ("sessionId", "session_id", "session.id")
-#: ``session/update`` statuses that end a session attempt in failure.
-_REJECTED_STATUSES = frozenset({"rejected", "refused", "error", "denied"})
-#: ``session/update`` statuses that mean the session is usable.
-_ACCEPTED_STATUSES = frozenset({"accepted", "ready", "ok", ""})
-#: Content block types that carry assistant answer text.
-_TEXT_BLOCK_TYPES = frozenset({"text"})
-#: Content block types that close the current turn.
-_RESULT_BLOCK_TYPES = frozenset({"result"})
-#: Content block types that represent a tool invocation.
-_TOOL_CALL_TYPES = frozenset({"tool_call", "tool_use"})
-_TOOL_UPDATE_TYPES = frozenset({"tool_call_update", "tool_use_update"})
-_TOOL_RESULT_TYPES = frozenset({"tool_call_result", "tool_result"})
+
+#: ``session/update`` kinds that carry the assistant's answer text pieces.
+_AGENT_TEXT_KINDS = frozenset({"agent_message_chunk"})
+#: ``session/update`` kinds that carry the agent's visible thinking.
+_THOUGHT_KINDS = frozenset({"agent_thought_chunk"})
+#: ``session/update`` kinds that echo the user's own message back (ignored —
+#: the question was already streamed by the capability that called consult).
+_USER_TEXT_KINDS = frozenset({"user_message_chunk"})
+#: ``session/update`` kinds that announce a tool invocation / its progress.
+_TOOL_CALL_KINDS = frozenset({"tool_call"})
+_TOOL_UPDATE_KINDS = frozenset({"tool_call_update"})
+#: ``session/update`` kinds rendered as plain log lines.
+_LOG_UPDATE_KINDS = frozenset(
+    {
+        "plan",
+        "plan_update",
+        "plan_removed",
+        "session_info_update",
+        "usage_update",
+        "current_mode_update",
+        "config_option_update",
+        "available_commands_update",
+        "compaction_update",
+        "compaction_summary_chunk",
+    }
+)
+
+#: ``session/prompt`` stop reasons that mean the agent declined to answer.
+_FAILED_STOP_REASONS = frozenset({"refusal", "cancelled"})
 
 
 class AcpHostError(Exception):
-    """The ACP host violated the protocol (or the handshake failed)."""
+    """The ACP agent violated the protocol (or the handshake failed)."""
 
 
 class AcpBackend(SubagentBackend):
-    """Consult any ACP host process as a subagent over stdio JSON-RPC."""
+    """Consult any ACP agent process as a subagent over stdio JSON-RPC."""
 
     kind = "acp"
     display_name = "ACP (Agent Client Protocol)"
@@ -144,26 +174,26 @@ class AcpBackend(SubagentBackend):
         self,
         host_factory: Callable[[], Awaitable[Any]] | None = None,
     ) -> None:
-        """Optionally inject a host spawner for offline tests.
+        """Optionally inject a process spawner for offline tests.
 
-        The default spawns the configured ACP host command as a subprocess with
+        The default spawns the configured ACP agent command as a subprocess with
         its stdio piped (see :func:`_spawn_host`). ``host_factory`` — awaited
         with no arguments and expected to return an object exposing the same
         duck-typed surface as an :class:`asyncio.subprocess.Process` (``stdin``
         writer, ``stdout`` reader, ``returncode``, ``wait``/``terminate``/
         ``kill``) — is the seam tests use to drive consult against an in-process
-        fake host when OS pipes are unavailable, mirroring the transport
+        fake agent when OS pipes are unavailable, mirroring the transport
         injection the remote Hermes backend already uses.
         """
         self._host_factory = host_factory
 
     async def detect(self) -> DetectResult:
-        """Report whether an ACP host command is configured and resolvable.
+        """Report whether an ACP agent command is configured and resolvable.
 
         ACP is a transport, so there is no universal ``--version`` probe and
         none is attempted (an ACP-mode CLI would wait for the handshake and
-        time out). Availability is "a host command is configured (env or
-        per-backend extra_args) and its first token resolves on PATH".
+        time out). Availability is "a command is configured (env or per-backend
+        extra_args) and its first token resolves on PATH".
         """
         command = acp_host_command(load_subagent_settings().backend(self.kind))
         if not command:
@@ -183,7 +213,7 @@ class AcpBackend(SubagentBackend):
             kind=self.kind,
             display_name=self.display_name,
             available=False,
-            detail=f"configured ACP host command not found on PATH: {command[0]}",
+            detail=f"configured ACP agent command not found on PATH: {command[0]}",
         )
 
     async def consult(
@@ -227,7 +257,7 @@ class AcpBackend(SubagentBackend):
             process = await spawn()
             session = _HostSession(process, emit)
             reader_task = asyncio.create_task(_pump_frames(process.stdout, session.frames))
-            sid = await _handshake(session, resume=session_id)
+            sid = await _handshake(session, resume=session_id, cwd=cwd)
             result.session_id = sid
             await emit(EVENT_LOG, f"ACP session {sid} started", {})
             await _run_turn(session, result, emit, sid, prompt)
@@ -246,7 +276,7 @@ class AcpBackend(SubagentBackend):
 
 
 def acp_host_command(config: BackendConfig | None = None) -> list[str]:
-    """The configured ACP host argv, or ``[]`` when nothing is configured.
+    """The configured ACP agent argv, or ``[]`` when nothing is configured.
 
     Precedence: the :data:`ACP_COMMAND_ENV` variable (JSON array of strings, or
     a shell-quoted string) wins; otherwise ``config.extra_args`` is treated as
@@ -314,7 +344,7 @@ def _build_prompt(
 async def _spawn_host(command: list[str], *, cwd: str | None) -> asyncio.subprocess.Process:
     env = {
         **os.environ,
-        # Whatever the host is, ask it to talk clean UTF-8 text on the pipes.
+        # Whatever the agent is, ask it to talk clean UTF-8 text on the pipes.
         "PYTHONIOENCODING": "utf-8",
         "PYTHONUNBUFFERED": "1",
     }
@@ -330,12 +360,12 @@ async def _spawn_host(command: list[str], *, cwd: str | None) -> asyncio.subproc
         )
     except FileNotFoundError as exc:
         raise AcpHostError(
-            f"ACP host command not found: {command[0]} (configure {ACP_COMMAND_ENV})"
+            f"ACP agent command not found: {command[0]} (configure {ACP_COMMAND_ENV})"
         ) from exc
 
 
 class _HostSession:
-    """One live host process plus the single queue its stdout feeds."""
+    """One live agent process plus the single queue its stdout feeds."""
 
     def __init__(self, process: asyncio.subprocess.Process, emit: Any) -> None:
         self.process = process
@@ -363,7 +393,7 @@ class _HostSession:
     async def _write(self, obj: dict[str, Any]) -> None:
         stdin = self.process.stdin
         if stdin is None:
-            raise AcpHostError("ACP host stdin closed unexpectedly")
+            raise AcpHostError("ACP agent stdin closed unexpectedly")
         stdin.write((json.dumps(obj, ensure_ascii=False) + "\n").encode("utf-8"))
         await stdin.drain()
 
@@ -395,63 +425,59 @@ async def _pump_frames(stream: asyncio.StreamReader | None, queue: asyncio.Queue
 # ---- handshake ---------------------------------------------------------------------
 
 
-async def _handshake(session: _HostSession, *, resume: str | None) -> str:
+async def _handshake(session: _HostSession, *, resume: str | None, cwd: str | None) -> str:
     try:
         return await asyncio.wait_for(
-            _establish_session(session, resume=resume),
+            _establish_session(session, resume=resume, cwd=cwd),
             timeout=_HANDSHAKE_TIMEOUT_SECONDS,
         )
     except asyncio.TimeoutError as exc:
         raise AcpHostError(
-            "ACP host did not complete the initialize/session handshake within "
-            f"{_HANDSHAKE_TIMEOUT_SECONDS:.0f}s — is the configured command an ACP host?"
+            "ACP agent did not complete the initialize/session handshake within "
+            f"{_HANDSHAKE_TIMEOUT_SECONDS:.0f}s — is the configured command an ACP agent?"
         ) from exc
 
 
-async def _establish_session(session: _HostSession, *, resume: str | None) -> str:
+async def _establish_session(_session: _HostSession, *, resume: str | None, cwd: str | None) -> str:
     # 1. initialize
-    await session.send_request("initialize", {"protocolVersion": _PROTOCOL_VERSION})
-    await _await_initialize(session)
-    # 2. session/new (fresh) or session/load (resume)
-    method = "session/load" if resume else "session/new"
-    params = {"session_id": resume} if resume else {}
-    request_id = await session.send_request(method, params)
-    saw_response_without_id = False
+    request_id = await _session.send_request("initialize", {"protocolVersion": _PROTOCOL_VERSION})
+    await _await_initialize(_session, request_id)
+    # 2. session/new (fresh) or session/load (resume) — both carry cwd + mcpServers.
+    workdir = os.path.abspath(cwd) if cwd else os.getcwd()
+    if resume:
+        method = "session/load"
+        params: dict[str, Any] = {"mcpServers": [], "cwd": workdir, "sessionId": resume}
+    else:
+        method = "session/new"
+        params = {"cwd": workdir, "mcpServers": []}
+    request_id = await _session.send_request(method, params)
     while True:
-        item = await session.frames.get()
+        item = await _session.frames.get()
         if item[0] == "eof":
-            raise AcpHostError(_eof_during("the session handshake", session.process))
+            raise AcpHostError(_eof_during("the session handshake", _session.process))
         if item[0] == "raw":
             if item[1].strip():
-                await session.emit(EVENT_LOG, item[1], {"stream": "stdout"})
+                await _session.emit(EVENT_LOG, item[1], {"stream": "stdout"})
             continue
         frame: dict[str, Any] = item[1]
         if frame.get("id") == request_id:
             if "error" in frame:
                 raise AcpHostError(
-                    f"ACP host rejected the session request: {_rpc_error_text(frame)}"
+                    f"ACP agent rejected the session request: {_rpc_error_text(frame)}"
                 )
             sid = _pick_session_id(frame.get("result"))
             if sid:
                 return sid
-            saw_response_without_id = True
+            raise AcpHostError("ACP agent accepted the session request but returned no sessionId")
+        if str(frame.get("method") or "") == "session/update":
+            # Pre-prompt session state (e.g. after a load) is just logged.
+            await _log_update(frame, _session)
             continue
-        if frame.get("method") == "session/update":
-            status = _update_status(frame)
-            if status in _REJECTED_STATUSES:
-                detail = _update_detail(frame) or status
-                raise AcpHostError(f"ACP host rejected the session: {detail}")
-            if status in _ACCEPTED_STATUSES or saw_response_without_id:
-                sid = _pick_session_id(frame.get("params"))
-                if sid:
-                    return sid
-            continue
-        await _log_unknown(frame, session)
+        await _handle_agent_frame(frame, _session)
 
 
-async def _await_initialize(session: _HostSession) -> None:
-    """Wait for the initialize reply: an id-matched result or a notification."""
-    request_id = 1  # the initialize request is always the first one sent
+async def _await_initialize(session: _HostSession, request_id: int) -> None:
+    """Wait for the id-matched initialize response (error → fail)."""
     while True:
         item = await session.frames.get()
         if item[0] == "eof":
@@ -461,18 +487,12 @@ async def _await_initialize(session: _HostSession) -> None:
                 await session.emit(EVENT_LOG, item[1], {"stream": "stdout"})
             continue
         frame: dict[str, Any] = item[1]
-        method = str(frame.get("method") or "")
-        if method == "initialize_result":
-            return
         if frame.get("id") == request_id:
             if "error" in frame:
-                raise AcpHostError(f"ACP host initialize failed: {_rpc_error_text(frame)}")
+                raise AcpHostError(f"ACP agent initialize failed: {_rpc_error_text(frame)}")
             return
-        if method and "id" in frame:
-            # A host request before we are ready cannot be answered yet.
-            await session.send_error(frame.get("id"), -32601, "method not found")
-            continue
-        await _log_unknown(frame, session)
+        if frame.get("method"):
+            await _handle_agent_frame(frame, session)
 
 
 def _eof_during(phase: str, process: asyncio.subprocess.Process) -> str:
@@ -481,7 +501,7 @@ def _eof_during(phase: str, process: asyncio.subprocess.Process) -> str:
         code = "?"
     else:
         code = str(process.returncode)
-    return f"ACP host closed its output during {phase} (exit {code})"
+    return f"ACP agent closed its output during {phase} (exit {code})"
 
 
 # ---- the prompt turn ----------------------------------------------------------------
@@ -494,20 +514,19 @@ async def _run_turn(
     session_id: str,
     prompt: str,
 ) -> None:
-    """Send the prompt and translate the host's stream until the turn ends."""
+    """Send ``session/prompt`` and translate the stream until the agent responds.
+
+    v1 streams the run through ``session/update`` notifications and ends the
+    turn with the JSON-RPC *response* to the prompt request (``stopReason``).
+    """
     request_id = await session.send_request(
-        "prompt",
-        {
-            "session_id": session_id,
-            "prompt": prompt,
-            "tools": [],
-        },
+        "session/prompt",
+        {"sessionId": session_id, "prompt": [{"type": "text", "text": prompt}]},
     )
     chunks: list[str] = []
-    result_text = ""
-    end_of_turn = False
+    got_response = False
 
-    while not end_of_turn:
+    while True:
         item = await session.frames.get()
         if item[0] == "eof":
             break
@@ -516,165 +535,227 @@ async def _run_turn(
                 await emit(EVENT_LOG, item[1], {"stream": "stdout"})
             continue
         frame: dict[str, Any] = item[1]
-        if frame.get("id") == request_id and "error" in frame:
-            await _fail(result, emit, f"ACP host prompt failed: {_rpc_error_text(frame)}")
-            return
-        method = str(frame.get("method") or "")
-        if method == "agent/message":
-            message = frame.get("params")
-            if not isinstance(message, dict):
-                continue
-            message = message.get("message")
-            if not isinstance(message, dict):
-                continue
-            content = message.get("content")
-            if not isinstance(content, list):
-                continue
-            for block in content:
-                if not isinstance(block, dict):
-                    continue
-                kind, text, meta, is_error, closes_turn = _map_block(block)
-                if is_error:
-                    await _fail(result, emit, text)
-                    return
-                if kind and text:
-                    await emit(kind, text, block, meta)
-                if kind == EVENT_TEXT:
-                    chunks.append(text)
-                elif kind == EVENT_RESULT and text:
-                    result_text = text
-                if closes_turn:
-                    end_of_turn = True
-                    break
-            continue
-        if method == "session/update":
-            status = _update_status(frame)
-            if status in _REJECTED_STATUSES:
-                detail = _update_detail(frame) or status
-                await _fail(result, emit, f"ACP host ended the session: {detail}")
+        if frame.get("id") == request_id:
+            if "error" in frame:
+                await _fail(result, emit, f"ACP agent prompt failed: {_rpc_error_text(frame)}")
                 return
+            got_response = True
+            stop_reason = str((frame.get("result") or {}).get("stopReason") or "")
+            if stop_reason in _FAILED_STOP_REASONS:
+                await _fail(result, emit, f"ACP agent stopped the turn ({stop_reason})")
+                return
+            break
+        method = str(frame.get("method") or "")
+        if method == "session/update":
+            await _handle_update(frame, result, chunks, emit)
             continue
-        if method == "session/input_request":
-            await _answer_input_request(session, emit, frame)
-            continue
-        await _log_unknown(frame, session)
+        await _handle_agent_frame(frame, session)
 
-    # EOF without a clean result block: only a non-zero exit with no answer text
-    # is a failure — otherwise the streamed text stands on its own.
-    if not end_of_turn and result.success and not chunks and not result_text:
+    if not got_response:
+        # The agent closed its output without answering the prompt.
         await session.process.wait()
         code = session.process.returncode
-        if code not in (0, None):
-            await _fail(result, emit, f"ACP host exited with code {code} before completing")
+        suffix = f" (exit {code})" if code not in (None, 0) else ""
+        await _fail(
+            result, emit, f"ACP agent closed its output before completing the prompt{suffix}"
+        )
+        return
+    result.final_text = "".join(chunks)
+
+
+# ---- session/update mapping ------------------------------------------------------------
+
+
+async def _handle_update(
+    frame: dict[str, Any], result: ConsultResult, chunks: list[str], emit: Any
+) -> None:
+    """Map one ``session/update`` notification into SubagentEvents."""
+    params = frame.get("params")
+    if not isinstance(params, dict):
+        return
+    update = params.get("update")
+    if not isinstance(update, dict):
+        await emit(EVENT_LOG, truncate_field(_compact(params)), params)
+        return
+    kind = str(update.get("sessionUpdate") or update.get("type") or "")
+
+    if kind in _USER_TEXT_KINDS:
+        return  # an echo of our own prompt — the capability already streamed it
+    if kind in _AGENT_TEXT_KINDS or kind in _THOUGHT_KINDS:
+        text = _content_text(update.get("content"))
+        if not text:
             return
-    result.final_text = "".join(chunks) or result_text
-
-
-async def _answer_input_request(session: _HostSession, emit: Any, frame: dict[str, Any]) -> None:
-    """Surface a host input request and auto-reply so a headless run never stalls."""
-    await emit(
-        EVENT_LOG,
-        "ACP host requested user input; auto-replied with empty input (headless consult).",
-        frame,
-    )
-    request_id = frame.get("id")
-    if request_id is not None:
-        # Accepted shapes for the empty auto-answer: see the schema note.
-        await session.send_response(request_id, {"input": ""})
-
-
-# ---- content mapping ----------------------------------------------------------------
-
-
-def _map_block(block: dict[str, Any]) -> tuple[str | None, str, dict[str, Any], bool, bool]:
-    """Map one ``agent/message`` content block to (kind, text, meta, error, end)."""
-    btype = str(block.get("type") or "")
-    if btype in _TEXT_BLOCK_TYPES:
-        delta = block.get("textDelta")
-        if isinstance(delta, str) and delta:
-            return EVENT_TEXT, delta, {"partial": True}, False, False
-        text = block.get("text")
-        if isinstance(text, str) and text:
-            return EVENT_TEXT, text, {}, False, False
-        return None, "", {}, False, False
-    if btype in _TOOL_CALL_TYPES:
-        return (
+        out_kind = EVENT_REASONING if kind in _THOUGHT_KINDS else EVENT_TEXT
+        if out_kind == EVENT_TEXT:
+            chunks.append(text)
+        await emit(
+            out_kind,
+            text,
+            update,
+            {"partial": True, "message_id": update.get("messageId")},
+        )
+        return
+    if kind in _TOOL_CALL_KINDS:
+        tool_call_id = str(update.get("toolCallId") or "")
+        await emit(
             EVENT_TOOL,
-            _tool_header(block),
-            {"tool": str(block.get("name") or "tool")},
-            False,
-            False,
+            _tool_call_header(update),
+            update,
+            {
+                "merge_id": tool_call_id,
+                "tool": str(update.get("name") or update.get("kind") or ""),
+            },
         )
-    if btype in _TOOL_UPDATE_TYPES:
-        text = _tool_header(block)
-        return (
-            EVENT_TOOL,
-            truncate_field(text),
-            {"tool": str(block.get("name") or "tool")},
-            False,
-            False,
-        )
-    if btype in _TOOL_RESULT_TYPES:
-        return (
-            EVENT_TOOL_RESULT,
-            truncate_field(_content_text(block.get("content")) or _compact(block)),
-            {},
-            False,
-            False,
-        )
-    if btype == "progress":
-        message = block.get("message")
-        if not isinstance(message, str) or not message.strip():
-            message = block.get("text")
-        return EVENT_LOG, truncate_field(str(message or _compact(block))), {}, False, False
-    if btype == "system":
-        return (
-            EVENT_LOG,
-            truncate_field(_content_text(block.get("content")) or _compact(block)),
-            {},
-            False,
-            False,
-        )
-    if btype == "error":
-        message = block.get("message")
-        if not isinstance(message, str) or not message.strip():
-            message = block.get("text")
-        return EVENT_ERROR, str(message or "ACP agent reported an error"), {}, True, True
-    if btype in _RESULT_BLOCK_TYPES:
-        text = block.get("text")
-        text = str(text) if isinstance(text, str) and text.strip() else ""
-        # The ``result`` block closes the turn; its text is only surfaced as the
-        # answer when nothing was already streamed (avoids duplication).
-        return (EVENT_RESULT, text, {}, False, True)
-    # Unknown block: keep it visible as a log rather than dropping it.
-    return EVENT_LOG, truncate_field(_compact(block)), {}, False, False
+        return
+    if kind in _TOOL_UPDATE_KINDS:
+        tool_call_id = str(update.get("toolCallId") or "")
+        status = str(update.get("status") or "")
+        if status in ("completed", "failed"):
+            title = str(update.get("title") or "")
+            label = f"{title} ({status})" if title else f"tool call {status}"
+            output = _tool_call_content(update)
+            await emit(
+                EVENT_TOOL_RESULT,
+                truncate_field(f"{label}\n{output}".strip() or label),
+                update,
+                {"merge_id": tool_call_id},
+            )
+        else:
+            # pending / in_progress — the row started by tool_call stays open.
+            title = str(update.get("title") or "")
+            await emit(
+                EVENT_TOOL,
+                truncate_field(f"{title} …" if title else "tool call …"),
+                update,
+                {"merge_id": tool_call_id},
+            )
+        return
+    if kind in _LOG_UPDATE_KINDS:
+        await emit(EVENT_LOG, _update_summary(update), update)
+        return
+    # Unknown sessionUpdate kind: keep it visible rather than dropping it.
+    await emit(EVENT_LOG, truncate_field(_compact(update)), update)
 
 
-def _tool_header(block: dict[str, Any]) -> str:
-    name = str(block.get("name") or block.get("tool") or "tool")
-    args = block.get("arguments")
-    if args is None:
-        args = block.get("input")
-    if not isinstance(args, (dict, list)) or not args:
-        return name
-    return truncate_field(f"{name} · {_compact(args)}")
+def _tool_call_header(update: dict[str, Any]) -> str:
+    title = str(update.get("title") or "").strip()
+    name = str(update.get("name") or update.get("kind") or "").strip()
+    if title and name:
+        return f"{title} ({name})"
+    return title or name or "tool call"
+
+
+def _tool_call_content(update: dict[str, Any]) -> str:
+    """Plain text of a completed tool call's ``content`` (tool results)."""
+    content = update.get("content")
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for entry in content:
+        if not isinstance(entry, dict):
+            continue
+        if str(entry.get("type") or "") in ("content", "diff", "terminal"):
+            if "content" in entry:
+                parts.append(_content_text(entry.get("content")))
+            else:
+                parts.append(_compact(entry))
+            continue
+        parts.append(_content_text(entry))
+    return "\n".join(part for part in parts if part)
+
+
+def _update_summary(update: dict[str, Any]) -> str:
+    """One readable line for lifecycle / status session updates."""
+    kind = str(update.get("sessionUpdate") or update.get("type") or "")
+    if kind in ("plan", "plan_update"):
+        # Plans carry their own content list of text blocks.
+        text = _content_text(update.get("content"))
+        if text:
+            return truncate_field(text)
+    return truncate_field(_compact(update))
 
 
 def _content_text(content: Any) -> str:
-    """Best-effort plain text of a content field (str, block dict, or list)."""
+    """Best-effort plain text of a ContentBlock / content field."""
     if isinstance(content, str):
         return content
     if isinstance(content, dict):
-        return str(content.get("text") or content.get("content") or "")
+        if content.get("type") == "text":
+            return str(content.get("text") or "")
+        text = content.get("text")
+        if isinstance(text, str):
+            return text
+        return str(content.get("content") or "") if "content" in content else ""
     if isinstance(content, list):
         parts: list[str] = []
         for entry in content:
-            if isinstance(entry, str):
-                parts.append(entry)
-            elif isinstance(entry, dict):
-                parts.append(_content_text(entry))
+            text = _content_text(entry)
+            if text:
+                parts.append(text)
         return "\n".join(parts)
     return ""
+
+
+# ---- other agent-initiated messages ---------------------------------------------------
+
+
+async def _handle_agent_frame(frame: dict[str, Any], session: _HostSession) -> None:
+    """Respond to agent requests we cannot serve; log the rest."""
+    method = str(frame.get("method") or "")
+    request_id = frame.get("id")
+    is_request = request_id is not None and "result" not in frame and "error" not in frame
+    if not method:
+        return  # a stray response to a request we never tracked
+    if method == "session/update":
+        await _log_update(frame, session)
+        return
+    if method == "elicitation/create":
+        await _answer_elicitation(session, frame)
+        return
+    if not is_request:
+        # A notification we do not model (e.g. elicitation/complete) — the
+        # lifecycle it announces is already handled at its request side.
+        return
+    # An unsolicited request (session/request_permission, fs/*, terminal/*,
+    # mcp/* …). This client advertises none of those capabilities, so say so —
+    # never auto-approve a permission or run a tool for the agent.
+    await session.emit(EVENT_LOG, f"ACP agent requested unsupported method {method!r}", frame)
+    await session.send_error(request_id, -32601, "method not found")
+
+
+async def _answer_elicitation(session: _HostSession, frame: dict[str, Any]) -> None:
+    """Auto-answer an ``elicitation/create`` request so a headless run never stalls.
+
+    The reply is a ``CreateElicitationResponse``; ``{"action": "decline"}`` is
+    valid for every elicitation mode and means "no input provided". The agent's
+    follow-up ``elicitation/complete`` notification is consumed by
+    :func:`_handle_agent_frame`. Full form/URL elicitation is future work.
+    """
+    request_id = frame.get("id")
+    message = ""
+    params = frame.get("params")
+    if isinstance(params, dict):
+        message = str(params.get("message") or "")
+    detail = f" ({message})" if message else ""
+    await session.emit(
+        EVENT_LOG,
+        f"ACP agent requested input; auto-replied decline (headless consult){detail}.",
+        frame,
+    )
+    if request_id is not None:
+        await session.send_response(request_id, {"action": "decline"})
+
+
+async def _log_update(frame: dict[str, Any], session: _HostSession) -> None:
+    """Pre-prompt session state: keep it visible but do not touch the answer."""
+    params = frame.get("params")
+    update = params.get("update") if isinstance(params, dict) else None
+    if isinstance(update, dict):
+        text = _update_summary(update)
+    else:
+        text = _compact(params) if params else ""
+    if text:
+        await session.emit(EVENT_LOG, text, frame)
 
 
 # ---- small frame helpers ---------------------------------------------------------------
@@ -690,27 +771,6 @@ def _pick_session_id(payload: Any) -> str:
     return ""
 
 
-def _update_status(frame: dict[str, Any]) -> str:
-    params = frame.get("params")
-    if not isinstance(params, dict):
-        return ""
-    value = params.get("status")
-    if value is None:
-        value = params.get("state")
-    return str(value or "").lower()
-
-
-def _update_detail(frame: dict[str, Any]) -> str:
-    params = frame.get("params")
-    if not isinstance(params, dict):
-        return ""
-    for key in ("detail", "message", "reason"):
-        value = params.get(key)
-        if isinstance(value, str) and value:
-            return value
-    return ""
-
-
 def _rpc_error_text(frame: dict[str, Any]) -> str:
     error = frame.get("error")
     if isinstance(error, dict):
@@ -719,17 +779,6 @@ def _rpc_error_text(frame: dict[str, Any]) -> str:
             return message
         return _compact(error)
     return "JSON-RPC error"
-
-
-async def _log_unknown(frame: dict[str, Any], session: _HostSession) -> None:
-    """Anything not understood is kept visible (and answered) rather than dropped."""
-    if "id" in frame and "method" in frame and "result" not in frame and "error" not in frame:
-        # An unknown host request: tell the peer we cannot serve it so it can
-        # proceed instead of waiting on a reply that will never come.
-        await session.send_error(frame.get("id"), -32601, "method not found")
-    method = str(frame.get("method") or "")
-    if method:
-        await session.emit(EVENT_LOG, truncate_field(_compact(frame)), frame)
 
 
 async def _fail(result: ConsultResult, emit: Any, message: str) -> ConsultResult:

--- a/deeptutor/services/subagent/registry.py
+++ b/deeptutor/services/subagent/registry.py
@@ -3,16 +3,17 @@
 Add a new subagent by writing a :class:`SubagentBackend` and listing it here;
 the capability, API and UI all discover it through these helpers. Local-CLI
 backends (Claude Code, Codex, Antigravity CLI, Kimi CLI, opencode,
-MiMo Code, Hermes Agent, OpenClaw, DeepSeek Harness), configured remote
-backends, and the in-process partner backend live in the same registry.
-``local_cli`` and ``detectable`` control which backends participate in
-connection discovery.
+MiMo Code, Hermes Agent, OpenClaw, DeepSeek Harness, a configured ACP host),
+configured remote backends, and the in-process partner backend live in the
+same registry. ``local_cli`` and ``detectable`` control which backends
+participate in connection discovery.
 """
 
 from __future__ import annotations
 
 import asyncio
 
+from deeptutor.services.subagent.acp import AcpBackend
 from deeptutor.services.subagent.antigravity import AntigravityBackend
 from deeptutor.services.subagent.base import SubagentBackend
 from deeptutor.services.subagent.claude_code import ClaudeCodeBackend
@@ -39,6 +40,7 @@ _BACKENDS: dict[str, SubagentBackend] = {
         HermesRemoteBackend(),
         OpenClawBackend(),
         DeepSeekHarnessBackend(),
+        AcpBackend(),
         PartnerBackend(),
     )
 }

--- a/tests/fixtures/acp_fake_host.py
+++ b/tests/fixtures/acp_fake_host.py
@@ -1,0 +1,279 @@
+"""Offline fake ACP host used by the AcpBackend integration tests.
+
+A minimal ACP "host" process that speaks newline-delimited JSON-RPC 2.0 over
+stdio from the host side of the transcript the backend drives: it answers the
+client's ``initialize`` / ``session/new`` / ``session/load`` / ``prompt``
+requests and streams ``agent/message`` notifications (and one optional
+``session/input_request``). It holds no real agent state — the point is to pin
+the backend's wire behaviour offline, not to emulate an agent.
+
+Usage: ``python acp_fake_host.py <scenario>`` where scenario selects the
+behaviour (see ``_SCENARIOS``). Only the Python standard library is used, so
+pytest can spawn it with ``sys.executable``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from typing import Any
+
+HOST_SESSION_ID = "acp-test-session-1"
+_VERSION = "fake-acp-host-1.0"
+
+# Our own id space for requests the host sends toward the client, so it never
+# collides with the client's request ids.
+_HOST_SEQ = 1000
+
+
+def send(obj: dict[str, Any]) -> None:
+    """Write one JSON-RPC frame (newline-delimited) and flush it out."""
+    sys.stdout.buffer.write((json.dumps(obj, ensure_ascii=False) + "\n").encode("utf-8"))
+    sys.stdout.buffer.flush()
+
+
+def read_request() -> dict[str, Any] | None:
+    """Read the next client frame; ``None`` on EOF."""
+    raw = sys.stdin.buffer.readline()
+    if not raw:
+        return None
+    text = raw.decode("utf-8", "replace").strip()
+    if not text:
+        return read_request()
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        sys.stderr.write(f"fake host: non-JSON client frame ignored: {text!r}\n")
+        sys.stderr.flush()
+        return read_request()
+    return parsed if isinstance(parsed, dict) else read_request()
+
+
+def respond(request: dict[str, Any], result: dict[str, Any]) -> None:
+    send({"jsonrpc": "2.0", "id": request.get("id"), "result": result})
+
+
+def notify(method: str, params: dict[str, Any]) -> None:
+    send({"jsonrpc": "2.0", "method": method, "params": params})
+
+
+def agent_message(session_id: str, blocks: list[dict[str, Any]], index: int) -> None:
+    notify(
+        "agent/message",
+        {
+            "session_id": session_id,
+            "message": {
+                "id": f"fake-msg-{index}",
+                "role": "assistant",
+                "content": blocks,
+            },
+        },
+    )
+
+
+def text_block(text: str, *, delta: bool = False) -> dict[str, Any]:
+    return {"type": "text", "textDelta" if delta else "text": text}
+
+
+def extract_question(request: dict[str, Any]) -> str:
+    """Best-effort read of the client's ``prompt`` text (str or content list)."""
+    params = request.get("params")
+    if not isinstance(params, dict):
+        return ""
+    prompt = params.get("prompt")
+    if isinstance(prompt, str):
+        return prompt
+    if isinstance(prompt, dict):
+        content = prompt.get("content")
+        if isinstance(content, list):
+            pieces = []
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    pieces.append(str(block.get("text") or ""))
+            return "".join(pieces)
+    return ""
+
+
+def stream_ok_turn(session_id: str, question: str, *, resumed: bool = False) -> None:
+    """Emit the happy-path turn: streamed text, a tool call, result content."""
+    index = 0
+    prefix = f"resumed:{session_id} " if resumed else ""
+    agent_message(session_id, [text_block(f"{prefix}You asked: {question}\n", delta=True)], index)
+    index += 1
+    agent_message(session_id, [text_block("The answer is 4.", delta=True)], index)
+    index += 1
+    agent_message(
+        session_id,
+        [
+            {
+                "type": "tool_call",
+                "id": "tc-1",
+                "name": "read_file",
+                "arguments": {"path": "a.txt"},
+            }
+        ],
+        index,
+    )
+    index += 1
+    agent_message(
+        session_id,
+        [
+            {
+                "type": "tool_call_result",
+                "tool_use_id": "tc-1",
+                "content": [{"type": "text", "text": "file says hello"}],
+            }
+        ],
+        index,
+    )
+    index += 1
+    agent_message(session_id, [text_block("Done.", delta=True)], index)
+    index += 1
+    # The "result" content block closes the turn (no text — streamed already).
+    agent_message(session_id, [{"type": "result"}], index)
+
+
+def run_scenario(scenario: str) -> int:
+    session_id: str | None = None
+    message_index = 0
+    turn_done = False
+
+    while True:
+        request = read_request()
+        if request is None:
+            return 0  # client closed stdin → clean exit
+        method = str(request.get("method") or "")
+        params = request.get("params") if isinstance(request.get("params"), dict) else {}
+
+        if method == "initialize":
+            if scenario == "hang_init":
+                # Never answer: pretend to be a non-ACP binary that goes quiet.
+                time.sleep(4)
+                return 0
+            respond(
+                request,
+                {
+                    "protocolVersion": 1,
+                    "agentCapabilities": {"load_session": True, "prompt_tools": False},
+                    "agentVersion": _VERSION,
+                },
+            )
+            if scenario == "malformed":
+                # Interleave a non-JSON line with the protocol stream.
+                sys.stdout.buffer.write(b"NOT-JSON banner\n")
+                sys.stdout.buffer.flush()
+            continue
+
+        if method == "session/new":
+            if scenario == "reject":
+                respond(request, {})
+                notify(
+                    "session/update",
+                    {
+                        "session_id": HOST_SESSION_ID,
+                        "status": "rejected",
+                        "detail": "session rejected by policy",
+                    },
+                )
+                return 0
+            if scenario == "update_accept":
+                # Accept via session/update; the request result carries no id.
+                respond(request, {})
+                notify(
+                    "session/update",
+                    {"session_id": HOST_SESSION_ID, "status": "accepted"},
+                )
+            else:
+                respond(request, {"sessionId": HOST_SESSION_ID})
+            session_id = HOST_SESSION_ID
+            continue
+
+        if method == "session/load":
+            # Accept any resume id and hand it straight back.
+            sid = str(params.get("session_id") or HOST_SESSION_ID)
+            session_id = sid
+            respond(request, {"sessionId": sid})
+            continue
+
+        if method == "prompt":
+            if scenario == "exit_early":
+                sys.stderr.write("fake host: exiting before answering\n")
+                sys.stderr.flush()
+                return 3
+            if scenario == "error_content":
+                agent_message(session_id or HOST_SESSION_ID, [text_block("partial")], 0)
+                agent_message(
+                    session_id or HOST_SESSION_ID,
+                    [{"type": "error", "message": "agent failed"}],
+                    1,
+                )
+                return 0
+            if scenario == "input":
+                question = extract_question(request)
+                agent_message(
+                    session_id or HOST_SESSION_ID,
+                    [text_block("Thinking…", delta=True)],
+                    message_index,
+                )
+                message_index += 1
+                # Ask the client for input and require the auto-empty reply.
+                request_id = _HOST_SEQ + 1
+                notify_with_id = {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": "session/input_request",
+                    "params": {
+                        "session_id": session_id or HOST_SESSION_ID,
+                        "message": {"content": [{"type": "text", "text": "Continue?"}]},
+                    },
+                }
+                send(notify_with_id)
+                reply = read_request()
+                got = ""
+                if reply is not None and reply.get("id") == request_id and "result" in reply:
+                    got = str((reply.get("result") or {}).get("input") or "")
+                if got != "":
+                    sys.stderr.write(f"fake host: unexpected input reply: {got!r}\n")
+                    sys.stderr.flush()
+                    return 7
+                agent_message(
+                    session_id or HOST_SESSION_ID,
+                    [text_block("Got empty input.", delta=True)],
+                    message_index,
+                )
+                message_index += 1
+                agent_message(
+                    session_id or HOST_SESSION_ID,
+                    [{"type": "result"}],
+                    message_index,
+                )
+                return 0
+            if scenario in ("ok", "malformed", "update_accept"):
+                stream_ok_turn(
+                    session_id or HOST_SESSION_ID,
+                    extract_question(request),
+                )
+                return 0
+            if scenario == "ok_resume":
+                stream_ok_turn(
+                    session_id or HOST_SESSION_ID,
+                    extract_question(request),
+                    resumed=True,
+                )
+                return 0
+            # Unknown scenario: behave like "ok" so the client sees a turn.
+            stream_ok_turn(session_id or HOST_SESSION_ID, extract_question(request))
+            return 0
+
+        # A response to the host's own request (e.g. session/input_request).
+        if "result" in request or "error" in request:
+            continue
+        sys.stderr.write(f"fake host: unhandled frame {request!r}\n")
+        sys.stderr.flush()
+        return 9
+
+
+if __name__ == "__main__":
+    scenario = sys.argv[1] if len(sys.argv) > 1 else "ok"
+    sys.exit(run_scenario(scenario))

--- a/tests/fixtures/acp_fake_host.py
+++ b/tests/fixtures/acp_fake_host.py
@@ -1,14 +1,16 @@
-"""Offline fake ACP host used by the AcpBackend integration tests.
+"""Offline fake ACP agent used by the AcpBackend integration tests.
 
-A minimal ACP "host" process that speaks newline-delimited JSON-RPC 2.0 over
-stdio from the host side of the transcript the backend drives: it answers the
-client's ``initialize`` / ``session/new`` / ``session/load`` / ``prompt``
-requests and streams ``agent/message`` notifications (and one optional
-``session/input_request``). It holds no real agent state — the point is to pin
-the backend's wire behaviour offline, not to emulate an agent.
+A minimal ACP v1 *agent* that speaks newline-delimited JSON-RPC 2.0 over
+stdio from the agent side of the transcript the backend drives: it answers the
+client's ``initialize`` / ``session/new`` / ``session/load`` / ``session/prompt``
+requests, streams ``session/update`` notifications (``agent_message_chunk``,
+``tool_call``, ``tool_call_update``, …), answers ``elicitation/create``
+requests from the client, and closes each turn with the ``session/prompt``
+response. It holds no real agent state — the point is to pin the backend's wire
+behaviour offline, not to emulate an agent.
 
 Usage: ``python acp_fake_host.py <scenario>`` where scenario selects the
-behaviour (see ``_SCENARIOS``). Only the Python standard library is used, so
+behaviour (see ``run_scenario``). Only the Python standard library is used, so
 pytest can spawn it with ``sys.executable``.
 """
 
@@ -22,10 +24,6 @@ from typing import Any
 HOST_SESSION_ID = "acp-test-session-1"
 _VERSION = "fake-acp-host-1.0"
 
-# Our own id space for requests the host sends toward the client, so it never
-# collides with the client's request ids.
-_HOST_SEQ = 1000
-
 
 def send(obj: dict[str, Any]) -> None:
     """Write one JSON-RPC frame (newline-delimited) and flush it out."""
@@ -35,109 +33,106 @@ def send(obj: dict[str, Any]) -> None:
 
 def read_request() -> dict[str, Any] | None:
     """Read the next client frame; ``None`` on EOF."""
-    raw = sys.stdin.buffer.readline()
-    if not raw:
-        return None
-    text = raw.decode("utf-8", "replace").strip()
-    if not text:
-        return read_request()
-    try:
-        parsed = json.loads(text)
-    except json.JSONDecodeError:
-        sys.stderr.write(f"fake host: non-JSON client frame ignored: {text!r}\n")
-        sys.stderr.flush()
-        return read_request()
-    return parsed if isinstance(parsed, dict) else read_request()
+    while True:
+        raw = sys.stdin.buffer.readline()
+        if not raw:
+            return None
+        text = raw.decode("utf-8", "replace").strip()
+        if not text:
+            continue
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            sys.stderr.write(f"fake host: non-JSON client frame ignored: {text!r}\n")
+            sys.stderr.flush()
+            continue
+        return parsed if isinstance(parsed, dict) else read_request()
 
 
 def respond(request: dict[str, Any], result: dict[str, Any]) -> None:
     send({"jsonrpc": "2.0", "id": request.get("id"), "result": result})
 
 
+def respond_error(request: dict[str, Any], message: str) -> None:
+    send({"jsonrpc": "2.0", "id": request.get("id"), "error": {"code": 1, "message": message}})
+
+
 def notify(method: str, params: dict[str, Any]) -> None:
     send({"jsonrpc": "2.0", "method": method, "params": params})
 
 
-def agent_message(session_id: str, blocks: list[dict[str, Any]], index: int) -> None:
-    notify(
-        "agent/message",
-        {
-            "session_id": session_id,
-            "message": {
-                "id": f"fake-msg-{index}",
-                "role": "assistant",
-                "content": blocks,
-            },
-        },
+def session_update(session_id: str, update: dict[str, Any]) -> None:
+    notify("session/update", {"sessionId": session_id, "update": update})
+
+
+def message_chunk(session_id: str, text: str) -> None:
+    session_update(
+        session_id,
+        {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": text}},
     )
 
 
-def text_block(text: str, *, delta: bool = False) -> dict[str, Any]:
-    return {"type": "text", "textDelta" if delta else "text": text}
-
-
 def extract_question(request: dict[str, Any]) -> str:
-    """Best-effort read of the client's ``prompt`` text (str or content list)."""
+    """Read the client's ``prompt`` — an array of content blocks in v1."""
     params = request.get("params")
     if not isinstance(params, dict):
         return ""
     prompt = params.get("prompt")
-    if isinstance(prompt, str):
-        return prompt
-    if isinstance(prompt, dict):
-        content = prompt.get("content")
-        if isinstance(content, list):
-            pieces = []
-            for block in content:
-                if isinstance(block, dict) and block.get("type") == "text":
-                    pieces.append(str(block.get("text") or ""))
-            return "".join(pieces)
-    return ""
+    if not isinstance(prompt, list):
+        return ""
+    pieces: list[str] = []
+    for block in prompt:
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text")
+            if isinstance(text, str):
+                pieces.append(text)
+    return "".join(pieces)
 
 
-def stream_ok_turn(session_id: str, question: str, *, resumed: bool = False) -> None:
-    """Emit the happy-path turn: streamed text, a tool call, result content."""
-    index = 0
+def end_prompt(request: dict[str, Any]) -> None:
+    """Close the prompt turn by replying to the client's prompt request."""
+    send({"jsonrpc": "2.0", "id": request.get("id"), "result": {"stopReason": "end_turn"}})
+
+
+def stream_ok_turn(
+    request: dict[str, Any], session_id: str, question: str, *, resumed: bool = False
+) -> None:
+    """Emit the happy-path turn: text chunks, a tool call + result, closing text."""
     prefix = f"resumed:{session_id} " if resumed else ""
-    agent_message(session_id, [text_block(f"{prefix}You asked: {question}\n", delta=True)], index)
-    index += 1
-    agent_message(session_id, [text_block("The answer is 4.", delta=True)], index)
-    index += 1
-    agent_message(
+    message_chunk(session_id, f"{prefix}You asked: {question}\n")
+    message_chunk(session_id, "The answer is 4.")
+    session_update(
         session_id,
-        [
-            {
-                "type": "tool_call",
-                "id": "tc-1",
-                "name": "read_file",
-                "arguments": {"path": "a.txt"},
-            }
-        ],
-        index,
+        {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "tc-1",
+            "title": "Reading project files",
+            "kind": "read",
+            "status": "pending",
+            "rawInput": {"path": "a.txt"},
+        },
     )
-    index += 1
-    agent_message(
+    session_update(
         session_id,
-        [
-            {
-                "type": "tool_call_result",
-                "tool_use_id": "tc-1",
-                "content": [{"type": "text", "text": "file says hello"}],
-            }
-        ],
-        index,
+        {
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "tc-1",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "content",
+                    "content": {"type": "text", "text": "file says hello"},
+                }
+            ],
+            "rawOutput": {"content": "file says hello"},
+        },
     )
-    index += 1
-    agent_message(session_id, [text_block("Done.", delta=True)], index)
-    index += 1
-    # The "result" content block closes the turn (no text — streamed already).
-    agent_message(session_id, [{"type": "result"}], index)
+    message_chunk(session_id, "Done.")
+    end_prompt(request)
 
 
 def run_scenario(scenario: str) -> int:
     session_id: str | None = None
-    message_index = 0
-    turn_done = False
 
     while True:
         request = read_request()
@@ -155,7 +150,7 @@ def run_scenario(scenario: str) -> int:
                 request,
                 {
                     "protocolVersion": 1,
-                    "agentCapabilities": {"load_session": True, "prompt_tools": False},
+                    "agentCapabilities": {"loadSession": True},
                     "agentVersion": _VERSION,
                 },
             )
@@ -167,106 +162,75 @@ def run_scenario(scenario: str) -> int:
 
         if method == "session/new":
             if scenario == "reject":
-                respond(request, {})
-                notify(
-                    "session/update",
-                    {
-                        "session_id": HOST_SESSION_ID,
-                        "status": "rejected",
-                        "detail": "session rejected by policy",
-                    },
-                )
+                respond_error(request, "session rejected by policy")
                 return 0
-            if scenario == "update_accept":
-                # Accept via session/update; the request result carries no id.
-                respond(request, {})
-                notify(
-                    "session/update",
-                    {"session_id": HOST_SESSION_ID, "status": "accepted"},
-                )
-            else:
-                respond(request, {"sessionId": HOST_SESSION_ID})
             session_id = HOST_SESSION_ID
+            respond(request, {"sessionId": session_id})
             continue
 
         if method == "session/load":
             # Accept any resume id and hand it straight back.
-            sid = str(params.get("session_id") or HOST_SESSION_ID)
-            session_id = sid
-            respond(request, {"sessionId": sid})
+            session_id = str(params.get("sessionId") or HOST_SESSION_ID)
+            respond(request, {"sessionId": session_id})
             continue
 
-        if method == "prompt":
+        if method == "session/prompt":
+            question = extract_question(request)
             if scenario == "exit_early":
                 sys.stderr.write("fake host: exiting before answering\n")
                 sys.stderr.flush()
                 return 3
-            if scenario == "error_content":
-                agent_message(session_id or HOST_SESSION_ID, [text_block("partial")], 0)
-                agent_message(
-                    session_id or HOST_SESSION_ID,
-                    [{"type": "error", "message": "agent failed"}],
-                    1,
+            if scenario == "prompt_error":
+                message_chunk(session_id or HOST_SESSION_ID, "partial")
+                send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": request.get("id"),
+                        "error": {"code": 1, "message": "agent failed"},
+                    }
                 )
                 return 0
-            if scenario == "input":
-                question = extract_question(request)
-                agent_message(
-                    session_id or HOST_SESSION_ID,
-                    [text_block("Thinking…", delta=True)],
-                    message_index,
+            if scenario == "elicitation":
+                # Ask the client for input (v1 elicitation) and require the
+                # auto-decline answer before finishing the turn.
+                request_id = 2001
+                send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "method": "elicitation/create",
+                        "params": {
+                            "mode": "form",
+                            "sessionId": session_id or HOST_SESSION_ID,
+                            "message": "Continue?",
+                        },
+                    }
                 )
-                message_index += 1
-                # Ask the client for input and require the auto-empty reply.
-                request_id = _HOST_SEQ + 1
-                notify_with_id = {
-                    "jsonrpc": "2.0",
-                    "id": request_id,
-                    "method": "session/input_request",
-                    "params": {
-                        "session_id": session_id or HOST_SESSION_ID,
-                        "message": {"content": [{"type": "text", "text": "Continue?"}]},
-                    },
-                }
-                send(notify_with_id)
                 reply = read_request()
                 got = ""
                 if reply is not None and reply.get("id") == request_id and "result" in reply:
-                    got = str((reply.get("result") or {}).get("input") or "")
-                if got != "":
-                    sys.stderr.write(f"fake host: unexpected input reply: {got!r}\n")
+                    got = str((reply.get("result") or {}).get("action") or "")
+                if got != "decline":
+                    sys.stderr.write(f"fake host: unexpected elicitation reply: {got!r}\n")
                     sys.stderr.flush()
                     return 7
-                agent_message(
-                    session_id or HOST_SESSION_ID,
-                    [text_block("Got empty input.", delta=True)],
-                    message_index,
+                notify(
+                    "elicitation/complete",
+                    {"sessionId": session_id or HOST_SESSION_ID, "elicitationId": "el-1"},
                 )
-                message_index += 1
-                agent_message(
-                    session_id or HOST_SESSION_ID,
-                    [{"type": "result"}],
-                    message_index,
-                )
+                message_chunk(session_id or HOST_SESSION_ID, "Got no input; declining.")
+                end_prompt(request)
                 return 0
-            if scenario in ("ok", "malformed", "update_accept"):
-                stream_ok_turn(
-                    session_id or HOST_SESSION_ID,
-                    extract_question(request),
-                )
+            if scenario in ("ok", "malformed"):
+                stream_ok_turn(request, session_id or HOST_SESSION_ID, question)
                 return 0
             if scenario == "ok_resume":
-                stream_ok_turn(
-                    session_id or HOST_SESSION_ID,
-                    extract_question(request),
-                    resumed=True,
-                )
+                stream_ok_turn(request, session_id or HOST_SESSION_ID, question, resumed=True)
                 return 0
             # Unknown scenario: behave like "ok" so the client sees a turn.
-            stream_ok_turn(session_id or HOST_SESSION_ID, extract_question(request))
+            stream_ok_turn(request, session_id or HOST_SESSION_ID, question)
             return 0
 
-        # A response to the host's own request (e.g. session/input_request).
         if "result" in request or "error" in request:
             continue
         sys.stderr.write(f"fake host: unhandled frame {request!r}\n")

--- a/tests/services/test_acp_backend.py
+++ b/tests/services/test_acp_backend.py
@@ -1,11 +1,13 @@
 """AcpBackend — the Agent Client Protocol (ACP) subagent backend (#1028, stage 1).
 
-The backend drives a spawnable ACP *host* process over newline-delimited
-JSON-RPC 2.0 on stdio. These tests exercise the whole wire contract offline:
-consult integration runs against a fake host speaking the host side of the
-transcript. Two hosts are used:
+The backend drives a spawnable ACP *agent* process over newline-delimited
+JSON-RPC 2.0 on stdio, speaking the schema-verified v1 transcript: the client
+sends ``initialize`` → ``session/new``/``session/load`` → ``session/prompt``,
+and the agent streams ``session/update`` notifications and closes the turn with
+the prompt response. These tests exercise that wire contract offline against a
+fake agent. Two agents are used:
 
-* an **in-process** fake host behind :class:`AcpBackend`'s injected
+* an **in-process** fake agent behind :class:`AcpBackend`'s injected
   ``host_factory`` seam (mirrors the transport injection the remote Hermes
   backend uses) — always runnable;
 * the real **subprocess** fixture :file:`tests/fixtures/acp_fake_host.py` via
@@ -32,6 +34,7 @@ from deeptutor.services.subagent.config import BackendConfig
 from deeptutor.services.subagent.types import (
     EVENT_ERROR,
     EVENT_LOG,
+    EVENT_REASONING,
     EVENT_TEXT,
     EVENT_TOOL,
     EVENT_TOOL_RESULT,
@@ -45,11 +48,11 @@ _QUESTION = "Is four the answer?"
 pytestmark = pytest.mark.asyncio
 
 
-# ---- in-process fake ACP host ----------------------------------------------------
+# ---- in-process fake ACP agent ----------------------------------------------------
 
 
 class _HostWriter:
-    """A consult-facing stdin: frames are enqueued for the in-process host."""
+    """A consult-facing stdin: frames are enqueued for the in-process agent."""
 
     def __init__(self, queue: asyncio.Queue) -> None:
         self._queue = queue
@@ -70,8 +73,8 @@ class _HostWriter:
             self._queue.put_nowait(b"")
 
 
-class _InMemoryHost:
-    """An ACP host that consult drives entirely in-process (no OS pipes).
+class _InMemoryAgent:
+    """An ACP v1 agent that consult drives entirely in-process (no OS pipes).
 
     The ``scenario`` behaviours mirror the subprocess fixture in
     :file:`tests/fixtures/acp_fake_host.py`; both encode the same transcript.
@@ -89,6 +92,9 @@ class _InMemoryHost:
         self.stdin = _HostWriter(self._inbound)
         self.stdout = self._stdout
         self._task: asyncio.Task | None = None
+        # Requests we answered, for asserting the exact client wire shape.
+        self.session_params: dict | None = None
+        self.prompt_params: dict | None = None
 
     # -- asyncio.subprocess.Process duck-type surface ---------------------------
     async def wait(self) -> int:
@@ -133,22 +139,26 @@ class _InMemoryHost:
     async def _respond(self, request: dict, result: dict) -> None:
         await self._write_frame({"jsonrpc": "2.0", "id": request.get("id"), "result": result})
 
+    async def _respond_error(self, request: dict, message: str) -> None:
+        await self._write_frame(
+            {"jsonrpc": "2.0", "id": request.get("id"), "error": {"code": 1, "message": message}}
+        )
+
     async def _notify(self, method: str, params: dict) -> None:
         await self._write_frame({"jsonrpc": "2.0", "method": method, "params": params})
 
-    async def _message(self, session_id: str, blocks: list[dict], index: int) -> None:
-        await self._notify(
-            "agent/message",
-            {
-                "session_id": session_id,
-                "message": {"id": f"fake-msg-{index}", "role": "assistant", "content": blocks},
-            },
+    async def _session_update(self, session_id: str, update: dict) -> None:
+        await self._notify("session/update", {"sessionId": session_id, "update": update})
+
+    async def _message_chunk(self, session_id: str, text: str) -> None:
+        await self._session_update(
+            session_id,
+            {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": text}},
         )
 
     async def _run_scenario(self) -> None:
         scenario = self.scenario
         session_id: str | None = None
-        index = 0
 
         while True:
             request = await self._read_frame()
@@ -167,7 +177,7 @@ class _InMemoryHost:
                     request,
                     {
                         "protocolVersion": 1,
-                        "agentCapabilities": {"load_session": True, "prompt_tools": False},
+                        "agentCapabilities": {"loadSession": True},
                         "agentVersion": "fake-acp-host-1.0",
                     },
                 )
@@ -175,89 +185,89 @@ class _InMemoryHost:
                     self._stdout.feed_data(b"NOT-JSON banner\n")
                 continue
 
-            if method == "session/new":
-                if scenario == "reject":
-                    await self._respond(request, {})
-                    await self._notify(
-                        "session/update",
-                        {
-                            "session_id": self.HOST_SESSION,
-                            "status": "rejected",
-                            "detail": "session rejected by policy",
-                        },
-                    )
+            if method in ("session/new", "session/load"):
+                self.session_params = params
+                if scenario == "reject" and method == "session/new":
+                    await self._respond_error(request, "session rejected by policy")
                     return
-                if scenario == "update_accept":
-                    await self._respond(request, {})
-                    await self._notify(
-                        "session/update",
-                        {"session_id": self.HOST_SESSION, "status": "accepted"},
-                    )
+                if method == "session/new":
+                    session_id = self.HOST_SESSION
                 else:
-                    await self._respond(request, {"sessionId": self.HOST_SESSION})
-                session_id = self.HOST_SESSION
-                continue
-
-            if method == "session/load":
-                session_id = str(params.get("session_id") or self.HOST_SESSION)
+                    session_id = str(params.get("sessionId") or self.HOST_SESSION)
                 await self._respond(request, {"sessionId": session_id})
                 continue
 
-            if method == "prompt":
-                question = self._prompt_text(request)
+            if method == "session/prompt":
+                self.prompt_params = params
+                question = self._prompt_text(params)
                 if scenario == "exit_early":
                     self._exit_code = 3
                     return
-                if scenario == "error_content":
-                    await self._message(
-                        session_id or self.HOST_SESSION,
-                        [{"type": "text", "text": "partial"}],
-                        index,
-                    )
-                    index += 1
-                    await self._message(
-                        session_id or self.HOST_SESSION,
-                        [{"type": "error", "message": "agent failed"}],
-                        index,
+                if scenario == "prompt_error":
+                    await self._message_chunk(session_id or self.HOST_SESSION, "partial")
+                    await self._write_frame(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": request.get("id"),
+                            "error": {"code": 1, "message": "agent failed"},
+                        }
                     )
                     return
-                if scenario == "input":
-                    await self._message(
-                        session_id or self.HOST_SESSION,
-                        [{"type": "text", "textDelta": "Thinking…"}],
-                        index,
-                    )
-                    index += 1
+                if scenario == "elicitation":
+                    await self._message_chunk(session_id or self.HOST_SESSION, "Thinking…")
                     request_id = 2001
                     await self._write_frame(
                         {
                             "jsonrpc": "2.0",
                             "id": request_id,
-                            "method": "session/input_request",
+                            "method": "elicitation/create",
                             "params": {
-                                "session_id": session_id or self.HOST_SESSION,
-                                "message": {"content": [{"type": "text", "text": "Continue?"}]},
+                                "mode": "form",
+                                "sessionId": session_id or self.HOST_SESSION,
+                                "message": "Continue?",
                             },
                         }
                     )
                     reply = await self._read_frame()
                     got = ""
                     if reply is not None and reply.get("id") == request_id and "result" in reply:
-                        got = str((reply.get("result") or {}).get("input") or "")
-                    if got != "":
+                        got = str((reply.get("result") or {}).get("action") or "")
+                    if got != "decline":
                         self._exit_code = 7
                         return
-                    await self._message(
-                        session_id or self.HOST_SESSION,
-                        [{"type": "text", "textDelta": "Got empty input."}],
-                        index,
+                    await self._notify(
+                        "elicitation/complete",
+                        {"sessionId": session_id or self.HOST_SESSION, "elicitationId": "el-1"},
                     )
-                    index += 1
-                    await self._message(
-                        session_id or self.HOST_SESSION, [{"type": "result"}], index
+                    await self._message_chunk(
+                        session_id or self.HOST_SESSION, "Got no input; declining."
                     )
+                    await self._respond(request, {"stopReason": "end_turn"})
                     return
-                await self._ok_turn(session_id or self.HOST_SESSION, question)
+                if scenario == "unsolicited_request":
+                    await self._message_chunk(session_id or self.HOST_SESSION, "Thinking…")
+                    request_id = 2002
+                    await self._write_frame(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": request_id,
+                            "method": "session/request_permission",
+                            "params": {"sessionId": session_id or self.HOST_SESSION},
+                        }
+                    )
+                    reply = await self._read_frame()
+                    code = ""
+                    if reply is not None and reply.get("id") == request_id and "error" in reply:
+                        code = str((reply.get("error") or {}).get("code") or "")
+                    if code != "-32601":
+                        self._exit_code = 7
+                        return
+                    await self._message_chunk(
+                        session_id or self.HOST_SESSION, "Permission declined; moving on."
+                    )
+                    await self._respond(request, {"stopReason": "end_turn"})
+                    return
+                await self._ok_turn(request, session_id or self.HOST_SESSION, question)
                 return
 
             if "result" in request or "error" in request:
@@ -266,48 +276,54 @@ class _InMemoryHost:
             return
 
     @staticmethod
-    def _prompt_text(request: dict) -> str:
-        params = request.get("params")
-        prompt = params.get("prompt") if isinstance(params, dict) else ""
-        return prompt if isinstance(prompt, str) else ""
+    def _prompt_text(params: dict) -> str:
+        prompt = params.get("prompt")
+        if not isinstance(prompt, list):
+            return ""
+        pieces: list[str] = []
+        for block in prompt:
+            if isinstance(block, dict) and block.get("type") == "text":
+                pieces.append(str(block.get("text") or ""))
+        return "".join(pieces)
 
-    async def _ok_turn(self, session_id: str, question: str) -> None:
+    async def _ok_turn(self, request: dict, session_id: str, question: str) -> None:
         prefix = f"resumed:{session_id} " if self.scenario == "ok_resume" else ""
-        index = 0
-        await self._message(
-            session_id, [{"type": "text", "textDelta": f"{prefix}You asked: {question}\n"}], index
-        )
-        index += 1
-        await self._message(session_id, [{"type": "text", "textDelta": "The answer is 4."}], index)
-        index += 1
-        await self._message(
+        await self._message_chunk(session_id, f"{prefix}You asked: {question}\n")
+        await self._message_chunk(session_id, "The answer is 4.")
+        await self._session_update(
             session_id,
-            [
-                {
-                    "type": "tool_call",
-                    "id": "tc-1",
-                    "name": "read_file",
-                    "arguments": {"path": "a.txt"},
-                }
-            ],
-            index,
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc-1",
+                "title": "Reading project files",
+                "kind": "read",
+                "status": "pending",
+                "rawInput": {"path": "a.txt"},
+            },
         )
-        index += 1
-        await self._message(
+        await self._session_update(
             session_id,
-            [
-                {
-                    "type": "tool_call_result",
-                    "tool_use_id": "tc-1",
-                    "content": [{"type": "text", "text": "file says hello"}],
-                }
-            ],
-            index,
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc-1",
+                "status": "completed",
+                "content": [
+                    {"type": "content", "content": {"type": "text", "text": "file says hello"}}
+                ],
+                "rawOutput": {"content": "file says hello"},
+            },
         )
-        index += 1
-        await self._message(session_id, [{"type": "text", "textDelta": "Done."}], index)
-        index += 1
-        await self._message(session_id, [{"type": "result"}], index)
+        if self.scenario == "ok_with_thought":
+            await self._session_update(
+                session_id,
+                {
+                    "sessionUpdate": "agent_thought_chunk",
+                    "content": {"type": "text", "text": "hmm…"},
+                },
+            )
+        await self._message_chunk(session_id, "Done.")
+        # The turn ends with the JSON-RPC response to the prompt request.
+        await self._respond(request, {"stopReason": "end_turn"})
 
 
 # ---- helpers ---------------------------------------------------------------------
@@ -342,12 +358,12 @@ class _SyncPipeWriter:
                 pass
 
 
-class _RealProcessHost:
-    """A consult-facing host that runs the fixture as a real subprocess.
+class _RealProcessAgent:
+    """A consult-facing agent that runs the fixture as a real subprocess.
 
     Some sandboxes forbid asyncio's duplex-pipe spawn (``WinError 5`` on the
     pipe creation) while a synchronous ``subprocess.Popen`` with pipes still
-    works. This host therefore spawns synchronously and bridges the child's
+    works. This agent therefore spawns synchronously and bridges the child's
     stdout to an :class:`asyncio.StreamReader` from a reader thread — exercising
     the real process and real byte framing end-to-end while consult stays
     async. Consult only ever sees the same duck-typed surface as the other
@@ -398,18 +414,18 @@ def _host_argv(scenario: str) -> list[str]:
 
 
 async def _consult_memory(scenario: str, monkeypatch, **kwargs):
-    """Run consult against the in-process fake host (always available)."""
-    host = _InMemoryHost(scenario)
-    backend = AcpBackend(host_factory=lambda: _ready(host))
-    return await _drive(backend, host, monkeypatch, **kwargs)
+    """Run consult against the in-process fake agent (always available)."""
+    agent = _InMemoryAgent(scenario)
+    backend = AcpBackend(host_factory=lambda: _ready(agent))
+    return await _drive(backend, agent, monkeypatch, **kwargs)
 
 
 async def _consult_real_process(scenario: str, monkeypatch, **kwargs):
     """Run consult against the real subprocess fixture through sync pipes."""
     loop = asyncio.get_running_loop()
-    host = _RealProcessHost(_host_argv(scenario), loop)
-    backend = AcpBackend(host_factory=lambda: _ready(host))
-    return await _drive(backend, host, monkeypatch, **kwargs)
+    agent = _RealProcessAgent(_host_argv(scenario), loop)
+    backend = AcpBackend(host_factory=lambda: _ready(agent))
+    return await _drive(backend, agent, monkeypatch, **kwargs)
 
 
 async def _consult_default_spawn(scenario: str, monkeypatch, **kwargs):
@@ -419,13 +435,13 @@ async def _consult_default_spawn(scenario: str, monkeypatch, **kwargs):
     return await _drive(backend, None, monkeypatch, **kwargs)
 
 
-async def _ready(host: _InMemoryHost) -> _InMemoryHost:
-    return host
+async def _ready(agent) -> _InMemoryAgent:
+    return agent
 
 
-async def _drive(backend, host, monkeypatch, *, question: str = _QUESTION, **kwargs):
-    if host is not None:
-        host.start()
+async def _drive(backend, agent, monkeypatch, *, question: str = _QUESTION, **kwargs):
+    if agent is not None:
+        agent.start()
     seen: list = []
 
     async def on_event(event):
@@ -436,8 +452,8 @@ async def _drive(backend, host, monkeypatch, *, question: str = _QUESTION, **kwa
         on_event=on_event,
         **kwargs,
     )
-    if host is not None:
-        await host.wait()
+    if agent is not None:
+        await agent.wait()
     return result, seen
 
 
@@ -555,7 +571,7 @@ async def test_detect_all_reports_acp(monkeypatch) -> None:
     assert "acp" in kinds
 
 
-# ---- consult integration (in-process host, always runs) ---------------------------
+# ---- consult integration (in-process agent, always runs) ---------------------------
 
 
 async def test_consult_streams_events_and_returns_session(monkeypatch) -> None:
@@ -566,7 +582,7 @@ async def test_consult_streams_events_and_returns_session(monkeypatch) -> None:
     assert result.session_id == "acp-test-session-1"
     assert result.event_count == len(seen)
 
-    # The handshake is announced, then text streams, a tool runs, and text closes.
+    # Session start is announced, then text chunks stream, a tool runs, closes.
     assert seen[0].kind == EVENT_LOG
     assert "session" in seen[0].text
     kinds = [e.kind for e in seen[1:]]
@@ -577,32 +593,46 @@ async def test_consult_streams_events_and_returns_session(monkeypatch) -> None:
 
     tool = next(e for e in seen if e.kind == EVENT_TOOL)
     tool_result = next(e for e in seen if e.kind == EVENT_TOOL_RESULT)
-    assert tool.text.startswith("read_file")
-    assert "a.txt" in tool.text
+    assert "Reading" in tool.text or "a.txt" in tool.text
     assert "file says hello" in tool_result.text
+    # Tool start and finish collapse to one row via the shared toolCallId.
+    assert tool.meta.get("merge_id") == "tc-1"
+    assert tool_result.meta.get("merge_id") == "tc-1"
 
-    # The question travelled through the prompt request to the host and back.
+    # The question travelled through the prompt content array and back.
     assert any(_QUESTION in t for t in _texts(seen))
     assert result.final_text.startswith("You asked:")
     assert "The answer is 4." in result.final_text
+    assert result.final_text.endswith("Done.")
 
 
-async def test_consult_accepts_session_via_session_update(monkeypatch) -> None:
-    """Session acceptance can arrive as session/update instead of in the result."""
-    result, _ = await _consult_memory("update_accept", monkeypatch)
+async def test_consult_sends_schema_conformant_session_and_prompt(monkeypatch) -> None:
+    """session/new carries cwd+mcpServers and session/prompt an array of blocks."""
+    agent = _InMemoryAgent("ok")
+    backend = AcpBackend(host_factory=lambda: _ready(agent))
+    result, _ = await _drive(backend, agent, monkeypatch)
+
     assert result.success is True
-    assert result.session_id == "acp-test-session-1"
-    assert "The answer is 4." in result.final_text
+    assert agent.session_params is not None
+    assert agent.session_params["cwd"]  # absolute working directory
+    assert agent.session_params["mcpServers"] == []
+    assert agent.prompt_params is not None
+    assert agent.prompt_params["sessionId"] == "acp-test-session-1"
+    assert agent.prompt_params["prompt"] == [{"type": "text", "text": _QUESTION}]
 
 
-async def test_consult_resumes_existing_session(monkeypatch) -> None:
-    """A session_id makes consult send session/load; the id round-trips."""
-    result, _ = await _consult_memory("ok_resume", monkeypatch, session_id="acp-sess-9")
+async def test_consult_resume_sends_session_load_with_session_id(monkeypatch) -> None:
+    agent = _InMemoryAgent("ok_resume")
+    backend = AcpBackend(host_factory=lambda: _ready(agent))
+    result, _ = await _drive(backend, agent, monkeypatch, session_id="acp-sess-9", question="again")
+
     assert result.success is True
+    assert agent.session_params is not None
+    assert agent.session_params["sessionId"] == "acp-sess-9"
+    assert agent.session_params["mcpServers"] == []
     assert result.session_id == "acp-sess-9"
-    # The fake host prefixes its answer with the id it was asked to load.
+    # The fake agent prefixes its answer with the id it was asked to load.
     assert result.final_text.startswith("resumed:acp-sess-9 ")
-    assert "The answer is 4." in result.final_text
 
 
 async def test_consult_system_prompt_is_prepended_on_fresh_run(monkeypatch) -> None:
@@ -623,13 +653,24 @@ async def test_consult_forwards_images_as_paths(monkeypatch) -> None:
     assert "b.png" in result.final_text
 
 
-async def test_consult_answers_input_request_with_empty_input(monkeypatch) -> None:
-    """A session/input_request is surfaced and auto-replied so a run never stalls."""
-    result, seen = await _consult_memory("input", monkeypatch)
+async def test_consult_answers_elicitation_with_decline(monkeypatch) -> None:
+    """A v1 elicitation/create request is surfaced and auto-declined so a run
+    never stalls; the agent then finishes the turn."""
+    result, seen = await _consult_memory("elicitation", monkeypatch)
     assert result.success is True
-    assert result.final_text.endswith("Got empty input.")
-    log = next(e for e in seen if e.kind == EVENT_LOG and "input" in e.text)
-    assert "auto-replied" in log.text or "empty input" in log.text
+    assert result.final_text.endswith("Got no input; declining.")
+    log = next(
+        e for e in seen if e.kind == EVENT_LOG and ("elicitation" in e.text or "input" in e.text)
+    )
+    assert "decline" in log.text
+
+
+async def test_consult_rejects_unsolicited_requests_with_method_not_found(monkeypatch) -> None:
+    """Unsupported agent requests (e.g. permission) are refused, not approved."""
+    result, seen = await _consult_memory("unsolicited_request", monkeypatch)
+    assert result.success is True
+    assert result.final_text.endswith("Permission declined; moving on.")
+    assert any("unsupported method" in e.text for e in seen)
 
 
 async def test_consult_session_rejected_is_a_failure(monkeypatch) -> None:
@@ -639,22 +680,22 @@ async def test_consult_session_rejected_is_a_failure(monkeypatch) -> None:
     assert any(e.kind == EVENT_ERROR for e in seen)
 
 
-async def test_consult_error_content_block_fails_run(monkeypatch) -> None:
-    result, seen = await _consult_memory("error_content", monkeypatch)
+async def test_consult_prompt_error_fails_run(monkeypatch) -> None:
+    result, seen = await _consult_memory("prompt_error", monkeypatch)
     assert result.success is False
     assert "agent failed" in result.error
     assert any(e.kind == EVENT_ERROR and "agent failed" in e.text for e in seen)
 
 
-async def test_consult_host_exit_before_answer_is_a_failure(monkeypatch) -> None:
+async def test_consult_agent_exit_before_answer_is_a_failure(monkeypatch) -> None:
     result, seen = await _consult_memory("exit_early", monkeypatch)
     assert result.success is False
-    assert "exited" in result.error and "3" in result.error
+    assert "3" in result.error and "prompt" in result.error
     assert any(e.kind == EVENT_ERROR for e in seen)
 
 
 async def test_consult_handshake_timeout_is_a_clean_failure(monkeypatch) -> None:
-    """A host that never answers initialize fails fast instead of hanging."""
+    """An agent that never answers initialize fails fast instead of hanging."""
     import deeptutor.services.subagent.acp as acp_mod
 
     monkeypatch.setattr(acp_mod, "_HANDSHAKE_TIMEOUT_SECONDS", 1.0)
@@ -669,6 +710,14 @@ async def test_consult_tolerates_non_json_stdout_lines(monkeypatch) -> None:
     assert result.success is True
     assert "The answer is 4." in result.final_text
     assert any("NOT-JSON banner" in e.text for e in seen)
+
+
+async def test_consult_thought_chunks_map_to_reasoning(monkeypatch) -> None:
+    """agent_thought_chunk text maps to reasoning and never joins the answer."""
+    result, seen = await _consult_memory("ok_with_thought", monkeypatch)
+    assert result.success is True
+    assert any(e.kind == EVENT_REASONING and e.text == "hmm…" for e in seen)
+    assert "hmm…" not in result.final_text
 
 
 async def test_consult_without_configured_command_fails_cleanly(monkeypatch) -> None:

--- a/tests/services/test_acp_backend.py
+++ b/tests/services/test_acp_backend.py
@@ -1,0 +1,720 @@
+"""AcpBackend — the Agent Client Protocol (ACP) subagent backend (#1028, stage 1).
+
+The backend drives a spawnable ACP *host* process over newline-delimited
+JSON-RPC 2.0 on stdio. These tests exercise the whole wire contract offline:
+consult integration runs against a fake host speaking the host side of the
+transcript. Two hosts are used:
+
+* an **in-process** fake host behind :class:`AcpBackend`'s injected
+  ``host_factory`` seam (mirrors the transport injection the remote Hermes
+  backend uses) — always runnable;
+* the real **subprocess** fixture :file:`tests/fixtures/acp_fake_host.py` via
+  the default OS-pipe spawn — run wherever asyncio can spawn piped children,
+  skipped in sandboxes that forbid it.
+
+Plus the detect/registry wiring and the command-resolution rules. No real
+agent CLI is required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+import subprocess
+import sys
+import threading
+
+import pytest
+
+from deeptutor.services.subagent.acp import ACP_COMMAND_ENV, AcpBackend
+from deeptutor.services.subagent.config import BackendConfig
+from deeptutor.services.subagent.types import (
+    EVENT_ERROR,
+    EVENT_LOG,
+    EVENT_TEXT,
+    EVENT_TOOL,
+    EVENT_TOOL_RESULT,
+)
+
+_FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "acp_fake_host.py"
+_QUESTION = "Is four the answer?"
+
+# Every test here is async (detect/consult are coroutines); run them all on the
+# pytest-asyncio loop like the other backend test modules.
+pytestmark = pytest.mark.asyncio
+
+
+# ---- in-process fake ACP host ----------------------------------------------------
+
+
+class _HostWriter:
+    """A consult-facing stdin: frames are enqueued for the in-process host."""
+
+    def __init__(self, queue: asyncio.Queue) -> None:
+        self._queue = queue
+        self._closed = False
+
+    def write(self, data: bytes) -> int:
+        if self._closed:
+            return 0
+        self._queue.put_nowait(data)
+        return len(data)
+
+    async def drain(self) -> None:  # noqa: D102 - queue writes never block
+        return None
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            self._queue.put_nowait(b"")
+
+
+class _InMemoryHost:
+    """An ACP host that consult drives entirely in-process (no OS pipes).
+
+    The ``scenario`` behaviours mirror the subprocess fixture in
+    :file:`tests/fixtures/acp_fake_host.py`; both encode the same transcript.
+    """
+
+    HOST_SESSION = "acp-test-session-1"
+
+    def __init__(self, scenario: str) -> None:
+        self.scenario = scenario
+        self._inbound: asyncio.Queue = asyncio.Queue()
+        self._stdout = asyncio.StreamReader()
+        self._exit_code = 0
+        self._done = asyncio.Event()
+        self.returncode: int | None = None
+        self.stdin = _HostWriter(self._inbound)
+        self.stdout = self._stdout
+        self._task: asyncio.Task | None = None
+
+    # -- asyncio.subprocess.Process duck-type surface ---------------------------
+    async def wait(self) -> int:
+        await self._done.wait()
+        assert self.returncode is not None
+        return self.returncode
+
+    def terminate(self) -> None:
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+
+    def kill(self) -> None:
+        self.terminate()
+
+    # -- engine -----------------------------------------------------------------
+    def start(self) -> asyncio.Task:
+        self._task = asyncio.create_task(self._run())
+        return self._task
+
+    async def _run(self) -> None:
+        try:
+            await self._run_scenario()
+        finally:
+            self.returncode = self._exit_code
+            self._stdout.feed_eof()
+            self._done.set()
+
+    async def _read_frame(self) -> dict | None:
+        while True:
+            raw = await self._inbound.get()
+            if not raw:
+                return None
+            try:
+                parsed = json.loads(raw.decode("utf-8", "replace"))
+            except ValueError:
+                continue
+            return parsed if isinstance(parsed, dict) else None
+
+    async def _write_frame(self, obj: dict) -> None:
+        self._stdout.feed_data((json.dumps(obj, ensure_ascii=False) + "\n").encode("utf-8"))
+
+    async def _respond(self, request: dict, result: dict) -> None:
+        await self._write_frame({"jsonrpc": "2.0", "id": request.get("id"), "result": result})
+
+    async def _notify(self, method: str, params: dict) -> None:
+        await self._write_frame({"jsonrpc": "2.0", "method": method, "params": params})
+
+    async def _message(self, session_id: str, blocks: list[dict], index: int) -> None:
+        await self._notify(
+            "agent/message",
+            {
+                "session_id": session_id,
+                "message": {"id": f"fake-msg-{index}", "role": "assistant", "content": blocks},
+            },
+        )
+
+    async def _run_scenario(self) -> None:
+        scenario = self.scenario
+        session_id: str | None = None
+        index = 0
+
+        while True:
+            request = await self._read_frame()
+            if request is None:
+                return
+            method = str(request.get("method") or "")
+            params = request.get("params") if isinstance(request.get("params"), dict) else {}
+
+            if method == "initialize":
+                if scenario == "hang_init":
+                    # Stay alive without answering; consult's timeout must fire.
+                    while await self._read_frame() is not None:
+                        pass
+                    return
+                await self._respond(
+                    request,
+                    {
+                        "protocolVersion": 1,
+                        "agentCapabilities": {"load_session": True, "prompt_tools": False},
+                        "agentVersion": "fake-acp-host-1.0",
+                    },
+                )
+                if scenario == "malformed":
+                    self._stdout.feed_data(b"NOT-JSON banner\n")
+                continue
+
+            if method == "session/new":
+                if scenario == "reject":
+                    await self._respond(request, {})
+                    await self._notify(
+                        "session/update",
+                        {
+                            "session_id": self.HOST_SESSION,
+                            "status": "rejected",
+                            "detail": "session rejected by policy",
+                        },
+                    )
+                    return
+                if scenario == "update_accept":
+                    await self._respond(request, {})
+                    await self._notify(
+                        "session/update",
+                        {"session_id": self.HOST_SESSION, "status": "accepted"},
+                    )
+                else:
+                    await self._respond(request, {"sessionId": self.HOST_SESSION})
+                session_id = self.HOST_SESSION
+                continue
+
+            if method == "session/load":
+                session_id = str(params.get("session_id") or self.HOST_SESSION)
+                await self._respond(request, {"sessionId": session_id})
+                continue
+
+            if method == "prompt":
+                question = self._prompt_text(request)
+                if scenario == "exit_early":
+                    self._exit_code = 3
+                    return
+                if scenario == "error_content":
+                    await self._message(
+                        session_id or self.HOST_SESSION,
+                        [{"type": "text", "text": "partial"}],
+                        index,
+                    )
+                    index += 1
+                    await self._message(
+                        session_id or self.HOST_SESSION,
+                        [{"type": "error", "message": "agent failed"}],
+                        index,
+                    )
+                    return
+                if scenario == "input":
+                    await self._message(
+                        session_id or self.HOST_SESSION,
+                        [{"type": "text", "textDelta": "Thinking…"}],
+                        index,
+                    )
+                    index += 1
+                    request_id = 2001
+                    await self._write_frame(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": request_id,
+                            "method": "session/input_request",
+                            "params": {
+                                "session_id": session_id or self.HOST_SESSION,
+                                "message": {"content": [{"type": "text", "text": "Continue?"}]},
+                            },
+                        }
+                    )
+                    reply = await self._read_frame()
+                    got = ""
+                    if reply is not None and reply.get("id") == request_id and "result" in reply:
+                        got = str((reply.get("result") or {}).get("input") or "")
+                    if got != "":
+                        self._exit_code = 7
+                        return
+                    await self._message(
+                        session_id or self.HOST_SESSION,
+                        [{"type": "text", "textDelta": "Got empty input."}],
+                        index,
+                    )
+                    index += 1
+                    await self._message(
+                        session_id or self.HOST_SESSION, [{"type": "result"}], index
+                    )
+                    return
+                await self._ok_turn(session_id or self.HOST_SESSION, question)
+                return
+
+            if "result" in request or "error" in request:
+                continue
+            self._exit_code = 9
+            return
+
+    @staticmethod
+    def _prompt_text(request: dict) -> str:
+        params = request.get("params")
+        prompt = params.get("prompt") if isinstance(params, dict) else ""
+        return prompt if isinstance(prompt, str) else ""
+
+    async def _ok_turn(self, session_id: str, question: str) -> None:
+        prefix = f"resumed:{session_id} " if self.scenario == "ok_resume" else ""
+        index = 0
+        await self._message(
+            session_id, [{"type": "text", "textDelta": f"{prefix}You asked: {question}\n"}], index
+        )
+        index += 1
+        await self._message(session_id, [{"type": "text", "textDelta": "The answer is 4."}], index)
+        index += 1
+        await self._message(
+            session_id,
+            [
+                {
+                    "type": "tool_call",
+                    "id": "tc-1",
+                    "name": "read_file",
+                    "arguments": {"path": "a.txt"},
+                }
+            ],
+            index,
+        )
+        index += 1
+        await self._message(
+            session_id,
+            [
+                {
+                    "type": "tool_call_result",
+                    "tool_use_id": "tc-1",
+                    "content": [{"type": "text", "text": "file says hello"}],
+                }
+            ],
+            index,
+        )
+        index += 1
+        await self._message(session_id, [{"type": "text", "textDelta": "Done."}], index)
+        index += 1
+        await self._message(session_id, [{"type": "result"}], index)
+
+
+# ---- helpers ---------------------------------------------------------------------
+
+
+class _SyncPipeWriter:
+    """A consult-facing stdin backed by a real (sync) child stdin pipe."""
+
+    def __init__(self, pipe) -> None:
+        self._pipe = pipe
+        self._closed = False
+
+    def write(self, data: bytes) -> int:
+        if self._closed:
+            return 0
+        try:
+            self._pipe.write(data)
+            return len(data)
+        except (BrokenPipeError, OSError):
+            return 0
+
+    async def drain(self) -> None:
+        if not self._closed:
+            await asyncio.to_thread(self._pipe.flush)
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            try:
+                self._pipe.close()
+            except Exception:  # noqa: BLE001 - best-effort pipe close
+                pass
+
+
+class _RealProcessHost:
+    """A consult-facing host that runs the fixture as a real subprocess.
+
+    Some sandboxes forbid asyncio's duplex-pipe spawn (``WinError 5`` on the
+    pipe creation) while a synchronous ``subprocess.Popen`` with pipes still
+    works. This host therefore spawns synchronously and bridges the child's
+    stdout to an :class:`asyncio.StreamReader` from a reader thread — exercising
+    the real process and real byte framing end-to-end while consult stays
+    async. Consult only ever sees the same duck-typed surface as the other
+    hosts.
+    """
+
+    def __init__(self, argv: list[str], loop: asyncio.AbstractEventLoop) -> None:
+        self._proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        self._loop = loop
+        self.stdout = asyncio.StreamReader()
+        self.stdin = _SyncPipeWriter(self._proc.stdin)
+        self._thread = threading.Thread(target=self._pump, daemon=True)
+        self._thread.start()
+
+    @property
+    def returncode(self):
+        return self._proc.poll()
+
+    def start(self) -> None:
+        """The pump thread is already running; kept for host-interface symmetry."""
+
+    async def wait(self) -> int:
+        return await asyncio.to_thread(self._proc.wait)
+
+    def terminate(self) -> None:
+        if self._proc.poll() is None:
+            self._proc.terminate()
+
+    def kill(self) -> None:
+        if self._proc.poll() is None:
+            self._proc.kill()
+
+    def _pump(self) -> None:
+        try:
+            for line in self._proc.stdout:
+                self._loop.call_soon_threadsafe(self.stdout.feed_data, line)
+        finally:
+            self._loop.call_soon_threadsafe(self.stdout.feed_eof)
+
+
+def _host_argv(scenario: str) -> list[str]:
+    return [sys.executable, str(_FIXTURE), scenario]
+
+
+async def _consult_memory(scenario: str, monkeypatch, **kwargs):
+    """Run consult against the in-process fake host (always available)."""
+    host = _InMemoryHost(scenario)
+    backend = AcpBackend(host_factory=lambda: _ready(host))
+    return await _drive(backend, host, monkeypatch, **kwargs)
+
+
+async def _consult_real_process(scenario: str, monkeypatch, **kwargs):
+    """Run consult against the real subprocess fixture through sync pipes."""
+    loop = asyncio.get_running_loop()
+    host = _RealProcessHost(_host_argv(scenario), loop)
+    backend = AcpBackend(host_factory=lambda: _ready(host))
+    return await _drive(backend, host, monkeypatch, **kwargs)
+
+
+async def _consult_default_spawn(scenario: str, monkeypatch, **kwargs):
+    """Run consult against the fixture via consult's own asyncio subprocess spawn."""
+    monkeypatch.setenv(ACP_COMMAND_ENV, json.dumps(_host_argv(scenario)))
+    backend = AcpBackend()
+    return await _drive(backend, None, monkeypatch, **kwargs)
+
+
+async def _ready(host: _InMemoryHost) -> _InMemoryHost:
+    return host
+
+
+async def _drive(backend, host, monkeypatch, *, question: str = _QUESTION, **kwargs):
+    if host is not None:
+        host.start()
+    seen: list = []
+
+    async def on_event(event):
+        seen.append(event)
+
+    result = await backend.consult(
+        question,
+        on_event=on_event,
+        **kwargs,
+    )
+    if host is not None:
+        await host.wait()
+    return result, seen
+
+
+def _asyncio_spawn_available() -> bool:
+    """Whether this environment can spawn piped children via asyncio."""
+    if _asyncio_spawn_available.result is not None:  # type: ignore[attr-defined]
+        return _asyncio_spawn_available.result  # type: ignore[attr-defined]
+
+    async def probe() -> bool:
+        try:
+            process = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-c",
+                "pass",
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            await process.wait()
+            return process.returncode == 0
+        except Exception:  # noqa: BLE001 - any spawn failure means "not available"
+            return False
+
+    try:
+        _asyncio_spawn_available.result = asyncio.run(probe())  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001 - no event loop available in this thread
+        _asyncio_spawn_available.result = False  # type: ignore[attr-defined]
+    return _asyncio_spawn_available.result  # type: ignore[attr-defined]
+
+
+_asyncio_spawn_available.result = None  # type: ignore[attr-defined]
+
+_requires_subprocess = pytest.mark.skipif(
+    not _asyncio_spawn_available(),
+    reason="asyncio cannot spawn piped children in this sandbox (WinError 5)",
+)
+
+
+def _texts(seen) -> list[str]:
+    return [e.text for e in seen]
+
+
+# ---- command resolution / detect -------------------------------------------------
+
+
+async def test_env_command_unset_means_unavailable(monkeypatch) -> None:
+    monkeypatch.delenv(ACP_COMMAND_ENV, raising=False)
+    detected = await AcpBackend().detect()
+
+    assert detected.kind == "acp"
+    assert detected.available is False
+    assert "configure" in detected.detail.lower() or ACP_COMMAND_ENV in detected.detail
+
+
+async def test_env_command_resolves_makes_available(monkeypatch) -> None:
+    monkeypatch.setenv(ACP_COMMAND_ENV, json.dumps(_host_argv("ok")))
+    detected = await AcpBackend().detect()
+    assert detected.available is True
+    assert detected.version == ""
+
+
+async def test_env_command_missing_binary_stays_unavailable(monkeypatch) -> None:
+    monkeypatch.setenv(ACP_COMMAND_ENV, json.dumps(["definitely-not-an-acp-host-xyz", "ok"]))
+    detected = await AcpBackend().detect()
+    assert detected.available is False
+    assert "definitely-not-an-acp-host-xyz" in detected.detail
+
+
+async def test_settings_extra_args_are_a_valid_command_source(monkeypatch) -> None:
+    """Persisted per-backend ``extra_args`` are the command when the env is unset."""
+    monkeypatch.delenv(ACP_COMMAND_ENV, raising=False)
+
+    class _Settings:
+        def backend(self, kind: str) -> BackendConfig:  # noqa: ARG002
+            return BackendConfig(extra_args=_host_argv("ok"))
+
+    import deeptutor.services.subagent.acp as acp_mod
+
+    monkeypatch.setattr(acp_mod, "load_subagent_settings", lambda: _Settings())
+    detected = await AcpBackend().detect()
+    assert detected.available is True
+
+
+async def test_extra_args_append_to_env_command(monkeypatch) -> None:
+    monkeypatch.setenv(ACP_COMMAND_ENV, json.dumps(["claude", "--acp"]))
+    import deeptutor.services.subagent.acp as acp_mod
+
+    command = acp_mod.acp_host_command(BackendConfig(extra_args=["--model", "x"]))
+    assert command == ["claude", "--acp", "--model", "x"]
+
+
+async def test_space_separated_env_command_is_parsed(monkeypatch) -> None:
+    monkeypatch.setenv(ACP_COMMAND_ENV, '"claude" --acp')
+    import deeptutor.services.subagent.acp as acp_mod
+
+    command = acp_mod.acp_host_command(BackendConfig())
+    assert command == ["claude", "--acp"]
+
+
+# ---- registry ---------------------------------------------------------------------
+
+
+async def test_registry_knows_acp_backend() -> None:
+    from deeptutor.services.subagent.registry import get_backend, list_backend_kinds
+
+    assert "acp" in list_backend_kinds()
+    assert isinstance(get_backend("acp"), AcpBackend)
+
+
+async def test_detect_all_reports_acp(monkeypatch) -> None:
+    monkeypatch.delenv(ACP_COMMAND_ENV, raising=False)
+    from deeptutor.services.subagent.registry import detect_all
+
+    kinds = {d.kind for d in await detect_all()}
+    assert "acp" in kinds
+
+
+# ---- consult integration (in-process host, always runs) ---------------------------
+
+
+async def test_consult_streams_events_and_returns_session(monkeypatch) -> None:
+    result, seen = await _consult_memory("ok", monkeypatch)
+
+    assert result.success is True
+    assert result.error == ""
+    assert result.session_id == "acp-test-session-1"
+    assert result.event_count == len(seen)
+
+    # The handshake is announced, then text streams, a tool runs, and text closes.
+    assert seen[0].kind == EVENT_LOG
+    assert "session" in seen[0].text
+    kinds = [e.kind for e in seen[1:]]
+    assert kinds[0] == EVENT_TEXT and kinds[1] == EVENT_TEXT
+    assert EVENT_TOOL in kinds
+    assert EVENT_TOOL_RESULT in kinds
+    assert kinds[-1] == EVENT_TEXT
+
+    tool = next(e for e in seen if e.kind == EVENT_TOOL)
+    tool_result = next(e for e in seen if e.kind == EVENT_TOOL_RESULT)
+    assert tool.text.startswith("read_file")
+    assert "a.txt" in tool.text
+    assert "file says hello" in tool_result.text
+
+    # The question travelled through the prompt request to the host and back.
+    assert any(_QUESTION in t for t in _texts(seen))
+    assert result.final_text.startswith("You asked:")
+    assert "The answer is 4." in result.final_text
+
+
+async def test_consult_accepts_session_via_session_update(monkeypatch) -> None:
+    """Session acceptance can arrive as session/update instead of in the result."""
+    result, _ = await _consult_memory("update_accept", monkeypatch)
+    assert result.success is True
+    assert result.session_id == "acp-test-session-1"
+    assert "The answer is 4." in result.final_text
+
+
+async def test_consult_resumes_existing_session(monkeypatch) -> None:
+    """A session_id makes consult send session/load; the id round-trips."""
+    result, _ = await _consult_memory("ok_resume", monkeypatch, session_id="acp-sess-9")
+    assert result.success is True
+    assert result.session_id == "acp-sess-9"
+    # The fake host prefixes its answer with the id it was asked to load.
+    assert result.final_text.startswith("resumed:acp-sess-9 ")
+    assert "The answer is 4." in result.final_text
+
+
+async def test_consult_system_prompt_is_prepended_on_fresh_run(monkeypatch) -> None:
+    config = BackendConfig(system_prompt="be brief")
+    result, _ = await _consult_memory("ok", monkeypatch, config=config)
+    assert result.final_text.startswith("You asked: be brief\n\nIs four the answer?")
+
+
+async def test_consult_system_prompt_skipped_on_resume(monkeypatch) -> None:
+    config = BackendConfig(system_prompt="be brief")
+    result, _ = await _consult_memory("ok_resume", monkeypatch, config=config, session_id="s-1")
+    assert "be brief" not in result.final_text
+
+
+async def test_consult_forwards_images_as_paths(monkeypatch) -> None:
+    result, _ = await _consult_memory("ok", monkeypatch, images=["C:/tmp/a.png", "C:/tmp/b.png"])
+    assert "a.png" in result.final_text
+    assert "b.png" in result.final_text
+
+
+async def test_consult_answers_input_request_with_empty_input(monkeypatch) -> None:
+    """A session/input_request is surfaced and auto-replied so a run never stalls."""
+    result, seen = await _consult_memory("input", monkeypatch)
+    assert result.success is True
+    assert result.final_text.endswith("Got empty input.")
+    log = next(e for e in seen if e.kind == EVENT_LOG and "input" in e.text)
+    assert "auto-replied" in log.text or "empty input" in log.text
+
+
+async def test_consult_session_rejected_is_a_failure(monkeypatch) -> None:
+    result, seen = await _consult_memory("reject", monkeypatch)
+    assert result.success is False
+    assert "reject" in result.error
+    assert any(e.kind == EVENT_ERROR for e in seen)
+
+
+async def test_consult_error_content_block_fails_run(monkeypatch) -> None:
+    result, seen = await _consult_memory("error_content", monkeypatch)
+    assert result.success is False
+    assert "agent failed" in result.error
+    assert any(e.kind == EVENT_ERROR and "agent failed" in e.text for e in seen)
+
+
+async def test_consult_host_exit_before_answer_is_a_failure(monkeypatch) -> None:
+    result, seen = await _consult_memory("exit_early", monkeypatch)
+    assert result.success is False
+    assert "exited" in result.error and "3" in result.error
+    assert any(e.kind == EVENT_ERROR for e in seen)
+
+
+async def test_consult_handshake_timeout_is_a_clean_failure(monkeypatch) -> None:
+    """A host that never answers initialize fails fast instead of hanging."""
+    import deeptutor.services.subagent.acp as acp_mod
+
+    monkeypatch.setattr(acp_mod, "_HANDSHAKE_TIMEOUT_SECONDS", 1.0)
+    result, seen = await _consult_memory("hang_init", monkeypatch)
+    assert result.success is False
+    assert "initialize" in result.error
+    assert any(e.kind == EVENT_ERROR for e in seen)
+
+
+async def test_consult_tolerates_non_json_stdout_lines(monkeypatch) -> None:
+    result, seen = await _consult_memory("malformed", monkeypatch)
+    assert result.success is True
+    assert "The answer is 4." in result.final_text
+    assert any("NOT-JSON banner" in e.text for e in seen)
+
+
+async def test_consult_without_configured_command_fails_cleanly(monkeypatch) -> None:
+    monkeypatch.delenv(ACP_COMMAND_ENV, raising=False)
+    backend = AcpBackend()
+    seen: list = []
+
+    async def on_event(event):
+        seen.append(event)
+
+    result = await backend.consult("q", on_event=on_event)
+    assert result.success is False
+    assert ACP_COMMAND_ENV in result.error or "configure" in result.error
+    assert any(e.kind == EVENT_ERROR for e in seen)
+
+
+# ---- consult integration (real subprocess fixture, always runs) -------------------
+
+
+async def test_subprocess_consult_streams_and_returns_session(monkeypatch) -> None:
+    result, seen = await _consult_real_process("ok", monkeypatch)
+    assert result.success is True
+    assert result.session_id == "acp-test-session-1"
+    assert "The answer is 4." in result.final_text
+    assert any(e.kind == EVENT_TOOL for e in seen)
+
+
+async def test_subprocess_consult_resumes_session(monkeypatch) -> None:
+    result, _ = await _consult_real_process("ok_resume", monkeypatch, session_id="acp-sess-9")
+    assert result.success is True
+    assert result.session_id == "acp-sess-9"
+    assert result.final_text.startswith("resumed:acp-sess-9 ")
+
+
+async def test_subprocess_consult_rejected_session_fails(monkeypatch) -> None:
+    result, seen = await _consult_real_process("reject", monkeypatch)
+    assert result.success is False
+    assert "reject" in result.error
+    assert any(e.kind == EVENT_ERROR for e in seen)
+
+
+@_requires_subprocess
+async def test_default_spawn_consult_streams_and_returns_session(monkeypatch) -> None:
+    """Pin consult's own asyncio spawn against the fixture (needs OS pipes)."""
+    result, seen = await _consult_default_spawn("ok", monkeypatch)
+    assert result.success is True
+    assert result.session_id == "acp-test-session-1"
+    assert "The answer is 4." in result.final_text
+    assert any(e.kind == EVENT_TOOL for e in seen)

--- a/tests/services/test_subagent_backends.py
+++ b/tests/services/test_subagent_backends.py
@@ -943,6 +943,7 @@ async def test_detect_all_excludes_partner_backend() -> None:
         "openclaw",
         "deepseek_harness",
         "hermes_remote",
+        "acp",
     }
 
 


### PR DESCRIPTION
## Summary (stage 1 of #1028)

DeepTutor as a standard **Agent Client Protocol (ACP) client**: a new `AcpBackend` in the subagent registry that speaks ACP (JSON-RPC 2.0 over newline-delimited stdio) to any spawnable ACP host process, so already-configured agents (Claude Code-style `--acp`, `acp-remote`, future hosts) can be driven through the existing subagent capability / `/agents` surface with no orchestration changes.

Wire transcript is **schema-conformant to ACP v1** (`schema/v1/schema.json`; verified against the types shipped by `@agentclientprotocol/sdk@1.4.0`):

- `session/new` `{cwd, mcpServers: []}` / `session/load` `{sessionId, mcpServers, cwd}`; emitted keys use `sessionId`.
- `session/prompt` `{sessionId, prompt: [{type: "text", text: …}]}`; turn ends with the prompt response's `stopReason`.
- Run events streamed from `session/update` notifications: `agent_message_chunk` → text, `agent_thought_chunk` → reasoning, `tool_call` / `tool_call_update` → tool / tool_result (shared `toolCallId`), lifecycle kinds → log.
- v1 **elicitation** (`elicitation/create`) auto-answered with the only universally-valid headless reply (`decline`) and surfaced as a log; fs/terminal/permission requests are refused `-32601` (never auto-approved).
- Handshake is bounded (a non-ACP binary fails fast); consult waits for the host's own turn end; child reaped within a grace window; non-JSON output logged, never dropped.

Host command is not hard-coded: `DEEPTUTOR_ACP_COMMAND` env (JSON argv or shell string) or per-backend `BackendConfig.extra_args`.

## Relation to #1028

`Part of #1028` — this is stage 1 (transport + mapping + offline tests). Follow-ups: pointing at a concrete host end-to-end, capability-negotiation/catalog surfacing, and the deeper tool protocol. Plan was also posted on #1028; no other open PR covers this.

## Test plan

- [x] `pytest tests/services/test_acp_backend.py tests/services/test_antigravity_backend.py` → **50 passed, 1 skipped** (the skip is the default asyncio-spawn test, sandbox-only — asyncio child pipes are blocked in this Windows sandbox while sync pipes work; the consult paths are covered through the in-process seam and a real-subprocess fixture bridge, and the skipped test runs in normal shells/CI)
- [x] Tests pin the exact wire shapes: the in-repo fake ACP host (`tests/fixtures/acp_fake_host.py`) and injected seam assert `session/new|load` params (`cwd`/`mcpServers`/`sessionId`), the `session/prompt` content array, elicitation decline round-trip, unsolicited-request refusal, reasoning mapping, and session resume
- [x] `uvx ruff@0.16.0 check deeptutor tests` + `format --check` clean on the changed files
- [ ] Real-host end-to-end: point `DEEPTUTOR_ACP_COMMAND` at an actual ACP host and confirm a prompt + tool call round-trip (no host binary available in this environment; schema-conformant shapes verified against the official v1 schema instead)

## Known gaps / intentionally not done

- Capability-matrix negotiation details, agent auth gates, exact elicitation form/URL content formats, and permission-response shapes are not exercised without a real host — parsed defensively, never asserted beyond the JSON-RPC envelope.
- No model-catalog / settings-page / `/agents` UI wiring; tools ride as `[]` for now; session-lifecycle methods beyond new/load/prompt are not driven.

See the schema-verification note in `deeptutor/services/subagent/acp.py` for the full per-field audit trail.
