### PR TITLE
feat(web): fully resizable reading workspace panels + focus preset

### DIFF
--- a/web/components/reading/workspace/ReadingWorkspace.tsx
+++ b/web/components/reading/workspace/ReadingWorkspace.tsx
@@ -18,6 +18,8 @@ import {
   History,
   Link2,
   Loader2,
+  Maximize2,
+  Minimize2,
   MoreHorizontal,
   NotebookPen,
   PanelLeftClose,
@@ -158,7 +160,7 @@ export function ReadingWorkspacePage() {
       const stored = Number(
         browserStorage.readRaw("local", "dt.reader.companionWidth"),
       );
-      return Number.isFinite(stored) && stored >= 300 && stored <= 640
+      return Number.isFinite(stored) && stored >= 300 && stored <= 1200
         ? stored
         : 380;
     } catch {
@@ -197,6 +199,43 @@ export function ReadingWorkspacePage() {
   const [companionOpen, setCompanionOpen] = useState(true);
   const [navigatorOpen, setNavigatorOpen] = useState(false);
   const [navigatorCollapsed, setNavigatorCollapsed] = useState(false);
+  // One-click focus preset: collapse the contents navigator and widen the
+  // companion to half the window; exiting restores both. Ephemeral like
+  // navigatorCollapsed — only the width itself persists across sessions.
+  const [companionFocus, setCompanionFocus] = useState(false);
+  const preFocusWidthRef = useRef<number | null>(null);
+
+  const toggleCompanionFocus = useCallback(() => {
+    if (companionFocus) {
+      setCompanionFocus(false);
+      setNavigatorCollapsed(false);
+      const restore = preFocusWidthRef.current;
+      if (restore !== null) {
+        setCompanionWidth(restore);
+        try {
+          browserStorage.writeRaw(
+            "local",
+            "dt.reader.companionWidth",
+            String(restore),
+          );
+        } catch {
+          // A blocked or private store just resets to default next time.
+        }
+      }
+      preFocusWidthRef.current = null;
+      return;
+    }
+    preFocusWidthRef.current = companionWidth;
+    setCompanionFocus(true);
+    setNavigatorCollapsed(true);
+    const half = Math.max(300, Math.round(window.innerWidth / 2));
+    setCompanionWidth(half);
+    try {
+      browserStorage.writeRaw("local", "dt.reader.companionWidth", String(half));
+    } catch {
+      // A blocked or private store just resets to default next time.
+    }
+  }, [companionFocus, companionWidth]);
   const [documentJump, setDocumentJump] = useState<JumpRequest | null>(null);
   const [pageHeadings, setPageHeadings] = useState<ReaderHeading[]>([]);
   const [activeHeadingId, setActiveHeadingId] = useState<string | null>(null);
@@ -262,7 +301,12 @@ export function ReadingWorkspacePage() {
       const startX = event.clientX;
       const startWidth = companionWidth;
       const reserved = navigatorCollapsed ? 420 : 650;
-      const max = Math.max(300, Math.min(640, window.innerWidth - reserved));
+      // The companion may claim up to half the window; the reader track keeps
+      // whatever remains (its own minmax(360px,1fr) floor still applies).
+      const max = Math.max(
+        300,
+        Math.min(window.innerWidth - reserved, Math.round(window.innerWidth / 2)),
+      );
       const onMove = (moveEvent: PointerEvent) => {
         const next = startWidth + (startX - moveEvent.clientX);
         setCompanionWidth(Math.min(max, Math.max(300, Math.round(next))));
@@ -488,6 +532,30 @@ export function ReadingWorkspacePage() {
               <PanelLeftClose size={14} />
             )}
           </button>
+          {isDesktopWide && companionOpen && (
+            <button
+              type="button"
+              onClick={toggleCompanionFocus}
+              className={`flex size-7 items-center justify-center rounded-md transition hover:bg-[var(--muted)] ${
+                companionFocus
+                  ? "text-[var(--primary)]"
+                  : "text-[var(--muted-foreground)] hover:text-[var(--primary)]"
+              }`}
+              aria-label={
+                companionFocus
+                  ? t("Exit companion focus")
+                  : t("Focus reading companion")
+              }
+              aria-pressed={companionFocus}
+              title={
+                companionFocus
+                  ? t("Exit companion focus")
+                  : t("Focus reading companion")
+              }
+            >
+              {companionFocus ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+            </button>
+          )}
           <button
             type="button"
             onClick={() => {

--- a/web/components/reading/workspace/ReadingWorkspace.tsx
+++ b/web/components/reading/workspace/ReadingWorkspace.tsx
@@ -210,6 +210,20 @@ export function ReadingWorkspacePage() {
   const [showSessions, setShowSessions] = useState(false);
   const [showLinker, setShowLinker] = useState(false);
   const [showNotebook, setShowNotebook] = useState(false);
+  // Live width of the three-column grid container. The app sidebar sits
+  // outside this grid, so innerWidth overstates the space the panels share;
+  // the drag ceiling and the render-time clamp both key off the measured
+  // container instead.
+  const gridRef = useRef<HTMLDivElement | null>(null);
+  const [gridWidth, setGridWidth] = useState(0);
+  useEffect(() => {
+    const el = gridRef.current;
+    if (!el) return;
+    setGridWidth(el.clientWidth);
+    const observer = new ResizeObserver(() => setGridWidth(el.clientWidth));
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
   const [showAddSource, setShowAddSource] = useState(false);
   const [showActions, setShowActions] = useState(false);
   const [showRename, setShowRename] = useState(false);
@@ -252,14 +266,17 @@ export function ReadingWorkspacePage() {
     preFocusWidthRef.current = companionWidth;
     setCompanionFocus(true);
     setNavigatorCollapsed(true);
-    const half = Math.max(300, Math.round(window.innerWidth / 2));
+    const half = Math.max(
+      COMPANION_MIN_WIDTH,
+      Math.round((gridWidth || window.innerWidth) / 2),
+    );
     setCompanionWidth(half);
     try {
       browserStorage.writeRaw("local", "dt.reader.companionWidth", String(half));
     } catch {
       // A blocked or private store just resets to default next time.
     }
-  }, [companionFocus, companionWidth]);
+  }, [companionFocus, companionWidth, gridWidth]);
   const [documentJump, setDocumentJump] = useState<JumpRequest | null>(null);
   const [pageHeadings, setPageHeadings] = useState<ReaderHeading[]>([]);
   const [activeHeadingId, setActiveHeadingId] = useState<string | null>(null);
@@ -326,10 +343,12 @@ export function ReadingWorkspacePage() {
       const startWidth = companionWidth;
       // The companion may grow until the reader — and the open navigator —
       // are left at their minimum widths; nothing is otherwise capped.
+      const frame = gridRef.current?.clientWidth ?? window.innerWidth;
       const max = Math.max(
         COMPANION_MIN_WIDTH,
-        window.innerWidth -
+        frame -
           (navigatorCollapsed ? 0 : navigatorWidth) -
+          (navigatorCollapsed ? 5 : 10) -
           READER_MIN_WIDTH,
       );
       const onMove = (moveEvent: PointerEvent) => {
@@ -447,10 +466,12 @@ export function ReadingWorkspacePage() {
     // Guard against a stored width that no longer fits (the window moved to
     // a smaller screen since it was persisted): the reader always keeps its
     // minimum, so clamp the companion to whatever the other tracks leave.
+    const frame = gridWidth || window.innerWidth;
     const ceiling = Math.max(
       COMPANION_MIN_WIDTH,
-      window.innerWidth -
+      frame -
         (navigatorCollapsed ? 0 : navigatorWidth) -
+        (navigatorCollapsed ? 5 : 10) -
         READER_MIN_WIDTH,
     );
     const width = Math.min(companionWidth, ceiling);
@@ -658,6 +679,7 @@ export function ReadingWorkspacePage() {
       </header>
 
       <div
+        ref={gridRef}
         className={`relative grid min-h-0 flex-1 grid-rows-[minmax(0,1fr)] overflow-hidden ${
           companionOpen
             ? navigatorCollapsed

--- a/web/components/reading/workspace/ReadingWorkspace.tsx
+++ b/web/components/reading/workspace/ReadingWorkspace.tsx
@@ -91,6 +91,15 @@ interface ReaderAskDetail {
   unit?: string;
 }
 
+// Panel sizing constraints for the desktop three-column workspace. Every
+// column is user-resizable; these are the floors/ceilings the drag handlers
+// and the grid template honor, so the reader never drops below a usable
+// column no matter how wide the side panels get.
+const NAVIGATOR_MIN_WIDTH = 184;
+const NAVIGATOR_MAX_WIDTH = 400;
+const READER_MIN_WIDTH = 360;
+const COMPANION_MIN_WIDTH = 300;
+
 export function ReadingWorkspacePage() {
   const params = useParams<{ workspaceId: string }>();
   const workspaceId = params.workspaceId;
@@ -160,11 +169,26 @@ export function ReadingWorkspacePage() {
       const stored = Number(
         browserStorage.readRaw("local", "dt.reader.companionWidth"),
       );
-      return Number.isFinite(stored) && stored >= 300 && stored <= 1200
+      return Number.isFinite(stored) && stored >= 300 && stored <= 2400
         ? stored
         : 380;
     } catch {
       return 380;
+    }
+  });
+  const [navigatorWidth, setNavigatorWidth] = useState(() => {
+    if (typeof window === "undefined") return 210;
+    try {
+      const stored = Number(
+        browserStorage.readRaw("local", "dt.reader.navigatorWidth"),
+      );
+      return Number.isFinite(stored) &&
+        stored >= NAVIGATOR_MIN_WIDTH &&
+        stored <= NAVIGATOR_MAX_WIDTH
+        ? stored
+        : 210;
+    } catch {
+      return 210;
     }
   });
   const [isDesktopWide, setIsDesktopWide] = useState(false);
@@ -300,12 +324,13 @@ export function ReadingWorkspacePage() {
       event.preventDefault();
       const startX = event.clientX;
       const startWidth = companionWidth;
-      const reserved = navigatorCollapsed ? 420 : 650;
-      // The companion may claim up to half the window; the reader track keeps
-      // whatever remains (its own minmax(360px,1fr) floor still applies).
+      // The companion may grow until the reader — and the open navigator —
+      // are left at their minimum widths; nothing is otherwise capped.
       const max = Math.max(
-        300,
-        Math.min(window.innerWidth - reserved, Math.round(window.innerWidth / 2)),
+        COMPANION_MIN_WIDTH,
+        window.innerWidth -
+          (navigatorCollapsed ? 0 : navigatorWidth) -
+          READER_MIN_WIDTH,
       );
       const onMove = (moveEvent: PointerEvent) => {
         const next = startWidth + (startX - moveEvent.clientX);
@@ -330,7 +355,43 @@ export function ReadingWorkspacePage() {
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);
     },
-    [companionWidth, navigatorCollapsed],
+    [companionWidth, navigatorCollapsed, navigatorWidth],
+  );
+
+  const startNavigatorResize = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const startX = event.clientX;
+      const startWidth = navigatorWidth;
+      const onMove = (moveEvent: PointerEvent) => {
+        const next = startWidth + (moveEvent.clientX - startX);
+        setNavigatorWidth(
+          Math.min(
+            NAVIGATOR_MAX_WIDTH,
+            Math.max(NAVIGATOR_MIN_WIDTH, Math.round(next)),
+          ),
+        );
+      };
+      const onUp = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        setNavigatorWidth((current) => {
+          try {
+            browserStorage.writeRaw(
+              "local",
+              "dt.reader.navigatorWidth",
+              String(current),
+            );
+          } catch {
+            // A blocked or private store just resets to default next time.
+          }
+          return current;
+        });
+      };
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+    },
+    [navigatorWidth],
   );
 
   if (loading) {
@@ -378,13 +439,30 @@ export function ReadingWorkspacePage() {
   // in this case. Every other combination (companion closed, or too narrow
   // for a three-column layout) is exactly what the className already says.
   const showResizeHandle = isDesktopWide && companionOpen;
-  const gridStyle: React.CSSProperties | undefined = showResizeHandle
-    ? {
-        gridTemplateColumns: navigatorCollapsed
-          ? `minmax(360px,1fr) 5px ${companionWidth}px`
-          : `minmax(184px,230px) minmax(360px,1fr) 5px ${companionWidth}px`,
-      }
-    : undefined;
+  // The navigator track only exists while the navigator is not collapsed, so
+  // its own handle follows the same condition.
+  const showNavigatorHandle = showResizeHandle && !navigatorCollapsed;
+  let gridStyle: React.CSSProperties | undefined;
+  if (showResizeHandle) {
+    // Guard against a stored width that no longer fits (the window moved to
+    // a smaller screen since it was persisted): the reader always keeps its
+    // minimum, so clamp the companion to whatever the other tracks leave.
+    const ceiling = Math.max(
+      COMPANION_MIN_WIDTH,
+      window.innerWidth -
+        (navigatorCollapsed ? 0 : navigatorWidth) -
+        READER_MIN_WIDTH,
+    );
+    const width = Math.min(companionWidth, ceiling);
+    gridStyle = {
+      // Five tracks with the navigator open — panel, its divider, reader,
+      // companion divider, companion — so each drag handle owns a track and
+      // auto-placement lines the children up. Collapsed drops the first two.
+      gridTemplateColumns: navigatorCollapsed
+        ? `minmax(${READER_MIN_WIDTH}px,1fr) 5px ${width}px`
+        : `${navigatorWidth}px 5px minmax(${READER_MIN_WIDTH}px,1fr) 5px ${width}px`,
+    };
+  }
 
   return (
     <main className="reading-v2 flex h-full min-h-0 flex-col overflow-hidden bg-[var(--background)] text-[var(--foreground)] dark:bg-[var(--background)] dark:text-[var(--foreground)]">
@@ -644,6 +722,18 @@ export function ReadingWorkspacePage() {
             }
           }}
         />
+
+        {showNavigatorHandle && (
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label={t("Resize contents navigator")}
+            onPointerDown={startNavigatorResize}
+            className="group/resize relative z-10 hidden cursor-col-resize xl:block"
+          >
+            <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-[var(--border)] transition-colors group-hover/resize:bg-[var(--primary)] group-active/resize:bg-[var(--primary)]" />
+          </div>
+        )}
 
         <section className="relative min-h-0 min-w-0 overflow-hidden border-r border-[var(--border)] bg-[var(--secondary)] dark:border-[var(--border)] dark:bg-[var(--secondary)]">
           {!activeTab ? (

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -3026,6 +3026,8 @@
   "Reading conversations": "Reading conversations",
   "Jump to a question": "Jump to a question",
   "Resize reading companion": "Resize reading companion",
+  "Focus reading companion": "Focus reading companion",
+  "Exit companion focus": "Exit companion focus",
   "Delete “{{title}}”? The transcript cannot be recovered.": "Delete “{{title}}”? The transcript cannot be recovered.",
   "New reading conversation": "New reading conversation",
   "Reading conversation": "Reading conversation",

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -3027,6 +3027,7 @@
   "Jump to a question": "Jump to a question",
   "Resize reading companion": "Resize reading companion",
   "Focus reading companion": "Focus reading companion",
+  "Resize contents navigator": "Resize contents navigator",
   "Exit companion focus": "Exit companion focus",
   "Delete “{{title}}”? The transcript cannot be recovered.": "Delete “{{title}}”? The transcript cannot be recovered.",
   "New reading conversation": "New reading conversation",

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -3026,6 +3026,8 @@
   "Reading conversations": "阅读对话",
   "Jump to a question": "跳到某个提问",
   "Resize reading companion": "调整阅读伙伴宽度",
+  "Focus reading companion": "对话专注模式",
+  "Exit companion focus": "退出专注模式",
   "Delete “{{title}}”? The transcript cannot be recovered.": "删除「{{title}}」？对话记录将无法恢复。",
   "New reading conversation": "新建阅读对话",
   "Reading conversation": "阅读对话",

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -3027,6 +3027,7 @@
   "Jump to a question": "跳到某个提问",
   "Resize reading companion": "调整阅读伙伴宽度",
   "Focus reading companion": "对话专注模式",
+  "Resize contents navigator": "调整目录宽度",
   "Exit companion focus": "退出专注模式",
   "Delete “{{title}}”? The transcript cannot be recovered.": "删除「{{title}}」？对话记录将无法恢复。",
   "New reading conversation": "新建阅读对话",


### PR DESCRIPTION
### Description

In the immersive reading workspace the companion column was drag-resizable only within a hard 640px cap, the contents navigator had a fixed 184-230px track, and the panel toggles were the only layout controls. On wide monitors the chat pane stays small, and the only escape hatch was leaving immersive reading for the full chat — which loses the viewport-grounded context (current page, selection, embedded page images) that makes the companion worth using in the first place.

This PR makes the workspace panels fully user-sized:

- **Every column is drag-resizable.** The contents navigator gains its own divider (184-400px, persisted in `dt.reader.navigatorWidth`) next to the existing companion handle. The companion's ceiling is now the reader's minimum width rather than half the window: with the navigator collapsed the companion can claim all but 360px of the frame, and nothing is otherwise capped. Both widths persist across sessions.
- **One-click focus preset.** A header toggle (desktop-wide screens, companion open) collapses the navigator and snaps the companion to half the frame; exiting restores the previous width and navigator state. Ephemeral like the navigator collapse state — only the widths persist.
- **Ceilings measure the grid, not the window.** The app sidebar sits outside the reading grid, so `innerWidth` overstates the space the panels share; a ResizeObserver tracks the container and both the drag-time ceiling and a render-time clamp keep the reader at or above its `minmax(360px,1fr)` floor with no horizontal overflow, even for widths persisted on a larger screen.
- **i18n.** New strings in both `en` and `zh` locales ("Focus reading companion" / "对话专注模式", "Exit companion focus" / "退出专注模式", "Resize contents navigator" / "调整目录宽度").

### How tested

- `tsc --noEmit` clean; production build succeeds.
- Exercised at 1600×900 against a real collection:
  - dragging the companion divider far past the limit clamps at the reader's floor: template `310px 5px minmax(360px,1fr) 5px 700px` on a 1380px grid (310 + 5 + 360 + 5 + 700 = 1380, no overflow, companion panel right edge flush with the grid edge);
  - the navigator divider drags between 184px and 400px and persists;
  - the focus toggle flips the layout to a half-frame companion with the navigator collapsed and restores the previous width on exit.
