### PR TITLE
fix(anthropic): stop sending `temperature` to Claude Sonnet 5 / Opus 4.8

### DIFF
--- a/deeptutor/services/provider_registry.py
+++ b/deeptutor/services/provider_registry.py
@@ -329,6 +329,16 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         backend="anthropic",
         default_api_base="https://api.anthropic.com/v1",
         supports_prompt_caching=True,
+        # Claude Sonnet 5 and Opus 4.8 reject an explicit `temperature`
+        # outright ("`temperature` is deprecated for this model."), where
+        # earlier Claude models still accept it. Dropping the parameter
+        # (value None) lets the API apply its own default. Like the Kimi
+        # case below, the limit is the vendor API's, not the route's, so it
+        # must live here to survive binding="openai" through a gateway.
+        model_overrides=(
+            ("claude-sonnet-5", {"temperature": None}),
+            ("claude-opus-4-8", {"temperature": None}),
+        ),
     ),
     ProviderSpec(
         name="openai",

--- a/tests/services/llm/test_model_overrides.py
+++ b/tests/services/llm/test_model_overrides.py
@@ -57,9 +57,29 @@ def test_tunable_moonshot_series_keeps_the_callers_temperature(model: str) -> No
     assert _payload("moonshot", model)["temperature"] == pytest.approx(0.7)
 
 
-@pytest.mark.parametrize("model", ["gpt-4o", "claude-sonnet-5", "deepseek-chat"])
+@pytest.mark.parametrize(
+    "model", ["gpt-4o", "claude-haiku-4-5-20251001", "claude-3-5-sonnet", "deepseek-chat"]
+)
 def test_unrelated_models_are_untouched(model: str) -> None:
     assert _payload("openai", model)["temperature"] == pytest.approx(0.7)
+
+
+@pytest.mark.parametrize("model", ["claude-sonnet-5", "claude-opus-4-8"])
+@pytest.mark.parametrize("binding", ["openai", "anthropic", "no-such-provider"])
+def test_claude_models_that_deprecated_temperature_never_send_it(
+    binding: str, model: str
+) -> None:
+    """Anthropic answers HTTP 400 ``\`temperature\` is deprecated for this
+    model.`` for Sonnet 5 and Opus 4.8. Haiku 4.5 still accepts it, so the
+    rule names models, not the vendor prefix.
+
+    Verified against the live API on 2026-09-09. Like the Kimi case, the limit
+    belongs to Anthropic's API and not to the route, so it must also fire for
+    ``binding="openai"`` — which is how every OpenAI-compatible gateway in
+    front of Claude reaches these models.
+    """
+    assert "temperature" not in _payload(binding, model)
+    assert model_overrides_for(model, find_by_name(binding)) == {"temperature": None}
 
 
 def test_configured_binding_wins_over_the_vendor_fallback() -> None:


### PR DESCRIPTION
## Problem

Anthropic rejects an explicit `temperature` on Claude Sonnet 5 and Opus 4.8:

```
HTTP 400 invalid_request_error: `temperature` is deprecated for this model.
```

Every chat turn fails, because DeepTutor always sends one (`OpenAICompatProvider._build_kwargs` → `_supports_temperature`, which only excludes `gpt-5`/`o1`/`o3`/`o4`).

Claude Haiku 4.5 still accepts it, so this is per model, not per vendor prefix.

## Fix

One `model_overrides` entry on the `anthropic` vendor spec, using the existing "`None` means send this parameter as absent" mechanism — the same one the Kimi models directly below it use.

Resolving it from the **vendor** spec rather than the configured binding is what makes it work for `binding="openai"`, which is how every OpenAI-compatible gateway in front of Claude reaches these models. That is exactly the situation #938 described for Moonshot, and the docstring on `model_overrides_for` already spells out why the route is not what should decide.

## Test change

`test_unrelated_models_are_untouched` used `claude-sonnet-5` as an example of a model that keeps the caller's temperature. That was correct when written — Anthropic deprecated the parameter afterwards. The example moves to `claude-haiku-4-5-20251001` and `claude-3-5-sonnet`, both verified against the live API to still accept it, and a new test pins the new rule across three bindings.

## Verification

- `pytest tests/services/llm/test_model_overrides.py` — 20 passed.
- Full suite: no new failures (the 9 that fail here also fail on a clean `dev` checkout — missing optional `partners` SDKs and no sandbox runner binary on macOS).
- Live check against the Anthropic API through an OpenAI-compatible gateway: `claude-sonnet-5` and `claude-opus-4-8` return 400 with `temperature`, succeed without; `claude-haiku-4-5-20251001` succeeds with it.