### PR TITLE
feat(watching): preserve note timestamps and add save retry UX

### DIFF
--- a/web/components/watching/WatchingPane.tsx
+++ b/web/components/watching/WatchingPane.tsx
@@ -79,6 +79,7 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
   const [noteSaveSuccess, setNoteSaveSuccess] = useState(false)
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
   const notesExportRequestRef = useRef(0)
+  const notesLoadRequestRef = useRef(0)
   const noteSubmitGuardRef = useRef(false)
   const [followTranscript, setFollowTranscript] = useState(true)
   const [transcriptQuery, setTranscriptQuery] = useState('')
@@ -223,6 +224,7 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
     notesExportRequestRef.current += 1
     setNotesExportBusy(false)
     setNotesCopied(false)
+    const requestId = ++notesLoadRequestRef.current
     if (!materialId) {
       setNotesLoading(false)
       return () => {
@@ -233,7 +235,7 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
     void (async () => {
       try {
         const loaded = await listVideoNotes(materialId)
-        if (!cancelled) setNotes(loaded)
+        if (!cancelled && notesLoadRequestRef.current === requestId) setNotes(loaded)
       } catch (caught) {
         if (!cancelled) {
           setNotesError(caught instanceof Error ? caught.message : t('Notes could not be loaded.'))
@@ -267,6 +269,7 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
     try {
       const saved = await createVideoNote(requestedMaterialId, noteDraft.trim(), anchorTime)
       if (activeMaterialIdRef.current !== requestedMaterialId) return
+      notesLoadRequestRef.current += 1
       setNotes(current => sortNotes([...current, saved]))
       setNoteDraft('')
       setNoteAnchorTime(null)

--- a/web/components/watching/WatchingPane.tsx
+++ b/web/components/watching/WatchingPane.tsx
@@ -70,6 +70,7 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
   const [notesLoading, setNotesLoading] = useState(false)
   const [notesError, setNotesError] = useState<string | null>(null)
   const [noteDraft, setNoteDraft] = useState('')
+  const [noteAnchorTime, setNoteAnchorTime] = useState<number | null>(null)
   const [editingNoteId, setEditingNoteId] = useState<string | null>(null)
   const [editingDraft, setEditingDraft] = useState('')
   const [noteBusy, setNoteBusy] = useState(false)
@@ -255,13 +256,15 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
   const addNote = async () => {
     if (!material || !noteDraft.trim() || noteBusy) return
     const requestedMaterialId = material.material_id
+    const anchorTime = noteAnchorTime ?? time
     setNoteBusy(true)
     setNotesError(null)
     try {
-      const saved = await createVideoNote(requestedMaterialId, noteDraft.trim(), time)
+      const saved = await createVideoNote(requestedMaterialId, noteDraft.trim(), anchorTime)
       if (activeMaterialIdRef.current !== requestedMaterialId) return
       setNotes(current => sortNotes([...current, saved]))
       setNoteDraft('')
+      setNoteAnchorTime(null)
       setNotesCopied(false)
     } catch (caught) {
       if (activeMaterialIdRef.current !== requestedMaterialId) return
@@ -771,9 +774,15 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
                 >
                   <textarea
                     value={noteDraft}
-                    onChange={event => setNoteDraft(event.target.value)}
+                    onChange={event => {
+                      const next = event.target.value
+                      if (!noteDraft.trim() && next.trim()) {
+                        setNoteAnchorTime(time)
+                      }
+                      setNoteDraft(next)
+                    }}
                     placeholder={t('Note at {{time}}', {
-                      time: formatTime(time),
+                      time: formatTime(noteAnchorTime ?? time),
                     })}
                     className="min-h-20 w-full resize-y rounded-lg border border-[var(--border)] bg-transparent px-3 py-2 text-sm"
                   />

--- a/web/components/watching/WatchingPane.tsx
+++ b/web/components/watching/WatchingPane.tsx
@@ -77,6 +77,7 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
   const [notesExportBusy, setNotesExportBusy] = useState(false)
   const [notesCopied, setNotesCopied] = useState(false)
   const [noteSaveSuccess, setNoteSaveSuccess] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
   const notesExportRequestRef = useRef(0)
   const notesLoadRequestRef = useRef(0)
@@ -311,6 +312,7 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
     const requestedMaterialId = material.material_id
     setNoteBusy(true)
     setNotesError(null)
+    setDeleteError(null)
     try {
       await deleteVideoNote(requestedMaterialId, pendingDeleteId)
       if (activeMaterialIdRef.current !== requestedMaterialId) return
@@ -323,7 +325,7 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
       setNotesCopied(false)
     } catch (caught) {
       if (activeMaterialIdRef.current !== requestedMaterialId) return
-      setNotesError(caught instanceof Error ? caught.message : t('Note was not deleted.'))
+      setDeleteError(caught instanceof Error ? caught.message : t('Note was not deleted.'))
     } finally {
       setNoteBusy(false)
     }
@@ -959,6 +961,11 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
         onCancel={() => setPendingDeleteId(null)}
       >
         {t('This note will be removed from Video Learning.')}
+        {deleteError && (
+          <p role="alert" className="mt-2 text-sm text-[var(--destructive)]">
+            {deleteError}
+          </p>
+        )}
       </ConfirmDialog>
     </section>
   )

--- a/web/components/watching/WatchingPane.tsx
+++ b/web/components/watching/WatchingPane.tsx
@@ -76,8 +76,10 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
   const [noteBusy, setNoteBusy] = useState(false)
   const [notesExportBusy, setNotesExportBusy] = useState(false)
   const [notesCopied, setNotesCopied] = useState(false)
+  const [noteSaveSuccess, setNoteSaveSuccess] = useState(false)
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
   const notesExportRequestRef = useRef(0)
+  const noteSubmitGuardRef = useRef(false)
   const [followTranscript, setFollowTranscript] = useState(true)
   const [transcriptQuery, setTranscriptQuery] = useState('')
   const [selectedTranscriptMatch, setSelectedTranscriptMatch] = useState(-1)
@@ -255,10 +257,13 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
 
   const addNote = async () => {
     if (!material || !noteDraft.trim() || noteBusy) return
+    if (noteSubmitGuardRef.current) return
+    noteSubmitGuardRef.current = true
     const requestedMaterialId = material.material_id
     const anchorTime = noteAnchorTime ?? time
     setNoteBusy(true)
     setNotesError(null)
+    setNoteSaveSuccess(false)
     try {
       const saved = await createVideoNote(requestedMaterialId, noteDraft.trim(), anchorTime)
       if (activeMaterialIdRef.current !== requestedMaterialId) return
@@ -266,11 +271,13 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
       setNoteDraft('')
       setNoteAnchorTime(null)
       setNotesCopied(false)
+      setNoteSaveSuccess(true)
     } catch (caught) {
       if (activeMaterialIdRef.current !== requestedMaterialId) return
       setNotesError(caught instanceof Error ? caught.message : t('Note was not saved.'))
     } finally {
       setNoteBusy(false)
+      noteSubmitGuardRef.current = false
     }
   }
 
@@ -816,11 +823,26 @@ export function WatchingPane({ onClose }: { onClose(): void }) {
                 </form>
 
                 {notesError && (
-                  <p
+                  <div
                     role="alert"
-                    className="rounded-lg border border-[var(--border)] bg-[var(--muted)] px-3 py-2 text-sm text-[var(--destructive)]"
+                    className="flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--muted)] px-3 py-2 text-sm text-[var(--destructive)]"
                   >
-                    {notesError}
+                    <span className="flex-1">{notesError}</span>
+                    <button
+                      type="button"
+                      onClick={() => void addNote()}
+                      disabled={noteBusy || !noteDraft.trim()}
+                      className="inline-flex shrink-0 items-center gap-1 rounded-md border border-[var(--border)] px-2 py-1 text-xs font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--muted)] disabled:opacity-50"
+                    >
+                      {noteBusy ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
+                      {t('Retry')}
+                    </button>
+                  </div>
+                )}
+
+                {noteSaveSuccess && !notesError && (
+                  <p className="text-xs text-[var(--muted-foreground)]">
+                    {t('Note saved.')}
                   </p>
                 )}
 

--- a/web/locales/en/app.json
+++ b/web/locales/en/app.json
@@ -3687,6 +3687,8 @@
   "Notes could not be loaded.": "Notes could not be loaded.",
   "Notes could not be copied.": "Notes could not be copied.",
   "Note was not saved.": "Note was not saved.",
+  "Retry": "Retry",
+  "Note saved.": "Note saved.",
   "Note was not deleted.": "Note was not deleted.",
   "Video learning panels": "Video learning panels",
   "Stopped": "Stopped",

--- a/web/locales/zh/app.json
+++ b/web/locales/zh/app.json
@@ -3687,6 +3687,8 @@
   "Notes could not be loaded.": "无法加载笔记。",
   "Notes could not be copied.": "无法复制笔记。",
   "Note was not saved.": "笔记未保存。",
+  "Retry": "重试",
+  "Note saved.": "笔记已保存。",
   "Note was not deleted.": "笔记未删除。",
   "Video learning panels": "视频学习面板",
   "Stopped": "已停止",

--- a/web/tests/watching-note-timestamps.test.ts
+++ b/web/tests/watching-note-timestamps.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const PANE_PATH = resolve(
+  process.cwd(),
+  "components/watching/WatchingPane.tsx",
+);
+const source = readFileSync(PANE_PATH, "utf8");
+
+test("note anchor time is captured at first keystroke, not save time", () => {
+  assert.match(source, /noteAnchorTime.*useState<number \| null>/);
+  assert.match(
+    source,
+    /if \(!noteDraft\.trim\(\) && next\.trim\(\)\) \{\s*setNoteAnchorTime\(time\)/,
+  );
+});
+
+test("addNote uses anchor time instead of live playback time", () => {
+  assert.match(source, /const anchorTime = noteAnchorTime \?\? time/);
+  assert.match(source, /createVideoNote\(requestedMaterialId, noteDraft\.trim\(\), anchorTime\)/);
+});
+
+test("draft is cleared and anchor is reset on successful save", () => {
+  assert.match(source, /setNoteDraft\(''\)/);
+  assert.match(source, /setNoteAnchorTime\(null\)/);
+});
+
+test("note submit has a duplicate guard ref", () => {
+  assert.match(source, /noteSubmitGuardRef/);
+});
+
+test("list load has a stale-request guard ref", () => {
+  assert.match(source, /notesLoadRequestRef/);
+});
+
+test("delete error is shown inside the confirmation dialog", () => {
+  assert.match(source, /deleteError/);
+  assert.match(
+    source,
+    /ConfirmDialog[\s\S]*?deleteError && \([\s\S]*?<p role="alert"/,
+  );
+});


### PR DESCRIPTION
## Summary

Implements #1256 in 4 focused phases:

1. **Timestamp anchoring** — capture playback time at first keystroke, not save time
2. **Retry and feedback** — keep drafts on failure, add retry button, show success confirmation, prevent duplicate submissions
3. **Stale load guard** — request ref prevents late list reloads from overwriting in-flight mutations (A→B→A safe)
4. **Delete error in dialog** — failed deletions show errors inside the confirmation dialog instead of a separate alert

Adds 6 focused regression tests.

Closes #1256

## Validation

- `npm run typecheck` — PASS
- `npm run test:node` — 1114/1114 passed
- `npm run i18n:check` — PASS