### PR TITLE
fix(llm): raise a streamed provider error instead of answering with it

### DIFF
--- a/deeptutor/services/llm/factory.py
+++ b/deeptutor/services/llm/factory.py
@@ -593,7 +593,7 @@ async def stream(
         await queue.put(chunk)
 
     async def _runner() -> None:
-        nonlocal in_think_block
+        nonlocal saw_output, in_think_block
         try:
             response = await provider.chat_stream_with_retry(
                 messages=request_messages,
@@ -609,9 +609,12 @@ async def stream(
                 in_think_block = False
                 await queue.put("</think>")
             # Some providers synthesize a final response only after the stream.
-            # Do not replay reasoning_content as user-visible answer text.
+            # Do not replay reasoning_content as user-visible answer text, and
+            # never surface an error-shaped response's operator message as if
+            # the model had written it: that case is raised below instead.
             if (
-                not saw_content
+                response.finish_reason != "error"
+                and not saw_content
                 and response.content
                 and response.content != response.reasoning_content
             ):

--- a/tests/services/llm/test_factory_provider_exec.py
+++ b/tests/services/llm/test_factory_provider_exec.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 from deeptutor.services.llm.config import LLMConfig
+from deeptutor.services.llm.exceptions import LLMAPIError
 from deeptutor.services.llm.factory import complete, complete_with_config, stream
 from deeptutor.services.llm.provider_core.base import LLMResponse
 
@@ -339,3 +340,50 @@ async def test_complete_passes_retry_delays(monkeypatch) -> None:
     await complete("hello", max_retries=3, retry_delay=0.5, exponential_backoff=True)
 
     assert provider.complete_kwargs["retry_delays"] == (0.5, 1.0, 2.0)
+
+
+@pytest.mark.asyncio
+async def test_stream_raises_when_provider_reports_error_before_any_output(monkeypatch) -> None:
+    """An error-shaped response must surface as an exception, not as answer text."""
+    cfg = _make_cfg()
+    provider = _FakeProvider(
+        stream_chunk="",
+        stream_response=LLMResponse(content="Error calling LLM: boom", finish_reason="error"),
+    )
+
+    monkeypatch.setattr("deeptutor.services.llm.factory.get_llm_config", lambda: cfg)
+    monkeypatch.setattr(
+        "deeptutor.services.llm.factory.get_runtime_provider",
+        lambda _config: provider,
+    )
+
+    chunks = []
+    with pytest.raises(LLMAPIError, match="boom"):
+        async for chunk in stream("hello"):
+            chunks.append(chunk)
+
+    assert chunks == []
+
+
+@pytest.mark.asyncio
+async def test_stream_keeps_delivered_output_when_provider_reports_error_late(
+    monkeypatch,
+) -> None:
+    """Text already streamed stays the answer; a late error neither replays nor crashes."""
+    cfg = _make_cfg()
+    provider = _FakeProvider(
+        stream_chunk="Hello",
+        stream_response=LLMResponse(content="Error calling LLM: boom", finish_reason="error"),
+    )
+
+    monkeypatch.setattr("deeptutor.services.llm.factory.get_llm_config", lambda: cfg)
+    monkeypatch.setattr(
+        "deeptutor.services.llm.factory.get_runtime_provider",
+        lambda _config: provider,
+    )
+
+    chunks = []
+    async for chunk in stream("hello"):
+        chunks.append(chunk)
+
+    assert chunks == ["Hello"]


### PR DESCRIPTION
### Description
`deeptutor.services.llm.factory.stream()` runs the provider call in an inner `_runner` coroutine. That coroutine assigns `saw_output = True` in the post-stream "synthesize final content" branch but only declares `nonlocal in_think_block`, so Python treats `saw_output` as a *local* of `_runner`, distinct from the flag the delta callbacks set. Two failure modes follow whenever a provider returns an error-shaped response (`finish_reason="error"`, which is how `_call_with_retry` reports exhausted retries and how `chat_stream` reports a stalled stream):

- **No delta, then error** — the synthesis branch enqueues `response.content` (e.g. `Error calling LLM: ...`) as ordinary answer text and sets the local flag, so the error check is skipped. The operator message streams to the user as if the model wrote it, and nothing is raised.
- **Some deltas, then error** — the synthesis branch is skipped, and the error check reads the never-assigned local: `UnboundLocalError: cannot access local variable 'saw_output'`, surfaced to callers as `LLMAPIError: [openai] cannot access local variable 'saw_output' ...`.

This PR:
- adds `saw_output` to the `nonlocal` declaration;
- gates the post-stream content synthesis on `finish_reason != "error"`, so an error-shaped response is never surfaced as answer text and falls through to the existing guard, which raises it via `map_error` as `LLMAPIError`.

The existing behaviour for text that was already delivered is kept: a late error after streamed content still ends the stream without discarding what the user has seen (same semantics the original guard intended, now actually reachable). This matches what the agentic loop already does in `runtime/agentic/client.py::_raise_for_error_response`, where an error-shaped response is turned back into an exception instead of being forwarded as a chunk.

### Related Issues
- None found for this specific defect (searched issues/PRs for `saw_output`, `Error calling LLM` + stream).

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [x] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
Two regression tests were added to `tests/services/llm/test_factory_provider_exec.py`, using the existing `_FakeProvider` harness:

- `test_stream_raises_when_provider_reports_error_before_any_output` — fails on `dev` with `DID NOT RAISE LLMAPIError` (the error text was yielded as content).
- `test_stream_keeps_delivered_output_when_provider_reports_error_late` — fails on `dev` with the `UnboundLocalError` described above.

Both pass with this change; `tests/services/llm` and `tests/runtime` are otherwise unchanged (528 passed locally). `ruff check` / `ruff format --check` (0.16.0, as pinned in CI) are clean, and all pre-commit hooks pass on the touched files (the local `deeptutor-repo-hygiene` hook could not launch on Windows because it shells out to `python3`, but `python scripts/check_repo_hygiene.py` passes).
