### PR TITLE
fix(workspace): resolve workspace items from partner presentations (#1267)

### DIFF
--- a/deeptutor/services/workspace/service.py
+++ b/deeptutor/services/workspace/service.py
@@ -19,7 +19,10 @@ import uuid
 
 from deeptutor.core.context import WorkspaceRuntimeContext
 from deeptutor.multi_user.context import get_current_user
-from deeptutor.services.path_service import get_path_service
+from deeptutor.multi_user.partner_access import visible_partners
+from deeptutor.multi_user.paths import get_path_service_for_scope
+from deeptutor.services.partners.scope import partner_scope
+from deeptutor.services.path_service import PathService, get_path_service
 from deeptutor.services.settings.interface_settings import atomic_update
 from deeptutor.utils.secret_files import ensure_private_directory
 
@@ -380,12 +383,18 @@ class ContentWorkspaceService:
                 raise WorkspaceError(f"The {operation} path cannot contain symbolic links.")
 
     @staticmethod
-    def _presentation_root(binding: WorkspaceBinding, *, create: bool = False) -> Path:
+    def _presentation_root(
+        binding: WorkspaceBinding,
+        *,
+        create: bool = False,
+        path_service: PathService | None = None,
+    ) -> Path:
         """Return private snapshot storage for one user-scoped workspace id."""
 
         if not re.fullmatch(r"ws_[0-9a-f]{32}", binding.workspace_id):
             raise WorkspaceError("Invalid workspace id.")
-        base = get_path_service().get_runtime_state_dir()
+        service = path_service if path_service is not None else get_path_service()
+        base = service.get_runtime_state_dir()
         presentations = base / "workspace_presentations"
         root = presentations / binding.workspace_id
         if create:
@@ -773,31 +782,76 @@ class ContentWorkspaceService:
     def resolve_published_item(
         self, workspace_id: str, workspace_item_id: str
     ) -> tuple[Path, WorkspaceItem]:
+        """Resolve a published workspace item from the user's or a partner's workspace.
+
+        Tries the user's direct workspace bindings first, then searches visible
+        partner workspace presentations if the item is not found (issue #1267).
+        """
         if not re.fullmatch(r"wsi_[0-9a-f]{32}", workspace_item_id):
             raise WorkspaceError("Invalid workspace item id.")
-        binding = self.binding_by_id(workspace_id)
-        root = self._presentation_root(binding)
-        for directory in (root / "items", root / "blobs"):
-            if directory.is_symlink():
-                raise WorkspaceError(
-                    "The private workspace presentation path cannot contain symbolic links."
-                )
-        manifest_path = root / "items" / f"{workspace_item_id}.json"
+
+        candidate_roots: list[Path] = []
+
+        # Try user's direct workspace binding first
         try:
-            payload = json.loads(manifest_path.read_text(encoding="utf-8"))
-            item = WorkspaceItem(**payload)
-        except (OSError, json.JSONDecodeError, TypeError) as exc:
-            raise WorkspaceError("The presented workspace item is unavailable.") from exc
-        if item.workspace_id != workspace_id or item.workspace_item_id != workspace_item_id:
-            raise WorkspaceError("The workspace item manifest is invalid.")
-        blob = (root / "blobs" / item.sha256).resolve()
-        try:
-            blob.relative_to(root.resolve())
-        except ValueError as exc:
-            raise WorkspaceError("The workspace item path is invalid.") from exc
-        if not blob.is_file():
-            raise WorkspaceError("The presented workspace item is unavailable.")
-        return blob, item
+            binding = self.binding_by_id(workspace_id)
+            candidate_roots.append(self._presentation_root(binding))
+        except WorkspaceError:
+            pass
+
+        # Search visible partner workspace presentations if user's binding misses
+        # (issue #1267). ``ContentWorkspaceService`` has no per-instance state and
+        # always resolves through the global ``get_path_service()``, so partner
+        # lookups must go through the partner's own ``PathService`` directly
+        # rather than instantiating another service for it.
+        if not candidate_roots:
+            for partner in visible_partners():
+                partner_id = str(partner.get("partner_id") or "").strip()
+                if not partner_id:
+                    continue
+                try:
+                    partner_path_service = get_path_service_for_scope(partner_scope(partner_id))
+                    partner_binding = WorkspaceBinding(
+                        workspace_id=workspace_id,
+                        root=partner_path_service.get_workspace_dir().resolve(),
+                        display_name="",
+                    )
+                    candidate_roots.append(
+                        self._presentation_root(partner_binding, path_service=partner_path_service)
+                    )
+                except WorkspaceError:
+                    continue
+
+        if not candidate_roots:
+            raise WorkspaceError("The workspace is no longer registered for this user.")
+
+        # Search candidate roots for the workspace item
+        for root in candidate_roots:
+            for directory in (root / "items", root / "blobs"):
+                if directory.is_symlink():
+                    raise WorkspaceError(
+                        "The private workspace presentation path cannot contain symbolic links."
+                    )
+            manifest_path = root / "items" / f"{workspace_item_id}.json"
+            if not manifest_path.is_file():
+                continue
+            try:
+                payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+                item = WorkspaceItem(**payload)
+            except (OSError, json.JSONDecodeError, TypeError) as exc:
+                raise WorkspaceError("The presented workspace item is unavailable.") from exc
+            if item.workspace_id != workspace_id or item.workspace_item_id != workspace_item_id:
+                raise WorkspaceError("The workspace item manifest is invalid.")
+            blob = (root / "blobs" / item.sha256).resolve()
+            try:
+                blob.relative_to(root.resolve())
+            except ValueError as exc:
+                raise WorkspaceError("The workspace item path is invalid.") from exc
+            if not blob.is_file():
+                raise WorkspaceError("The presented workspace item is unavailable.")
+            return blob, item
+
+        raise WorkspaceError("The presented workspace item is unavailable.")
 
 
 _service = ContentWorkspaceService()

--- a/tests/services/workspace/test_content_workspace.py
+++ b/tests/services/workspace/test_content_workspace.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -149,6 +150,63 @@ def test_private_presentation_store_rejects_symlink_redirection(
     with pytest.raises(WorkspaceError, match="symbolic links"):
         service.publish(binding, [{"path": "notes.md"}])
     assert not any(outside.iterdir())
+
+
+def test_resolve_published_item_searches_partner_workspaces(
+    workspace_service, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that resolve_published_item falls back to partner workspaces (issue #1267).
+
+    When a workspace item is not found in the user's direct bindings, the service
+    should search visible partner workspace presentations before raising an error.
+    """
+    from deeptutor.services.workspace import service as service_module
+
+    user_service, paths = workspace_service
+
+    user_binding = user_service.current_binding(ensure_output=True)
+    (user_binding.root / "document.md").write_text("user document", encoding="utf-8")
+    user_item = user_service.publish(user_binding, [{"path": "document.md", "title": "Doc"}])[0]
+
+    blob, _loaded = user_service.resolve_published_item(
+        user_item.workspace_id, user_item.workspace_item_id
+    )
+    assert blob.read_text(encoding="utf-8") == "user document"
+
+    # Publish an item into a separate partner workspace tree. ContentWorkspaceService
+    # has no per-instance state, so building the partner's content means pointing the
+    # global path service at the partner's own runtime tree while publishing, then
+    # restoring it before exercising the fallback under test.
+    partner_paths = PathService(workspace_root=tmp_path / "partner_workspace" / "runtime")
+    partner_paths.ensure_all_directories()
+    monkeypatch.setattr(service_module, "get_path_service", lambda: partner_paths)
+    try:
+        partner_binding = user_service.current_binding(ensure_output=True)
+        (partner_binding.root / "partner_doc.md").write_text("partner document", encoding="utf-8")
+        partner_item = user_service.publish(
+            partner_binding, [{"path": "partner_doc.md", "title": "Partner Doc"}]
+        )[0]
+    finally:
+        monkeypatch.setattr(service_module, "get_path_service", lambda: paths)
+
+    # Mock visible_partners to surface the partner workspace to the user
+    mock_partner = {"partner_id": "test-partner-1", "name": "Test Partner"}
+
+    with patch(
+        "deeptutor.services.workspace.service.visible_partners",
+        return_value=[mock_partner],
+    ):
+        with patch(
+            "deeptutor.services.workspace.service.get_path_service_for_scope",
+            return_value=partner_paths,
+        ):
+            # User should be able to resolve the partner's item through fallback
+            blob, loaded = user_service.resolve_published_item(
+                partner_item.workspace_id, partner_item.workspace_item_id
+            )
+            assert blob.read_text(encoding="utf-8") == "partner document"
+            assert loaded.title == "Partner Doc"
+            assert loaded.workspace_item_id == partner_item.workspace_item_id
 
 
 def test_private_presentation_subdirectory_rejects_symlink_redirection(


### PR DESCRIPTION
## Issue
Fixes #1267 - Partner Chat Artifact Downloads (404 errors)

## Problem
When a Partner Chat session generates downloadable artifacts, users cannot
download them via the workspace items endpoint (`/files/workspace-items/`).
The endpoint returns 404 because `resolve_published_item` only checks the
user's direct workspace bindings, not partner workspace presentations.

## Solution
Modified `ContentWorkspaceService.resolve_published_item` to search partner
workspace presentations as a fallback when an item is not found in user bindings.

## Changes
- **deeptutor/services/workspace/service.py**:
  - Added fallback search through visible partner workspaces
  - Maintains security: only searches partners visible to the user
  - Backward compatible: user bindings take precedence
  
- **tests/services/workspace/test_content_workspace.py**:
  - Added `test_resolve_published_item_searches_partner_workspaces`
  - Verifies partner workspace fallback with mocked partners

## How It Works
1. Try to resolve item from user's direct workspace binding
2. If not found, search all visible partner workspaces
3. Return first match found (user's workspace takes priority)
4. Only raises error if item not found in any location

## Status of Issue #1267
This PR addresses **Problem 2** (workspace items endpoint). The overall issue
has 4 problems; here's the status:

| Problem | Component | Status |
|---------|-----------|--------|
| 1 | Workspace router mount | ✅ Already fixed (main.py) |
| 2 | Workspace items endpoint | ✅ **This PR** |
| 3 | Output path resolution | ✅ Fixed (commit 0d1696ab) |
| 4 | Frontend redirect & attachments | ⏳ Separate issue |

## Related
- Similar fix: Issue #1259 (Partner KB provisioning)
- Previous partial fix: Commit 0d1696ab (output downloads)

