### PR TITLE
feat(codex-auth): discover stable client version (#1296)

### DIFF
--- a/deeptutor/services/codex_auth/catalog.py
+++ b/deeptutor/services/codex_auth/catalog.py
@@ -20,13 +20,18 @@ from .constants import (
 )
 from .contracts import CatalogSnapshot, CodexAuthError, CodexCredentials, CodexModel
 from .storage import CodexCredentialStore
+from .version import validate_stable_version
 
 
-def parse_models_response(payload: Mapping[str, Any]) -> tuple[CodexModel, ...]:
+def parse_models_response(
+    payload: Mapping[str, Any],
+    *,
+    incompatible_code: str = "catalog_invalid",
+) -> tuple[CodexModel, ...]:
     raw_models = payload.get("models")
     if not isinstance(raw_models, list):
         raise CodexAuthError(
-            "catalog_invalid",
+            incompatible_code,
             "Codex returned an invalid model catalog.",
             502,
         )
@@ -41,7 +46,7 @@ def parse_models_response(payload: Mapping[str, Any]) -> tuple[CodexModel, ...]:
     for raw_model in raw_models:
         if not isinstance(raw_model, dict):
             raise CodexAuthError(
-                "catalog_invalid",
+                incompatible_code,
                 "Codex returned an invalid model catalog.",
                 502,
             )
@@ -51,7 +56,7 @@ def parse_models_response(payload: Mapping[str, Any]) -> tuple[CodexModel, ...]:
         display_name = raw_model.get("display_name")
         if not isinstance(slug, str) or not slug:
             raise CodexAuthError(
-                "catalog_invalid",
+                incompatible_code,
                 "Codex returned an invalid model catalog.",
                 502,
             )
@@ -132,7 +137,9 @@ class CodexModelCatalog:
         self,
         credentials: CodexCredentials,
         force: bool,
+        client_version: str | None = None,
     ) -> CatalogSnapshot:
+        requested_version = validate_stable_version(client_version or CODEX_CLIENT_VERSION)
         now = int(self._clock())
         account_hash = hashlib.sha256(credentials.account_id.encode("utf-8")).hexdigest()
         cache = self._matching_cache(credentials, account_hash)
@@ -150,25 +157,37 @@ class CodexModelCatalog:
         try:
             response = await self._http.get(
                 CODEX_MODELS_URL,
-                params={"client_version": CODEX_CLIENT_VERSION},
+                params={"client_version": requested_version},
                 headers=headers,
             )
         except httpx.RequestError as exc:
             return self._stale_or_raise(cache, now, exc)
 
         if response.status_code == 401:
-            await self.invalidate()
+            await self.invalidate(expected_generation=credentials.generation)
             raise CodexAuthError(
                 "catalog_unauthorized",
                 "Codex authentication is no longer authorized.",
                 401,
             )
         if response.status_code == 403:
-            await self.invalidate()
+            await self.invalidate(expected_generation=credentials.generation)
             raise CodexAuthError(
                 "catalog_forbidden",
                 "This Codex account cannot access the model catalog.",
                 403,
+            )
+        if response.status_code == 429:
+            raise CodexAuthError(
+                "catalog_rate_limited",
+                "The Codex model catalog is temporarily rate limited.",
+                429,
+            )
+        if response.status_code in {400, 422}:
+            raise CodexAuthError(
+                "catalog_version_rejected",
+                "Codex rejected the requested model-catalog client version.",
+                response.status_code,
             )
         if response.status_code == 304:
             if cache is None:
@@ -178,7 +197,10 @@ class CodexModelCatalog:
                     502,
                 )
             snapshot = replace(cache, source="revalidated-cache", fetched_at=now)
-            self._store.save_catalog_cache(snapshot.to_dict())
+            self._store.save_catalog_cache(
+                snapshot.to_dict(),
+                expected_generation=credentials.generation,
+            )
             return snapshot
 
         try:
@@ -212,19 +234,34 @@ class CodexModelCatalog:
                 502,
             )
 
+        try:
+            models = parse_models_response(payload, incompatible_code="catalog_incompatible")
+        except CodexAuthError as exc:
+            if exc.code != "catalog_incompatible":
+                raise
+            raise CodexAuthError(
+                exc.code,
+                "The model catalog is incompatible with the requested client version.",
+                502,
+            ) from exc
+
         snapshot = CatalogSnapshot(
-            models=parse_models_response(payload),
+            models=models,
             source="live",
             fetched_at=now,
             etag=response.headers.get("etag"),
             generation=credentials.generation,
             account_hash=account_hash,
+            client_version=requested_version,
         )
-        self._store.save_catalog_cache(snapshot.to_dict())
+        self._store.save_catalog_cache(
+            snapshot.to_dict(),
+            expected_generation=credentials.generation,
+        )
         return snapshot
 
