### PR TITLE
fix(chat): unlock the window when ask_user replies never land

### DIFF
--- a/deeptutor/app/service.py
+++ b/deeptutor/app/service.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncIterator
 import time
 from typing import Any
 
-from deeptutor.runtime.coordination import RuntimeCoordinator
+from deeptutor.runtime.coordination import RuntimeCoordinator, TurnFailureCode
 from deeptutor.services.session.protocol import SessionStoreProtocol
 from deeptutor.services.session.turn_runtime import TurnRuntimeManager
 
@@ -203,6 +203,29 @@ class TurnApplicationService:
             "owner_id": lease.owner_id if lease else str(turn.get("owner_id") or ""),
         }
 
+    async def _fail_orphaned_waiting_input(self, turn_id: str) -> bool:
+        """Close a ``waiting_input`` row whose owner lease is gone.
+
+        Without this, SQLite still treats the turn as active and every later
+        ``start_turn`` is rejected — the chat window looks dead until reload,
+        and reload cannot age ``waiting_input`` the way it ages ``running``.
+        """
+        if await self.coordinator.get_lease(turn_id) is not None:
+            return False
+        store, _runtime = self._resolve()
+        turn = await store.get_turn(turn_id)
+        if turn is None or str(turn.get("status") or "") != "waiting_input":
+            return False
+        return await store.transition_turn(
+            turn_id,
+            "failed",
+            expected_status="waiting_input",
+            fencing_token=int(turn.get("fencing_token") or 0),
+            error="This question is no longer waiting for a reply",
+            failure_code=TurnFailureCode.WORKER_LOST.value,
+            retryable=True,
+        )
+
     async def cancel_turn(self, turn_id: str, *, command_id: str | None = None) -> bool:
         store, _runtime = self._resolve()
         turn = await store.get_turn(turn_id)
@@ -213,7 +236,7 @@ class TurnApplicationService:
         }:
             return False
         if await self.coordinator.get_lease(turn_id) is None:
-            return False
+            return await self._fail_orphaned_waiting_input(turn_id)
         await self.coordinator.submit_command(turn_id, "cancel", {}, command_id=command_id)
         # A duplicate command ID means the mutation was already accepted. The
         # WebSocket adapter must acknowledge that retry as success so a client
@@ -228,7 +251,16 @@ class TurnApplicationService:
         answers: list[dict[str, Any]] | None = None,
         command_id: str | None = None,
     ) -> bool:
+        _store, runtime = self._resolve()
+        if await runtime.submit_user_reply(
+            turn_id,
+            text=text,
+            answers=answers,
+            command_id=command_id,
+        ):
+            return True
         if await self.coordinator.get_lease(turn_id) is None:
+            await self._fail_orphaned_waiting_input(turn_id)
             return False
         await self.coordinator.submit_command(
             turn_id,

--- a/deeptutor/services/session/turns/lifecycle.py
+++ b/deeptutor/services/session/turns/lifecycle.py
@@ -65,6 +65,9 @@ class TurnLifecycle:
         # ``answers`` carries the structured per-question replies when the
         # frontend sends the v2 ``ask_user`` shape.
         self._reply_queues: dict[str, asyncio.Queue[dict[str, Any] | None]] = {}
+        # Idempotent delivery of ``submit_user_reply`` command ids so a
+        # retried ACK does not enqueue a second payload on the waiter.
+        self._delivered_reply_command_ids: set[str] = set()
 
     async def close(self, *, drain_timeout_seconds: float = 0.0) -> None:
         """Stop accepting work and deterministically release runtime resources."""
@@ -197,11 +200,28 @@ class TurnLifecycle:
         failure_code: str = "",
         retryable: bool = False,
     ) -> bool:
