### PR TITLE
feat(settings): expand response language options

### DIFF
--- a/deeptutor/api/routers/settings.py
+++ b/deeptutor/api/routers/settings.py
@@ -79,6 +79,24 @@ public_router = APIRouter()
 
 TOUR_CACHE = None
 
+# The UI locale is en/zh; reader-facing model output supports the wider set
+# already accepted by the shared prompt-language helper.
+ResponseLanguage = Literal[
+    "en",
+    "zh",
+    "zh-tw",
+    "ja",
+    "ko",
+    "es",
+    "fr",
+    "de",
+    "ru",
+    "pt",
+    "it",
+    "ar",
+    "pl",
+]
+
 
 def get_enabled_optional_tools() -> list[str]:
     """Compatibility export; the source of truth lives in the service layer."""
@@ -137,7 +155,7 @@ class SidebarNavOrder(BaseModel):
 class UISettings(BaseModel):
     theme: Literal["light", "dark", "glass", "snow"] = "snow"
     language: Literal["zh", "en"] = "en"
-    response_language: Literal["zh", "en"] = "en"
+    response_language: ResponseLanguage = "en"
     sidebar_description: Optional[str] = None
     sidebar_nav_order: Optional[SidebarNavOrder] = None
     code_block_theme: Optional[str] = None
@@ -160,7 +178,7 @@ class UISettingsUpdate(BaseModel):
     # so PUT /ui cannot persist a theme/language the app can't render.
     theme: Literal["light", "dark", "glass", "snow"] | None = None
     language: Literal["zh", "en"] | None = None
-    response_language: Literal["zh", "en"] | None = None
+    response_language: ResponseLanguage | None = None
     sidebar_description: str | None = None
     sidebar_nav_order: SidebarNavOrder | None = None
     code_block_theme: str | None = None

--- a/deeptutor/services/config/settings_spec.py
+++ b/deeptutor/services/config/settings_spec.py
@@ -130,6 +130,22 @@ _LANGUAGE_CHOICES: tuple[tuple[str, str, str], ...] = (
     ("zh", "简体中文", "Interface and replies in Simplified Chinese."),
 )
 
+_RESPONSE_LANGUAGE_CHOICES: tuple[tuple[str, str, str], ...] = (
+    ("en", "English", "Replies in English."),
+    ("zh", "简体中文", "Replies in Simplified Chinese."),
+    ("zh-tw", "繁體中文", "Replies in Traditional Chinese."),
+    ("ja", "日本語", "Replies in Japanese."),
+    ("ko", "한국어", "Replies in Korean."),
+    ("es", "Español", "Replies in Spanish."),
+    ("fr", "Français", "Replies in French."),
+    ("de", "Deutsch", "Replies in German."),
+    ("ru", "Русский", "Replies in Russian."),
+    ("pt", "Português", "Replies in Portuguese."),
+    ("it", "Italiano", "Replies in Italian."),
+    ("ar", "العربية", "Replies in Arabic."),
+    ("pl", "Polski", "Replies in Polish."),
+)
+
 _THEME_CHOICES: tuple[tuple[str, str, str], ...] = (
     ("snow", "Default", "Pure-white neutral theme."),
     ("light", "Light", "Warm light theme."),
@@ -195,7 +211,7 @@ def _interface_specs() -> list[SettingSpec]:
             label="Reply language",
             summary="Language the assistant writes its answers in.",
             read=response_read,
-            choices=_static_choices(_LANGUAGE_CHOICES, response_read),
+            choices=_static_choices(_RESPONSE_LANGUAGE_CHOICES, response_read),
             write=_write_ui("response_language"),
             effect_detail="Applies from the next turn onwards.",
         ),

--- a/deeptutor/services/prompt/language.py
+++ b/deeptutor/services/prompt/language.py
@@ -20,7 +20,29 @@ _LANGUAGE_LABELS: dict[str, str] = {
     "ru": "Русский",
     "pt": "Português",
     "it": "Italiano",
+    "ar": "العربية",
+    "pl": "Polski",
 }
