### PR TITLE
chore(lightrag): upgrade native SDK to 1.5.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -263,7 +263,7 @@ jobs:
 
       - name: Install optional LightRAG SDK
         if: matrix.python-version == '3.12'
-        run: pip install "lightrag-hku==1.5.7rc2"
+        run: pip install "lightrag-hku==1.5.7"
 
       - name: Install optional GraphRAG SDK
         if: matrix.python-version == '3.12'

--- a/deeptutor/services/rag/pipelines/lightrag/engine.py
+++ b/deeptutor/services/rag/pipelines/lightrag/engine.py
@@ -25,7 +25,7 @@ from .ingress import IngressError, StagedDocument, pending_root
 from .worker import OwnerLoopBridge
 
 LIGHTRAG_DISTRIBUTION = "lightrag-hku"
-LIGHTRAG_VERSION = "1.5.7rc2"
+LIGHTRAG_VERSION = "1.5.7"
 PARSER_ENGINE = "deeptutor"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,10 +252,10 @@ math-animator = ["manim>=0.19.0"]
 graphrag = ["graphrag>=3.0.1,<4.0.0; python_version < '3.14'"]
 
 # Built-in LightRAG provider. The exact release is intentional: the adapter
-# isolates a private rc2 source-resolver seam and locks it with smoke tests.
+# isolates a private source-resolver seam and locks it with smoke tests.
 # MinerU remains an independently selected DeepTutor parser and is not a
 # transitive dependency of this extra.
-rag-lightrag = ["lightrag-hku==1.5.7rc2"]
+rag-lightrag = ["lightrag-hku==1.5.7"]
 
 # Optional cross-encoder reranker for the default LlamaIndex engine. The
 # sentence-transformers/torch stack is heavy and model-dependent, so it stays

--- a/tests/services/rag/test_lightrag_native_smoke.py
+++ b/tests/services/rag/test_lightrag_native_smoke.py
@@ -17,9 +17,9 @@ from deeptutor.services.rag.pipelines.lightrag import engine, ingress, storage
 
 
 async def _fake_llm(_prompt, **_kwargs) -> str:
-    # This superset satisfies rc2's table/equation analysis schemas. Entity
-    # extraction may validly produce zero records; the document still reaches
-    # PROCESSED with real parser, chunk, storage and embedding code.
+    # This superset satisfies the stable SDK's table/equation analysis schemas.
+    # Entity extraction may validly produce zero records; the document still
+    # reaches PROCESSED with real parser, chunk, storage and embedding code.
     return '{"name":"fixture","description":"fixture analysis","equation":"x^2","type":"Other"}'
 
 
@@ -60,7 +60,7 @@ async def _process(working_dir: Path, staged: ingress.StagedDocument) -> dict:
         await engine.finalize(rag, cancel_pending=failed)
 
 
-def test_real_rc2_raw_bridge_reaches_processed(monkeypatch, tmp_path: Path) -> None:
+def test_real_stable_raw_bridge_reaches_processed(monkeypatch, tmp_path: Path) -> None:
     _configure_real_sdk(monkeypatch)
     working = tmp_path / "version-1"
     working.mkdir()
@@ -95,7 +95,7 @@ def test_real_rc2_raw_bridge_reaches_processed(monkeypatch, tmp_path: Path) -> N
     assert meta["parser_inputs"] == [{"engine": "text_only", "parser_signature": "fixture-parser"}]
 
 
-def test_real_rc2_sidecar_bridge_reaches_processed(monkeypatch, tmp_path: Path) -> None:
+def test_real_stable_sidecar_bridge_reaches_processed(monkeypatch, tmp_path: Path) -> None:
     _configure_real_sdk(monkeypatch)
     working = tmp_path / "version-1"
     working.mkdir()
@@ -140,7 +140,7 @@ def test_real_rc2_sidecar_bridge_reaches_processed(monkeypatch, tmp_path: Path) 
     assert list((ingress.pending_root(working) / "__parsed__").glob("paper.pdf"))
 
 
