### PR TITLE
fix(config): let a book capability's agents.yaml settings take effect

### DIFF
--- a/deeptutor/services/config/loader.py
+++ b/deeptutor/services/config/loader.py
@@ -236,6 +236,7 @@ def get_agent_params(module_name: str) -> dict:
         "question": ("capabilities", "question"),
         "co_writer": ("capabilities", "co_writer"),
         "visualize": ("capabilities", "visualize"),
+        "book": ("capabilities", "book"),
         "brainstorm": ("tools", "brainstorm"),
         "vision_solver": ("plugins", "vision_solver"),
         "math_animator": ("plugins", "math_animator"),

--- a/deeptutor/services/setup/init.py
+++ b/deeptutor/services/setup/init.py
@@ -75,6 +75,7 @@ DEFAULT_AGENTS_SETTINGS = {
         "question": {"temperature": 0.7, "max_tokens": 4096},
         "co_writer": {"temperature": 0.7, "max_tokens": 4096},
         "visualize": {"temperature": 0.4, "max_tokens": 16384},
+        "book": {"temperature": 0.5, "max_tokens": 4096},
         "chat": {
             "temperature": 0.2,
             "responding": {"max_tokens": 8000},

--- a/tests/services/config/test_book_capability_config.py
+++ b/tests/services/config/test_book_capability_config.py
@@ -1,0 +1,59 @@
+"""Tests for the book capability's LLM parameters via agents.yaml."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from deeptutor.services.config import loader as loader_module
+from deeptutor.services.config.loader import get_agent_params
+from deeptutor.services.setup.init import DEFAULT_AGENTS_SETTINGS
+
+
+def _write_agents_yaml(tmp_path: Path, content: dict[str, Any]) -> Path:
+    settings_dir = tmp_path / "data" / "user" / "settings"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    agents_file = settings_dir / "agents.yaml"
+    agents_file.write_text(yaml.dump(content), encoding="utf-8")
+    return tmp_path
+
+
+class TestGetAgentParamsBook:
+    """Verify get_agent_params("book") resolves capabilities.book from agents.yaml."""
+
+    def test_reads_configured_max_tokens_and_temperature(self, tmp_path: Path, monkeypatch):
+        project_root = _write_agents_yaml(
+            tmp_path,
+            {"capabilities": {"book": {"max_tokens": 32000, "temperature": 0.6}}},
+        )
+        monkeypatch.setattr(loader_module, "PROJECT_ROOT", project_root)
+
+        params = get_agent_params("book")
+
+        assert params["max_tokens"] == 32000
+        assert params["temperature"] == 0.6
+
+    def test_uses_seeded_default_when_book_section_absent(self, tmp_path: Path, monkeypatch):
+        project_root = _write_agents_yaml(
+            tmp_path,
+            {"capabilities": {"solve": {"temperature": 0.3}}},
+        )
+        monkeypatch.setattr(loader_module, "PROJECT_ROOT", project_root)
+
+        params = get_agent_params("book")
+
+        assert params["max_tokens"] == 4096
+        assert params["temperature"] == 0.5
+
+
+def test_default_agents_settings_seeds_book_capability():
+    """DEFAULT_AGENTS_SETTINGS must carry a "book" entry, like its sibling
+    capabilities, so get_agent_params("book") has a module default to seed
+    from instead of silently falling through to the bare global default.
+    """
+    assert DEFAULT_AGENTS_SETTINGS["capabilities"]["book"] == {
+        "temperature": 0.5,
+        "max_tokens": 4096,
+    }


### PR DESCRIPTION
`get_agent_params("book")` never reads `agents.yaml`. `section_map` in `deeptutor/services/config/loader.py` maps module names to their `agents.yaml` section, and "book" was never added to it (the four book agents in `deeptutor/book/agents/` all call `get_agent_params(module_name="book")`). Without an entry, the function returns the bare global defaults (`temperature=0.5`, `max_tokens=4096`) before it ever opens the file, so a `capabilities.book.max_tokens` set by the user has no effect. That lines up with the "LLM returned empty response" failures with a reasoning model: there's no way to raise the token budget for book synthesis at all.

Added `"book": ("capabilities", "book")` to `section_map`, and a matching `"book"` entry to `DEFAULT_AGENTS_SETTINGS["capabilities"]` in `deeptutor/services/setup/init.py` so it seeds the same way `solve`/`research`/etc. do. Kept the seeded default at 0.5/4096, same as what the code silently returned before, so this only changes behavior for someone who actually sets `capabilities.book` in their `agents.yaml`.

Scoped to this one config-plumbing gap. The issue also describes two other causes (a provider-format extraction issue and a reasoning-model token-budget-sharing issue); didn't touch either, those need their own fix and tests.

Added `tests/services/config/test_book_capability_config.py`: one test pins that a configured `max_tokens`/`temperature` is honored (fails on `dev`, passes here), one pins that the no-override default is unchanged, one asserts `DEFAULT_AGENTS_SETTINGS` actually carries the `book` entry. Ran the full suite on Python 3.12 in Docker: 6775 passed, 47 skipped, same 8 failures as on `dev` (missing `git`/`libmagic` in the container, a sandbox cgroup test), none touching config or setup. `ruff check`, `ruff format --check`, `lint-imports`, and `scripts/check_architecture.py` all pass.
