### PR TITLE
fix(web): support current Codex chat history imports

### DIFF
--- a/web/lib/chat-import/codex.ts
+++ b/web/lib/chat-import/codex.ts
@@ -56,6 +56,32 @@ function eventMessage(line: CodexLine): NormalizedMessage | null {
   return { role, content, created_at: created || undefined };
 }
 
+function responseItemMessage(line: CodexLine): NormalizedMessage | null {
+  if (line.type !== "response_item") return null;
+  const p = line.payload ?? {};
+  if (p.type !== "message" || (p.role !== "user" && p.role !== "assistant")) {
+    return null;
+  }
+  if (!Array.isArray(p.content)) return null;
+
+  const parts = p.content.flatMap((item) => {
+    if (!item || typeof item !== "object") return [];
+    const block = item as Record<string, unknown>;
+    if (block.type !== "input_text" && block.type !== "output_text") return [];
+    return typeof block.text === "string" ? [block.text] : [];
+  });
+  const content = cleanText(parts.join("\n\n"));
+  if (!content) return null;
+  const created = isoToEpochSeconds(line.timestamp, 0);
+  return { role: p.role, content, created_at: created || undefined };
+}
+
+function preferredMessages(lines: CodexLine[]): NormalizedMessage[] {
+  const legacy = lines.map(eventMessage).filter((message) => message !== null);
+  if (legacy.length) return legacy;
+  return lines.map(responseItemMessage).filter((message) => message !== null);
+}
+
 /** A scanned file plus the `YYYY-MM-DD` recovered from its directory trail. */
 interface CodexFile {
   handle: FileSystemFileHandle;
@@ -106,7 +132,7 @@ export async function scanCodex(
     const meta = readMeta(head);
     if (meta.isSubagent) continue;
     const cwd = meta.cwd || "(unknown)";
-    const firstUser = head.map(eventMessage).find((m) => m?.role === "user");
+    const firstUser = preferredMessages(head).find((m) => m.role === "user");
     const ref: SessionRef = {
       externalId: meta.id || handle.name.replace(/\.jsonl$/, ""),
       provisionalTitle: firstUser ? deriveTitle(firstUser.content) : "",
@@ -137,7 +163,8 @@ export async function parseCodexSession(
   ref: SessionRef,
 ): Promise<NormalizedSession | null> {
   const file = await ref.handle.getFile();
-  const messages: NormalizedMessage[] = [];
+  const legacyMessages: NormalizedMessage[] = [];
+  const responseItemMessages: NormalizedMessage[] = [];
   let cwd = ref.cwd;
   let isSubagent = false;
 
@@ -154,10 +181,13 @@ export async function parseCodexSession(
       if (p.thread_source === "subagent") isSubagent = true;
       continue;
     }
-    const msg = eventMessage(rec);
-    if (msg) messages.push(msg);
+    const legacyMessage = eventMessage(rec);
+    if (legacyMessage) legacyMessages.push(legacyMessage);
+    const responseItem = responseItemMessage(rec);
+    if (responseItem) responseItemMessages.push(responseItem);
   }
 
+  const messages = legacyMessages.length ? legacyMessages : responseItemMessages;
   if (isSubagent || !messages.length) return null;
   const fallbackTs = file.lastModified / 1000;
   const firstTs = messages.find((m) => m.created_at)?.created_at ?? fallbackTs;

--- a/web/lib/imports-api.ts
+++ b/web/lib/imports-api.ts
@@ -24,6 +24,9 @@ export async function importChatHistory(
   sessions: NormalizedSession[],
   agent?: { id: string; name: string },
 ): Promise<ImportResult> {
+  if (sessions.length === 0) {
+    throw new Error("No sessions to import");
+  }
   const response = await apiFetch(apiUrl("/api/imports/chat-history"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/web/tests/chat-import-codex.spec.ts
+++ b/web/tests/chat-import-codex.spec.ts
@@ -1,0 +1,129 @@
+import { File as NodeFile } from "node:buffer";
+
+import { describe, expect, it } from "vitest";
+
+import { parseCodexSession } from "@/lib/chat-import/codex";
+import type { SessionRef } from "@/lib/chat-import/types";
+
+function sessionRef(records: unknown[]): SessionRef {
+  const jsonl = records.map((record) => JSON.stringify(record)).join("\n");
+  const file = new NodeFile([jsonl], "rollout-test.jsonl", {
+    lastModified: Date.parse("2026-06-25T12:00:00Z"),
+  });
+
+  return {
+    externalId: "session-1",
+    provisionalTitle: "",
+    cwd: "/workspace/project",
+    date: "2026-06-25",
+    lastModified: file.lastModified,
+    sizeBytes: file.size,
+    handle: {
+      getFile: async () => file as unknown as File,
+    } as FileSystemFileHandle,
+  };
+}
+
+describe("parseCodexSession", () => {
+  it("parses current response_item message records", async () => {
+    const ref = sessionRef([
+      {
+        timestamp: "2026-06-25T10:00:00Z",
+        type: "session_meta",
+        payload: { id: "session-1", cwd: "/workspace/project", thread_source: "user" },
+      },
+      {
+        timestamp: "2026-06-25T10:00:01Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "developer",
+          content: [{ type: "input_text", text: "hidden instructions" }],
+        },
+      },
+      {
+        timestamp: "2026-06-25T10:00:02Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Explain Fourier transforms" }],
+        },
+      },
+      {
+        timestamp: "2026-06-25T10:00:03Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "assistant",
+          content: [
+            { type: "output_text", text: "A Fourier transform" },
+            { type: "output_text", text: "decomposes a signal." },
+          ],
+        },
+      },
+    ]);
+
+    const parsed = await parseCodexSession(ref);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.title).toBe("Explain Fourier transforms");
+    expect(parsed?.messages).toEqual([
+      {
+        role: "user",
+        content: "Explain Fourier transforms",
+        created_at: Date.parse("2026-06-25T10:00:02Z") / 1000,
+      },
+      {
+        role: "assistant",
+        content: "A Fourier transform\n\ndecomposes a signal.",
+        created_at: Date.parse("2026-06-25T10:00:03Z") / 1000,
+      },
+    ]);
+  });
+
+  it("prefers legacy event messages when both storage layers are present", async () => {
+    const ref = sessionRef([
+      {
+        timestamp: "2026-06-25T10:00:00Z",
+        type: "session_meta",
+        payload: { cwd: "/workspace/project", thread_source: "user" },
+      },
+      {
+        timestamp: "2026-06-25T10:00:01Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "duplicate user" }],
+        },
+      },
+      {
+        timestamp: "2026-06-25T10:00:01Z",
+        type: "event_msg",
+        payload: { type: "user_message", message: "legacy user" },
+      },
+      {
+        timestamp: "2026-06-25T10:00:02Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "duplicate assistant" }],
+        },
+      },
+      {
+        timestamp: "2026-06-25T10:00:02Z",
+        type: "event_msg",
+        payload: { type: "agent_message", message: "legacy assistant" },
+      },
+    ]);
+
+    const parsed = await parseCodexSession(ref);
+
+    expect(parsed?.messages.map((message) => message.content)).toEqual([
+      "legacy user",
+      "legacy assistant",
+    ]);
+  });
+});