-    async def invalidate(self) -> None:
-        self._store.clear_catalog_cache()
+    async def invalidate(self, expected_generation: int | None = None) -> None:
+        self._store.clear_catalog_cache(expected_generation=expected_generation)
 
     def _matching_cache(
         self,
@@ -239,7 +276,7 @@ class CodexModelCatalog:
         except CodexAuthError as exc:
             if exc.code != "catalog_corrupt":
                 raise
-            self._store.clear_catalog_cache()
+            self._store.clear_catalog_cache(expected_generation=credentials.generation)
             return None
         if snapshot.generation != credentials.generation:
             return None

--- a/deeptutor/services/codex_auth/constants.py
+++ b/deeptutor/services/codex_auth/constants.py
@@ -5,6 +5,11 @@ CODEX_UPSTREAM_COMMIT = "81da9deb065d7adb283816b19b40f89bcc484276"
 # 3d2ee51ca2d5db578f328aa75e20aa22c0197c9a. Older versions omit eligible models.
 # This request version is independent of the installed CLI and OAuth audit above.
 CODEX_CLIENT_VERSION = "0.153.4"
+CODEX_NPM_PACKAGE = "@openai/codex"
+CODEX_NPM_METADATA_URL = f"https://registry.npmjs.org/{CODEX_NPM_PACKAGE}/latest"
+CODEX_VERSION_TIMEOUT_SECONDS = 3
+CODEX_MAX_VERSION_BYTES = 64 * 1024
+CODEX_MAX_VERSION_LENGTH = 32
 CODEX_OAUTH_ISSUER = "https://auth.openai.com"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_SCOPE = "openid profile email offline_access api.connectors.read api.connectors.invoke"

--- a/deeptutor/services/codex_auth/contracts.py
+++ b/deeptutor/services/codex_auth/contracts.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 import json
 from typing import Any, Literal
 
+from .constants import CODEX_CLIENT_VERSION
+
 CatalogSource = Literal["live", "fresh-cache", "revalidated-cache", "stale-cache"]
 
 
@@ -200,6 +202,7 @@ class CatalogSnapshot:
     etag: str | None
     generation: int
     account_hash: str
+    client_version: str = CODEX_CLIENT_VERSION
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -209,6 +212,7 @@ class CatalogSnapshot:
             "etag": self.etag,
             "generation": self.generation,
             "account_hash": self.account_hash,
+            "client_version": self.client_version,
         }
 
     @classmethod
@@ -227,6 +231,11 @@ class CatalogSnapshot:
                 etag=str(payload["etag"]) if payload.get("etag") is not None else None,
                 generation=int(payload["generation"]),
                 account_hash=str(payload["account_hash"]),
+                client_version=(
+                    str(payload["client_version"])
+                    if payload.get("client_version") is not None
+                    else CODEX_CLIENT_VERSION
+                ),
             )
         except (KeyError, TypeError, ValueError) as exc:
             raise CodexAuthError(

--- a/deeptutor/services/codex_auth/service.py
+++ b/deeptutor/services/codex_auth/service.py
@@ -25,6 +25,7 @@ from .catalog import CodexModelCatalog
 from .constants import (
     CODEX_CALLBACK_PATH,
     CODEX_CALLBACK_PORTS,
+    CODEX_CLIENT_VERSION,
     CODEX_LOGIN_TIMEOUT_SECONDS,
 )
 from .contracts import (
@@ -45,6 +46,7 @@ from .oauth import (
     oauth_state_matches,
 )
 from .storage import CodexCredentialStore
+from .version import CodexClientVersionDiscovery
 
 logger = logging.getLogger(__name__)
 
@@ -392,6 +394,7 @@ class CodexOAuthService:
         callback_factory: Callable[[str], Awaitable[Any]] | None = None,
         clock: Callable[[], float] = time.time,
         callback_forward_port: int = 3782,
+        version_discovery: CodexClientVersionDiscovery | None = None,
     ) -> None:
         if (
             isinstance(callback_forward_port, bool)
@@ -408,6 +411,7 @@ class CodexOAuthService:
             self._owned_http = httpx.AsyncClient(timeout=30)
             oauth_client = CodexOAuthClient(self._owned_http)
         self._oauth = oauth_client
+        self._version_discovery = version_discovery or CodexClientVersionDiscovery()
         self._callback_factory = callback_factory or self._start_default_callback
         self._clock = clock
         self._operation: _LoginOperation | None = None
@@ -577,15 +581,16 @@ class CodexOAuthService:
                     remove_codex_catalog(self._model_catalog)
             operation.operation_state = "fetching_models"
             await self._catalog.invalidate()
-            snapshot = await self._catalog.get(committed, force=True)
-            async with self._catalog_sync_lock:
-                sync_result = sync_codex_catalog(
-                    self._model_catalog,
-                    snapshot,
-                    account_id=committed.account_id,
-                )
-            self._last_snapshot = snapshot
-            operation.activated = sync_result.activated
+            fetched = await self._fetch_catalog_snapshot(committed, discover=True)
+            if fetched is not None:
+                snapshot, _version = fetched
+                async with self._catalog_sync_lock:
+                    sync_result = await self._publish_catalog_snapshot(
+                        snapshot,
+                        account_id=committed.account_id,
+                    )
+                    if sync_result is not None:
+                        operation.activated = sync_result.activated
             operation.operation_state = "completed"
         except CodexAuthError as exc:
             operation.error_code = exc.code
@@ -651,14 +656,97 @@ class CodexOAuthService:
                     "Codex authentication changed before models could be refreshed.",
                     409,
                 )
-            snapshot = await self._catalog.get(credentials, force=True)
-            sync_codex_catalog(
-                self._model_catalog,
+            fetched = await self._fetch_catalog_snapshot(credentials, discover=True)
+            if fetched is None:
+                raise CodexAuthError(
+                    "authentication_changed",
+                    "Codex authentication changed before models could be refreshed.",
+                    409,
+                )
+            snapshot, _version = fetched
+            await self._publish_catalog_snapshot(
                 snapshot,
                 account_id=credentials.account_id,
             )
-            self._last_snapshot = snapshot
             return self.public_status()
+
+    async def _fetch_catalog_snapshot(
+        self,
+        credentials: CodexCredentials,
+        *,
+        discover: bool,
+    ) -> tuple[CatalogSnapshot, str] | None:
+        account_binding = _codex_account_binding(credentials.account_id)
+        discovered: str | None = None
+        if discover:
+            try:
+                discovered = await self._version_discovery.discover()
+            except CodexAuthError as exc:
+                # Discovery is an optimization. The public operation stays
+                # successful when npm is unavailable and the known version works.
+                logger.warning("Codex client-version discovery failed: %s", exc.code)
+            current = self._store.load_credentials()
+            if current is None or current.generation != credentials.generation:
+                return None
+
+        candidates: list[str] = []
+        for version in (
+            discovered,
+            self._store.load_client_version(account_binding),
+            CODEX_CLIENT_VERSION,
+        ):
+            if version is not None and version not in candidates:
+                candidates.append(version)
+        candidates = candidates[:2]
+
+        for attempt, version in enumerate(candidates):
+            try:
+                snapshot = await self._catalog.get(
+                    credentials,
+                    force=True,
+                    client_version=version,
+                )
+            except CodexAuthError as exc:
+                if exc.code == "generation_changed":
+                    return None
+                retryable = exc.code in {"catalog_version_rejected", "catalog_incompatible"}
+                if not retryable or attempt >= len(candidates) - 1:
+                    raise
+                continue
+            if version == discovered and snapshot.source == "live":
+                try:
+                    self._store.record_client_version(
+                        account_binding,
+                        version,
+                        expected_generation=credentials.generation,
+                    )
+                except CodexAuthError as exc:
+                    if exc.code == "generation_changed":
+                        return None
+                    raise
+            return snapshot, version
+        return None
+
+    async def _publish_catalog_snapshot(
+        self,
+        snapshot: CatalogSnapshot,
+        *,
+        account_id: str,
+    ) -> CatalogSyncResult | None:
+        credentials = self._store.load_credentials()
+        if (
+            credentials is None
+            or credentials.generation != snapshot.generation
+            or _codex_account_binding(credentials.account_id) != snapshot.account_hash
+        ):
+            return None
+        sync_result = sync_codex_catalog(
+            self._model_catalog,
+            snapshot,
+            account_id=account_id,
+        )
+        self._last_snapshot = snapshot
+        return sync_result
 
     async def get_token(self) -> CodexToken:
         async with self._refresh_lock:

--- a/deeptutor/services/codex_auth/storage.py
+++ b/deeptutor/services/codex_auth/storage.py
@@ -17,6 +17,8 @@ from typing import Any, BinaryIO
 from .contracts import CodexAuthError, CodexCredentials
 
 _SCHEMA_VERSION = 1
+_MAX_ACCOUNT_BINDING_LENGTH = 64
+_MAX_CLIENT_VERSION_LENGTH = 32
 
 
 def _is_reparse_point(path: Path) -> bool:
@@ -169,6 +171,19 @@ class CodexCredentialStore:
                 "Stored Codex authentication state is invalid.",
                 500,
             )
+        client_versions = state.get("client_versions", {})
+        if not isinstance(client_versions, dict) or not all(
+            isinstance(account_hash, str)
+            and 0 < len(account_hash) <= _MAX_ACCOUNT_BINDING_LENGTH
+            and isinstance(version, str)
+            and 0 < len(version) <= _MAX_CLIENT_VERSION_LENGTH
+            for account_hash, version in client_versions.items()
+        ):
+            raise CodexAuthError(
+                "state_corrupt",
+                "Stored Codex authentication state is invalid.",
+                500,
+            )
         return state
 
     @staticmethod
@@ -236,6 +251,7 @@ class CodexCredentialStore:
                     **state,
                     "schema_version": _SCHEMA_VERSION,
                     "generation": next_generation,
+                    "client_versions": {},
                 },
             )
             for path in (self.credentials_path, self.catalog_cache_path):