-def test_real_rc2_append_uses_only_new_doc_and_links_existing_entity(
+def test_real_stable_append_uses_only_new_doc_and_links_existing_entity(
     monkeypatch, tmp_path: Path
 ) -> None:
     async def entity_llm(prompt, **_kwargs) -> str:

--- a/tests/services/rag/test_lightrag_native_smoke.py
+++ b/tests/services/rag/test_lightrag_native_smoke.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import replace
+import base64
+import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -27,7 +29,7 @@ async def _fake_embedding(texts: list[str]) -> np.ndarray:
     return np.ones((len(texts), 32), dtype=float)
 
 
-def _configure_real_sdk(monkeypatch, llm=_fake_llm) -> None:
+def _configure_real_sdk(monkeypatch, llm=_fake_llm, vision=None) -> None:
     monkeypatch.setattr(engine, "build_llm_model_func", lambda **_kwargs: llm)
     monkeypatch.setattr(
         engine,
@@ -44,10 +46,22 @@ def _configure_real_sdk(monkeypatch, llm=_fake_llm) -> None:
     monkeypatch.setattr(
         engine, "constructor_kwargs_from_settings", lambda: {"entity_extract_max_gleaning": 0}
     )
+    if vision is not None:
+        monkeypatch.setattr(engine, "build_vision_model_func", lambda **_kwargs: vision)
 
 
-async def _process(working_dir: Path, staged: ingress.StagedDocument) -> dict:
-    rag = engine.build_rag(working_dir, enable_vlm=False)
+async def _process(
+    working_dir: Path,
+    staged: ingress.StagedDocument,
+    *,
+    enable_vlm: bool = False,
+    indexing_snapshot=None,
+) -> dict:
+    rag = engine.build_rag(
+        working_dir,
+        enable_vlm=enable_vlm,
+        indexing_snapshot=indexing_snapshot,
+    )
     await engine.initialize(rag)
     failed = True
     try:
@@ -96,7 +110,13 @@ def test_real_stable_raw_bridge_reaches_processed(monkeypatch, tmp_path: Path) -
 
 
 def test_real_stable_sidecar_bridge_reaches_processed(monkeypatch, tmp_path: Path) -> None:
-    _configure_real_sdk(monkeypatch)
+    vision_calls: list[tuple[str, dict]] = []
+
+    async def fake_vision(prompt, **kwargs) -> str:
+        vision_calls.append((prompt, kwargs))
+        return '{"name":"fixture image","description":"synthetic fixture","type":"Other"}'
+
+    _configure_real_sdk(monkeypatch, vision=fake_vision)
     working = tmp_path / "version-1"
     working.mkdir()
     source = tmp_path / "paper.pdf"
@@ -126,11 +146,20 @@ def test_real_stable_sidecar_bridge_reaches_processed(monkeypatch, tmp_path: Pat
             parser_signature="fixture-parser",
         ),
     )
-    # The image asset still passes through the real Sidecar writer; disabling
-    # i only avoids requiring a vision call in this deterministic offline test.
-    staged = replace(staged, process_options=staged.process_options.replace("i", ""))
-
-    rows = asyncio.run(_process(working, staged))
+    snapshot = SimpleNamespace(
+        config=SimpleNamespace(binding="offline"),
+        owner=object(),
+        descriptor={"endpoint": "offline://fixture"},
+        fingerprint="fixture-indexing-model",
+    )
+    rows = asyncio.run(
+        _process(
+            working,
+            staged,
+            enable_vlm=True,
+            indexing_snapshot=snapshot,
+        )
+    )
 
     assert len(rows) == 1
     row = next(iter(rows.values()))
@@ -138,6 +167,21 @@ def test_real_stable_sidecar_bridge_reaches_processed(monkeypatch, tmp_path: Pat
     assert row.file_path == "paper.pdf"
     assert storage.has_output(working) is True
     assert list((ingress.pending_root(working) / "__parsed__").glob("paper.pdf"))
+    drawings_path = next(
+        (ingress.pending_root(working) / "__parsed__").glob("paper.pdf.parsed/*.drawings.json")
+    )
+    drawings = json.loads(drawings_path.read_text(encoding="utf-8"))["drawings"]
+    assert [item["llm_analyze_result"]["status"] for item in drawings.values()] == ["success"]
+    assert len(vision_calls) == 1
+    prompt, kwargs = vision_calls[0]
+    assert prompt.startswith("You are an expert image analyzer.")
+    assert kwargs["stream"] is False
+    assert kwargs["response_format"] == {"type": "json_object"}
+    assert len(kwargs["image_inputs"]) == 1
+    image = kwargs["image_inputs"][0]
+    assert base64.b64decode(image["base64"]) == b"fixture image"
+    assert image["mime_type"] == "image/png"
+    assert image["modality"] == "image"
 
 
 def test_real_stable_append_uses_only_new_doc_and_links_existing_entity(

--- a/tests/services/rag/test_lightrag_pipeline.py
+++ b/tests/services/rag/test_lightrag_pipeline.py
@@ -278,8 +278,8 @@ def test_build_rag_keeps_indexing_snapshot_out_of_embedding_kwargs(
 
 
 @REQUIRES_LIGHTRAG
-def test_distribution_identity_is_exact_rc2() -> None:
-    assert engine.installed_version() == "1.5.7rc2"
+def test_distribution_identity_is_exact_stable() -> None:
+    assert engine.installed_version() == "1.5.7"
     assert engine.LIGHTRAG_DISTRIBUTION == "lightrag-hku"
 
 
@@ -293,7 +293,7 @@ def test_preflight_rejects_a_different_installed_lightrag_version(monkeypatch) -
     report = preflight._lightrag_preflight()
     package = next(check for check in report["checks"] if check["key"] == "package")
     assert package["ok"] is False
-    assert package["detail"] == "Found 1.5.8; required 1.5.7rc2."
+    assert package["detail"] == "Found 1.5.8; required 1.5.7."
 
 
 def test_workspace_is_stable_and_version_specific(tmp_path: Path) -> None:
@@ -603,7 +603,7 @@ def test_storage_publishes_schema_two_metadata(tmp_path: Path, monkeypatch) -> N
     meta = json.loads((tmp_path / "meta.json").read_text(encoding="utf-8"))
     assert meta["state"] == "published"
     assert meta["lightrag_adapter_schema"] == 2
-    assert meta["lightrag_package_version"] == "1.5.7rc2"
+    assert meta["lightrag_package_version"] == "1.5.7"
     assert meta["parser_inputs"] == []
     assert storage.meta_is_native_published(tmp_path) is True
 

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -170,7 +170,7 @@ def test_lightrag_extra_is_the_exact_native_sdk_without_parser_transitives() -> 
         extras = tomllib.load(file)["project"]["optional-dependencies"]
 
     requirements = extras["rag-lightrag"]
-    assert requirements == ["lightrag-hku==1.5.7rc2"]
+    assert requirements == ["lightrag-hku==1.5.7"]
     names = [requirement.lower().split("=", 1)[0].split("<", 1)[0] for requirement in requirements]
     assert "raganything" not in names
     assert "mineru" not in names


### PR DESCRIPTION
### Description

DeepTutor's native LightRAG integration currently pins the
`lightrag-hku==1.5.7rc2` prerelease. This upgrades the package extra, CI
installation, runtime version contract, and associated provenance expectations
to the exact stable `1.5.7` release.

The rc2-to-stable SDK and dependency changes were audited against DeepTutor's
native parser, Sidecar, storage, query, and publication boundaries. No product
adapter changes beyond the exact version pin were required.

The real-SDK smoke coverage now also executes the offline VLM image path with
synthetic model functions and verifies the vision payload, terminal document
state, and persisted drawing-analysis result.

### Related Issues

- Related to #1265

### Module(s) Affected

- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [x] Other: packaging and CI

### Validation

Candidate head: `a99ef5fef229822df5127b4c82c629790799723b`.

- Fresh non-editable installs on Python 3.11, 3.12, 3.13, and 3.14 resolved
  exactly `lightrag-hku==1.5.7` and passed dependency and import checks.
- A freshly installed wheel reports the exact stable dependency in its metadata.
- Native parser, pipeline, indexing, lifecycle, API, packaging, and real-SDK
  tests: 227 passed.
- Full Python suite: 6,733 passed, 23 skipped, and one environment-only failure.
  The exact `dev` base has the same failure: the host lacks the container-only
  sandbox runner and returns exit code 127.
- A copied rc2-created local JSON/GraphML/NanoVectorDB index opened, queried in
  all five modes, appended, persisted, and restarted under 1.5.7 without
  observed identity loss. The exercised stable-written fixture was also
  readable after rollback to rc2; this does not claim compatibility for other
  storage backends.
- A disposable merge with Draft PR #1265 head
  `4dd9254c0f1d192dc4dab6574aeb67c40f54ec0a` passed 233 applicable role,
  indexing-policy, VLM, pipeline, API, and document-provider tests.
- Frontend `check:fast` and the production build passed.
- Remote CI on exact head `a99ef5fef229822df5127b4c82c629790799723b`
  completed with three substantive failing jobs plus the aggregate Test Summary.
  Each failure matches the exact `dev` base
  `42fab3cf429a1fbf36b257ab8d116a3814964202`: the same two unchanged Markdown
  formatting findings, the same three frontend route-budget overages (`305/300`,
  `324/320`, and `525/515`), and the same three Python 3.12 mastery-test failures
  caused by the missing `zh/mastery_loop.yaml` fixture. All other executed matrix
  jobs passed; Four-worker browser acceptance was skipped.

### Checklist

- [x] I have read and followed the contribution guidelines.
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

`ruff format --check .` continues to report the two unchanged Markdown
code-block formatting findings in the built-in DOCX and XLSX skills. Their
candidate blobs are byte-identical to the exact `dev` base.

### Contribution-check follow-up

`pre-commit run --all-files` was run on this exact head and on `dev` at `42fab3cf429a1fbf36b257ab8d116a3814964202`, using the same Ubuntu ARM64 environment, Python 3.11 tooling, task-owned Node 22.23.2, and identical pinned hook configuration. Fourteen hooks passed. Full mypy failed only on the same two baseline errors:

- `deeptutor/services/workspace/service.py:686`: cannot infer the lambda type.
- `deeptutor/services/config/readiness.py:786`: incompatible `verify_remote` import types.

The checks introduced no tracked-file changes. No unrelated baseline repair is included, and full pre-commit is not reported as passing.

Completed remote CI for this exact head has three substantive failures plus the derived Test Summary: Lint and Format, Web Node Tests, and Python 3.12. Direct comparison with [the exact dev-base run](https://github.com/HKUDS/DeepTutor/actions/runs/34015350623) found identical failure signals: the same DOCX/XLSX Markdown formatting findings; the same three route-budget overruns (305/300 KB, 324/320 KB, 525/515 KB); and the same three mastery tests failing on the missing Chinese prompt file. All other executed jobs passed; four-worker browser acceptance was skipped.
