### PR TITLE
fix(turns): reap an unowned waiting_input turn when a reply arrives (#1297)

### DIFF
--- a/deeptutor/app/service.py
+++ b/deeptutor/app/service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator
+import contextlib
 import time
 from typing import Any
 
@@ -229,6 +230,14 @@ class TurnApplicationService:
         command_id: str | None = None,
     ) -> bool:
         if await self.coordinator.get_lease(turn_id) is None:
+            # Nobody owns the turn: a queued command would never be read. If
+            # the durable row still says ``waiting_input`` it is a zombie —
+            # the worker that owned the waiter is gone, and without this the
+            # session is blocked forever while the card sits on screen
+            # (#1297). Reap it synchronously (the background recovery pass
+            # would only sweep it on its next tick) so the client's ack
+            # rejection comes with a terminal state to recover from.
+            await self._reap_unowned_waiting_turn(turn_id)
             return False
         await self.coordinator.submit_command(
             turn_id,
@@ -236,6 +245,69 @@ class TurnApplicationService:
             {"text": text or "", "answers": answers},
             command_id=command_id,
         )
+        return True
+
+    async def _reap_unowned_waiting_turn(self, turn_id: str) -> bool:
+        """Fail a persisted ``waiting_input`` turn that has no live lease.
+
+        Mirrors :class:`TurnRecoveryService`'s terminal write (CAS on status
+        with the fencing token, ``worker_lost`` failure code, error+done
+        events) so whatever raced us wins cleanly and subscribed clients
+        stop deterministically. Returns ``True`` when a zombie was reaped.
+        """
+        store, _runtime = self._resolve()
+        try:
+            turn = await store.get_turn(turn_id)
+        except Exception:
+            return False
+        if turn is None or turn.get("status") != "waiting_input":
+            return False
+        error = "The worker executing this turn was lost; resend your answer as a new message"
+        metadata = {
+            "turn_terminal": True,
+            "status": "failed",
+            "error_code": "worker_lost",
+            "retryable": True,
+        }
+        reap_event: dict[str, Any] = {
+            "type": "error",
+            "source": "turn_recovery",
+            "stage": "recovery",
+            "content": error,
+            "metadata": metadata,
+            "session_id": turn.get("session_id", ""),
+        }
+        done_event: dict[str, Any] = {
+            "type": "done",
+            "source": "turn_recovery",
+            "stage": "recovery",
+            "content": "",
+            "metadata": {"status": "failed", "error_code": "worker_lost", "retryable": True},
+            "session_id": turn.get("session_id", ""),
+        }
+        try:
+            transitioned = await store.transition_turn(
+                turn_id,
+                "failed",
+                expected_status=str(turn["status"]),
+                fencing_token=int(turn.get("fencing_token") or 0),
+                error=error,
+                failure_code="worker_lost",
+                retryable=True,
+            )
+            if not transitioned:
+                # A recovery pass or a late executor write beat us to it.
+                return False
+            await store.append_events(
+                turn_id,
+                [reap_event, done_event],
+                fencing_token=int(turn.get("fencing_token") or 0),
+            )
+        except Exception:
+            return False
+        for event in (reap_event, done_event):
+            with contextlib.suppress(Exception):
+                await self.coordinator.publish_event(turn_id, event)
         return True
 
     async def submit_user_input(

--- a/tests/app/test_waiting_turn_recovery.py
+++ b/tests/app/test_waiting_turn_recovery.py
@@ -1,0 +1,206 @@
+"""A ``waiting_input`` turn whose waiter is gone must not block the session.
+
+#1297: the row says ``waiting_input`` after the worker that owned the turn
+died; every card submission hits a missing in-memory queue, the session can
+never start another turn, and the background recovery pass only sweeps it
+asynchronously. The synchronous reap at submission time must fire for the
+zombie shape — persisted ``waiting_input`` with no live lease — and only for
+it: a turn owned elsewhere (live lease) and a finished turn's history are
+untouched. The terminal write mirrors :class:`TurnRecoveryService` (CAS with
+fencing token, ``worker_lost`` failure code, error+done events) so the
+client's subscription terminates deterministically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from deeptutor.app.service import TurnApplicationService
+from deeptutor.core.stream import StreamEvent, StreamEventType
+from deeptutor.runtime.coordination import MemoryCoordinator
+from deeptutor.services.session.sqlite_store import SQLiteSessionStore
+from deeptutor.services.session.turn_runtime import TurnRuntimeManager
+
+
+class _ContextBuilder:
+    def __init__(self, *_args, **_kwargs) -> None:
+        pass
+
+    async def build(self, **_kwargs):
+        return SimpleNamespace(
+            conversation_history=[],
+            conversation_summary="",
+            context_text="",
+            token_count=0,
+            budget=0,
+        )
+
+
+def _application(store, runtime, coordinator) -> TurnApplicationService:
+    return TurnApplicationService(
+        SimpleNamespace(get=lambda: store),
+        SimpleNamespace(get=lambda _store: runtime),
+        coordinator,
+    )
+
+
+def _payload() -> dict:
+    return {
+        "content": "hello",
+        "capability": "chat",
+        "tools": [],
+        "knowledge_bases": [],
+        "attachments": [],
+        "language": "en",
+        "config": {},
+    }
+
+
+async def _seed_waiting_turn(store: SQLiteSessionStore) -> dict:
+    """Persist the exact state #1297 observed: a turn stuck on waiting_input
+    with no live worker behind it (a dead process leaves precisely this)."""
+    session = await store.create_session(title="Stuck")
+    turn = await store.begin_turn(session["id"], "chat", turn_id="zombie-turn")
+    await store.update_turn_status(turn["id"], "waiting_input")
+    return turn
+
+
+@pytest.fixture(autouse=True)
+def _workspace_root(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Point the workspace binding at a real folder for this test process.
+
+    Turn execution builds a workspace runtime context; without this the
+    binding resolves to the developer's own (absent) workspace folder and
+    every turn fails before reaching the ask_user pause.
+    """
+    root = tmp_path / "workspace"
+    root.mkdir()
+    monkeypatch.setenv("DEEPTUTOR_WORKSPACE_ROOT", str(root))
+    monkeypatch.delenv("DEEPTUTOR_WORKSPACE_ALLOWED_ROOTS", raising=False)
+
+
+@pytest.fixture
+def llm_and_context(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("deeptutor.services.llm.config.get_llm_config", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        "deeptutor.services.session.context_builder.ContextBuilder", _ContextBuilder
+    )
+
+
+@pytest.mark.asyncio
+async def test_zombie_waiting_turn_is_reaped_on_submission(tmp_path, llm_and_context) -> None:
+    coordinator = MemoryCoordinator(lease_ttl_seconds=5)
+    store = SQLiteSessionStore(tmp_path / "shared.sqlite3")
+    runtime = TurnRuntimeManager(store, coordinator=coordinator, owner_id="worker-a")
+    app = _application(store, runtime, coordinator)
+    turn = await _seed_waiting_turn(store)
+
+    accepted = await app.submit_user_reply(turn["id"], text="my answer")
+    assert accepted is False
+
+    row = await store.get_turn(turn["id"])
+    assert row["status"] == "failed"
+    assert "worker" in (row.get("error") or "")
+    assert row.get("failure_code") == "worker_lost"
+    assert row.get("retryable") in (True, 1)
+
+    # The subscriber-facing stream carries the terminal pair so any client
+    # watching the zombie turn stops immediately.
+    events = await store.get_turn_events(turn["id"])
+    types = [event["type"] for event in events]
+    assert "error" in types
+    assert types[-1] == "done"
+
+    # The session accepts new turns again — the zombie no longer blocks it.
+    _session, fresh = await app.start_turn(_payload())
+    assert fresh["status"] in ("queued", "running")
+
+
+@pytest.mark.asyncio
+async def test_live_lease_blocks_the_reap(tmp_path, llm_and_context) -> None:
+    coordinator = MemoryCoordinator(lease_ttl_seconds=30)
+    store = SQLiteSessionStore(tmp_path / "shared.sqlite3")
+    runtime = TurnRuntimeManager(store, coordinator=coordinator, owner_id="worker-a")
+    app = _application(store, runtime, coordinator)
+    turn = await _seed_waiting_turn(store)
+
+    # Another worker owns the turn right now (renewing, mid-handoff): the
+    # application service accepts the reply and routes it to the owner via
+    # the coordinator — only an unowned zombie hits the reap.
+    await coordinator.acquire_turn(turn["id"], turn["session_id"], owner_id="worker-b")
+    accepted = await app.submit_user_reply(turn["id"], text="my answer")
+    assert accepted is True
+
+    row = await store.get_turn(turn["id"])
+    assert row["status"] == "waiting_input"
+
+
+@pytest.mark.asyncio
+async def test_terminal_turns_are_never_touched(tmp_path, llm_and_context) -> None:
+    coordinator = MemoryCoordinator(lease_ttl_seconds=5)
+    store = SQLiteSessionStore(tmp_path / "shared.sqlite3")
+    runtime = TurnRuntimeManager(store, coordinator=coordinator, owner_id="worker-a")
+    app = _application(store, runtime, coordinator)
+
+    session = await store.create_session(title="done")
+    turn = await store.begin_turn(session["id"], "chat", turn_id="finished-turn")
+    await store.update_turn_status(turn["id"], "completed")
+
+    assert await app.submit_user_reply(turn["id"], text="late") is False
+    row = await store.get_turn(turn["id"])
+    assert row["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_live_owner_still_receives_replies(tmp_path, llm_and_context) -> None:
+    """The reap never interferes with the healthy multiworker path: a reply
+    routed to the worker that owns the waiter is delivered and the turn
+    completes."""
+    waiting = asyncio.Event()
+
+    class Engine:
+        async def execute(self, context):
+            yield StreamEvent(
+                type=StreamEventType.WAIT_FOR_INPUT,
+                source="chat",
+                content="Continue?",
+            )
+            waiting.set()
+            reply = await context.runtime.wait_for_user_reply()
+            yield StreamEvent(
+                type=StreamEventType.CONTENT,
+                source="chat",
+                content=f"reply:{reply['text']}",
+            )
+
+    coordinator = MemoryCoordinator(lease_ttl_seconds=5)
+    path = tmp_path / "shared.sqlite3"
+    store_a = SQLiteSessionStore(path)
+    store_b = SQLiteSessionStore(path)
+    runtime_a = TurnRuntimeManager(
+        store_a, coordinator=coordinator, owner_id="worker-a", turn_engine=Engine()
+    )
+    runtime_b = TurnRuntimeManager(
+        store_b, coordinator=coordinator, owner_id="worker-b", turn_engine=Engine()
+    )
+    app_a = _application(store_a, runtime_a, coordinator)
+    app_b = _application(store_b, runtime_b, coordinator)
+
+    _session, turn = await app_a.start_turn(_payload())
+    await asyncio.wait_for(waiting.wait(), timeout=2)
+
+    delivered = await app_b.submit_user_reply(turn["id"], text="ping")
+    assert delivered is True
+
+    # The owner consumes the routed command, the pipeline resumes, and the
+    # turn leaves waiting_input on its own — reap never interfered.
+    row = await store_b.get_turn(turn["id"])
+    for _ in range(100):
+        row = await store_b.get_turn(turn["id"])
+        if row["status"] != "waiting_input":
+            break
+        await asyncio.sleep(0.05)
+    assert row["status"] in ("running", "completed")


### PR DESCRIPTION
# fix(turns): reap an unowned waiting_input turn when a reply arrives (#1297)

## Context

#1297: after a worker dies, the turn row stays `waiting_input` while every card submission silently does nothing. The issue pins the mechanism precisely — `submit_user_reply` only delivers when a process-local reply queue exists, and a dead worker's queue is gone.

Tracing the reply path shows where the silence lives: `TurnApplicationService.submit_user_reply` short-circuits **before** anything else when the turn has no live lease — it returns `False` without touching the durable record. So:

- the client's `command_ack` comes back `accepted=false`, and the card/composer fallbacks (#1273/#1278, `useCardSubmission`, the composer's send-as-new-message fall-through) are *already wired* to recover from exactly that ack — but the turn row itself still says `waiting_input`, blocking the session's next turn until the background recovery pass happens to sweep it, and the user's answer was dropped with no visible terminal state to recover from.
- PR #1332 covers the sibling case (lease alive, queue missing) with a log line; the unowned case it deliberately leaves untouched.

## What this PR does

On the lease-missing branch of `TurnApplicationService.submit_user_reply`, before returning `False`, reap the zombie: if the persisted row says `waiting_input`, transition it to `failed` and emit the terminal event pair. The write mirrors `TurnRecoveryService` exactly, so the two recovery paths compose instead of racing:

- CAS via `transition_turn(expected_status="waiting_input", fencing_token=…)` — a recovery pass or a late executor write wins cleanly if it gets there first;
- `failure_code="worker_lost"`, `retryable=True`, same error copy family ("The worker executing this turn was lost; …");
- `error` + `done` events appended to the turn and published on the coordinator, so a subscribed client stops streaming immediately instead of waiting for a heartbeat timeout.

Nothing else changes: live-lease replies route as before, terminal turns are never rewritten (the reap checks the row first), and a turn the background recovery has already claimed fails the CAS and returns without writing.

## Why synchronous, when `TurnRecoveryService` exists

The recovery pass is leader-driven and tick-based (default 10s). The learner hitting "Submit" is *right now* — the reap at submission time converts their dead click into an immediate, visible terminal state, which is exactly the "visibly report the rejection" behavior #1297 asks for. The background pass remains the safety net for turns nobody pokes.

## Test plan

Covered by the automated suite (`tests/app/test_waiting_turn_recovery.py`):

- [x] Zombie (`waiting_input`, no lease) is reaped on submission: row → `failed`, `worker_lost`/retryable, error+done events appended, and the session accepts new turns again (`test_zombie_waiting_turn_is_reaped_on_submission`)
- [x] Live lease blocks the reap — the service accepts and routes the reply instead (`test_live_lease_blocks_the_reap`)
- [x] Terminal turns are never rewritten (`test_terminal_turns_are_never_touched`)
- [x] Healthy multiworker path unaffected: reply routed to the owning worker resumes the turn (`test_live_owner_still_receives_replies`)

Not verified — needs a real deployment:

- [ ] End-to-end on Docker Compose: kill the worker mid-`ask_user`, submit from the UI, observe the card recover and the session continue (the multiworker harness covers the pieces; a live compose run was not available)