+
+
+# Model output can use every language for which the prompt helper has a
+# reader-facing label. UI locale stays en/zh; response language is the wider
+# contract consumed by Settings and prompts.
+SUPPORTED_RESPONSE_LANGUAGES: tuple[str, ...] = (
+    "en",
+    "zh",
+    "zh-tw",
+    "ja",
+    "ko",
+    "es",
+    "fr",
+    "de",
+    "ru",
+    "pt",
+    "it",
+    "ar",
+    "pl",
+)
 
 
 def normalize_language(language: str | None) -> str:

--- a/deeptutor/services/settings/interface_settings.py
+++ b/deeptutor/services/settings/interface_settings.py
@@ -16,6 +16,7 @@ import threading
 from typing import Any
 
 from deeptutor.services.path_service import get_path_service
+from deeptutor.services.prompt.language import SUPPORTED_RESPONSE_LANGUAGES
 from deeptutor.tools.builtin import USER_TOGGLEABLE_TOOL_NAMES
 
 DEFAULT_UI_SETTINGS: dict[str, Any] = {
@@ -28,6 +29,23 @@ DEFAULT_UI_SETTINGS: dict[str, Any] = {
 
 _LOCKS_GUARD = threading.Lock()
 _LOCKS: dict[str, threading.Lock] = {}
+
+_RESPONSE_LANGUAGE_ALIASES: dict[str, str] = {
+    "english": "en",
+    "chinese": "zh",
+    "simplified chinese": "zh",
+    "traditional chinese": "zh-tw",
+    "japanese": "ja",
+    "korean": "ko",
+    "spanish": "es",
+    "french": "fr",
+    "german": "de",
+    "russian": "ru",
+    "portuguese": "pt",
+    "italian": "it",
+    "arabic": "ar",
+    "polish": "pl",
+}
 
 
 def _settings_lock(path: Path) -> threading.Lock:
@@ -75,6 +93,33 @@ def _normalize_language(language: Any, default: str = "en") -> str:
     return "en"
 
 
+def _normalize_response_language(language: Any, default: str = "en") -> str:
+    """Normalize only the wider model-output-language domain.
+
+    Interface language remains en/zh. This function accepts the labels a user
+    may have copied from an issue or another deployment, then maps region
+    variants to their supported prompt-language base.
+    """
+    fallback = default if isinstance(default, str) and default.strip() else "en"
+    fallback = _normalize_response_language(fallback, "en") if fallback != "en" else "en"
+
+    if language is None or str(language).strip() == "":
+        language = fallback
+
+    if not isinstance(language, str):
+        return fallback
+
+    code = language.strip().lower().replace("_", "-")
+    code = _RESPONSE_LANGUAGE_ALIASES.get(code, code)
+    if code == "zh-cn":
+        code = "zh"
+    elif code.startswith("pt-"):
+        code = "pt"
+    if code in SUPPORTED_RESPONSE_LANGUAGES:
+        return code
+    return fallback
+
+
 def resolve_languages(saved: Mapping[str, Any]) -> dict[str, str]:
     """Normalize the two language fields out of a raw ``interface.json`` dict.
 
@@ -93,7 +138,7 @@ def resolve_languages(saved: Mapping[str, Any]) -> dict[str, str]:
     language = _normalize_language(saved.get("language"), DEFAULT_UI_SETTINGS["language"])
     return {
         "language": language,
-        "response_language": _normalize_language(saved.get("response_language"), language),
+        "response_language": _normalize_response_language(saved.get("response_language"), language),
     }
 
 
@@ -243,4 +288,4 @@ def get_ui_language(default: str = "en") -> str:
 def get_response_language(default: str = "en") -> str:
     """Get the preferred reader-facing model output language."""
     settings = get_ui_settings()
-    return _normalize_language(settings.get("response_language"), default)
+    return _normalize_response_language(settings.get("response_language"), default)

--- a/tests/api/test_settings_router.py
+++ b/tests/api/test_settings_router.py
@@ -74,6 +74,24 @@ async def test_ui_languages_are_persisted_independently(
     assert response["response_language"] == "zh"
 
 
+@pytest.mark.asyncio
+async def test_ui_accepts_extended_response_languages(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    settings_file = tmp_path / "interface.json"
+    monkeypatch.setattr(settings_router, "_settings_file", lambda: settings_file)
+
+    response = await settings_router.update_ui_settings(
+        settings_router.UISettingsUpdate(language="en", response_language="ja")
+    )
+    assert response["response_language"] == "ja"
+
+    response = await settings_router.update_ui_settings(
+        settings_router.UISettingsUpdate(response_language="pt")
+    )
+    assert response["response_language"] == "pt"
+
+
 class _FakeEmbeddingAdapter:
     def __init__(self, config: dict[str, Any]):
         self.config = config

--- a/tests/multi_user/test_ui_language_scoping.py
+++ b/tests/multi_user/test_ui_language_scoping.py
@@ -8,6 +8,7 @@ from deeptutor.services.settings.interface_settings import (
     get_response_language,
     get_ui_language,
     get_ui_settings,
+    resolve_languages,
 )
 
 
@@ -57,3 +58,25 @@ def test_response_language_is_scoped_independently_per_user(mu_isolated_root, as
     with as_user("u_alice", role="user"):
         assert get_ui_language() == "zh"
         assert get_response_language() == "en"
+
+
+def test_response_language_normalizes_supported_labels_and_variants():
+    assert (
+        resolve_languages({"language": "en", "response_language": "japanese"})["response_language"]
+        == "ja"
+    )
+    assert (
+        resolve_languages({"language": "en", "response_language": "zh-cn"})["response_language"]
+        == "zh"
+    )
+    assert (
+        resolve_languages({"language": "en", "response_language": "pt-BR"})["response_language"]
+        == "pt"
+    )
+
+
+def test_response_language_falls_back_when_unsupported():
+    assert resolve_languages({"language": "zh", "response_language": "klingon"}) == {
+        "language": "zh",
+        "response_language": "zh",
+    }

--- a/web/components/settings/SettingsOverview.tsx
+++ b/web/components/settings/SettingsOverview.tsx
@@ -7,14 +7,21 @@ import { useTranslation } from "react-i18next";
 import { apiFetch, apiUrl } from "@/lib/api";
 import SettingsReadinessPanel from "@/components/settings/SettingsReadinessPanel";
 import SettingsStatusPanel from "@/components/settings/SettingsStatusPanel";
-import { SettingRow, SettingSection } from "@/components/settings/shared";
+import {
+  selectClass,
+  SettingRow,
+  SettingSection,
+} from "@/components/settings/shared";
 import { setPendingPrompt } from "@/lib/pending-prompt";
 import {
   settingsAnchorHref,
   type Lang,
 } from "@/features/settings/navigation/settings-nav";
 import { useSettings } from "@/features/settings/store/SettingsStore";
-import { useUiSettings } from "@/features/settings/store";
+import {
+  RESPONSE_LANGUAGE_OPTIONS,
+  useUiSettings,
+} from "@/features/settings/store";
 
 /** The en/zh segmented control both language rows use. */
 function LanguageToggle({
@@ -142,10 +149,21 @@ export default function SettingsOverview() {
               "Sets the default language for chat and capability responses.",
             )}
             control={
-              <LanguageToggle
+              <select
                 value={responseLanguage}
-                onChange={updateResponseLanguage}
-              />
+                onChange={(event) =>
+                  void updateResponseLanguage(
+                    event.target.value as typeof responseLanguage,
+                  )
+                }
+                className={`${selectClass} min-w-[160px] pr-8`}
+              >
+                {RESPONSE_LANGUAGE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
             }
           />
         </SettingSection>

--- a/web/context/app-shell-storage.ts
+++ b/web/context/app-shell-storage.ts
@@ -4,6 +4,55 @@ import { browserStorage } from "@/shared/storage";
 
 export type AppLanguage = "en" | "zh";
 
+/** Model output can use more languages than the app UI locale supports. */
+export type ResponseLanguage =
+  | "en"
+  | "zh"
+  | "zh-tw"
+  | "ja"
+  | "ko"
+  | "es"
+  | "fr"
+  | "de"
+  | "ru"
+  | "pt"
+  | "it"
+  | "ar"
+  | "pl";
+
+const SUPPORTED_RESPONSE_LANGUAGE_CODES: readonly ResponseLanguage[] = [
+  "en",
+  "zh",
+  "zh-tw",
+  "ja",
+  "ko",
+  "es",
+  "fr",
+  "de",
+  "ru",
+  "pt",
+  "it",
+  "ar",
+  "pl",
+];
+
+const RESPONSE_LANGUAGE_ALIASES: Record<string, ResponseLanguage> = {
+  "simplified chinese": "zh",
+  "traditional chinese": "zh-tw",
+  chinese: "zh",
+  japanese: "ja",
+  korean: "ko",
+  spanish: "es",
+  french: "fr",
+  german: "de",
+  russian: "ru",
+  portuguese: "pt",
+  italian: "it",
+  arabic: "ar",
+  polish: "pl",
+  "zh-cn": "zh",
+};
+
 export const ACTIVE_SESSION_STORAGE_KEY = "deeptutor.activeSessionId.tab";
 export const LANGUAGE_STORAGE_KEY = "deeptutor-language";
 export const RESPONSE_LANGUAGE_STORAGE_KEY = "deeptutor-response-language";
@@ -76,10 +125,16 @@ export function normalizeLanguage(
 export function resolveResponseLanguage(
   value: string | null | undefined,
   legacyLanguage: string | null | undefined = "en",
-): AppLanguage {
-  return value === "zh" || value === "en"
-    ? value
-    : normalizeLanguage(legacyLanguage);
+): ResponseLanguage {
+  const code = value?.trim().toLowerCase();
+  if ((SUPPORTED_RESPONSE_LANGUAGE_CODES as readonly string[]).includes(code ?? "")) {
+    return code as ResponseLanguage;
+  }
+  const base = code?.split("-", 1)[0];
+  if ((SUPPORTED_RESPONSE_LANGUAGE_CODES as readonly string[]).includes(base ?? "")) {
+    return base as ResponseLanguage;
+  }
+  return RESPONSE_LANGUAGE_ALIASES[code ?? ""] ?? normalizeLanguage(legacyLanguage);
 }
 
 export function readStoredLanguage(): AppLanguage {
@@ -142,7 +197,7 @@ export function hasStoredResponseLanguage(): boolean {
   }
 }
 
-export function readStoredResponseLanguage(): AppLanguage {
+export function readStoredResponseLanguage(): ResponseLanguage {
   if (typeof window === "undefined") return "en";
   try {
     return resolveResponseLanguage(
@@ -154,7 +209,7 @@ export function readStoredResponseLanguage(): AppLanguage {
   }
 }
 
-export function writeStoredResponseLanguage(language: AppLanguage): void {
+export function writeStoredResponseLanguage(language: ResponseLanguage): void {
   if (typeof window === "undefined") return;
   try {
     browserStorage.writeRaw("local", RESPONSE_LANGUAGE_STORAGE_KEY, language);

--- a/web/contracts/generated/api.ts
+++ b/web/contracts/generated/api.ts
@@ -13056,7 +13056,23 @@ export interface components {
       /** Language */
       readonly language?: ("zh" | "en") | null;
       /** Response Language */
-      readonly response_language?: ("zh" | "en") | null;
+      readonly response_language?:
+        | (
+            | "en"
+            | "zh"
+            | "zh-tw"
+            | "ja"
+            | "ko"
+            | "es"
+            | "fr"
+            | "de"
+            | "ru"
+            | "pt"
+            | "it"
+            | "ar"
+            | "pl"
+          )
+        | null;
       /** Sidebar Description */
       readonly sidebar_description?: string | null;
       readonly sidebar_nav_order?:

--- a/web/contracts/schema/openapi.json
+++ b/web/contracts/schema/openapi.json
@@ -8738,8 +8738,19 @@
             "anyOf": [
               {
                 "enum": [
+                  "en",
                   "zh",
-                  "en"
+                  "zh-tw",
+                  "ja",
+                  "ko",
+                  "es",
+                  "fr",
+                  "de",
+                  "ru",
+                  "pt",
+                  "it",
+                  "ar",
+                  "pl"
                 ],
                 "type": "string"
               },

--- a/web/features/settings/store/SettingsStore.tsx
+++ b/web/features/settings/store/SettingsStore.tsx
@@ -22,6 +22,7 @@ import {
   hasStoredResponseLanguage,
   writeStoredLanguage,
   writeStoredResponseLanguage,
+  type ResponseLanguage,
 } from "@/context/app-shell-storage";
 import { useAppShell } from "@/context/AppShellContext";
 import { apiFetch, apiUrl } from "@/lib/api";
@@ -188,11 +189,32 @@ export type Catalog = {
 export type UiSettings = {
   theme: "light" | "dark" | "glass" | "snow";
   language: "en" | "zh";
-  response_language: "en" | "zh";
+  response_language: ResponseLanguage;
   code_block_theme: string;
   code_block_show_line_numbers: boolean;
   code_block_wrap_long_lines: boolean;
 };
+
+export type ResponseLanguageOption = {
+  value: ResponseLanguage;
+  label: string;
+};
+
+export const RESPONSE_LANGUAGE_OPTIONS: readonly ResponseLanguageOption[] = [
+  { value: "en", label: "English" },
+  { value: "zh", label: "简体中文" },
+  { value: "zh-tw", label: "繁體中文" },
+  { value: "ja", label: "日本語" },
+  { value: "ko", label: "한국어" },
+  { value: "es", label: "Español" },
+  { value: "fr", label: "Français" },
+  { value: "de", label: "Deutsch" },
+  { value: "ru", label: "Русский" },
+  { value: "pt", label: "Português" },
+  { value: "it", label: "Italiano" },
+  { value: "ar", label: "العربية" },
+  { value: "pl", label: "Polski" },
+];
 
 type CodeBlockUiSettings = Pick<
   UiSettings,

--- a/web/tests/appearance-settings-page.test.ts
+++ b/web/tests/appearance-settings-page.test.ts
@@ -39,6 +39,21 @@ test("settings source contract: language settings live on Overview instead of Ap
   assert.match(overview, /updateResponseLanguage/);
 });
 
+test("settings source contract: model output language offers the extended registry", () => {
+  const overview = readOverviewPage();
+
+  assert.match(overview, /RESPONSE_LANGUAGE_OPTIONS\.map/);
+  const responseRow = overview.indexOf('t("Model output language")');
+  const responseControl = overview.indexOf("<select", responseRow);
+  const responseHandler = overview.indexOf(
+    "updateResponseLanguage",
+    responseControl,
+  );
+  assert.notEqual(responseRow, -1);
+  assert.notEqual(responseControl, -1);
+  assert.notEqual(responseHandler, -1);
+});
+
 test("appearance source contract: code blocks section follows the theme section", () => {
   const source = readAppearancePage();
 

--- a/web/tests/language-preferences.test.ts
+++ b/web/tests/language-preferences.test.ts
@@ -8,6 +8,15 @@ test("response language remains independent from the interface language", () => 
   assert.equal(resolveResponseLanguage("en", "zh"), "en");
 });
 
+test("response language accepts and normalizes the extended registry", () => {
+  assert.equal(resolveResponseLanguage("ja", "en"), "ja");
+  assert.equal(resolveResponseLanguage("zh-tw", "en"), "zh-tw");
+  assert.equal(resolveResponseLanguage("Japanese", "en"), "ja");
+  assert.equal(resolveResponseLanguage("zh-cn", "en"), "zh");
+  assert.equal(resolveResponseLanguage("pt-BR", "en"), "pt");
+  assert.equal(resolveResponseLanguage("klingon", "zh"), "zh");
+});
+
 test("legacy settings inherit the interface language when response language is missing", () => {
   assert.equal(resolveResponseLanguage(null, "zh"), "zh");
   assert.equal(resolveResponseLanguage(undefined, "en"), "en");


### PR DESCRIPTION
## Summary

- Expand response language choices beyond English and Chinese (addresses #1176).
- Update settings spec, API, frontend store, and contracts consistently.
- Add focused backend and frontend tests.

Closes #1176

## Validation

- Backend: `pytest tests/api/test_settings_router.py tests/multi_user/test_ui_language_scoping.py` — 66 passed
- Frontend: `npm run test:node` — 0 failures; `npm run typecheck` — PASS