### PR TITLE
fix(book): configure agent token budget (#1316)

### DIFF
--- a/deeptutor/services/config/loader.py
+++ b/deeptutor/services/config/loader.py
@@ -211,6 +211,7 @@ def get_agent_params(module_name: str) -> dict:
             - "solve": Solve module agents
             - "research": Research module agents
             - "question": Question module agents
+            - "book": Book module agents
             - "brainstorm": Brainstorm tool settings
             - "co_writer": CoWriter module agents
             - "narrator": Narrator agent (independent, for TTS)
@@ -236,6 +237,7 @@ def get_agent_params(module_name: str) -> dict:
         "question": ("capabilities", "question"),
         "co_writer": ("capabilities", "co_writer"),
         "visualize": ("capabilities", "visualize"),
+        "book": ("capabilities", "book"),
         "brainstorm": ("tools", "brainstorm"),
         "vision_solver": ("plugins", "vision_solver"),
         "math_animator": ("plugins", "math_animator"),

--- a/deeptutor/services/setup/init.py
+++ b/deeptutor/services/setup/init.py
@@ -75,6 +75,7 @@ DEFAULT_AGENTS_SETTINGS = {
         "question": {"temperature": 0.7, "max_tokens": 4096},
         "co_writer": {"temperature": 0.7, "max_tokens": 4096},
         "visualize": {"temperature": 0.4, "max_tokens": 16384},
+        "book": {"temperature": 0.5, "max_tokens": 16384},
         "chat": {
             "temperature": 0.2,
             "responding": {"max_tokens": 8000},

--- a/tests/book/test_book_agent_params.py
+++ b/tests/book/test_book_agent_params.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from deeptutor.book.agents.spine_synthesizer import SpineSynthesizer
+from deeptutor.services.config import loader as loader_module
+
+
+def _write_agents_yaml(tmp_path: Path, content: dict[str, Any]) -> Path:
+    settings_dir = tmp_path / "data" / "user" / "settings"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    agents_file = settings_dir / "agents.yaml"
+    agents_file.write_text(yaml.dump(content), encoding="utf-8")
+    return tmp_path
+
+
+def test_spine_synthesizer_uses_book_default_in_stale_agents_yaml(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = _write_agents_yaml(
+        tmp_path,
+        {"capabilities": {"solve": {"temperature": 0.3, "max_tokens": 8192}}},
+    )
+    monkeypatch.setattr(loader_module, "PROJECT_ROOT", project_root)
+
+    agent = SpineSynthesizer()
+
+    assert agent.get_temperature() == 0.5
+    assert agent.get_max_tokens() == 16384
+
+
+def test_agents_yaml_overrides_book_token_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_root = _write_agents_yaml(
+        tmp_path,
+        {"capabilities": {"book": {"temperature": 0.2, "max_tokens": 24576}}},
+    )
+    monkeypatch.setattr(loader_module, "PROJECT_ROOT", project_root)
+
+    agent = SpineSynthesizer()
+
+    assert agent.get_temperature() == 0.2
+    assert agent.get_max_tokens() == 24576


### PR DESCRIPTION
## Summary

- Map the `book` agent module to `capabilities.book` in `agents.yaml`.
- Add a shipped default of `temperature: 0.5` and `max_tokens: 16384` for book agents.
- Preserve user overrides while ensuring deployments with an older `agents.yaml` that lacks the `book` section still receive the new budget instead of silently falling back to 4096.

## Context

Reasoning models can spend the shared output budget on reasoning before emitting the final JSON. Book spine synthesis previously used the generic 4096 fallback because `book` was absent from the agent parameter lookup, so a long reasoning phase could leave no usable text and the pipeline would degrade to a placeholder chapter. This makes the budget configurable and raises the book-specific default.

## Testing

- `pytest tests/book/test_book_agent_params.py tests/book/test_spine_synthesizer_llm_call.py tests/services/config/test_llm_probe_config.py::TestGetAgentParamsLlmProbe -q` — 8 passed.
- `ruff check deeptutor/services/config/loader.py deeptutor/services/setup/init.py tests/book/test_book_agent_params.py`
- `ruff format --check deeptutor/services/config/loader.py deeptutor/services/setup/init.py tests/book/test_book_agent_params.py`

Fixes #1316
