### PR TITLE
fix: resolve service mypy errors

### DIFF
--- a/deeptutor/services/config/readiness.py
+++ b/deeptutor/services/config/readiness.py
@@ -776,17 +776,21 @@ async def _selected_remote_parser_reachable(
 ) -> bool | None:
     try:
         if engine_id == "tika":
-            from deeptutor.services.parsing.engines.tika.remote import verify_remote
+            from deeptutor.services.parsing.engines.tika.remote import (
+                verify_remote as verify_tika_remote,
+            )
 
             ok, _ = await asyncio.wait_for(
-                asyncio.to_thread(verify_remote, config, 2.0), timeout=3.0
+                asyncio.to_thread(verify_tika_remote, config, 2.0), timeout=3.0
             )
             return bool(ok)
         if engine_id == "docling" and bool(getattr(config, "is_remote", False)):
-            from deeptutor.services.parsing.engines.docling.remote import verify_remote
+            from deeptutor.services.parsing.engines.docling.remote import (
+                verify_remote as verify_docling_remote,
+            )
 
             ok, _ = await asyncio.wait_for(
-                asyncio.to_thread(verify_remote, config, 2.0), timeout=3.0
+                asyncio.to_thread(verify_docling_remote, config, 2.0), timeout=3.0
             )
             return bool(ok)
         if engine_id == "mineru" and bool(getattr(config, "is_cloud", False)):

--- a/deeptutor/services/partners/workspace.py
+++ b/deeptutor/services/partners/workspace.py
@@ -341,10 +341,10 @@ def list_assets(partner_id: str) -> dict[str, list[dict[str, Any]]]:
     # cannot see one. Left out, an assigned WeKnora or linked KB was invisible
     # in the partner's library AND never excluded from the picker, so the user
     # kept assigning it and kept seeing nothing happen.
-    for name, entry in sorted(_partner_kb_config(root).items()):
+    for name, kb_entry in sorted(_partner_kb_config(root).items()):
         if any(row["name"] == name for row in kbs):
             continue
-        kbs.append({"name": name, "documents": 0, "type": entry.get("type", "")})
+        kbs.append({"name": name, "documents": 0, "type": kb_entry.get("type", "")})
 
     skills: list[dict[str, Any]] = []
     skills_root = service.get_workspace_dir() / "skills"

--- a/deeptutor/services/workspace/service.py
+++ b/deeptutor/services/workspace/service.py
@@ -683,7 +683,13 @@ class ContentWorkspaceService:
                 generated=relative.startswith("outputs/"),
             )
             manifest = manifests / f"{item_id}.json"
-            atomic_update(manifest, lambda _stored, payload=item.to_dict(): payload)
+
+            def replace_manifest(
+                _stored: dict[str, Any], payload: dict[str, Any] = item.to_dict()
+            ) -> dict[str, Any]:
+                return payload
+
+            atomic_update(manifest, replace_manifest)
             published.append(item)
         return published
 


### PR DESCRIPTION
### Description

The repository's mypy hook reports four errors in partner asset listing, workspace manifest publication and remote-parser readiness. Use distinct names for filesystem entries and configured knowledge-base rows, retain separate Tika/Docling verifier bindings, and replace the manifest lambda with an explicitly typed local callback that preserves its captured payload.

The existing mypy configuration and runtime behavior are retained.

### Module(s) Affected

- [x] `services`

### Validation

Head: `86dec0bf59c0b4cb747e214d8e9b8721387a2969`. Base: `5f7e165161e08dfd58283ebfac0a531682abaae4`. Ubuntu ARM64, Python 3.12.3, pre-commit 4.6.2, repository-pinned mypy 1.13.0 and Ruff 0.16.0.

* Exact base: `pre-commit run mypy --all-files` reproduces all four reported errors.
* Exact head: `pre-commit run --all-files` passes all **15 hooks**, including mypy; it leaves tracked files unchanged.
* `python -m pytest -q tests/services/partners/test_partner_workspace.py tests/services/workspace/test_content_workspace.py tests/services/config/test_readiness.py`: **48 passed**.
* Four additional synthetic checks exercise the Tika and Docling verifier branches with successful and unsuccessful responses, confirming the selected verifier receives the original configuration and timeout. No network calls are made.
* Full backend and frontend suites were not rerun locally for this three-file type repair.
* Remote CI completed for `86dec0bf59c0b4cb747e214d8e9b8721387a2969`: **14 checks passed**, **1 skipped** ([Repository Hygiene](https://github.com/HKUDS/DeepTutor/actions/runs/34174724147), [Tests](https://github.com/HKUDS/DeepTutor/actions/runs/34174724148)). Passed: Lint and Format, Check tracked generated files, Web Node Tests, six Import Check jobs, Python Tests on 3.11/3.12/3.13/3.14, and Test Summary. Four-worker browser acceptance was skipped because its fixture URL was not configured; it was not executed.

### Checklist

- [x] Read current contribution guidance and target `dev`.
- [x] Run the complete pre-commit gate and affected existing tests.
- [x] Preserve manifest payload capture and parser branch behavior.
- [x] Executed remote checks pass on the published head; optional four-worker acceptance is skipped.