@@ -251,11 +267,65 @@ class CodexCredentialStore:
                 message="Stored Codex model data is invalid.",
             )
 
-    def save_catalog_cache(self, payload: Mapping[str, Any]) -> None:
+    def save_catalog_cache(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        expected_generation: int | None = None,
+    ) -> None:
         with self._locked():
+            if (
+                expected_generation is not None
+                and int(self._read_state_unlocked()["generation"]) != expected_generation
+            ):
+                raise self._generation_changed()
             _atomic_write_json(self.catalog_cache_path, payload)
 
-    def clear_catalog_cache(self) -> None:
+    def load_client_version(self, account_binding: str) -> str | None:
         with self._locked():
+            state = self._read_state_unlocked()
+            versions = state.get("client_versions", {})
+            if not isinstance(versions, dict):
+                return None
+            version = versions.get(account_binding)
+            return version if isinstance(version, str) and version else None
+
+    def record_client_version(
+        self,
+        account_binding: str,
+        version: str,
+        *,
+        expected_generation: int,
+    ) -> None:
+        if not account_binding or len(account_binding) > _MAX_ACCOUNT_BINDING_LENGTH:
+            raise CodexAuthError(
+                "state_corrupt",
+                "Stored Codex authentication state is invalid.",
+                500,
+            )
+        if not version or len(version) > _MAX_CLIENT_VERSION_LENGTH:
+            raise CodexAuthError(
+                "state_corrupt",
+                "Stored Codex authentication state is invalid.",
+                500,
+            )
+        with self._locked():
+            state = self._read_state_unlocked()
+            if int(state["generation"]) != expected_generation:
+                raise self._generation_changed()
+            versions = state.get("client_versions", {})
+            next_state = {
+                **state,
+                "client_versions": {**versions, account_binding: version},
+            }
+            _atomic_write_json(self.state_path, next_state)
+
+    def clear_catalog_cache(self, expected_generation: int | None = None) -> None:
+        with self._locked():
+            if (
+                expected_generation is not None
+                and int(self._read_state_unlocked()["generation"]) != expected_generation
+            ):
+                return
             _assert_safe_regular_path(self.catalog_cache_path)
             self.catalog_cache_path.unlink(missing_ok=True)

