### PR TITLE
fix: avoid progress errors after empty knowledge base creation

### DIFF
--- a/web/hooks/useKnowledgeBases.ts
+++ b/web/hooks/useKnowledgeBases.ts
@@ -205,8 +205,6 @@ export function useKnowledgeBases() {
             progress_percent: 0,
           },
         });
-      } else {
-        progress.subscribeWs(params.name);
       }
       await load({ force: true, showSpinner: false });
       return result;

--- a/web/hooks/useKnowledgeProgress.ts
+++ b/web/hooks/useKnowledgeProgress.ts
@@ -150,7 +150,9 @@ export function useKnowledgeProgress(options?: UseKnowledgeProgressOptions) {
       socketTargetsRef.current[kbName] = {
         taskId: expectedTaskId,
         retry:
-          existingTarget?.taskId === expectedTaskId ? existingTarget.retry : 0,
+          existingTarget && existingTarget.taskId === expectedTaskId
+            ? existingTarget.retry
+            : 0,
       };
       const query = expectedTaskId
         ? `?task_id=${encodeURIComponent(expectedTaskId)}`
@@ -164,7 +166,7 @@ export function useKnowledgeProgress(options?: UseKnowledgeProgressOptions) {
 
       socket.onopen = () => {
         const target = socketTargetsRef.current[kbName];
-        if (target?.taskId === expectedTaskId) target.retry = 0;
+        if (target && target.taskId === expectedTaskId) target.retry = 0;
       };
 
       socket.onmessage = (event) => {

--- a/web/tests/knowledge-create-progress.spec.tsx
+++ b/web/tests/knowledge-create-progress.spec.tsx
@@ -1,0 +1,99 @@
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { useKnowledgeBases } from "@/hooks/useKnowledgeBases";
+import { useKnowledgeProgress } from "@/hooks/useKnowledgeProgress";
+
+const fixture = vi.hoisted(() => ({
+  t: (key: string) => key,
+  create: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: fixture.t }) }));
+vi.mock("@/features/knowledge/api/catalog", async (original) => ({
+  ...(await original<typeof import("@/features/knowledge/api/catalog")>()),
+  createKnowledgeBase: fixture.create,
+  listKnowledgeBases: async () => [],
+  listRagProviders: async () => [],
+  getKnowledgeUploadPolicy: async () => {
+    throw new Error("use default upload policy");
+  },
+}));
+
+class Socket {
+  static instances: Socket[] = [];
+  onopen?: () => void;
+  close = vi.fn();
+  constructor(public url: string) {
+    Socket.instances.push(this);
+  }
+}
+
+class Stream {
+  static instances: Stream[] = [];
+  addEventListener = vi.fn();
+  close = vi.fn();
+  constructor(public url: string) {
+    Stream.instances.push(this);
+  }
+}
+
+beforeEach(() => {
+  fixture.create.mockReset().mockResolvedValue({ task_id: null, files: [] });
+  Socket.instances = [];
+  Stream.instances = [];
+  vi.stubGlobal("WebSocket", Socket);
+  vi.stubGlobal("EventSource", Stream);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+it("completes empty creation without opening a progress socket or task stream", async () => {
+  const { result } = renderHook(() => useKnowledgeBases());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await act(async () => {
+    await result.current.createKb({
+      name: "empty",
+      provider: "llamaindex",
+      files: [],
+    });
+  });
+  expect(Socket.instances).toHaveLength(0);
+  expect(Stream.instances).toHaveLength(0);
+  expect(result.current.error).toBeNull();
+});
+
+it("tracks creation when the server accepts an indexing task", async () => {
+  fixture.create.mockResolvedValue({ task_id: "index-task", files: ["text.txt"] });
+  const { result } = renderHook(() => useKnowledgeBases());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  await act(async () => {
+    await result.current.createKb({
+      name: "papers",
+      provider: "llamaindex",
+      files: [new File(["hello"], "text.txt")],
+    });
+  });
+  expect(Socket.instances).toHaveLength(1);
+  expect(Socket.instances[0].url).toContain("/papers/progress?task_id=index-task");
+  expect(Stream.instances).toHaveLength(1);
+  expect(Stream.instances[0].url).toContain("/tasks/index-task/stream");
+  expect(result.current.tasksByKb.papers).toMatchObject({
+    taskId: "index-task",
+    executing: true,
+  });
+});
+
+it("subscribes without a task ID and tolerates opening a removed target", () => {
+  const { result } = renderHook(() => useKnowledgeProgress());
+  act(() => result.current.subscribeWs("kb"));
+  const socket = Socket.instances[0];
+  expect(socket.url).toContain("/kb/progress");
+  expect(socket.url).not.toContain("task_id");
+  expect(() => socket.onopen?.()).not.toThrow();
+  act(() => result.current.cleanupKb("kb"));
+  expect(socket.close).toHaveBeenCalledOnce();
+  expect(() => socket.onopen?.()).not.toThrow();
+});


### PR DESCRIPTION
### Description

Creating an empty knowledge base succeeds without an indexing task, but the frontend still subscribes to progress and can dereference an absent retry target. Skip that subscription when the response has no task ID and check that a target exists before reading or resetting its retry count. Creation with an accepted indexing task retains its WebSocket and task-stream tracking.

### Module(s) Affected

- [x] `web` (Frontend)
- [x] `tests`

### Validation

Head: `eabdfa8669d274cbd0389b4be3a96b28f33a581b`; base `dev` at `42fab3cf429a1fbf36b257ab8d116a3814964202`. Validation used Ubuntu ARM64, Node 22.23.2 and Python 3.12.3 for pre-commit.

* Three real-hook regression tests passed: empty creation without a socket/stream, task-backed creation with both, and missing-target subscription/open callbacks.
* `npm run check:fast` passed: contracts, architecture, TypeScript, 1,099 Node tests, 40 Vitest tests, lint and locale checks.
* `npm run build` passed.
* `pre-commit run --all-files` completed: fourteen hooks passed; mypy reports the same two errors reproduced on the exact dev base under the same environment and hook configuration: `services/workspace/service.py:686` (lambda inference) and `services/config/readiness.py:786` (incompatible `verify_remote` imports). No tracked files changed during the final run.
* `npm run perf:check` failed three route budgets on this candidate: `/` 305/300 KB, `/co-writer` 324/320 KB and `/co-writer/[docId]` 525/515 KB. These are the checker's units; no clean-base build comparison was performed for this PR. The knowledge-base route passes at 371/550 KB.
* `git diff --check` passed. Remote CI completed on this exact head: generated-file hygiene and all six import checks passed; Python 3.11, 3.13 and 3.14 passed. Python 3.12 failed three mastery tests because `zh/mastery_loop.yaml` is absent. Lint failed Markdown code-block formatting in the built-in DOCX/XLSX skills. Web checks and build passed before the same three route-budget failures listed above. The optional four-worker browser job was skipped. The repository gate is not green.

### Checklist

- [x] I have read the contribution guidelines and targeted `dev`.
- [x] I have added relevant regression tests.
- [x] Documentation was assessed; this restores existing behavior without a new interface.
- [ ] All pre-commit and repository checks pass (the failures and comparison above remain disclosed).
