### PR TITLE
fix(skills): distinguish missing file from missing skill in read_skill

### DIFF
--- a/deeptutor/services/skill/service.py
+++ b/deeptutor/services/skill/service.py
@@ -166,6 +166,10 @@ class SkillNotFoundError(Exception):
     pass
 
 
+class SkillFileNotFoundError(Exception):
+    """The skill exists but the requested file inside it does not."""
+
+
 class SkillExistsError(Exception):
     pass
 
@@ -465,7 +469,7 @@ class SkillService:
         if not target.is_relative_to(skill_dir.resolve()):
             raise InvalidSkillPathError(f"Illegal skill file path: {rel_path}")
         if not target.is_file():
-            raise SkillNotFoundError(f"{name}/{candidate}")
+            raise SkillFileNotFoundError(f"File not found in skill: {name}/{candidate}")
         text = target.read_text(encoding="utf-8", errors="replace")
         if len(text) > _MAX_READ_CHARS:
             text = text[:_MAX_READ_CHARS] + "\n\n[... truncated ...]"

--- a/deeptutor/tools/builtin/__init__.py
+++ b/deeptutor/tools/builtin/__init__.py
@@ -1290,6 +1290,7 @@ class ReadSkillTool(_PromptHintsMixin, BaseTool):
         from deeptutor.services.skill.service import (
             InvalidSkillNameError,
             InvalidSkillPathError,
+            SkillFileNotFoundError,
             SkillNotFoundError,
             SkillService,
         )
@@ -1316,6 +1317,14 @@ class ReadSkillTool(_PromptHintsMixin, BaseTool):
         for service in services:
             try:
                 content = service.read_skill_file(name, rel_path)
+            except SkillFileNotFoundError:
+                return ToolResult(
+                    content=(
+                        f"(file not found in skill {name!r}: {rel_path!r} — "
+                        "check the skill's SKILL.md or references/ for the correct path)"
+                    ),
+                    success=False,
+                )
             except SkillNotFoundError:
                 continue
             except (InvalidSkillNameError, InvalidSkillPathError) as exc:

--- a/tests/services/skill/test_read_skill_error_messages.py
+++ b/tests/services/skill/test_read_skill_error_messages.py
@@ -1,0 +1,37 @@
+"""Tests that read_skill distinguishes missing skill from missing file."""
+
+from pathlib import Path
+
+import pytest
+
+from deeptutor.services.skill.service import SkillService
+
+
+class TestReadSkillErrorMessages:
+    def _make_skill(self, root: Path) -> SkillService:
+        skill_dir = root / "skills" / "ncea-tutor"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# NCEA Tutor\n")
+        return SkillService(root=root / "skills")
+
+    def test_missing_file_returns_file_error(self, tmp_path: Path) -> None:
+        service = self._make_skill(tmp_path)
+        with pytest.raises(Exception) as exc_info:
+            service.read_skill_file("ncea-tutor", "references/qbank.md")
+        assert "ncea-tutor/references/qbank.md" in str(exc_info.value)
+        assert "not found" in str(exc_info.value).lower()
+
+    def test_missing_skill_still_raises_skill_not_found(self, tmp_path: Path) -> None:
+        service = self._make_skill(tmp_path)
+        from deeptutor.services.skill.service import SkillNotFoundError
+
+        with pytest.raises(SkillNotFoundError):
+            service.read_skill_file("nonexistent", "SKILL.md")
+
+    def test_existing_file_reads_correctly(self, tmp_path: Path) -> None:
+        service = self._make_skill(tmp_path)
+        refs = tmp_path / "skills" / "ncea-tutor" / "references"
+        refs.mkdir()
+        (refs / "qbank.md").write_text("# QBank\n")
+        content = service.read_skill_file("ncea-tutor", "references/qbank.md")
+        assert "# QBank" in content


### PR DESCRIPTION
## Summary

- `SkillService.read_skill_file` now raises a dedicated `SkillFileNotFoundError` when the skill exists but the requested file does not (#1347).
- `ReadSkillTool` catches it and returns "file not found in skill" instead of the misleading "skill not found" that sent the model into a renaming loop.
- Adds 3 focused tests.

Closes #1347

## Validation

- Backend: `pytest tests/services/skill/test_read_skill_error_messages.py` — 3 passed; `pytest tests/services/skill/` — 47 passed (2 excluded: pre-existing sandbox socket failures in test_skill_login.py)
- Ruff format/check — PASS