--- a/deeptutor/services/codex_auth/version.py
+++ b/deeptutor/services/codex_auth/version.py
@@ -1,0 +1,141 @@
+"""Metadata-only discovery of the stable Codex npm client version."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import json
+from re import fullmatch
+from typing import Any
+
+import httpx
+
+from .constants import (
+    CODEX_MAX_VERSION_BYTES,
+    CODEX_MAX_VERSION_LENGTH,
+    CODEX_NPM_METADATA_URL,
+    CODEX_VERSION_TIMEOUT_SECONDS,
+)
+from .contracts import CodexAuthError
+
+_SEMVER = r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+
+
+def validate_stable_version(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) > CODEX_MAX_VERSION_LENGTH
+        or fullmatch(_SEMVER, value) is None
+    ):
+        raise CodexAuthError(
+            "client_version_invalid",
+            "Codex published an invalid client version.",
+            502,
+        )
+    return value
+
+
+class CodexClientVersionDiscovery:
+    """Fetch one bounded package-metadata document per explicit refresh.
+
+    Discovery intentionally creates a private HTTP client. The OAuth and
+    catalog clients may carry authorization state, and package metadata must
+    never inherit it.
+    """
+
+    def __init__(
+        self,
+        client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        self._client_factory = client_factory or self._default_client
+
+    @staticmethod
+    def _default_client() -> httpx.AsyncClient:
+        timeout = httpx.Timeout(CODEX_VERSION_TIMEOUT_SECONDS)
+        return httpx.AsyncClient(follow_redirects=False, timeout=timeout)
+
+    async def discover(self) -> str:
+        try:
+            async with self._client_factory() as http:
+                async with http.stream(
+                    "GET",
+                    CODEX_NPM_METADATA_URL,
+                    headers={"Accept": "application/vnd.npm.install-v1+json"},
+                ) as response:
+                    if response.is_redirect:
+                        raise CodexAuthError(
+                            "client_version_redirect",
+                            "Codex version discovery was redirected.",
+                            502,
+                        )
+                    if response.status_code == 429:
+                        raise CodexAuthError(
+                            "client_version_rate_limited",
+                            "Codex version discovery is temporarily rate limited.",
+                            429,
+                        )
+                    if response.status_code in {401, 403}:
+                        raise CodexAuthError(
+                            "client_version_forbidden",
+                            "Codex version metadata is not available.",
+                            502,
+                        )
+                    response.raise_for_status()
+                    payload = await self._bounded_json(response)
+        except httpx.TimeoutException as exc:
+            raise CodexAuthError(
+                "client_version_timeout",
+                "Codex version discovery timed out.",
+                504,
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            raise CodexAuthError(
+                "client_version_unavailable",
+                "Codex version metadata is temporarily unavailable.",
+                503,
+            ) from exc
+        except httpx.RequestError as exc:
+            raise CodexAuthError(
+                "client_version_unavailable",
+                "Codex version metadata is temporarily unavailable.",
+                503,
+            ) from exc
+        return self._version_from_metadata(payload)
+
+    @staticmethod
+    async def _bounded_json(response: httpx.Response) -> Any:
+        declared = response.headers.get("content-length")
+        if declared is not None and declared.isdigit() and int(declared) > CODEX_MAX_VERSION_BYTES:
+            raise CodexAuthError(
+                "client_version_too_large",
+                "Codex version metadata exceeded DeepTutor's safety limit.",
+                502,
+            )
+        chunks: list[bytes] = []
+        size = 0
+        async for chunk in response.aiter_bytes():
+            size += len(chunk)
+            if size > CODEX_MAX_VERSION_BYTES:
+                raise CodexAuthError(
+                    "client_version_too_large",
+                    "Codex version metadata exceeded DeepTutor's safety limit.",
+                    502,
+                )
+            chunks.append(chunk)
+        try:
+            return json.loads(b"".join(chunks))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise CodexAuthError(
+                "client_version_invalid",
+                "Codex returned invalid version metadata.",
+                502,
+            ) from exc
+
+    @staticmethod
+    def _version_from_metadata(payload: object) -> str:
+        if not isinstance(payload, dict):
+            raise CodexAuthError(
+                "client_version_invalid",
+                "Codex returned invalid version metadata.",
+                502,
+            )
+        return validate_stable_version(payload.get("version"))

--- a/tests/services/codex_auth/test_catalog.py
+++ b/tests/services/codex_auth/test_catalog.py
@@ -127,8 +127,11 @@ async def test_live_catalog_uses_account_headers_and_client_version(tmp_path: Pa
     queue = ResponseQueue(httpx.Response(200, json=_fixture(), headers={"ETag": '"catalog-v1"'}))
     clock = [1_000]
     catalog, http = _catalog(tmp_path, queue, clock)
+    credentials = CodexCredentialStore(tmp_path).commit_credentials(
+        _credentials(), expected_generation=0
+    )
     try:
-        snapshot = await catalog.get(_credentials(), force=True)
+        snapshot = await catalog.get(credentials, force=True)
     finally:
         await http.aclose()
 
@@ -148,8 +151,11 @@ async def test_fresh_cache_skips_network_and_etag_304_revalidates(tmp_path: Path
     )
     clock = [1_000]
     catalog, http = _catalog(tmp_path, queue, clock)
+    credentials = CodexCredentialStore(tmp_path).commit_credentials(
+        _credentials(), expected_generation=0
+    )
     try:
-        live = await catalog.get(_credentials(), force=True)
+        live = await catalog.get(credentials, force=True)
         clock[0] = 1_100
         fresh = await catalog.get(_credentials(), force=False)
         assert len(queue.requests) == 1
@@ -174,8 +180,11 @@ async def test_network_failure_uses_only_matching_stale_cache(tmp_path: Path) ->
     )
     clock = [1_000]
     catalog, http = _catalog(tmp_path, queue, clock)
+    credentials = CodexCredentialStore(tmp_path).commit_credentials(
+        _credentials(), expected_generation=0
+    )
     try:
-        await catalog.get(_credentials(), force=True)
+        await catalog.get(credentials, force=True)
         clock[0] = 1_301
         stale = await catalog.get(_credentials(), force=False)
         with pytest.raises(CodexAuthError) as wrong_generation:
@@ -195,8 +204,12 @@ async def test_cache_is_partitioned_by_account(tmp_path: Path) -> None:
     )
     clock = [1_000]
     catalog, http = _catalog(tmp_path, queue, clock)
+    credentials = CodexCredentialStore(tmp_path).commit_credentials(
+        _credentials(account_id="account-a"),
+        expected_generation=0,
+    )
     try:
-        await catalog.get(_credentials(account_id="account-a"), force=True)
+        await catalog.get(credentials, force=True)
         clock[0] = 1_301
         with pytest.raises(CodexAuthError) as exc_info:
             await catalog.get(
@@ -225,8 +238,11 @@ async def test_auth_errors_never_use_stale_cache(
     )
     clock = [1_000]
     catalog, http = _catalog(tmp_path, queue, clock)
+    credentials = CodexCredentialStore(tmp_path).commit_credentials(
+        _credentials(), expected_generation=0
+    )
     try:
-        await catalog.get(_credentials(), force=True)
+        await catalog.get(credentials, force=True)
         clock[0] = 1_301
         with pytest.raises(CodexAuthError) as exc_info:
             await catalog.get(_credentials(), force=True)

--- a/tests/services/codex_auth/test_client_version.py
+++ b/tests/services/codex_auth/test_client_version.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from deeptutor.services.codex_auth.constants import CODEX_CLIENT_VERSION
+from deeptutor.services.codex_auth.contracts import (
+    CatalogSnapshot,
+    CodexAuthError,
+    CodexCredentials,
+    CodexModel,
+)
+from deeptutor.services.codex_auth.oauth import OAuthCallbackResult
+from deeptutor.services.codex_auth.service import (
+    CODEX_PROFILE_ID,
+    CodexOAuthService,
+    sync_codex_catalog,
+)
+from deeptutor.services.codex_auth.storage import CodexCredentialStore
+from deeptutor.services.config.model_catalog import ModelCatalogService
+
+pytestmark = pytest.mark.asyncio
+
+
+def _model(slug: str) -> CodexModel:
+    return CodexModel(
+        slug=slug,
+        display_name=slug,
+        priority=1,
+        visibility="list",
+        default_reasoning_level="medium",
+        supported_reasoning_levels=("medium",),
+        supports_reasoning_summary=True,
+        supports_parallel_tool_calls=True,
+        use_responses_lite=False,
+    )
+
+
+def _credentials(account_id: str = "account-123", generation: int = 1) -> CodexCredentials:
+    return CodexCredentials(
+        schema_version=1,
+        access_token="access-secret",
+        refresh_token="refresh-secret",
+        id_token="id-secret",
+        account_id=account_id,
+        expires_at=2_000_000_000,
+        generation=generation,
+    )
+
+
+def _snapshot(
+    credentials: CodexCredentials,
+    client_version: str,
+) -> CatalogSnapshot:
+    return CatalogSnapshot(
+        models=(_model("gpt-5.6-sol"),),
+        source="live",
+        fetched_at=1_000,
+        etag='"catalog-v1"',
+        generation=credentials.generation,
+        account_hash=hashlib.sha256(credentials.account_id.encode()).hexdigest(),
+        client_version=client_version,
+    )
+
+
+class FakeDiscovery:
+    def __init__(self, result: str | None = None, error: CodexAuthError | None = None) -> None:
+        self.result = result
+        self.error = error
+        self.calls = 0
+
+    async def discover(self) -> str:
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        assert self.result is not None
+        return self.result
+
+
+class FakeCatalog:
+    def __init__(
+        self,
+        snapshot: CatalogSnapshot,
+        errors: list[CodexAuthError] | None = None,
+        store: CodexCredentialStore | None = None,
+    ) -> None:
+        self.snapshot = snapshot
+        self.errors = list(errors or [])
+        self.versions: list[str] = []
+        self.saved_snapshots: list[dict] = []
+        self._store = store
+
+    async def get(
+        self,
+        credentials: CodexCredentials,
+        force: bool,
+        client_version: str | None = None,
+    ) -> CatalogSnapshot:
+        del force
+        assert client_version is not None
+        self.versions.append(client_version)
+        if self.errors:
+            raise self.errors.pop(0)
+        if client_version != self.snapshot.client_version:
+            snapshot = CatalogSnapshot(
+                models=self.snapshot.models,
+                source=self.snapshot.source,
+                fetched_at=self.snapshot.fetched_at,
+                etag=self.snapshot.etag,
+                generation=self.snapshot.generation,
+                account_hash=self.snapshot.account_hash,
+                client_version=client_version,
+            )
+            self.snapshot = snapshot
+            self._save(snapshot)
+            return snapshot
+        self._save(self.snapshot)
+        return self.snapshot
+
+    def _save(self, snapshot: CatalogSnapshot) -> None:
+        self.saved_snapshots.append(snapshot.to_dict())
+        if self._store is not None:
+            self._store.save_catalog_cache(
+                snapshot.to_dict(),
+                expected_generation=snapshot.generation,
+            )
+
+    async def invalidate(self) -> None:
+        return None
+
+
+class FakeCallback:
+    def __init__(self) -> None:
+        self.port = 1455
+        self._result: asyncio.Future = asyncio.get_running_loop().create_future()
+        self.expected_state: str | None = None
+
+    async def wait(self, timeout: float):
+        return await asyncio.wait_for(asyncio.shield(self._result), timeout)
+
+    async def cancel(self) -> None:
+        if not self._result.done():
+            self._result.cancel()
+
+    def complete(self) -> None:
+        self._result.set_result(
+            OAuthCallbackResult(
+                code="authorization-code",
+                state=self.expected_state,
+                error=None,
+            )
+        )
+
+
+class FakeOAuth:
+    async def exchange_code(
+        self,
+        code: str,
+        redirect_uri: str,
+        verifier: str,
+    ) -> dict:
+        del code, redirect_uri, verifier
+        return {
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "id_token": "new-id",
+            "account_id": "account-123",
+            "expires_in": 3_600,
+        }
+
+
+def _store(tmp_path: Path) -> tuple[CodexCredentialStore, CodexCredentials]:
+    store = CodexCredentialStore(tmp_path / "secrets")
+    credentials = store.commit_credentials(_credentials(generation=0), expected_generation=0)
+    return store, credentials
+
+
+def _model_catalog(tmp_path: Path) -> ModelCatalogService:
+    model_catalog = ModelCatalogService(tmp_path / "model-catalog.json")
+    sync_codex_catalog(model_catalog, _snapshot(_credentials(), CODEX_CLIENT_VERSION))
+    return model_catalog
+
+
+def _service(
+    store: CodexCredentialStore,
+    catalog: FakeCatalog,
+    discovery: FakeDiscovery,
+    model_catalog: ModelCatalogService,
+    *,
+    callback_factory=None,
+) -> CodexOAuthService:
+    return CodexOAuthService(
+        store,
+        catalog,  # type: ignore[arg-type]
+        model_catalog,
+        oauth_client=FakeOAuth(),  # type: ignore[arg-type]
+        version_discovery=discovery,  # type: ignore[arg-type]
+        callback_factory=callback_factory,
+    )
+
+
+async def test_refresh_uses_discovered_version_and_persists_it_after_success(
+    tmp_path: Path,
+) -> None:
+    store, credentials = _store(tmp_path)
+    discovery = FakeDiscovery("9.8.7")
+    catalog = FakeCatalog(_snapshot(credentials, "9.8.7"), store=store)
+    service = _service(store, catalog, discovery, _model_catalog(tmp_path))
+
+    await service.refresh_models()
+
+    assert catalog.versions == ["9.8.7"]
+    assert discovery.calls == 1
+    binding = hashlib.sha256(credentials.account_id.encode()).hexdigest()
+    assert store.load_client_version(binding) == "9.8.7"
+    assert store.load_catalog_cache()["client_version"] == "9.8.7"
+
+
+async def test_discovery_failure_falls_back_before_the_built_in_version(
+    tmp_path: Path,
+) -> None:
+    store, credentials = _store(tmp_path)
+    binding = hashlib.sha256(credentials.account_id.encode()).hexdigest()
+    store.record_client_version(
+        binding,
+        "1.2.3",
+        expected_generation=credentials.generation,
+    )
+    discovery = FakeDiscovery(error=CodexAuthError("client_version_timeout", "timed out", 504))
+    catalog = FakeCatalog(_snapshot(credentials, "1.2.3"))
+    service = _service(store, catalog, discovery, _model_catalog(tmp_path))
+
+    await service.refresh_models()
+
+    assert catalog.versions == ["1.2.3"]
+    assert store.load_client_version(binding) == "1.2.3"
+
+
+async def test_version_rejection_retries_previous_version_at_most_once(
+    tmp_path: Path,
+) -> None:
+    store, credentials = _store(tmp_path)
+    binding = hashlib.sha256(credentials.account_id.encode()).hexdigest()
+    store.record_client_version(
+        binding,
+        "1.2.3",
+        expected_generation=credentials.generation,
+    )
+    discovery = FakeDiscovery("9.9.9")
+    catalog = FakeCatalog(
+        _snapshot(credentials, "1.2.3"),
+        errors=[
+            CodexAuthError("catalog_version_rejected", "version rejected", 400),
+        ],
+    )
+    service = _service(store, catalog, discovery, _model_catalog(tmp_path))
+
+    await service.refresh_models()
+
+    assert catalog.versions == ["9.9.9", "1.2.3"]
+    assert store.load_client_version(binding) == "1.2.3"
+
+
+async def test_rate_limit_is_not_mistaken_for_version_incompatibility(
+    tmp_path: Path,
+) -> None:
+    store, credentials = _store(tmp_path)
+    discovery = FakeDiscovery("9.9.9")
+    catalog = FakeCatalog(
+        _snapshot(credentials, "9.9.9"),
+        errors=[
+            CodexAuthError("catalog_rate_limited", "rate limited", 429),
+        ],
+    )
+    service = _service(store, catalog, discovery, _model_catalog(tmp_path))
+
+    with pytest.raises(CodexAuthError) as exc_info:
+        await service.refresh_models()
+
+    assert exc_info.value.code == "catalog_rate_limited"
+    assert catalog.versions == ["9.9.9"]
+
+
+async def test_status_and_inference_do_not_discover_a_version(tmp_path: Path) -> None:
+    store, committed = _store(tmp_path)
+    discovery = FakeDiscovery("9.8.7")
+    service = _service(
+        store,
+        FakeCatalog(_snapshot(committed, "9.8.7")),
+        discovery,
+        _model_catalog(tmp_path),
+    )
+
+    service.public_status()
+    async with service.inference_guard():
+        pass
+
+    assert discovery.calls == 0
+
+
+async def test_login_discovers_and_publishes_the_stable_version(tmp_path: Path) -> None:
+    store = CodexCredentialStore(tmp_path / "secrets")
+    discovery = FakeDiscovery("9.8.7")
+    catalog = FakeCatalog(_snapshot(_credentials(), "9.8.7"), store=store)
+    model_catalog = ModelCatalogService(tmp_path / "model-catalog.json")
+    callback = FakeCallback()
+
+    async def callback_factory(_state: str) -> FakeCallback:
+        callback.expected_state = _state
+        return callback
+
+    service = _service(
+        store,
+        catalog,
+        discovery,
+        model_catalog,
+        callback_factory=callback_factory,
+    )
+
+    started = await service.start_login()
+    callback.complete()
+    status = await _wait_until_terminal(service)
+
+    assert status["operation_state"] == "completed", status
+    assert catalog.versions == ["9.8.7"]
+    assert any(
+        profile["id"] == CODEX_PROFILE_ID
+        for profile in model_catalog.load()["services"]["llm"]["profiles"]
+    )
+    assert started["operation_id"] == status["operation_id"]
+
+
+async def test_late_cache_or_history_write_cannot_cross_generations(
+    tmp_path: Path,
+) -> None:
+    store, credentials = _store(tmp_path)
+    binding = hashlib.sha256(credentials.account_id.encode()).hexdigest()
+    store.commit_credentials(
+        _credentials(generation=credentials.generation),
+        expected_generation=credentials.generation,
+    )
+
+    with pytest.raises(CodexAuthError) as cache_error:
+        store.save_catalog_cache(
+            _snapshot(credentials, "9.8.7").to_dict(),
+            expected_generation=credentials.generation,
+        )
+    with pytest.raises(CodexAuthError) as history_error:
+        store.record_client_version(
+            binding,
+            "9.8.7",
+            expected_generation=credentials.generation,
+        )
+
+    assert cache_error.value.code == "generation_changed"
+    assert history_error.value.code == "generation_changed"
+    assert store.load_catalog_cache() is None
+
+
+async def test_logout_clears_account_version_history(tmp_path: Path) -> None:
+    store, credentials = _store(tmp_path)
+    binding = hashlib.sha256(credentials.account_id.encode()).hexdigest()
+    store.record_client_version(
+        binding,
+        "1.2.3",
+        expected_generation=credentials.generation,
+    )
+    service = _service(
+        store,
+        FakeCatalog(_snapshot(credentials, "1.2.3")),
+        FakeDiscovery(),
+        _model_catalog(tmp_path),
+    )
+
+    await service.logout()
+
+    assert store.load_client_version(binding) is None
+    assert store.load_catalog_cache() is None
+
+
+async def test_same_account_credential_renewal_preserves_history(tmp_path: Path) -> None:
+    store, credentials = _store(tmp_path)
+    binding = hashlib.sha256(credentials.account_id.encode()).hexdigest()
+    store.record_client_version(
+        binding,
+        "1.2.3",
+        expected_generation=credentials.generation,
+    )
+    renewed = store.commit_credentials(
+        _credentials(generation=credentials.generation),
+        expected_generation=credentials.generation,
+    )
+
+    assert renewed.generation == credentials.generation + 1
+    assert store.load_client_version(binding) == "1.2.3"
+
+
+async def _wait_until_terminal(service: CodexOAuthService) -> dict:
+    for _ in range(100):
+        status = service.public_status()
+        if status["operation_state"] in {"completed", "cancelled", "expired", "failed"}:
+            return status
+        await asyncio.sleep(0)
+    raise AssertionError("login did not finish")

--- a/tests/services/codex_auth/test_service.py
+++ b/tests/services/codex_auth/test_service.py
@@ -192,13 +192,14 @@ def _snapshot(
     source: str,
     *models: CodexModel,
 ) -> CatalogSnapshot:
+    account_id = source if source.startswith("account-") else "account-123"
     return CatalogSnapshot(
         models=models,
         source=source,  # type: ignore[arg-type]
         fetched_at=1_000,
         etag='"v1"',
         generation=1,
-        account_hash="account-hash",
+        account_hash=hashlib.sha256(account_id.encode()).hexdigest(),
     )
 
 
@@ -629,8 +630,9 @@ class FakeCatalog:
         self,
         credentials: CodexCredentials,
         force: bool,
+        client_version: str | None = None,
     ) -> CatalogSnapshot:
-        self.calls.append((credentials.generation, force))
+        self.calls.append((credentials.generation, force, client_version))
         if self.get_started is not None:
             self.get_started.set()
         if self.get_release is not None:

--- a/tests/services/codex_auth/test_service.py
+++ b/tests/services/codex_auth/test_service.py
@@ -11,6 +11,7 @@ from urllib.parse import parse_qs, urlsplit
 import pytest
 
 from deeptutor.services.codex_auth import service as service_module
+from deeptutor.services.codex_auth.constants import CODEX_CLIENT_VERSION
 from deeptutor.services.codex_auth.contracts import (
     CatalogSnapshot,
     CodexAuthError,
@@ -613,6 +614,11 @@ class FakeOAuthClient:
             raise self.revoke_error
 
 
+class FakeVersionDiscovery:
+    async def discover(self) -> str:
+        return CODEX_CLIENT_VERSION
+
+
 class FakeCatalog:
     def __init__(
         self,
@@ -693,6 +699,7 @@ async def _oauth_service(
         catalog,
         model_catalog,
         oauth_client=oauth,
+        version_discovery=FakeVersionDiscovery(),
         callback_factory=callback_factory,
         clock=(lambda: (clock or [1_000])[0]),
         callback_forward_port=callback_forward_port,

--- a/tests/services/codex_auth/test_storage.py
+++ b/tests/services/codex_auth/test_storage.py
@@ -129,6 +129,26 @@ def test_catalog_cache_round_trip(tmp_path: Path) -> None:
     }
 
 
+def test_client_version_history_is_partitioned_by_account(tmp_path: Path) -> None:
+    store = CodexCredentialStore(tmp_path)
+    account_a = "a" * 64
+    account_b = "b" * 64
+
+    store.record_client_version(
+        account_a,
+        "1.2.3",
+        expected_generation=0,
+    )
+    store.record_client_version(
+        account_b,
+        "4.5.6",
+        expected_generation=0,
+    )
+
+    assert store.load_client_version(account_a) == "1.2.3"
+    assert store.load_client_version(account_b) == "4.5.6"
+
+
 def test_existing_symlink_target_is_rejected(tmp_path: Path) -> None:
     store = CodexCredentialStore(tmp_path)
     store.root.mkdir(parents=True)

--- a/tests/services/codex_auth/test_version_discovery.py
+++ b/tests/services/codex_auth/test_version_discovery.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from deeptutor.services.codex_auth.constants import CODEX_NPM_METADATA_URL
+from deeptutor.services.codex_auth.contracts import CodexAuthError
+from deeptutor.services.codex_auth.version import (
+    CodexClientVersionDiscovery,
+    validate_stable_version,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _client_factory(
+    responder,
+) -> tuple[list[httpx.Request], httpx.AsyncClient]:
+    requests: list[httpx.Request] = []
+
+    def transport(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return responder(request)
+
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(transport),
+        follow_redirects=False,
+    )
+    return requests, client
+
+
+async def test_discovery_reads_only_stable_version_metadata() -> None:
+    requests, client = _client_factory(
+        lambda _request: httpx.Response(200, json={"version": "1.2.3"})
+    )
+    discovery = CodexClientVersionDiscovery(lambda: client)
+
+    assert await discovery.discover() == "1.2.3"
+    assert requests[0].url == httpx.URL(CODEX_NPM_METADATA_URL)
+    assert requests[0].headers["accept"] == "application/vnd.npm.install-v1+json"
+    assert not requests[0].headers.keys() & {"authorization", "cookie", "chatgpt-account-id"}
+
+
+async def test_discovery_refuses_redirects() -> None:
+    _requests, client = _client_factory(lambda _request: httpx.Response(302))
+    discovery = CodexClientVersionDiscovery(lambda: client)
+
+    with pytest.raises(CodexAuthError) as exc_info:
+        await discovery.discover()
+
+    assert exc_info.value.code == "client_version_redirect"
+
+
+async def test_discovery_enforces_response_limit() -> None:
+    _requests, client = _client_factory(lambda _request: httpx.Response(200, content=b"x" * 65_537))
+    discovery = CodexClientVersionDiscovery(lambda: client)
+
+    with pytest.raises(CodexAuthError) as exc_info:
+        await discovery.discover()
+
+    assert exc_info.value.code == "client_version_too_large"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response", "error_code"),
+    [
+        (httpx.Response(429), "client_version_rate_limited"),
+        (httpx.Response(403), "client_version_forbidden"),
+        (httpx.Response(500), "client_version_unavailable"),
+        (httpx.Response(200, content=b"{broken"), "client_version_invalid"),
+        (httpx.Response(200, json={"version": "1.2.3-beta"}), "client_version_invalid"),
+    ],
+)
+async def test_discovery_classifies_failures(
+    response: httpx.Response,
+    error_code: str,
+) -> None:
+    _requests, client = _client_factory(lambda _request: response)
+    discovery = CodexClientVersionDiscovery(lambda: client)
+
+    with pytest.raises(CodexAuthError) as exc_info:
+        await discovery.discover()
+
+    assert exc_info.value.code == error_code
+
+
+async def test_discovery_classifies_timeout() -> None:
+    def responder(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("timed out")
+
+    _requests, client = _client_factory(responder)
+    discovery = CodexClientVersionDiscovery(lambda: client)
+
+    with pytest.raises(CodexAuthError) as exc_info:
+        await discovery.discover()
+
+    assert exc_info.value.code == "client_version_timeout"
+
+
+def test_stable_version_validation_rejects_metadata_noise() -> None:
+    assert validate_stable_version("0.153.4") == "0.153.4"
+    for value in ("latest", "1.2", "1.2.3+build", "1.2.3-rc.1", 1.2, None):
+        with pytest.raises(CodexAuthError):
+            validate_stable_version(value)
+
+
+def test_npm_metadata_document_is_small_and_json() -> None:
+    payload = {"name": "@openai/codex", "version": "1.2.3"}
+    encoded = json.dumps(payload).encode("utf-8")
+
+    assert len(encoded) < 64 * 1024


### PR DESCRIPTION
Closes #1296

## Summary
- Add metadata-only discovery of the stable `@openai/codex` npm version for sign-in and explicit model refresh.
- Use a private HTTP client for npm requests with no OAuth credentials, cookies, or account headers.
- Bound discovery to 3 seconds, 64 KiB, stable semantic versions, and no redirects.
- Persist a discovered version only after a valid live catalog response.
- Add account-bound version history with fallback to the last successful account version, then the built-in `0.153.4`.
- Retry the previous version at most once for explicit version rejection or incompatible catalog structure.
- Keep authentication, rate-limit, availability, malformed-response, and version-incompatibility failures distinct.
- Guard catalog caches, version history, invalidation, and managed-profile publication by credential generation and account binding.
- Clear version history and catalog cache on logout while preserving history across same-account credential renewal.
- Preserve the existing model selection when refreshing managed Codex models.

## Verification
- [x] `pytest tests/services/codex_auth --ignore=tests/services/codex_auth/test_oauth.py` - 140 passed
- [x] `pytest tests/services/codex_auth/test_oauth.py` - 15 passed
- [x] `ruff check` - passed
- [x] `ruff format --check` - passed
- [x] `git diff --check` - passed
- [x] Live npm metadata smoke test: HTTP 200, 3,521 bytes, 0 redirects, `@openai/codex` `0.153.4`

## Security notes
- npm discovery does not read or install the local Codex CLI.
- npm requests are metadata-only and isolated from OAuth client state.
- Account history stores only hashed account bindings and version strings.
- Status reads and inference do not query npm.
