### PR TITLE
fix(llm): survive api_key key pools in the config resolver

### DIFF
--- a/deeptutor/services/llm/config.py
+++ b/deeptutor/services/llm/config.py
@@ -201,7 +201,11 @@ def _get_llm_config_from_resolver() -> LLMConfig:
         raise LLMConfigError(
             "No effective LLM endpoint resolved. Please configure base_url or provider defaults."
         )
-    is_placeholder_key = resolved.api_key in {"", "no-key", "sk-no-key-required"}
+    # api_key may be a list (key pool); only the resolved primary key counts
+    # for the placeholder check — set membership on the raw list raises
+    # TypeError for unhashable list (PR #962 semantics).
+    primary_key = primary_api_key(resolved.api_key)
+    is_placeholder_key = primary_key in {None, "", "no-key", "sk-no-key-required"}
     if (
         resolved.provider_name == "openai"
         and resolved.provider_mode == "standard"

--- a/tests/services/llm/test_config_module.py
+++ b/tests/services/llm/test_config_module.py
@@ -277,7 +277,6 @@ def test_placeholder_detection_uses_primary_key_of_list(monkeypatch) -> None:
         config_module.get_llm_config()
 
 
-
 def _catalog_with_profiles() -> dict:
     return {
         "services": {
@@ -315,7 +314,6 @@ def _patch_catalog(monkeypatch, catalog: dict | None) -> None:
             return catalog
 
     monkeypatch.setattr(mc_module, "get_model_catalog_service", lambda: _FakeService())
-
 
 
 def _resolved_for_selection(selection: dict | None) -> ResolvedLLMConfig:

--- a/tests/services/llm/test_config_module.py
+++ b/tests/services/llm/test_config_module.py
@@ -20,7 +20,7 @@ def test_get_llm_config_from_resolver(monkeypatch) -> None:
     """Resolver-backed loading should populate provider metadata."""
     _reset_config_cache()
 
-    def _fake_resolver() -> ResolvedLLMConfig:
+    def _fake_resolver(*_args, **_kwargs) -> ResolvedLLMConfig:
         return ResolvedLLMConfig(
             model="openai/gpt-4o-mini",
             provider_name="openrouter",
@@ -54,7 +54,7 @@ def test_get_llm_config_raises_when_resolver_fails(monkeypatch) -> None:
     monkeypatch.setattr(
         config_module,
         "resolve_llm_runtime_config",
-        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
     )
 
     with pytest.raises(RuntimeError, match="boom"):
@@ -66,7 +66,7 @@ def test_scoped_llm_config_takes_precedence_over_global_cache(monkeypatch) -> No
     monkeypatch.setattr(
         config_module,
         "resolve_llm_runtime_config",
-        lambda: ResolvedLLMConfig(
+        lambda *_args, **_kwargs: ResolvedLLMConfig(
             model="gpt-global",
             provider_name="openai",
             provider_mode="standard",
@@ -101,7 +101,7 @@ def test_initialize_environment_sets_openai_env(monkeypatch) -> None:
     monkeypatch.setattr(
         config_module,
         "resolve_llm_runtime_config",
-        lambda: ResolvedLLMConfig(
+        lambda *_args, **_kwargs: ResolvedLLMConfig(
             model="gpt-4o-mini",
             provider_name="openai",
             provider_mode="standard",
@@ -128,7 +128,7 @@ def test_initialize_environment_skips_openai_env_for_custom_anthropic(monkeypatc
     monkeypatch.setattr(
         config_module,
         "resolve_llm_runtime_config",
-        lambda: ResolvedLLMConfig(
+        lambda *_args, **_kwargs: ResolvedLLMConfig(
             model="claude-sonnet-4-20250514",
             provider_name="custom_anthropic",
             provider_mode="direct",
@@ -154,7 +154,7 @@ def test_resolver_missing_model_raises(monkeypatch) -> None:
     monkeypatch.setattr(
         config_module,
         "resolve_llm_runtime_config",
-        lambda: ResolvedLLMConfig(
+        lambda *_args, **_kwargs: ResolvedLLMConfig(
             model="",
             provider_name="openai",
             provider_mode="standard",
@@ -178,7 +178,7 @@ def test_official_openai_without_real_key_raises(monkeypatch) -> None:
     monkeypatch.setattr(
         config_module,
         "resolve_llm_runtime_config",
-        lambda: ResolvedLLMConfig(
+        lambda *_args, **_kwargs: ResolvedLLMConfig(
             model="gpt-4o-mini",
             provider_name="openai",
             provider_mode="standard",
@@ -196,3 +196,147 @@ def test_official_openai_without_real_key_raises(monkeypatch) -> None:
 
     with pytest.raises(LLMConfigError, match="OpenAI API key is not configured"):
         config_module.get_llm_config()
+
+
+def test_profile_api_key_list_resolves_without_crash(monkeypatch) -> None:
+    """A profile api_key configured as a key array must resolve (PR #962).
+
+    Regression: the upstream refactor wrote the placeholder check as
+    ``resolved.api_key in {...}``, which raises ``TypeError: unhashable type:
+    'list'`` the moment a profile carries a key pool.
+    """
+    _reset_config_cache()
+    keys = ["sk-one", "sk-two", "sk-three", "sk-four"]
+
+    monkeypatch.setattr(
+        config_module,
+        "resolve_llm_runtime_config",
+        lambda *_args, **_kwargs: ResolvedLLMConfig(
+            model="doubao-seed-1-6",
+            provider_name="openai_compat_test",
+            provider_mode="standard",
+            binding_hint="openai_compat_test",
+            binding="openai_compat_test",
+            api_key=list(keys),
+            base_url="https://example.com/v1",
+            effective_url="https://example.com/v1",
+            api_version=None,
+            extra_headers={},
+            reasoning_effort=None,
+            context_window=None,
+        ),
+    )
+
+    config = config_module.get_llm_config()
+    assert config.api_key == keys
+    assert config.get_api_key() == "sk-one"
+
+
+def test_profile_api_key_list_reaches_provider_key_pool() -> None:
+    """The full key list must flow resolver → LLMConfig → provider KeyPool."""
+    from deeptutor.services.llm.provider_factory import _build_runtime_provider
+
+    keys = ["sk-one", "sk-two", "sk-three", "sk-four"]
+    config = LLMConfig(
+        model="doubao-seed-1-6",
+        api_key=list(keys),
+        base_url="https://example.com/v1",
+        binding="openai_compat_test",
+        provider_name="openai_compat_test",
+    )
+
+    provider = _build_runtime_provider(config)
+    assert provider._key_pool is not None
+    assert list(provider._key_pool._keys) == keys
+
+
+def test_placeholder_detection_uses_primary_key_of_list(monkeypatch) -> None:
+    """A list whose keys are all placeholders still counts as unconfigured."""
+    _reset_config_cache()
+
+    monkeypatch.setattr(
+        config_module,
+        "resolve_llm_runtime_config",
+        lambda *_args, **_kwargs: ResolvedLLMConfig(
+            model="gpt-4o-mini",
+            provider_name="openai",
+            provider_mode="standard",
+            binding_hint="openai",
+            binding="openai",
+            api_key=[""],
+            base_url="https://api.openai.com/v1",
+            effective_url="https://api.openai.com/v1",
+            api_version=None,
+            extra_headers={},
+            reasoning_effort=None,
+            context_window=None,
+        ),
+    )
+
+    with pytest.raises(LLMConfigError, match="OpenAI API key is not configured"):
+        config_module.get_llm_config()
+
+
+
+def _catalog_with_profiles() -> dict:
+    return {
+        "services": {
+            "llm": {
+                "active_profile_id": "prof-active-weak",
+                "active_model_id": "model-active-weak-1",
+                "profiles": [
+                    {
+                        "id": "prof-active-weak",
+                        "binding": "openai_compat_test",
+                        "models": [{"id": "model-active-weak-1", "model": "glmfree-air"}],
+                    },
+                    {
+                        "id": "prof-strong",
+                        "binding": "openai_compat_test",
+                        "active_model_id": "model-strong-2",
+                        "models": [
+                            {"id": "model-strong-1", "model": "doubao-seed-other"},
+                            {"id": "model-strong-2", "model": "doubao-seed-1-6"},
+                        ],
+                    },
+                ],
+            }
+        }
+    }
+
+
+def _patch_catalog(monkeypatch, catalog: dict | None) -> None:
+    from deeptutor.services.config import model_catalog as mc_module
+
+    class _FakeService:
+        def load(self):
+            if catalog is None:
+                raise RuntimeError("catalog unavailable")
+            return catalog
+
+    monkeypatch.setattr(mc_module, "get_model_catalog_service", lambda: _FakeService())
+
+
+
+def _resolved_for_selection(selection: dict | None) -> ResolvedLLMConfig:
+    """Stand-in resolver: model from the selection, else the weak active."""
+    if selection is None:
+        model = "glmfree-air"
+    elif selection["profile_id"] == "prof-strong" and selection["model_id"] == "model-strong-2":
+        model = "doubao-seed-1-6"
+    else:
+        raise AssertionError(f"unexpected selection payload: {selection}")
+    return ResolvedLLMConfig(
+        model=model,
+        provider_name="openai_compat_test",
+        provider_mode="standard",
+        binding_hint="openai_compat_test",
+        binding="openai_compat_test",
+        api_key="sk-test",
+        base_url="https://example.com/v1",
+        effective_url="https://example.com/v1",
+        api_version=None,
+        extra_headers={},
+        reasoning_effort=None,
+        context_window=None,
+    )


### PR DESCRIPTION
Fix: survive api_key key pools in the LLM config resolver

## Problem

A catalog profile configured with **multiple API keys** (`api_key` as a JSON
array — the key-pool shape the provider layer is designed for) crashes
`get_llm_config()` for the whole process:

```
TypeError: unhashable type: 'list'
  at deeptutor/services/llm/config.py:204
  in _get_llm_config_from_resolver
  is_placeholder_key = resolved.api_key in {"", "no-key", "sk-no-key-required"}
```

Every LLM call in the process goes through `get_llm_config()`, so one
multi-key profile takes down chat, agents, and background generation alike —
not just the multi-key deployment itself.

## Root cause

Regression of #962's behavior. `cc23cbe3a` (#863) added a **second**
placeholder check in `_get_llm_config_from_resolver` without unwrapping the
key through `primary_api_key()` — the helper #962 introduced for exactly
this reason. The provider layer (`OpenAICompatProvider`) already accepts
`api_key: str | list[str]` and rotates via `KeyPool`; only the resolver
entry was left behind.

## Fix

- Placeholder check unwraps through `primary_api_key()` (primary key counts,
  matching the provider's notion of the configured key)
- The full key list is passed through to the provider so `KeyPool` keeps
  rotating across all keys

## Tests

`tests/services/llm/test_config_module.py`:

- a 4-key array reaches the provider's `KeyPool` intact
- the placeholder check uses the primary key, not set membership on the list
- single-key profiles behave exactly as before (no regression)

All 10 tests in the module pass.
