### PR TITLE
fix(chat): always clear sending state in useCardSubmission (#1289)

### DIFF
--- a/web/hooks/use-card-submission.ts
+++ b/web/hooks/use-card-submission.ts
@@ -38,8 +38,10 @@ export function useCardSubmission(onSubmit: SubmitUserReply) {
       // ``undefined`` is a host that does not report a verdict; only an
       // explicit ``false`` reopens the card. The picked answers survive in the
       // caller's state, so retrying is one click.
+      // Clear ``sending`` unconditionally: truthy or undefined both mean the
+      // host accepted the payload and the loading state must end immediately.
+      setSending(false);
       if (accepted === false) {
-        setSending(false);
         setFailed(true);
       }
     },


### PR DESCRIPTION
## Summary

Fixes #1289 — Submit button stays permanently disabled in Mastery Path mode after typing an answer in the question input box.

## Root Cause

In `web/hooks/use-card-submission.ts`, the `submit` callback only called `setSending(false)` when `onSubmit` returned **explicitly `false`**. When `answerMasteryQuestion` calls `sendMessage(...)` (fire-and-forget) and returns `true`, the `accepted === false` branch was never entered — `sending` stayed `true` forever, locking all card controls including the Submit button (`disabled={locked || !answer}` where `locked = settled || sending || skipping`).

## Fix

Move `setSending(false)` **outside** the `if (accepted === false)` guard so it always clears the sending state after `onSubmit` resolves. `setFailed(true)` remains conditional — only an explicit `false` from the host means the submission was rejected and the card must reopen.

```diff
- if (accepted === false) {
-   setSending(false);
-   setFailed(true);
- }
+ setSending(false);
+ if (accepted === false) {
+   setFailed(true);
+ }
```

## Testing

- Browser-tested: Submit button now unlocks immediately after dispatching a mastery question answer
- Existing `ask-user-terminal-turn.spec.tsx` confirms empty-submit is still rejected while awaiting reply
- Hook behavior unchanged for the `accepted === false` path (failed state set, card reopens)
