### PR TITLE
fix: restore formatting and deterministic CI checks

### DIFF
--- a/deeptutor/learning/tests/test_mastery_mode.py
+++ b/deeptutor/learning/tests/test_mastery_mode.py
@@ -8,6 +8,7 @@ that is exactly where the guarantee now is.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -397,16 +398,18 @@ async def test_a_built_goal_reports_its_identity_too(path_id):
 def _pack(language: str) -> dict:
     import yaml
 
-    return yaml.safe_load(
-        open(f"deeptutor/capabilities/mastery/prompts/{language}/mastery_loop.yaml")
-    )
+    prompts = Path(__file__).resolve().parents[2] / "capabilities" / "mastery" / "prompts"
+    return yaml.safe_load((prompts / language / "mastery_loop.yaml").read_text(encoding="utf-8"))
 
 
-def test_study_never_offers_to_do_the_reviewing_itself():
+def test_study_never_offers_to_do_the_reviewing_itself(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The sentence this guards taught the tutor that due reviews are study's
     to handle, so "I want to review" was answered by quizzing a due item
     without leaving study — the learner asked for a mode and got a workaround.
     """
+    monkeypatch.chdir(tmp_path)
     for language in ("zh", "en"):
         study = _pack(language)["session"]["study"]
         assert "mastery_status" in study
@@ -416,7 +419,10 @@ def test_study_never_offers_to_do_the_reviewing_itself():
         assert "review" in study
 
 
-def test_naming_an_activity_is_documented_as_a_mode_request():
+def test_naming_an_activity_is_documented_as_a_mode_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
     for language in ("zh", "en"):
         playbook = _pack(language)["playbook"]
         assert "mastery_mode" in playbook
@@ -424,9 +430,12 @@ def test_naming_an_activity_is_documented_as_a_mode_request():
         assert marker in playbook, language
 
 
-def test_the_outline_metaphor_is_gone_from_learner_facing_copy():
+def test_the_outline_metaphor_is_gone_from_learner_facing_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """'Map' was a metaphor the product does not use anywhere the learner can
     see; the word is 'outline'."""
+    monkeypatch.chdir(tmp_path)
     for language in ("zh", "en"):
         pack = _pack(language)
         blob = "\n".join(

--- a/deeptutor/skills/builtin/docx/SKILL.md
+++ b/deeptutor/skills/builtin/docx/SKILL.md
@@ -83,6 +83,7 @@ doc.save("out.docx")
 check = Document("out.docx")
 assert check.paragraphs, "generated DOCX has no paragraphs"
 import zipfile
+
 with zipfile.ZipFile("out.docx") as package:
     assert package.testzip() is None, "generated DOCX has a corrupt ZIP member"
 ```

--- a/deeptutor/skills/builtin/xlsx/SKILL.md
+++ b/deeptutor/skills/builtin/xlsx/SKILL.md
@@ -107,6 +107,7 @@ wb.save("out.xlsx")
 check = load_workbook("out.xlsx", data_only=False)
 assert check.sheetnames, "generated workbook has no worksheets"
 import zipfile
+
 with zipfile.ZipFile("out.xlsx") as package:
     assert package.testzip() is None, "generated XLSX has a corrupt ZIP member"
 ```

--- a/web/components/sidebar/SidebarShell.tsx
+++ b/web/components/sidebar/SidebarShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import {
@@ -14,7 +15,6 @@ import { useAppShell } from "@/context/AppShellContext";
 import { BookText, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { BrandGlyph } from "@/components/common/BrandIcon";
-import OrganizedSessionList from "@/components/courses/OrganizedSessionList";
 import SessionList from "@/components/SessionList";
 import { useSidebarDrawer } from "@/components/layout/AppShell";
 import { useDevice } from "@/hooks/useDevice";
@@ -36,6 +36,25 @@ import {
 
 const GITHUB_REPO_URL = "https://github.com/HKUDS/DeepTutor";
 const DOCS_URL = "https://deeptutor.info/";
+
+// Session data arrives after mount; defer its organization UI with it so
+// every workspace route does not download it as part of the initial shell.
+const OrganizedSessionList = dynamic(
+  () => import("@/components/courses/OrganizedSessionList"),
+  {
+    ssr: false,
+    loading: () => (
+      <div aria-busy="true" className="space-y-1.5 px-2 py-1">
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="h-4 w-3/4 animate-pulse rounded bg-[var(--muted)]/40"
+          />
+        ))}
+      </div>
+    ),
+  },
+);
 
 interface SidebarShellProps {
   sessions?: SessionSummary[];

--- a/web/features/co-writer/components/CoWriterWorkspace.tsx
+++ b/web/features/co-writer/components/CoWriterWorkspace.tsx
@@ -71,9 +71,7 @@ import { useSelectionEdit } from "@/features/co-writer/hooks/useSelectionEdit";
 import { useSplitPane } from "@/features/co-writer/hooks/useSplitPane";
 import { useSynchronizedScroll } from "@/features/co-writer/hooks/useSynchronizedScroll";
 import { useDocumentLifecycle } from "@/features/co-writer/hooks/useDocumentLifecycle";
-import SaveToNotebookModal, {
-  type NotebookSavePayload,
-} from "@/components/notebook/SaveToNotebookModal";
+import type { NotebookSavePayload } from "@/components/notebook/SaveToNotebookModal";
 import { CO_WRITER_SAMPLE_TEMPLATE } from "@/app/(workspace)/co-writer/sampleTemplate";
 
 const MarkdownRenderer = dynamic(
@@ -81,6 +79,11 @@ const MarkdownRenderer = dynamic(
   {
     ssr: false,
   },
+);
+
+const SaveToNotebookModal = dynamic(
+  () => import("@/components/notebook/SaveToNotebookModal"),
+  { ssr: false },
 );
 
 type EditAction = "rewrite" | "shorten" | "expand";

--- a/web/tests/co-writer-lazy-notebook.spec.tsx
+++ b/web/tests/co-writer-lazy-notebook.spec.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import CoWriterWorkspace from "@/features/co-writer/components/CoWriterWorkspace";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: "en" } }),
+}));
+vi.mock("@/components/common/MarkdownRenderer", () => ({ default: () => null }));
+vi.mock("@/features/knowledge/api/catalog", () => ({
+  listKnowledgeBases: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("@/lib/co-writer-api", () => ({
+  getCoWriterDocument: vi.fn().mockResolvedValue({
+    id: "document-1",
+    title: "Existing document",
+    content: "Existing draft content",
+    updated_at: 1,
+  }),
+  updateCoWriterDocument: vi.fn().mockResolvedValue({}),
+  exportCoWriterDocx: vi.fn(),
+}));
+vi.mock("@/lib/notebook-api", () => ({
+  listNotebooks: vi.fn().mockResolvedValue([{ id: "notebook-1", name: "My notebook" }]),
+  createNotebook: vi.fn(),
+}));
+
+it("opens and closes the dynamically loaded notebook picker without changing the draft", async () => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      disconnect() {}
+    },
+  );
+  try {
+    render(<CoWriterWorkspace docId="document-1" />);
+    expect(await screen.findByDisplayValue("Existing draft content")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Save to Notebook" }));
+    const dialog = await screen.findByRole("dialog", { name: "Save to Notebook" });
+    expect(await within(dialog).findByText("My notebook")).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole("button", { name: "Close" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(screen.getByDisplayValue("Existing draft content")).toBeInTheDocument();
+  } finally {
+    vi.unstubAllGlobals();
+  }
+});

--- a/web/tests/e2e/settings-navigation.audit.ts
+++ b/web/tests/e2e/settings-navigation.audit.ts
@@ -4,6 +4,34 @@ test.describe('Settings navigation', () => {
   test('reports what is ready without dressing optional gaps as faults', async ({
     page,
   }) => {
+    // Keep this fixture independent of any backend on developer machines.
+    await page.route('**/api/**', route =>
+      route.fulfill({ status: 404, json: {} })
+    )
+    await page.route('**/api/settings', route =>
+      route.fulfill({
+        status: 200,
+        json: {
+          ui: { theme: 'snow', language: 'en', response_language: 'en' },
+          catalog: {
+            version: 1,
+            services: {
+              llm: { active_profile_id: null, profiles: [] },
+              task: { active_profile_id: null, profiles: [] },
+              embedding: { active_profile_id: null, profiles: [] },
+              search: { active_profile_id: null, profiles: [] },
+              tts: { active_profile_id: null, profiles: [] },
+              stt: { active_profile_id: null, profiles: [] },
+              imagegen: { active_profile_id: null, profiles: [] },
+              videogen: { active_profile_id: null, profiles: [] },
+            },
+          },
+        },
+      })
+    )
+    await page.route('**/api/settings/draft', route =>
+      route.fulfill({ status: 200, json: { draft: null } })
+    )
     await page.route('**/api/settings/readiness', route =>
       route.fulfill({
         status: 200,
@@ -79,7 +107,7 @@ test.describe('Settings navigation', () => {
 
     // The selected parser that cannot be reached is the one thing called out.
     await expect(
-      panel.getByText(/endpoint is unreachable|服务地址连不上/)
+      matrix.getByText(/endpoint is unreachable|服务地址连不上/)
     ).toBeVisible()
     // The optional tool is folded behind its disclosure, not in the open list.
     await expect(

--- a/web/tests/sidebar-lazy-history.spec.tsx
+++ b/web/tests/sidebar-lazy-history.spec.tsx
@@ -1,0 +1,72 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import { SidebarShell } from "@/components/sidebar/SidebarShell";
+
+const fixture = vi.hoisted(() => ({ push: vi.fn(), close: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/co-writer",
+  useRouter: () => ({ push: fixture.push }),
+}));
+vi.mock("next/image", () => ({ default: () => null }));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: "en" } }),
+}));
+vi.mock("@/context/AppShellContext", () => ({
+  useAppShell: () => ({ sidebarCollapsed: false, setSidebarCollapsed: vi.fn() }),
+}));
+vi.mock("@/components/layout/AppShell", () => ({
+  useSidebarDrawer: () => ({ close: fixture.close }),
+}));
+vi.mock("@/hooks/useDevice", () => ({
+  useDevice: () => ({ isMobile: false }),
+}));
+vi.mock("@/components/sidebar/VersionBadge", () => ({
+  VersionBadge: () => null,
+}));
+
+it("loads conversation history while navigation remains usable, then preserves session actions", async () => {
+  const onSelect = vi.fn();
+  const onRename = vi.fn();
+  const onOrganize = vi.fn();
+  const { container } = render(
+    <SidebarShell
+      showSessions
+      sessions={[
+        {
+          id: "session-1",
+          session_id: "session-1",
+          title: "Retained session",
+          created_at: 1,
+          updated_at: 1,
+          message_count: 1,
+          last_message: "Hello",
+        },
+      ]}
+      onSelectSession={onSelect}
+      onRenameSession={onRename}
+      onDeleteSession={vi.fn()}
+      onOrganizeSession={onOrganize}
+    />,
+  );
+  expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: "Co-Writer" })).toHaveAttribute("href", "/co-writer");
+
+  fireEvent.click(await screen.findByText("Retained session"));
+  expect(onSelect).toHaveBeenCalledWith("session-1");
+  expect(fixture.close).toHaveBeenCalled();
+  expect(container.querySelector('[aria-busy="true"]')).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("button", { name: "Conversation actions" }));
+  fireEvent.click(screen.getByRole("menuitem", { name: "Pin" }));
+  expect(onOrganize).toHaveBeenCalledWith("session-1", { pinned: true });
+
+  fireEvent.click(screen.getByRole("button", { name: "Conversation actions" }));
+  fireEvent.click(screen.getByRole("menuitem", { name: "Rename chat" }));
+  const input = screen.getByDisplayValue("Retained session");
+  fireEvent.change(input, { target: { value: "Renamed session" } });
+  await act(async () => {
+    fireEvent.keyDown(input, { key: "Enter" });
+  });
+  expect(onRename).toHaveBeenCalledWith("session-1", "Renamed session");
+});


### PR DESCRIPTION
### Description

Repository CI fails on `dev` because Ruff requires blank lines in two embedded Python examples, the optional GraphRAG configuration loader changes the working directory before mastery prompt tests run, three workspace routes exceed their initial JavaScript budgets, and the settings browser audit lacks the settings catalog fixture needed to display readiness.

Add the formatting whitespace, resolve prompt fixtures relative to the test file, and split the session-organization list and notebook picker into client chunks. Existing rendering conditions and callbacks remain intact. Route thresholds and measurement logic are unchanged. The three prompt tests retain their content assertions and now explicitly run from another working directory. Make the readiness browser audit self-contained with synthetic settings/draft/readiness responses and scope its parser-error assertion to the readiness matrix, where it has one match.

### Related issues

These failures were observed while validating #1281 and reproduced separately on its exact `dev` base. This PR contains only the shared CI repairs and does not include the embedding compatibility change.

### Modules affected

- Tests and builtin-skill documentation examples
- Web sidebar and co-writer component loading

### Validation

Base: `42fab3cf429a1fbf36b257ab8d116a3814964202`. Head: `ece09ecd748b81b4006f6f6422a62f91ad9f3799`. Local environment: Ubuntu ARM64, Python 3.12.3, Ruff 0.16.0, Node 22.23.2, synthetic CI configuration.

- `ruff check .` and `ruff format --check .`: passed. The same two formatting failures reproduce on the base and #1281.
- `python -m pytest -q tests/services/rag/test_graphrag_completion_adapter.py tests/services/rag/test_graphrag_pipeline.py deeptutor/learning/tests/test_mastery_mode.py`: 120 passed; the same command on the base has 117 passed and the three prompt-path failures.
- Python source is unchanged from validated parent `86aa5d0edf364a11516b47c181bae4692641ae5d`. On that parent, `python -m pytest -q tests deeptutor/learning/tests`: 6,747 passed, nine skipped, one sandbox exit-code-127 failure. The base has 6,744 passed, nine skipped and four failures: the same sandbox failure plus the three fixed mastery failures. Full local Python validation is not green.
- `npm --prefix web run check:fast` on the parent (application and unit-test sources unchanged): passed, including contracts, architecture, types, 1,099 Node tests, 39 Vitest tests, lint and locales. Two rendered regressions exercise actual dynamic imports: sidebar loading/navigation/selection/pin/rename, and notebook picker open/close with the draft preserved.
- `npm --prefix web run build` and `npm --prefix web run perf:check`: passed. All nine existing thresholds pass. Initial-script measurements change from 305 to 296 KB for `/` (budget 300 KB), 324 to 315 KB for `/co-writer` (320 KB), and 525 to 380 KB for `/co-writer/[docId]` (515 KB). This does not claim reduced total post-hydration downloads.
- Full production-build browser audit on this head: **46 passed**, including all three settings navigation tests. The build uses an unbound browser API base, and the repaired readiness test intercepts all API requests with synthetic responses. Production build/TypeScript and all nine route budgets pass on this head.
- `pre-commit run --all-files` on this head: 14 hooks pass; mypy still reports the two errors reproduced on the exact base in `deeptutor/services/workspace/service.py:686` and `deeptutor/services/config/readiness.py:786`.
- Frozen independent read-only review: primary passed on the parent; settings-only delta review passed on this head with no blockers or in-scope defects. Existing local sandbox/mypy limitations remain disclosed.
- Remote CI passed on `ece09ecd748b81b4006f6f6422a62f91ad9f3799`: **14 checks succeeded**, including lint/format, generated-file hygiene, all six import checks, all four Python versions (3.11–3.14), the frontend gate and Test Summary. The frontend job reports **46 browser audits passed**, including all three settings tests, and all nine unchanged route budgets passed. Four-worker browser acceptance was skipped because its repository endpoint is not configured. [CI run](https://github.com/HKUDS/DeepTutor/actions/runs/34113506551).

### Checklist

- [x] Read the contribution guidance and targeted `dev` using the required commit format.
- [x] Preserved prompt assertions, route budgets and existing UI callbacks.
- [x] Added rendered interaction coverage for the deferred components.
- [x] GitHub CI passed on the exact updated head; the configured four-worker browser check was skipped.
- [ ] All local repository checks pass; the baseline sandbox and mypy limitations are listed above.

