### PR TITLE
fix(book): isolate LLM scratchpad from generated content

### DIFF
--- a/deeptutor/book/blocks/_llm_writer.py
+++ b/deeptutor/book/blocks/_llm_writer.py
@@ -139,6 +139,7 @@ async def llm_json(
     temperature: float = 0.4,
     language: str | None = None,
     expected_key: str | None = None,
+    reasoning_effort: str | None = None,
 ) -> dict[str, Any]:
     """Run a structured JSON LLM call with robust parsing and one safe retry.
 
@@ -146,8 +147,9 @@ async def llm_json(
     tokens and leave the visible JSON object empty. For structured book blocks
     we first honor the configured reasoning mode, then retry once with low
     reasoning effort if parsing fails or the expected top-level key is missing.
-    ("low" rather than "minimal": local/Qwen models served via vLLM reject
-    "minimal", and "minimal" disables thinking entirely.)
+    When a caller explicitly supplies an effort (book reader-facing blocks use
+    ``"none"``), the same value is used for the retry so it cannot silently
+    re-enable reasoning.
 
     Also strips thinking/reasoning preamble text (common with local models)
     before JSON parsing.
@@ -175,13 +177,14 @@ async def llm_json(
         recovered = parse_json_response(raw, fallback={})
         return _normalize_json_payload(recovered, expected_key=expected_key)
 
-    data = await _once(None)
+    data = await _once(reasoning_effort)
     if _json_has_expected(data, expected_key):
         return data
 
-    retry_data = await _once("low")
+    retry_effort = "low" if reasoning_effort is None else reasoning_effort
+    retry_data = await _once(retry_effort)
     if _json_has_expected(retry_data, expected_key):
-        retry_data.setdefault("_metadata", {})["reasoning_retry"] = "low"
+        retry_data.setdefault("_metadata", {})["reasoning_retry"] = retry_effort
         return retry_data
     return data or retry_data
 

--- a/deeptutor/book/blocks/callout.py
+++ b/deeptutor/book/blocks/callout.py
@@ -10,7 +10,7 @@ from typing import Any
 from ..models import BlockType, SourceAnchor
 from ._llm_writer import llm_text
 from ._prompts import get_book_prompt, load_book_prompts
-from .base import BlockContext, BlockGenerator
+from .base import BlockContext, BlockGenerator, GenerationFailure
 
 _VARIANT_LABELS = {
     "key_idea": ("Key Idea", "核心要点"),
@@ -50,7 +50,10 @@ class CalloutGenerator(BlockGenerator):
             max_tokens=250,
             temperature=0.5,
             language=ctx.language,
+            reasoning_effort="none",
         )
+        if not body.strip():
+            raise GenerationFailure("LLM returned no visible callout content.")
         return (
             {"variant": variant, "label": label, "body": body},
             [],

--- a/deeptutor/book/blocks/code.py
+++ b/deeptutor/book/blocks/code.py
@@ -86,6 +86,7 @@ class CodeGenerator(BlockGenerator):
             max_tokens=900,
             temperature=0.3,
             language=ctx.language,
+            reasoning_effort="none",
         )
 
         code = str(data.get("code") or "").strip()

--- a/deeptutor/book/blocks/deep_dive.py
+++ b/deeptutor/book/blocks/deep_dive.py
@@ -41,6 +41,7 @@ class DeepDiveGenerator(BlockGenerator):
             temperature=0.4,
             language=ctx.language,
             expected_key="suggestions",
+            reasoning_effort="none",
         )
         suggestions_raw = data.get("suggestions") if isinstance(data, dict) else None
         suggestions: list[dict[str, str]] = []

--- a/deeptutor/book/blocks/flash_cards.py
+++ b/deeptutor/book/blocks/flash_cards.py
@@ -43,6 +43,7 @@ class FlashCardsGenerator(BlockGenerator):
             temperature=0.4,
             language=ctx.language,
             expected_key="cards",
+            reasoning_effort="none",
         )
         cards_raw = data.get("cards") if isinstance(data, dict) else None
         cards: list[dict[str, str]] = []

--- a/deeptutor/book/blocks/section.py
+++ b/deeptutor/book/blocks/section.py
@@ -208,6 +208,7 @@ class SectionGenerator(BlockGenerator):
                 temperature=0.4,
                 language=ctx.language,
                 expected_key="subsections",
+                reasoning_effort="none",
             )
         except Exception as exc:
             logger.warning(f"SectionGenerator outline LLM failed: {exc}")
@@ -307,11 +308,14 @@ class SectionGenerator(BlockGenerator):
                 max_tokens=_subsection_token_budget(target_words),
                 temperature=0.5,
                 language=ctx.language,
+                reasoning_effort="none",
             )
         except Exception as exc:
             logger.warning(f"SectionGenerator subsection LLM failed: {exc}")
-            return f"### {heading}\n\n_(generation failed: {exc})_"
+            raise GenerationFailure("LLM failed to generate visible subsection content.") from exc
         body = body.strip()
+        if not body:
+            raise GenerationFailure("LLM returned no visible subsection content.")
         if not body.startswith("###"):
             body = f"### {heading}\n\n{body}"
         return body

--- a/deeptutor/book/blocks/text.py
+++ b/deeptutor/book/blocks/text.py
@@ -14,7 +14,7 @@ from ..models import BlockType, SourceAnchor
 from ._llm_writer import llm_text
 from ._prompts import get_book_prompt, load_book_prompts
 from ._rag_helpers import optional_rag_lookup
-from .base import BlockContext, BlockGenerator
+from .base import BlockContext, BlockGenerator, GenerationFailure
 
 _NONE_LABEL = {"zh": "(无)", "en": "(none)"}
 
@@ -67,7 +67,10 @@ class TextGenerator(BlockGenerator):
             max_tokens=1400,
             temperature=0.45,
             language=ctx.language,
+            reasoning_effort="none",
         )
+        if not body.strip():
+            raise GenerationFailure("LLM returned no visible text content.")
 
         return (
             {
@@ -106,6 +109,7 @@ async def generate_bridge_text(
         max_tokens=300,
         temperature=0.5,
         language=language,
+        reasoning_effort="none",
     )
     return body.strip()
 

--- a/deeptutor/book/blocks/timeline.py
+++ b/deeptutor/book/blocks/timeline.py
@@ -39,6 +39,7 @@ class TimelineGenerator(BlockGenerator):
             temperature=0.4,
             language=ctx.language,
             expected_key="events",
+            reasoning_effort="none",
         )
         events_raw = data.get("events") if isinstance(data, dict) else None
         events: list[dict[str, str]] = []

--- a/deeptutor/book/prompts/en/callout.yaml
+++ b/deeptutor/book/prompts/en/callout.yaml
@@ -1,7 +1,8 @@
 system: |
   You are the Callout writer for DeepTutor's BookEngine. Produce a single
   short (<=60 words) sticky-note style insight. No JSON, no title, no lists –
-  just the body text.
+  just the polished reader-facing body text. Do not include planning notes,
+  word budgets, draft comments, or self-talk.
 
 user_template: |
   Chapter: {chapter_title}

--- a/deeptutor/book/prompts/en/section.yaml
+++ b/deeptutor/book/prompts/en/section.yaml
@@ -30,7 +30,9 @@ subsection_system: |
   tightly written Markdown subsection that matches the given heading, role,
   and word target. You may use lists, `code`, and $math$. Do not emit any
   H1/H2 headings (start from H3 / ### only); do not repeat the full chapter
-  title; do not wrap output in JSON or code fences.
+  title; do not wrap output in JSON or code fences. Return only polished
+  reader-facing prose; omit planning notes, word budgets, draft comments, and
+  self-talk.
 
 subsection_user: |
   Chapter: {chapter_title}

--- a/deeptutor/book/prompts/en/text.yaml
+++ b/deeptutor/book/prompts/en/text.yaml
@@ -2,7 +2,9 @@ system: |
   You are the Text Block writer of DeepTutor's BookEngine. Produce a compact,
   well-structured Markdown explanation that fits the given chapter slot. You
   may use ###, lists, `code`, and inline math ($...$). Do not repeat the full
-  chapter title and do not output JSON or code-fence wrappers.
+  chapter title and do not output JSON or code-fence wrappers. Return only
+  polished reader-facing prose: do not include planning notes, word budgets,
+  draft comments, or self-talk.
 
 user_template: |
   Chapter: {chapter_title}
@@ -19,7 +21,8 @@ bridge_system: |
   1-2 short Markdown sentences that smoothly carry the reader forward. Use a
   plain, natural tone — like a connecting paragraph inside a textbook
   chapter. No headings, no bullet lists, no code fences, no JSON, and do not
-  repeat the full chapter title.
+  repeat the full chapter title. Return only the polished transition; do not
+  include planning notes, word budgets, draft comments, or self-talk.
 
 bridge_user_template: |
   Chapter: {chapter_title}

--- a/deeptutor/book/prompts/zh/callout.yaml
+++ b/deeptutor/book/prompts/zh/callout.yaml
@@ -1,7 +1,8 @@
 system: |
   你是 DeepTutor BookEngine 的 Callout 写作者。请输出一个简短（≤80 字）、
   清晰、有强烈记忆点的提示，用于 Markdown 卡片展示。不要 JSON、不要标题、
-  不要列表。
+  不要列表。只输出润色后的读者正文，不要输出规划过程、字数预算、草稿备注或
+  自言自语。
 
 user_template: |
   章节：{chapter_title}

--- a/deeptutor/book/prompts/zh/section.yaml
+++ b/deeptutor/book/prompts/zh/section.yaml
@@ -27,7 +27,8 @@ subsection_system: |
   你是 DeepTutor 的 Section Subsection 写作者。请输出一段紧凑、有信息密度的
   Markdown 讲解，符合给定的标题、定位、字数目标。可以使用列表/`代码`/$math$。
   不要再输出任何 H1/H2 标题，只能从 H3 (###) 开始；不要重复整章标题；不要
-  输出 JSON 或代码块包裹。
+  输出 JSON 或代码块包裹。只输出润色后的读者正文，不要输出规划过程、字数预算、
+  草稿备注或自言自语。
 
 subsection_user: |
   所属章节：{chapter_title}

--- a/deeptutor/book/prompts/zh/text.yaml
+++ b/deeptutor/book/prompts/zh/text.yaml
@@ -2,6 +2,7 @@ system: |
   你是 DeepTutor BookEngine 的 Text Block 写作者。请输出一段紧凑、结构清晰的
   Markdown 讲解文本，配合给定的章节信息。可以使用 ###/列表/`代码`/数学公式
   （$...$）。不要重复完整的章节标题，不要输出 JSON 或代码块标记。
+  只输出润色后的读者正文，不要输出规划过程、字数预算、草稿备注或自言自语。
 
 user_template: |
   章节：{chapter_title}
@@ -16,7 +17,8 @@ bridge_system: |
   你是 DeepTutor BookEngine 的过渡句写作者。请基于上一段内容与下一段提示，
   写 1-2 句简短自然的过渡 Markdown，用于把读者从前一块内容平滑引导到下一块。
   语气朴素自然，就像教科书里章节内的衔接段落。不要写小标题，不要使用列表/
-  代码块/JSON，不要重复整章标题。
+  代码块/JSON，不要重复整章标题。只输出润色后的过渡句，不要输出规划过程、
+  字数预算、草稿备注或自言自语。
 
 bridge_user_template: |
   章节：{chapter_title}

--- a/deeptutor/services/llm/factory.py
+++ b/deeptutor/services/llm/factory.py
@@ -398,6 +398,12 @@ async def _complete_with_resolved_config(
         raise map_error(
             RuntimeError(response.content or "LLM request failed"), provider=config.provider_name
         )
+    # Provider adapters keep hidden reasoning in ``reasoning_content``.  A
+    # few gateways duplicate that field into ``content`` when no visible
+    # answer is present; never let that duplicate become user-facing text.
+    if response.content and response.reasoning_content:
+        if response.content == response.reasoning_content:
+            return ""
     return response.content or ""
 
 

--- a/deeptutor/services/llm/provider_core/openai_compat_provider.py
+++ b/deeptutor/services/llm/provider_core/openai_compat_provider.py
@@ -816,8 +816,6 @@ class OpenAICompatProvider(LLMProvider):
                     finish_reason = ch.finish_reason
             if not content and m.content:
                 content = m.content
-            if not content and getattr(m, "reasoning", None):
-                content = m.reasoning
 
         tool_calls = []
         for tc in raw_tool_calls:
@@ -839,6 +837,12 @@ class OpenAICompatProvider(LLMProvider):
         reasoning_content = getattr(msg, "reasoning_content", None) or None
         if not reasoning_content and getattr(msg, "reasoning", None):
             reasoning_content = msg.reasoning
+
+        # ``reasoning`` is a private trace on gateways such as OpenRouter.  It
+        # must never be promoted to visible content when the provider omits a
+        # final answer (the old fallback here leaked untagged scratchpads).
+        if content and reasoning_content and content == reasoning_content:
+            content = None
 
         usage = self._extract_usage(response)
 

--- a/deeptutor/services/llm/reasoning_params.py
+++ b/deeptutor/services/llm/reasoning_params.py
@@ -9,6 +9,11 @@ _THINKING_STYLE_MAP = {
     "enable_thinking": lambda enabled: {"enable_thinking": enabled},
     "reasoning_split": lambda enabled: {"reasoning_split": enabled},
 }
+# These values are used by callers that need a guaranteed reader-facing
+# response.  ``minimal``/``minimum`` are retained as off sentinels for
+# provider-native thinking controls for backwards compatibility; OpenRouter
+# receives the canonical ``none`` value below.
+_THINKING_OFF_EFFORTS = frozenset({"none", "minimal", "minimum"})
 _PROVIDER_THINKING_STYLES = {
     "deepseek": "thinking_type",
     "volcengine": "thinking_type",
@@ -153,15 +158,30 @@ def build_openai_compatible_reasoning_kwargs(
             semantic_effort = "minimal"
 
     kwargs: dict[str, Any] = {}
+    # OpenRouter exposes a provider-neutral reasoning object.  Keep the
+    # explicit off request and exclude any reasoning trace from the response;
+    # this is important for models whose gateway response otherwise uses the
+    # ``reasoning`` field alongside ``content``.
+    if provider_name == "openrouter" and semantic_effort == "none":
+        kwargs["extra_body"] = {
+            "reasoning": {"effort": "none", "exclude": True},
+        }
     if resolved_effort:
         suppress_top_level = bool(
-            thinking_style and (semantic_effort == "minimal" or thinking_style == "enable_thinking")
+            thinking_style
+            and (semantic_effort in _THINKING_OFF_EFFORTS or thinking_style == "enable_thinking")
         )
-        if not suppress_top_level:
+        if not suppress_top_level and not (
+            provider_name == "openrouter" and semantic_effort == "none"
+        ):
             kwargs["reasoning_effort"] = resolved_effort
 
-    if thinking_style and resolved_effort is not None:
-        thinking_enabled = semantic_effort != "minimal"
+    if (
+        thinking_style
+        and resolved_effort is not None
+        and not (provider_name == "openrouter" and semantic_effort == "none")
+    ):
+        thinking_enabled = semantic_effort not in _THINKING_OFF_EFFORTS
         extra = _THINKING_STYLE_MAP.get(thinking_style, lambda _enabled: None)(thinking_enabled)
         if extra:
             kwargs.setdefault("extra_body", {}).update(extra)

--- a/tests/book/test_llm_writer.py
+++ b/tests/book/test_llm_writer.py
@@ -60,3 +60,30 @@ async def test_llm_json_retries_structured_calls_with_low_reasoning(
     assert calls == [None, "low"]
     assert data["events"][0]["title"] == "Ready"
     assert data["_metadata"]["reasoning_retry"] == "low"
+
+
+@pytest.mark.asyncio
+async def test_llm_json_reader_facing_retry_keeps_reasoning_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str | None] = []
+
+    async def fake_llm_text(**kwargs: object) -> str:
+        effort = kwargs.get("reasoning_effort")
+        calls.append(effort if isinstance(effort, str) else None)
+        if len(calls) == 1:
+            return ""
+        return '{"events": [{"date": "2026", "title": "Ready"}]}'
+
+    monkeypatch.setattr(_llm_writer, "llm_text", fake_llm_text)
+
+    data = await _llm_writer.llm_json(
+        user_prompt="timeline",
+        system_prompt="system",
+        expected_key="events",
+        reasoning_effort="none",
+    )
+
+    assert calls == ["none", "none"]
+    assert data["events"][0]["title"] == "Ready"
+    assert data["_metadata"]["reasoning_retry"] == "none"

--- a/tests/book/test_reader_content_isolation.py
+++ b/tests/book/test_reader_content_isolation.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from deeptutor.book.blocks import text as text_block
+from deeptutor.book.blocks.base import BlockContext
+from deeptutor.book.models import Block, BlockStatus, BlockType, Chapter, Page
+
+
+def _text_context() -> BlockContext:
+    chapter = Chapter(id="ch-isolation", title="Mechanics", summary="Stress and strain")
+    block = Block(type=BlockType.TEXT, params={"role": "explanation"})
+    return BlockContext(
+        book_id="book-isolation",
+        chapter=chapter,
+        page=Page(id="page-isolation", book_id="book-isolation", chapter_id=chapter.id),
+        block=block,
+        rag_enabled=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_text_block_persists_only_visible_reader_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    async def fake_llm_text(**kwargs: object) -> str:
+        calls.append(kwargs)
+        return "Polished reader paragraph."
+
+    monkeypatch.setattr(text_block, "llm_text", fake_llm_text)
+    ctx = _text_context()
+
+    result = await text_block.TextGenerator().generate(ctx)
+
+    assert result.status == BlockStatus.READY
+    assert result.payload["body"] == "Polished reader paragraph."
+    assert calls[0]["reasoning_effort"] == "none"
+
+
+@pytest.mark.asyncio
+async def test_text_block_does_not_mark_reasoning_only_response_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_llm_text(**_kwargs: object) -> str:
+        # Provider separation turns a reasoning-only response into empty
+        # visible content; the block must not persist an empty READY payload.
+        return ""
+
+    monkeypatch.setattr(text_block, "llm_text", fake_llm_text)
+    ctx = _text_context()
+
+    result = await text_block.TextGenerator().generate(ctx)
+
+    assert result.status == BlockStatus.ERROR
+    assert result.payload == {}
+    assert "no visible text" in result.error
+    assert result.metadata["failure"]["retryable"] is True

--- a/tests/services/llm/test_factory_provider_exec.py
+++ b/tests/services/llm/test_factory_provider_exec.py
@@ -221,6 +221,25 @@ async def test_stream_does_not_replay_reasoning_as_final_content(monkeypatch) ->
 
 
 @pytest.mark.asyncio
+async def test_complete_does_not_return_duplicated_reasoning_as_content(monkeypatch) -> None:
+    cfg = _make_cfg()
+    provider = _FakeProvider(
+        complete_response=LLMResponse(
+            content="Let me draft ~320 words.",
+            reasoning_content="Let me draft ~320 words.",
+        )
+    )
+
+    monkeypatch.setattr("deeptutor.services.llm.factory.get_llm_config", lambda: cfg)
+    monkeypatch.setattr(
+        "deeptutor.services.llm.factory.get_runtime_provider",
+        lambda _config: provider,
+    )
+
+    assert await complete("hello") == ""
+
+
+@pytest.mark.asyncio
 async def test_complete_injects_openai_image_parts(monkeypatch) -> None:
     cfg = _make_cfg(model="gpt-4o-mini", binding="openai", provider_name="openai")
     provider = _FakeProvider()

--- a/tests/services/llm/test_openai_compat_reasoning_content.py
+++ b/tests/services/llm/test_openai_compat_reasoning_content.py
@@ -36,6 +36,19 @@ def _reasoning_only_chunk():
     )
 
 
+def _response_with_reasoning_alias(alias: str):
+    message = SimpleNamespace(
+        content=None,
+        reasoning_content=None,
+        reasoning=None,
+        tool_calls=None,
+    )
+    setattr(message, alias, "Let me draft ~320 words.\nWord budget matters.")
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+    )
+
+
 @pytest.mark.parametrize(
     "provider_cls",
     [ServicesOpenAICompatProvider],
@@ -47,6 +60,48 @@ def test_parse_keeps_reasoning_content_out_of_visible_content(provider_cls) -> N
 
     assert response.content is None
     assert response.reasoning_content == "internal reasoning"
+
+
+@pytest.mark.parametrize("alias", ["reasoning", "reasoning_content"])
+def test_parse_never_promotes_untagged_reasoning_to_content(alias: str) -> None:
+    provider = ServicesOpenAICompatProvider.__new__(ServicesOpenAICompatProvider)
+
+    response = provider._parse(_response_with_reasoning_alias(alias))
+
+    assert response.content is None
+    assert response.reasoning_content == "Let me draft ~320 words.\nWord budget matters."
+
+
+def test_parse_keeps_visible_content_separate_from_reasoning() -> None:
+    provider = ServicesOpenAICompatProvider.__new__(ServicesOpenAICompatProvider)
+    message = SimpleNamespace(
+        content="Polished reader paragraph.",
+        reasoning="Let me draft ~320 words.",
+        reasoning_content=None,
+        tool_calls=None,
+    )
+    response = provider._parse(
+        SimpleNamespace(choices=[SimpleNamespace(message=message, finish_reason="stop")])
+    )
+
+    assert response.content == "Polished reader paragraph."
+    assert response.reasoning_content == "Let me draft ~320 words."
+
+
+def test_parse_drops_content_when_gateway_duplicates_reasoning() -> None:
+    provider = ServicesOpenAICompatProvider.__new__(ServicesOpenAICompatProvider)
+    message = SimpleNamespace(
+        content="Let me draft ~320 words.",
+        reasoning="Let me draft ~320 words.",
+        reasoning_content=None,
+        tool_calls=None,
+    )
+    response = provider._parse(
+        SimpleNamespace(choices=[SimpleNamespace(message=message, finish_reason="stop")])
+    )
+
+    assert response.content is None
+    assert response.reasoning_content == "Let me draft ~320 words."
 
 
 @pytest.mark.parametrize(
@@ -85,6 +140,36 @@ def test_services_provider_minimal_reasoning_uses_extra_body_only() -> None:
 
     assert "reasoning_effort" not in kwargs
     assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
+
+
+def test_openrouter_none_reasoning_is_excluded_from_response() -> None:
+    kwargs = _build_services_kwargs(
+        "openrouter",
+        "none",
+        model="z-ai/glm-4.5-air",
+    )
+
+    assert "reasoning_effort" not in kwargs
+    assert kwargs["extra_body"] == {
+        "reasoning": {"effort": "none", "exclude": True},
+    }
+
+    qwen_kwargs = _build_services_kwargs("openrouter", "none", model="qwen/qwen3-30b-a3b")
+    assert qwen_kwargs["extra_body"] == {
+        "reasoning": {"effort": "none", "exclude": True},
+    }
+
+
+@pytest.mark.parametrize("provider", ["deepseek", "dashscope"])
+@pytest.mark.parametrize("effort", ["none", "minimal", "minimum"])
+def test_provider_native_off_reasoning_disables_thinking(provider: str, effort: str) -> None:
+    kwargs = _build_services_kwargs(provider, effort)
+
+    assert "reasoning_effort" not in kwargs
+    if provider == "deepseek":
+        assert kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
+    else:
+        assert kwargs["extra_body"] == {"enable_thinking": False}
 
 
 @pytest.mark.parametrize("binding", ["deepseek", "openai"])


### PR DESCRIPTION
## Summary

Fixes book generation leaking LLM scratchpad/planning text into reader-facing chapter content (Issue #1352).

## Changes

- Disable reasoning explicitly for reader-facing Book block generation and preserve that setting across structured-output retries.
- Keep OpenRouter/provider reasoning fields separate from visible `content`; exclude reasoning traces from OpenRouter responses.
- Treat empty visible text as a retryable block failure instead of persisting placeholders.
- Add English/Chinese prompt guardrails and regression tests for untagged scratchpad output.

## Validation

- `.venv/bin/python -m pytest -q tests/book tests/services/llm` (535 passed)
- `.venv/bin/python -m compileall -q deeptutor/book/blocks deeptutor/services/llm tests/book tests/services/llm`
- `git diff --check`

Closes #1352