--- a/web/tests/imports-api.spec.ts
+++ b/web/tests/imports-api.spec.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { importChatHistory } from "@/lib/imports-api";
+
+describe("importChatHistory", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not send an empty import request", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(importChatHistory("codex", [])).rejects.toThrow(
+      "No sessions to import",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- parse messages stored in the current Codex `response_item/message` format
- preserve support for legacy `event_msg` records without duplicating messages
- prevent empty chat-history import requests from reaching the backend
- add regression coverage for both Codex storage formats and empty imports

## Bug fixed

Recent Codex sessions store user and assistant messages as `response_item`
records with structured `input_text` and `output_text` content. DeepTutor's
import adapter only recognized the legacy `event_msg` format.

As a result, the folder scan found Codex sessions, but the full parser returned
an empty session list. The frontend then submitted `sessions: []` to
`POST /api/imports/chat-history`, causing the backend to return HTTP 400 with
`No sessions to import`.

This change adds support for the current format while preferring legacy records
when both storage layers are present, preventing duplicate imported messages.

## Validation

- `pre-commit run --all-files`
- `npm run test:unit` - 52 tests passed
- `npm run typecheck`
- `.venv/bin/pytest tests/api/test_imports.py -q` - 9 tests passed
- replayed a real Codex JSONL session - 71 user/assistant messages parsed