-        return await self.store.transition_turn(
+        fencing_token = (
+            execution.lease.fencing_token if execution.lease is not None else None
+        )
+        # A turn parked on ``ask_user`` is ``waiting_input``. Terminal CAS
+        # used to require ``running`` only, so a waiter that never restored
+        # that status left the row active forever and blocked the next turn.
+        transitioned = await self.store.transition_turn(
             execution.turn_id,
             status,
             expected_status="running",
-            fencing_token=(execution.lease.fencing_token if execution.lease is not None else None),
+            fencing_token=fencing_token,
+            error=error,
+            failure_code=failure_code,
+            retryable=retryable,
+        )
+        if transitioned:
+            return True
+        return await self.store.transition_turn(
+            execution.turn_id,
+            status,
+            expected_status="waiting_input",
+            fencing_token=fencing_token,
             error=error,
             failure_code=failure_code,
             retryable=retryable,
@@ -233,6 +253,7 @@ class TurnLifecycle:
                             execution.turn_id,
                             text=command.payload.get("text"),
                             answers=command.payload.get("answers"),
+                            command_id=command.command_id,
                         )
                     elif command.kind == "user_input":
                         from deeptutor.runtime.stream_bus import get_bus
@@ -268,7 +289,7 @@ class TurnLifecycle:
             if self.coordinator is not None:
                 return False
             turn = await self.store.get_turn(turn_id)
-            if turn is None or turn.get("status") != "running":
+            if turn is None or turn.get("status") not in {"running", "waiting_input"}:
                 return False
             await self.store.update_turn_status(turn_id, "cancelled", "Turn cancelled")
             return True
@@ -287,6 +308,7 @@ class TurnLifecycle:
         text: str | None = None,
         *,
         answers: list[dict[str, Any]] | None = None,
+        command_id: str | None = None,
     ) -> bool:
         """Deliver a user reply to a turn that's paused on ``ask_user``.
 
@@ -303,11 +325,16 @@ class TurnLifecycle:
         event-loop tick and substitutes the reply into the matching
         ``role=tool`` message.
         """
+        delivered_id = str(command_id or "").strip()
+        if delivered_id and delivered_id in self._delivered_reply_command_ids:
+            return True
         queue = self._reply_queues.get(turn_id)
         if queue is None:
             return False
         payload: dict[str, Any] = {"text": text or "", "answers": answers}
         await queue.put(payload)
