### PR TITLE
fix: render LaTeX in mastery question cards

### DIFF
--- a/web/components/chat/home/MasteryQuestionCard.tsx
+++ b/web/components/chat/home/MasteryQuestionCard.tsx
@@ -21,6 +21,7 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import MarkdownRenderer from "@/components/common/MarkdownRenderer";
 import { useCardSubmission } from "@/hooks/use-card-submission";
 import { REPLY_NOT_DELIVERED } from "@/lib/ask-user-state";
 import { decodeEscapedUnicodeForDisplay } from "@/lib/markdown-display";
@@ -85,9 +86,14 @@ function OptionRow({
         {letter}
       </span>
       {/* The body is the option. It is never printed beside its own letter. */}
-      <span className={"min-w-0 flex-1 text-[13.5px] leading-relaxed " + body}>
-        {decodeEscapedUnicodeForDisplay(option.body)}
-      </span>
+      <div className={"min-w-0 flex-1 text-[13.5px] leading-relaxed " + body}>
+        <MarkdownRenderer
+          content={decodeEscapedUnicodeForDisplay(option.body)}
+          variant="compact"
+          enableMath
+          className="![font:inherit] [&>p]:my-0"
+        />
+      </div>
     </button>
   );
 }
@@ -197,7 +203,12 @@ export const MasteryQuestionCard = memo(function MasteryQuestionCard({
       ) : null}
 
       <div className="mt-0.5 font-serif text-[15.5px] font-semibold leading-relaxed tracking-[-0.01em] text-[var(--foreground)]">
-        {decodeEscapedUnicodeForDisplay(question.prompt)}
+        <MarkdownRenderer
+          content={decodeEscapedUnicodeForDisplay(question.prompt)}
+          variant="compact"
+          enableMath
+          className="![font:inherit] [&>p]:my-0"
+        />
       </div>
 
       {hasChoices ? (
@@ -269,7 +280,12 @@ export const MasteryQuestionCard = memo(function MasteryQuestionCard({
           </div>
           {grade.explanation ? (
             <div className="mt-1 text-[12.5px] leading-relaxed text-[var(--muted-foreground)]">
-              {decodeEscapedUnicodeForDisplay(grade.explanation)}
+              <MarkdownRenderer
+                content={decodeEscapedUnicodeForDisplay(grade.explanation)}
+                variant="compact"
+                enableMath
+                className="![font:inherit] [&>p]:my-0"
+              />
             </div>
           ) : null}
         </div>

--- a/web/tests/mastery-question-card.spec.tsx
+++ b/web/tests/mastery-question-card.spec.tsx
@@ -1,0 +1,115 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import MasteryQuestionCard from '@/components/chat/home/MasteryQuestionCard'
+import { initI18n } from '@/i18n/init'
+import type { MasteryQuestion } from '@/lib/mastery-question'
+
+initI18n('en')
+
+const question: MasteryQuestion = {
+  questionId: 'limit-question',
+  prompt: String.raw`当 $x\to0$ 时，哪个等价式正确？`,
+  questionType: 'choice',
+  objectiveName: 'Equivalent infinitesimals',
+  difficulty: 'medium',
+  attempt: 1,
+  options: [
+    { label: 'A', body: String.raw`$x-\sin x\sim\dfrac{x^3}{3}$` },
+    { label: 'B', body: String.raw`\(x-\sin x\sim\dfrac{x^3}{6}\)` },
+  ],
+  allowFreeText: true,
+}
+
+describe('mastery question math', () => {
+  it('renders the prompt and option bodies, but submits the stable option label', async () => {
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+    const { container } = render(
+      <MasteryQuestionCard
+        question={question}
+        grade={null}
+        answered={false}
+        submittedAnswer=""
+        onSubmit={onSubmit}
+      />
+    )
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.katex')).toHaveLength(3)
+    })
+    // Read the visible label: jsdom cannot compute names through KaTeX MathML.
+    const option = screen.getByText('B').closest('button')!
+    expect(option.querySelector('.mfrac')).not.toBeNull()
+    expect(container.querySelector('.katex-error')).toBeNull()
+    expect(container).not.toHaveTextContent('$x\\to0$')
+
+    await user.click(option)
+    await user.click(screen.getByText('Submit'))
+    expect(onSubmit).toHaveBeenCalledExactlyOnceWith({
+      text: 'B',
+      answers: [{ questionId: question.questionId, text: 'B' }],
+    })
+  })
+
+  it('renders display math in a stored verdict and keeps answered options locked', async () => {
+    const onSubmit = vi.fn()
+    const { container } = render(
+      <MasteryQuestionCard
+        question={question}
+        grade={{
+          questionId: question.questionId,
+          isCorrect: false,
+          learnerAnswer: 'A',
+          correctLabel: 'B',
+          correctBody: question.options[1].body,
+          explanation: String.raw`由泰勒展开：\[x-\sin x\sim\dfrac{x^3}{6}\]`,
+        }}
+        answered
+        submittedAnswer="A"
+        onSubmit={onSubmit}
+      />
+    )
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.katex')).toHaveLength(4)
+      expect(container.querySelector('.katex-display .mfrac')).not.toBeNull()
+    })
+    expect(screen.getByText('Not quite')).toBeVisible()
+    expect(screen.getByText(/Answer: B/)).toBeVisible()
+    expect(screen.getByText('A').closest('button')).toBeDisabled()
+    expect(screen.getByText('B').closest('button')).toBeDisabled()
+    expect(screen.queryByText('Submit')).toBeNull()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('preserves escaped Unicode and submits a free-text formula verbatim', async () => {
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <MasteryQuestionCard
+        question={{
+          ...question,
+          prompt: String.raw`\u8bf7\u9009\u62e9`,
+          options: [{ label: 'A', body: String.raw`\u666e\u901a\u6587\u672c` }],
+        }}
+        grade={null}
+        answered={false}
+        submittedAnswer=""
+        onSubmit={onSubmit}
+      />
+    )
+
+    expect(await screen.findByText('请选择')).toBeVisible()
+    expect(await screen.findByText('普通文本')).toBeVisible()
+    await user.click(screen.getByRole('button', { name: /Answer in my own words/ }))
+    const answer = String.raw`$\dfrac{x^3}{6}$`
+    await user.paste(answer)
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
+    expect(onSubmit).toHaveBeenCalledExactlyOnceWith({
+      text: answer,
+      answers: [{ questionId: question.questionId, text: answer }],
+    })
+  })
+})


### PR DESCRIPTION
### Description

Mastery Path question cards displayed valid LaTeX as source text in the question stem, option bodies, and grading explanation. For example, `$x-\sin x\sim\dfrac{x^3}{6}$` appeared literally instead of as a formatted formula, even though adjacent chat prose rendered mathematics.

Route those three fields through the existing `MarkdownRenderer` with math enabled, following the approach in #588. That earlier fix covered `QuizViewer`; mastery uses its own `MasteryQuestionCard`.

The renderer inherits the card typography and keeps compact paragraph spacing. Existing Unicode decoding and option-label grading remain intact. No dependencies or backend contracts change.

Three rendered regression tests use the actual Markdown/KaTeX pipeline and cover:

- inline math in the prompt and options, including `\(...\)` delimiters, plus submission of the stable option label;
- display math in a saved grading explanation and disabled answered options;
- escaped Unicode text and verbatim free-text formula submission.

### Related Issues

- Closes #1364
- Related to #587 and #588

### Module(s) Affected

- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Verification

- Regression before the fix: both math-rendering cases fail with zero KaTeX elements; the Unicode/free-text case passes.
- `npm run test:unit -- tests/mastery-question-card.spec.tsx tests/markdown-math-renderer.spec.tsx`: 5 passed.
- `npm run test:unit`: 52 passed across 22 files.
- Contract generation check, dependency-boundary check, TypeScript check, lint, and i18n checks passed (lint: 0 errors).
- `npm run build`: passed.
- `npm run perf:check`: all route budgets passed, including the mastery route.
- `git diff --check`: passed.

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary). (No new feature or configuration requires a documentation change.)
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

Prepared with automated assistance from a clean worktree based on `dev`. Saved local data and the v1.6.6 frontend bundle were used to diagnose the issue; only a generic math fixture is included in the tests/report. Validation uses real React/KaTeX rendering in jsdom; no manual browser screenshot validation is claimed.
