### PR TITLE
fix(rag): surface embedding connectivity failures (#1356)

### DIFF
--- a/deeptutor/services/rag/pipelines/llamaindex/errors.py
+++ b/deeptutor/services/rag/pipelines/llamaindex/errors.py
@@ -10,6 +10,32 @@ def search_error_result(query: str, exc: Exception) -> Dict[str, Any]:
     message = str(exc)
     lower = message.lower()
 
+    connection_failed = any(
+        marker in lower
+        for marker in (
+            "cannot connect to",
+            "connection refused",
+            "all connection attempts failed",
+            "cannot reach embedding api",
+        )
+    )
+    timed_out = "timed out" in lower and any(marker in lower for marker in ("embedding", "ollama"))
+    if connection_failed or timed_out:
+        return {
+            "query": query,
+            "answer": (
+                "Knowledge retrieval failed because the configured embedding "
+                "service is unavailable. Check the embedding endpoint and "
+                "provider, start the service if it is local, then retry. "
+                f"Details: {message}"
+            ),
+            "content": "",
+            "provider": "llamaindex",
+            "error": message,
+            "error_type": "embedding_connectivity",
+            "log_message": "Embedding service unavailable during RAG query.",
+        }
+
     if "embedding provider returned invalid" in lower:
         return {
             "query": query,

--- a/deeptutor/tools/builtin/__init__.py
+++ b/deeptutor/tools/builtin/__init__.py
@@ -124,10 +124,13 @@ class RAGTool(_PromptHintsMixin, BaseTool):
             **extra_kwargs,
         )
         content = result.get("answer") or result.get("content", "")
+        failed = bool(result.get("error"))
         return ToolResult(
             content=content,
-            sources=_rag_sources(result, query=query, kb_name=kb_name),
+            sources=[] if failed else _rag_sources(result, query=query, kb_name=kb_name),
             metadata=result,
+            success=not failed,
+            terminate_turn=result.get("error_type") == "embedding_connectivity",
         )
 
 

--- a/tests/core/test_builtin_tools.py
+++ b/tests/core/test_builtin_tools.py
@@ -294,6 +294,28 @@ async def test_rag_tool_forwards_query_and_extra_kwargs(monkeypatch: pytest.Monk
 
 
 @pytest.mark.asyncio
+async def test_rag_tool_marks_embedding_connectivity_failure_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_rag_search(**_kwargs: Any) -> dict[str, Any]:
+        return {
+            "answer": "embedding service is unavailable",
+            "content": "",
+            "error": "Cannot connect to Ollama at http://localhost:11434/api/embed",
+            "error_type": "embedding_connectivity",
+        }
+
+    _install_module(monkeypatch, "deeptutor.tools.rag_tool", rag_search=fake_rag_search)
+
+    result = await RAGTool().execute(query="what is a tensor", kb_name="demo-kb")
+
+    assert result.success is False
+    assert result.terminate_turn is True
+    assert result.sources == []
+    assert result.metadata["error_type"] == "embedding_connectivity"
+
+
+@pytest.mark.asyncio
 async def test_rag_tool_cites_retrieved_sources(monkeypatch: pytest.MonkeyPatch) -> None:
     """The retrieval's own provenance must reach the citation stream — echoing
     the query back was all a grounded answer used to carry (issue #694)."""

--- a/tests/services/rag/test_llamaindex_embedding_failures.py
+++ b/tests/services/rag/test_llamaindex_embedding_failures.py
@@ -7,6 +7,22 @@ from types import SimpleNamespace
 import pytest
 
 
+def test_search_error_result_classifies_embedding_connectivity_failure() -> None:
+    from deeptutor.services.rag.pipelines.llamaindex.errors import search_error_result
+
+    result = search_error_result(
+        "what is this?",
+        RuntimeError(
+            "Cannot connect to Ollama at http://localhost:11434/api/embed. "
+            "Make sure Ollama is running."
+        ),
+    )
+
+    assert result["error_type"] == "embedding_connectivity"
+    assert "embedding service is unavailable" in result["answer"]
+    assert "localhost:11434" in result["answer"]
+
+
 def test_custom_embedding_rejects_null_coordinates(monkeypatch: pytest.MonkeyPatch) -> None:
     from deeptutor.services.rag.pipelines.llamaindex import (
         embedding_adapter as embedding_module,


### PR DESCRIPTION
## Summary
- Normalize common embedding connectivity failures (`connection refused`, `cannot connect`, Ollama/embedding timeouts, etc.) to `error_type=embedding_connectivity`.
- Preserve the provider and endpoint details in the actionable RAG error message.
- Mark failed RAG tool results as unsuccessful, omit fabricated citation sources, and terminate the turn for embedding connectivity failures.
- Keep ordinary RAG errors non-terminal so the model can still handle them.

Closes #1356.

## Design note
This intentionally does not add a separate embedding preflight request before every retrieval. That would double embedding calls in the normal path. Instead, the first failing search response is normalized into an actionable terminal result. A dedicated health-check command can be layered on later if maintainers prefer explicit endpoint diagnostics.

## Validation
- PASS: `python -m pytest tests/services/rag/test_llamaindex_embedding_failures.py tests/core/test_builtin_tools.py` (30 passed, 2 warnings)
- PASS: `python -m ruff check` on all changed files
- PASS: `python -m ruff format --check` on all changed files
- PASS: `git diff --check`

A wider local run also included `tests/core/agentic/test_tool_dispatch_events.py` and `tests/agents/chat/test_kb_seed_context.py`. The latter already fails during test workspace initialization with `WorkspaceError: The selected workspace folder does not exist.`, independent of this change.