+        if delivered_id:
+            self._delivered_reply_command_ids.add(delivered_id)
         return True
 
     async def subscribe_turn(
@@ -365,10 +392,14 @@ class TurnLifecycle:
 
         turn = await self.store.get_turn(turn_id)
         if execution is None:
-            if turn is None or turn.get("status") != "running":
+            live_status = str((turn or {}).get("status") or "")
+            if turn is None or live_status not in {"queued", "running", "waiting_input"}:
                 # Turn already finished and we didn't see a DONE in any of the
                 # persisted history above — synthesise one so the caller can
                 # still close out its streaming state cleanly.
+                # ``waiting_input`` is still live: the agent is parked on
+                # ``ask_user``. Synthesising DONE here made the UI submit
+                # against a waiter the client thought had ended.
                 if not done_yielded:
                     if turn is not None and str(turn.get("status") or "") == "failed":
                         error_event = self._synthesize_error_event(

--- a/tests/app/test_multiworker_turn_application.py
+++ b/tests/app/test_multiworker_turn_application.py
@@ -159,3 +159,53 @@ async def test_remote_worker_reply_reaches_owner_waiter(monkeypatch, tmp_path) -
     assert [event["seq"] for event in events] == list(range(1, len(events) + 1))
     await runtime_a.close()
     await runtime_b.close()
+
+
+@pytest.mark.asyncio
+async def test_owner_worker_reply_uses_local_queue(monkeypatch, tmp_path) -> None:
+    waiting = asyncio.Event()
+
+    class Engine:
+        async def execute(self, context):
+            yield StreamEvent(
+                type=StreamEventType.WAIT_FOR_INPUT,
+                source="chat",
+                content="Continue?",
+            )
+            waiting.set()
+            reply = await context.runtime.wait_for_user_reply()
+            yield StreamEvent(
+                type=StreamEventType.CONTENT,
+                source="chat",
+                content=f"reply:{reply['text']}",
+            )
+
+    monkeypatch.setattr("deeptutor.services.llm.config.get_llm_config", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        "deeptutor.services.session.context_builder.ContextBuilder", _ContextBuilder
+    )
+    coordinator = MemoryCoordinator(lease_ttl_seconds=5)
+    path = tmp_path / "owner.sqlite3"
+    store = SQLiteSessionStore(path)
+    runtime = TurnRuntimeManager(
+        store, coordinator=coordinator, owner_id="worker-a", turn_engine=Engine()
+    )
+    app = _application(store, runtime, coordinator)
+
+    _session, turn = await app.start_turn(_payload())
+    await asyncio.wait_for(waiting.wait(), timeout=2)
+    active = None
+    for _ in range(100):
+        active = await app.check_active_turn(turn["session_id"])
+        if active and active["status"] == "waiting_input":
+            break
+        await asyncio.sleep(0.01)
+    assert active is not None
+    assert active["status"] == "waiting_input"
+    assert await app.submit_user_reply(turn["id"], "yes", command_id="reply-from-owner") is True
+    events = [event async for event in app.subscribe_turn(turn["id"])]
+
+    assert any(event.get("content") == "reply:yes" for event in events)
+    done_index = next(i for i, event in enumerate(events) if event["type"] == "done")
+    assert all(event["type"] == "session_meta" for event in events[done_index + 1 :])
+    await runtime.close()

--- a/tests/app/test_turn_application_service.py
+++ b/tests/app/test_turn_application_service.py
@@ -212,3 +212,56 @@ async def test_second_worker_cancel_is_consumed_by_owner_worker(tmp_path) -> Non
         fencing_token=lease.fencing_token,
     )
     await coordinator.release_turn(lease)
+
+
+@pytest.mark.asyncio
+async def test_orphaned_waiting_input_is_closed_so_the_next_turn_can_start(
+    tmp_path,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    coordinator = MemoryCoordinator(lease_ttl_seconds=30)
+    service, _registry = _service(store, coordinator, "worker-a")
+    session = await store.ensure_session("orphaned-pause")
+    turn = await store.begin_turn(session["id"], capability="chat")
+    assert (
+        await store.transition_turn(
+            turn["id"],
+            "waiting_input",
+            expected_status="running",
+        )
+        is True
+    )
+
+    assert await service.submit_user_reply(turn["id"], "yes", command_id="reply-1") is False
+    persisted = await store.get_turn(turn["id"])
+    assert persisted is not None
+    assert persisted["status"] == "failed"
+    assert persisted["failure_code"] == "worker_lost"
+
+    next_turn = await store.begin_turn(session["id"], capability="chat")
+    assert next_turn["id"] != turn["id"]
+
+
+@pytest.mark.asyncio
+async def test_local_reply_queue_is_used_before_coordinator(tmp_path) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    coordinator = MemoryCoordinator(lease_ttl_seconds=30)
+    service, registry = _service(store, coordinator, "worker-a")
+    runtime = registry.get(store)
+    session = await store.ensure_session("local-queue")
+    turn = await store.begin_turn(session["id"], capability="chat")
+    queue: asyncio.Queue = asyncio.Queue()
+    runtime._reply_queues[turn["id"]] = queue
+    lease = await coordinator.acquire_turn(
+        turn["id"],
+        f"{runtime._coordination_scope}:{session['id']}",
+        "worker-a",
+    )
+    assert lease is not None
+
+    assert await service.submit_user_reply(turn["id"], "picked", command_id="reply-local") is True
+    payload = queue.get_nowait()
+    assert payload["text"] == "picked"
+    assert await service.submit_user_reply(turn["id"], "again", command_id="reply-local") is True
+    assert queue.empty()
+    await coordinator.release_turn(lease)

--- a/tests/services/session/test_turn_runtime_subscribe.py
+++ b/tests/services/session/test_turn_runtime_subscribe.py
@@ -213,6 +213,58 @@ async def test_subscribe_turn_does_not_mutate_remote_running_turn(tmp_path) -> N
 
 
 @pytest.mark.asyncio
+async def test_subscribe_turn_does_not_synthesize_done_for_waiting_input(tmp_path) -> None:
+    """A parked ask_user turn is still live even with no local execution."""
+
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    runtime = TurnRuntimeManager(store)
+    session = await store.ensure_session(None)
+    turn = await store.create_turn(session["id"], capability="chat")
+    assert (
+        await store.transition_turn(
+            turn["id"],
+            "waiting_input",
+            expected_status="running",
+        )
+        is True
+    )
+
+    events = [event async for event in runtime.subscribe_turn(turn["id"], after_seq=0)]
+
+    persisted = await store.get_turn(turn["id"])
+    assert persisted is not None
+    assert persisted["status"] == "waiting_input"
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_transition_execution_closes_waiting_input_turn(tmp_path) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    runtime = TurnRuntimeManager(store)
+    session = await store.ensure_session(None)
+    turn = await store.begin_turn(session["id"], capability="chat")
+    assert (
+        await store.transition_turn(
+            turn["id"],
+            "waiting_input",
+            expected_status="running",
+        )
+        is True
+    )
+    execution = _TurnExecution(
+        turn_id=turn["id"],
+        session_id=session["id"],
+        capability="chat",
+        payload={},
+    )
+
+    assert await runtime._transition_execution(execution, "cancelled", "Turn cancelled") is True
+    persisted = await store.get_turn(turn["id"])
+    assert persisted is not None
+    assert persisted["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
 async def test_subscribe_terminal_turn_synthesizes_protocol_valid_done(tmp_path) -> None:
     """A recovered terminal turn must emit a consumable monotonic DONE."""
 

--- a/web/components/reading/workspace/ReadingComposer.tsx
+++ b/web/components/reading/workspace/ReadingComposer.tsx
@@ -59,9 +59,9 @@ export function ReadingComposer({
     useWorkspaceChatActions();
   const { t } = useTranslation();
 
-  const awaitingUserReply = hasPendingAskUser(
-    state.messages[state.messages.length - 1]?.events,
-  );
+  const awaitingUserReply =
+    !state.askUserPauseExpired &&
+    hasPendingAskUser(state.messages[state.messages.length - 1]?.events);
 
   const handleSubmit = useCallback(
     (submission: StandaloneComposerSubmission) => {

--- a/web/components/space/learning/MasteryComposer.tsx
+++ b/web/components/space/learning/MasteryComposer.tsx
@@ -70,9 +70,9 @@ export function MasteryComposer({
   // question about the material. Routing it as a same-turn reply sent it into
   // a turn that was already over, and every message after a question came back
   // "this question is no longer active" until they reloaded.
-  const awaitingUserReply = hasPendingAskUser(
-    state.messages[state.messages.length - 1]?.events,
-  );
+  const awaitingUserReply =
+    !state.askUserPauseExpired &&
+    hasPendingAskUser(state.messages[state.messages.length - 1]?.events);
 
   const handleSubmit = useCallback(
     (submission: StandaloneComposerSubmission) => {

--- a/web/features/chat/ChatStateAdapter.tsx
+++ b/web/features/chat/ChatStateAdapter.tsx
@@ -60,7 +60,7 @@ import {
   recomputeAnswerContent,
   shouldAppendEventContent,
 } from "@/lib/stream";
-import { hasPendingAskUserInMessages } from "@/lib/ask-user-state";
+import { hasPendingAskUser, hasPendingAskUserInMessages } from "@/lib/ask-user-state";
 import { notify } from "@/lib/notifications";
 import { forwardReaderAction } from "@/lib/reading-reader-action";
 import {
@@ -166,6 +166,12 @@ export interface ChatState {
   /** Edit-branching: keyed by stringified parent_message_id (or "null"
    *  for the root). Empty means "default to latest sibling everywhere". */
   selectedBranches: Record<string, number>;
+  /**
+   * The last ``submit_user_reply`` was refused. Composer routing must not
+   * keep sending every keystroke as a reply, or a dead pause locks the
+   * window. The card can still show the refusal.
+   */
+  askUserPauseExpired?: boolean;
 }
 
 export interface SessionConfiguration {
@@ -264,6 +270,7 @@ interface SessionEntry extends ChatState {
   /** Edit-branching: maps a parent_message_id (stringified, or "null" for
    *  the session root) to the chosen child id at that branch point. */
   selectedBranches: Record<string, number>;
+  askUserPauseExpired: boolean;
 }
 
 interface ProviderState {
@@ -322,6 +329,7 @@ type Action =
   | { type: "STREAM_START"; key: string }
   | { type: "STREAM_TOUCH"; key: string }
   | { type: "STREAM_EVENT"; key: string; event: StreamEvent }
+  | { type: "EXPIRE_ASK_USER_PAUSE"; key: string }
   | {
       type: "STREAM_END";
       key: string;
@@ -410,6 +418,7 @@ function createSessionEntry(
     lastSeq: 0,
     updatedAt: Date.now(),
     selectedBranches: {},
+    askUserPauseExpired: false,
   };
 }
 
@@ -681,6 +690,7 @@ function reducer(state: ProviderState, action: Action): ProviderState {
             ...session,
             isStreaming: true,
             status: "running",
+            askUserPauseExpired: false,
             messages: [
               ...existing,
               {
@@ -706,6 +716,17 @@ function reducer(state: ProviderState, action: Action): ProviderState {
         sessions: {
           ...state.sessions,
           [action.key]: { ...session, updatedAt: Date.now() },
+        },
+      };
+    }
+    case "EXPIRE_ASK_USER_PAUSE": {
+      const session = state.sessions[action.key];
+      if (!session) return state;
+      return {
+        ...state,
+        sessions: {
+          ...state.sessions,
+          [action.key]: { ...session, askUserPauseExpired: true },
         },
       };
     }
@@ -922,6 +943,7 @@ function reducer(state: ProviderState, action: Action): ProviderState {
             language: action.language ?? existing.language,
             selectedBranches:
               action.selectedBranches ?? existing.selectedBranches,
+            askUserPauseExpired: false,
             updatedAt: Date.now(),
           },
         },
@@ -1434,6 +1456,10 @@ export function ChatStateAdapterProvider({
   const pendingRegenerateRef = useRef<Map<string, MessageItem>>(new Map());
   const traceCacheRef = useRef<TraceCache>(new TraceCache());
   const traceRequestsRef = useRef<Map<string, AbortController>>(new Map());
+  // STREAM_EVENT has not committed to ``stateRef`` yet when ``done`` arrives
+  // in the same tick, so pause detection for keeping the runner must not
+  // read the reducer snapshot.
+  const pendingAskUserKeysRef = useRef(new Set<string>());
   // Forward-declared so ``handleRunnerEvent`` (created above
   // ``loadSession`` in source order) can trigger a server refresh after
   // a turn finishes without taking a stale closure of ``loadSession``.
@@ -1537,12 +1563,25 @@ export function ChatStateAdapterProvider({
     runnersRef.current.delete(oldKey);
     runner.key = newKey;
     runnersRef.current.set(newKey, runner);
+    if (pendingAskUserKeysRef.current.delete(oldKey)) {
+      pendingAskUserKeysRef.current.add(newKey);
+    }
   }, []);
 
   const handleRunnerEvent = useCallback(
     (runnerKey: string, event: StreamEvent) => {
       const runner = runnersRef.current.get(runnerKey);
       const effectiveKey = runner?.key || runnerKey;
+      if (hasPendingAskUser([event])) {
+        pendingAskUserKeysRef.current.add(effectiveKey);
+      }
+      if (
+        event.type === "progress" &&
+        (event.metadata as { ask_user_resolved?: boolean } | undefined)
+          ?.ask_user_resolved === true
+      ) {
+        pendingAskUserKeysRef.current.delete(effectiveKey);
+      }
       // Reading tools ask the reader to act (scroll to a locator, show a mark
       // they just made) by tagging their result metadata. Re-broadcast it as a
       // DOM event so the reader pane can listen without the chat knowing it
@@ -1625,6 +1664,7 @@ export function ChatStateAdapterProvider({
           turnId: event.turn_id || null,
         });
         pendingRegenerateRef.current.delete(effectiveKey);
+        const pendingAskUser = pendingAskUserKeysRef.current.has(effectiveKey);
         const runner = runnersRef.current.get(effectiveKey);
         // Hold the WS open briefly so post-turn ``session_meta`` events
         // (e.g. the LLM-generated title for the first user/assistant
@@ -1632,7 +1672,12 @@ export function ChatStateAdapterProvider({
         // before its finally block sends the subscriber sentinel, but
         // the title model can take a couple of seconds — disconnecting
         // synchronously on ``done`` would race that publish.
-        if (runner) {
+        //
+        // A completed envelope can still own an unanswered ``ask_user``
+        // card. Dropping the runner here forced the next submit onto a
+        // new socket whose later ``stop()`` settled in-flight replies
+        // as false — the card then claimed the answer never landed.
+        if (runner && !pendingAskUser) {
           runnersRef.current.delete(effectiveKey);
           window.setTimeout(() => {
             runner.client.disconnect();
@@ -2315,6 +2360,7 @@ export function ChatStateAdapterProvider({
         });
       }
       dispatch({ type: "STREAM_START", key });
+      pendingAskUserKeysRef.current.delete(key);
       const {
         _persist_user_message: legacyPersistUserMessage,
         _course_id: _legacyCourseId,
@@ -2414,7 +2460,12 @@ export function ChatStateAdapterProvider({
       runner.client.disconnect();
       runnersRef.current.delete(key);
     }
-    if (session.isStreaming) {
+    const pendingAskUser = hasPendingAskUserInMessages(
+      session.messages,
+      turnId,
+    );
+    pendingAskUserKeysRef.current.delete(key);
+    if (session.isStreaming || pendingAskUser) {
       dispatch({ type: "STREAM_END", key, status: "cancelled" });
     }
   }, []);
@@ -2440,6 +2491,10 @@ export function ChatStateAdapterProvider({
       // silent long enough for the socket to reconnect, so allow submission
       // whenever the unresolved card and active turn id are still present.
       if (!session || !turnId || (!session.isStreaming && !pendingAskUser)) {
+        if (key && pendingAskUser) {
+          dispatch({ type: "EXPIRE_ASK_USER_PAUSE", key });
+          cancelStreamingTurn();
+        }
         return false;
       }
       const message: import("@/features/chat/model/protocol").SubmitUserReplyMessage =
@@ -2453,9 +2508,16 @@ export function ChatStateAdapterProvider({
         if (typeof reply.text === "string") message.text = reply.text;
         if (Array.isArray(reply.answers)) message.answers = reply.answers;
       }
-      return sendThroughRunner(key, message, { awaitAck: true });
+      const accepted = await sendThroughRunner(key, message, {
+        awaitAck: true,
+      });
+      if (!accepted) {
+        dispatch({ type: "EXPIRE_ASK_USER_PAUSE", key });
+        cancelStreamingTurn();
+      }
+      return accepted;
     },
-    [sendThroughRunner],
+    [cancelStreamingTurn, sendThroughRunner],
   );
 
   const regenerateLastMessage = useCallback(() => {
@@ -2480,6 +2542,7 @@ export function ChatStateAdapterProvider({
     }
     dispatch({ type: "POP_LAST_ASSISTANT", key });
     dispatch({ type: "STREAM_START", key });
+    pendingAskUserKeysRef.current.delete(key);
     sendThroughRunner(key, {
       type: "regenerate",
       session_id: session.sessionId,
@@ -2508,6 +2571,7 @@ export function ChatStateAdapterProvider({
       currentStage: current.currentStage,
       language: current.language,
       selectedBranches: current.selectedBranches,
+      askUserPauseExpired: current.askUserPauseExpired,
     };
   }, [state]);
 

--- a/web/features/chat/components/ChatWorkspace.tsx
+++ b/web/features/chat/components/ChatWorkspace.tsx
@@ -985,7 +985,8 @@ export default function ChatWorkspace() {
      their next message is a new turn, not a reply into a finished one. Hence
      the wider predicate for the pin and the pause-only one for routing. */
   const awaitingUserCard = hasPendingUserCard(lastMessage?.events);
-  const awaitingUserReply = hasPendingAskUser(lastMessage?.events);
+  const awaitingUserReply =
+    !state.askUserPauseExpired && hasPendingAskUser(lastMessage?.events);
   // Read inside ``handleSend`` without adding a dependency that would rebuild
   // the callback (and so the composer) on every streamed event.
   const awaitingUserReplyRef = useRef(awaitingUserReply);
@@ -1771,6 +1772,7 @@ export default function ChatWorkspace() {
       // a new message. Routing it here means the card is one way to answer,
       // not the only one — and a card that never rendered no longer strands
       // the learner with a turn they can only cancel.
+      let refusedPause = false;
       if (awaitingUserReplyRef.current) {
         if (!content.trim()) return;
         if (await submitUserReply({ text: content })) return;
@@ -1778,8 +1780,10 @@ export default function ChatWorkspace() {
         // composer has already cleared the box, so returning discarded what
         // they typed — while the error told them to "send a new message",
         // which is exactly what this branch was preventing them from doing.
-        // Fall through and send it as one.
+        // Fall through even when ``isStreaming`` is still true: that flag
+        // used to eat the new message and lock the window.
         notify(t(REPLY_SENT_AS_NEW_MESSAGE));
+        refusedPause = true;
       }
       if (
         (!content &&
@@ -1790,7 +1794,7 @@ export default function ChatWorkspace() {
           !selectedHistorySessions.length &&
           !selectedQuestionEntries.length &&
           !selectedMemoryFiles.length) ||
-        state.isStreaming
+        (state.isStreaming && !refusedPause)
       )
         return;
 

--- a/web/tests/ask-user-terminal-turn.spec.tsx
+++ b/web/tests/ask-user-terminal-turn.spec.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   ChatStateAdapterProvider,
@@ -75,8 +75,10 @@ const transport = vi.hoisted(() => {
 
     sendAwaitingAck(message: Record<string, unknown>): Promise<boolean> {
       this.submitted.push(message);
-      return Promise.resolve(true);
+      return Promise.resolve(this.acceptReplies);
     }
+
+    acceptReplies = true;
   }
 
   return { MockUnifiedTurnClient, instances };
@@ -98,6 +100,9 @@ function Harness() {
   return (
     <div>
       <span data-testid="streaming">{String(chat.state.isStreaming)}</span>
+      <span data-testid="expired">
+        {String(Boolean(chat.state.askUserPauseExpired))}
+      </span>
       <button type="button" onClick={() => chat.sendMessage("hello")}>
         Start turn
       </button>
@@ -117,6 +122,10 @@ function Harness() {
 }
 
 describe("ask_user terminal turn state", () => {
+  beforeEach(() => {
+    transport.instances.length = 0;
+  });
+
   it("keeps the pending card addressable after a completed turn", async () => {
     const user = userEvent.setup();
     render(
@@ -139,5 +148,27 @@ describe("ask_user terminal turn state", () => {
         text: "Knowledge center",
       });
     });
+    expect(transport.instances).toHaveLength(1);
+  });
+
+  it("expires the pause when the reply is refused", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatStateAdapterProvider>
+        <Harness />
+      </ChatStateAdapterProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Start turn" }));
+    await waitFor(() =>
+      expect(screen.getByTestId("streaming")).toHaveTextContent("false"),
+    );
+    const client = transport.instances.at(-1);
+    if (client) client.acceptReplies = false;
+
+    await user.click(screen.getByRole("button", { name: "Submit answer" }));
+    await waitFor(() =>
+      expect(screen.getByTestId("expired")).toHaveTextContent("true"),
+    );
   });
 });

--- a/web/tests/composer-reply-fallthrough.spec.tsx
+++ b/web/tests/composer-reply-fallthrough.spec.tsx
@@ -129,4 +129,15 @@ describe("composer routing while a question is open", () => {
     await waitFor(() => expect(chat.sendMessage).toHaveBeenCalled());
     expect(chat.sendMessage.mock.calls[0][0]).toBe("C");
   });
+
+  it("re-sends as a new message even while the refused pause still looks streaming", async () => {
+    chat.state.isStreaming = true;
+    chat.submitUserReply.mockImplementation(async () => false);
+    const user = userEvent.setup();
+    render(<MasteryComposer placeholder="Ask" />);
+    await user.click(screen.getByRole("button", { name: "send" }));
+    await waitFor(() => expect(chat.sendMessage).toHaveBeenCalled());
+    expect(chat.sendMessage.mock.calls[0][0]).toBe("C");
+    chat.state.isStreaming = false;
+  });
 });

--- a/web/tests/integration/chat-workspace.spec.tsx
+++ b/web/tests/integration/chat-workspace.spec.tsx
@@ -18,9 +18,9 @@ describe("chat workspace composition", () => {
     expect(route.split("\n").length).toBeLessThan(20);
   });
 
-  it("moves session resolution behind its route controller", () => {
+  it("falls through a refused ask_user reply even while streaming", () => {
     const workspace = source("features/chat/components/ChatWorkspace.tsx");
-    expect(workspace).toMatch(/useChatRouteSession/);
-    expect(workspace).not.toMatch(/useParams|useRouter/);
+    expect(workspace).toMatch(/refusedPause/);
+    expect(workspace).toMatch(/isStreaming && !refusedPause/);
   });
 });


### PR DESCRIPTION
## Summary
- Deliver `ask_user` answers through the local reply queue first, then the coordinator; close orphan `waiting_input` turns so they stop blocking `start_turn`.
- Keep the chat WebSocket runner while a pending card is still waiting, and after a refused submit expire the pause and send a new message even if streaming still looks true.
- Add pytest and vitest coverage for pause/resume, orphan waiters, and composer unlock (fixes #1359).

## Test plan
- [ ] In the main chat window, trigger `ask_user`, submit the card, and confirm the turn resumes without “reply not delivered”.
- [ ] After a refused submit (or a stale waiter), type a new composer message and confirm it sends instead of locking the session.
- [ ] Reload a session that was stuck on `waiting_input` and confirm a new turn can start.
- [ ] Run `pytest tests/app/test_turn_application_service.py tests/app/test_multiworker_turn_application.py tests/services/session/test_turn_runtime_subscribe.py`
- [ ] Run `vitest` for `web/tests/ask-user-terminal-turn.spec.tsx`, `web/tests/composer-reply-fallthrough.spec.tsx`, and `web/tests/integration/chat-workspace.spec.tsx`


Made with [Cursor](https://cursor.com)