### PR TITLE
fix(learner): complete surface map for first-party learner screens + flip preset on restrictions assignment (#1222)

### DIFF
--- a/deeptutor/api/routers/auth.py
+++ b/deeptutor/api/routers/auth.py
@@ -401,7 +401,7 @@ async def require_admin(
     return payload
 
 
-def _learning_surface_for_path(path: str) -> str:
+def _learning_surface_for_path(path: str, method: str = "GET") -> str:
     normalized = "/" + str(path or "").lstrip("/")
     for root, surface in (
         ("/api/reading", "reading"),
@@ -410,9 +410,20 @@ def _learning_surface_for_path(path: str) -> str:
         ("/api/question", "chat"),
         ("/api/question-notebook", "chat"),
         ("/api/sessions", "chat"),
+        # Mastery Path progress/topics are the learner's own per-user data;
+        # the router already scopes every record to the current account, so
+        # all methods (including progress PATCH/POST) belong to "chat".
+        ("/api/mastery-paths", "chat"),
     ):
         if normalized == root or normalized.startswith(f"{root}/"):
             return surface
+    # Knowledge-center browsing is a legitimate learner activity, but KB
+    # mutations affect shared/admin-owned resources — read-only methods only.
+    if method.upper() in ("GET", "HEAD", "OPTIONS") and (
+        normalized == "/api/knowledge-bases"
+        or normalized.startswith("/api/knowledge-bases/")
+    ):
+        return "reading"
     return ""
 
 
@@ -424,7 +435,7 @@ async def require_learning_surface(
     from deeptutor.multi_user.learning_access import assert_learning_surface
 
     try:
-        assert_learning_surface(_learning_surface_for_path(request.url.path))
+        assert_learning_surface(_learning_surface_for_path(request.url.path, request.method))
     except PermissionError as exc:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
 

--- a/deeptutor/api/routers/multi_user.py
+++ b/deeptutor/api/routers/multi_user.py
@@ -45,6 +45,7 @@ from deeptutor.multi_user.identity import (
     list_user_info,
     set_book_permission,
     set_password,
+    set_preset,
 )
 from deeptutor.multi_user.knowledge_access import admin_kb_base_dir
 from deeptutor.multi_user.model_access import is_owner_bound
@@ -660,6 +661,16 @@ async def put_guardian_restrictions(
         )
     grant = deepcopy(_restriction_grant(learner_user_id, learner_record))
     policy = grant.get("learning_policy")
+    if not isinstance(policy, dict):
+        # Assigning guardian restrictions is what makes an account a learning
+        # account. Seed the default learning policy and flip the preset to
+        # "learner" so the frontend renders the scoped learner shell instead
+        # of the full app (a `standard` preset + `learning_policy` mix makes
+        # the client load admin surfaces that all default-deny to 403, #1222).
+        grant = deepcopy(learner_grant(learner_user_id))
+        policy = grant.get("learning_policy")
+        if isinstance(policy, dict) and _learner_username:
+            set_preset(_learner_username, "learner")
     if not isinstance(policy, dict):
         raise HTTPException(status_code=409, detail="Learner account has no learning policy")
     reading = policy.get("reading")

--- a/tests/multi_user/test_learning_surface_map.py
+++ b/tests/multi_user/test_learning_surface_map.py
@@ -1,0 +1,89 @@
+"""Regression tests for the learner surface map and restrictions preset flip (#1222).
+
+Two failure modes covered:
+
+1. ``_learning_surface_for_path`` used to map only five prefixes, so the
+   learner shell's own Knowledge Center (`/api/knowledge-bases/*`) and Mastery
+   Path (`/api/mastery-paths/*`) endpoints default-denied to 403.
+2. Assigning guardian restrictions to a `standard`-preset account left the
+   account in a `standard` preset + `learning_policy` mix: the frontend then
+   rendered the full admin shell and every surface request 403'd. The PUT
+   restrictions handler now seeds the default policy and flips the preset to
+   ``learner``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deeptutor.api.routers.auth import _learning_surface_for_path
+
+
+@pytest.mark.parametrize(
+    ("path", "method", "expected"),
+    [
+        # Pre-existing mappings keep working.
+        ("/api/reading/materials", "GET", "reading"),
+        ("/api/courses", "GET", "reading"),
+        ("/api/chat/sessions", "GET", "chat"),
+        ("/api/question/generate", "POST", "chat"),
+        ("/api/sessions/abc", "GET", "chat"),
+        # Mastery Path: the learner's own per-user progress, all methods.
+        ("/api/mastery-paths/topics", "GET", "chat"),
+        ("/api/mastery-paths/topics/index", "GET", "chat"),
+        ("/api/mastery-paths/progress/book-1", "GET", "chat"),
+        ("/api/mastery-paths/progress/book-1", "PATCH", "chat"),
+        ("/api/mastery-paths/progress/book-1/redo", "POST", "chat"),
+        # Knowledge Center: read-only for learners.
+        ("/api/knowledge-bases", "GET", "reading"),
+        ("/api/knowledge-bases/kb1/files", "GET", "reading"),
+        ("/api/knowledge-bases/kb1/files/a.pdf", "GET", "reading"),
+        # KB mutations stay denied — they affect shared/admin resources.
+        ("/api/knowledge-bases", "POST", ""),
+        ("/api/knowledge-bases/kb1/upload", "POST", ""),
+        ("/api/knowledge-bases/kb1/files/a.pdf", "DELETE", ""),
+        # Everything else still default-denies.
+        ("/api/settings", "GET", ""),
+        ("/api/system/status", "GET", ""),
+        ("/api/partners", "GET", ""),
+        ("/api/memory/overview", "GET", ""),
+        ("", "GET", ""),
+    ],
+)
+def test_learning_surface_map(path: str, method: str, expected: str) -> None:
+    assert _learning_surface_for_path(path, method) == expected
+
+
+def test_put_restrictions_flips_standard_preset_to_learner(
+    mu_isolated_root, seed_user
+):
+    """PUT restrictions on a standard-preset account seeds the policy and
+    flips the account preset to ``learner`` (#1222 preset/policy mix)."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from deeptutor.api.routers.multi_user import (
+        GuardianRestrictionsPayload,
+        put_guardian_restrictions,
+    )
+    from deeptutor.multi_user.identity import get_user_by_id
+
+    # The first account in an empty store is promoted to admin by save_user;
+    # seed a bootstrap account first so the learner keeps role="user".
+    seed_user("bootstrap-admin")
+    record = seed_user("student-standard")
+    learner_user_id = record["id"]
+    admin = SimpleNamespace(user_id="u_admin", role="admin")
+
+    payload = GuardianRestrictionsPayload(
+        age_band="13-15",
+        allow_upload=True,
+        allowed_surfaces=["chat", "reading"],
+        extensions=[],
+    )
+
+    result = asyncio.run(put_guardian_restrictions(learner_user_id, payload, admin))
+    assert result["restrictions"]["age_band"] == "13-15"
+
+    _username, updated = get_user_by_id(learner_user_id)
+    assert updated.get("preset") == "learner"


### PR DESCRIPTION
## What this fixes

Two **server-side** gaps behind the learner-account 403 storm reported in #1222 (complements the frontend work in #1225 — the breakage is two-sided).

### 1. The surface map doesn't cover first-party learner screens

`_learning_surface_for_path` maps only five prefixes. The scoped learner shell (preset=`learner`) links **Knowledge Center** and **Mastery Path** in its nav, but their endpoints fall through to the default-deny and 403:

```
learner login → click 知识中心 (Knowledge Center)
  → GET /api/knowledge-bases → 403 "This learning account cannot use the requested server surface."
learner → click 精通之路 (Mastery Path)
  → GET /api/mastery-paths/topics/index → 403 (same)
```

Measured against a live deployment (v1.6.5 image) by driving the real learner UI and capturing every API call — full endpoint/status table in [this comment](https://github.com/HKUDS/DeepTutor/issues/1222#issuecomment-5538884494).

**Fix:**
- `/api/mastery-paths` → `chat`, **all methods**. Progress/objectives/sessions are the learner's *own* per-user data; the router already scopes every record to the current account, so `PATCH progress`, `POST redo`, etc. are legitimate learner activities and required for the feature to work at all.
- `/api/knowledge-bases` → `reading`, **read-only methods only** (`GET`/`HEAD`/`OPTIONS`). Browsing the assigned library is a legitimate learner activity; `POST`/`DELETE` still default-deny because they touch shared/admin-owned resources.

### 2. Admin-created learner accounts get a broken preset/policy mix

Accounts created via the admin Users API keep `preset: "standard"` when a guardian later assigns restrictions. The frontend keys the app shell off `preset`, loads the full admin UI, and *every* shell request 403s in a storm right after login (`/api/settings`, `/api/knowledge-bases`, `/api/mastery-paths/topics/index`, `/api/courses`, `/api/documents`, …).

**Fix:** `PUT /learners/{id}/restrictions` now treats "assigning restrictions" as the moment an account becomes a learning account — it seeds the default learning policy via `learner_grant()` (instead of 409ing) and flips the account preset to `learner`, so the frontend renders the scoped learner shell.

## Verification

- New regression tests: **22 passing** (`tests/multi_user/test_learning_surface_map.py`) — surface-map parametrization incl. mutation denial, plus the preset flip end-to-end.
- Existing `tests/multi_user/` suite: 197 passed / 12 failed; the 12 failures reproduce identically on unmodified `main` in a minimal venv (pre-existing, unrelated to this change).
- Live-deployment verification of the equivalent hot-patch: learner login, Knowledge Center, Mastery Path, immersive reading, chat — all functional with zero 403s; KB upload/delete still correctly 403 for the learner.

## Notes

- Frontend-side scoping (rendering from `learning_policy` instead of calling denied endpoints) is tracked in #1222 / PR #1225; this PR is the complementary server side.
- The default-deny philosophy is unchanged — this only admits the first-party surfaces the learner shell itself links to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
