### PR TITLE
fix(web): fall back when crypto.randomUUID is unavailable for command ids

### DIFF
--- a/web/features/chat/transport/TurnRuntimeClient.ts
+++ b/web/features/chat/transport/TurnRuntimeClient.ts
@@ -56,6 +56,28 @@ const ACKNOWLEDGED_COMMAND_TYPES = new Set([
   "user_input",
 ]);
 
+/**
+ * Generates a command id for acknowledged commands.
+ *
+ * `crypto.randomUUID()` is only available in secure contexts (HTTPS). When
+ * DeepTutor is served over plain HTTP (e.g. a LAN or VPS deployment) it is
+ * undefined, and submitting an acknowledged command (`submit_user_reply`,
+ * `cancel_turn`, `user_input`) would throw inside `prepareCommand` before the
+ * command is ever enqueued, so the answer never reaches the server and the UI
+ * reports the reply as "not delivered". Fall back to an RFC 4122 v4-style
+ * UUID in that case.
+ */
+function createCommandId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
 function prepareCommand(command: ClientCommand): {
   command: ClientCommand;
   commandId: string | null;
@@ -68,7 +90,7 @@ function prepareCommand(command: ClientCommand): {
   const record = command as unknown as Record<string, unknown>;
   const existing =
     typeof record.command_id === "string" ? record.command_id.trim() : "";
-  const commandId = existing || globalThis.crypto.randomUUID();
+  const commandId = existing || createCommandId();
   return {
     command: { ...command, command_id: commandId } as ClientCommand,
     commandId,

--- a/web/tests/turn-runtime-client.test.ts
+++ b/web/tests/turn-runtime-client.test.ts
@@ -387,3 +387,34 @@ test("stopping releases waiters that will never be acknowledged", async () => {
 
   assert.equal(await verdict, false);
 });
+
+
+test("acknowledged commands get a generated command_id when crypto.randomUUID is unavailable", () => {
+  const original = globalThis.crypto?.randomUUID;
+  const cryptoObject = globalThis.crypto as {
+    randomUUID?: typeof globalThis.crypto.randomUUID;
+  };
+  if (cryptoObject) cryptoObject.randomUUID = undefined;
+  try {
+    const { client, sockets } = harness();
+    client.connect();
+    sockets[0].open();
+    client.send(
+      buildSubmitUserReply({
+        turnId: "turn-1",
+        text: "A",
+        answers: [{ questionId: "q", text: "B" }],
+      }),
+    );
+    const sent = sockets[0].sent.find(
+      (item) => item.type === "submit_user_reply",
+    ) as Record<string, unknown>;
+    assert.ok(sent, "submit_user_reply should be sent");
+    assert.match(
+      String(sent.command_id),
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  } finally {
+    if (cryptoObject) cryptoObject.randomUUID = original;
+  }
+});


### PR DESCRIPTION
## Summary

Fixes a client-side crash that made user answers to `ask_user` (and other acknowledged commands) never reach the server when DeepTutor is served over plain HTTP.

## Problem

`prepareCommand` in `web/features/chat/transport/TurnRuntimeClient.ts` generates a `command_id` for acknowledged commands (`submit_user_reply`, `cancel_turn`, `user_input`) via:

```ts
const commandId = existing || globalThis.crypto.randomUUID();
```

`crypto.randomUUID()` is only available in **secure contexts** (HTTPS). When DeepTutor is deployed over plain HTTP (e.g. a LAN or VPS deployment on `http://host:port`), it is `undefined`, so calling it throws a `TypeError` inside `prepareCommand`. The command is never enqueued or sent; the UI reports *"这道题已经不再等待作答，你的回答没能送达"* / "your reply could not be delivered", and the turn stays stuck waiting for input.

## Fix

Add a `createCommandId()` helper that uses `crypto.randomUUID()` when available and otherwise falls back to an RFC 4122 v4-style UUID generated from `Math.random()`:

```ts
function createCommandId(): string {
  if (typeof globalThis.crypto?.randomUUID === "function") {
    return globalThis.crypto.randomUUID();
  }
  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
    const r = (Math.random() * 16) | 0;
    const v = c === "x" ? r : (r & 0x3) | 0x8;
    return v.toString(16);
  });
}
```

## Verification

- New unit test in `web/tests/turn-runtime-client.test.ts`: with `crypto.randomUUID` forced to `undefined`, `submit_user_reply` is still sent with a valid v4 `command_id`.
- The fallback logic was also exercised against a live deployment over HTTP (2000 generated ids, all valid and unique).
- Existing tests pass the same `sendAwaitingAck`/`cancel` paths unchanged (they pass an explicit `command_id`, which is preserved).

## Notes

- HTTPS remains the recommended deployment, but the client should not crash when it is not used.
