### PR TITLE
fix(turns): recover replies after waiter queue loss

### DIFF
--- a/deeptutor/services/session/turns/lifecycle.py
+++ b/deeptutor/services/session/turns/lifecycle.py
@@ -252,6 +252,7 @@ class TurnLifecycle:
                         )
                         if not delivered:
                             turn = await self.store.get_turn(execution.turn_id)
+                            persisted_status = str((turn or {}).get("status") or "")
                             logger.warning(
                                 "submit_user_reply command %s for turn %s was "
                                 "accepted (lease owner=%s) but not delivered: no "
@@ -259,8 +260,19 @@ class TurnLifecycle:
                                 command.command_id,
                                 execution.turn_id,
                                 lease.owner_id,
-                                turn.get("status") if turn else "unknown",
+                                persisted_status or "unknown",
                             )
+                            if persisted_status == "waiting_input":
+                                # The owner lease is alive, but the execution
+                                # that owned the ask_user waiter is not. A
+                                # queued command can never reach a queue that
+                                # no longer exists, so the false-positive ACK
+                                # must be followed by a terminal stream; the
+                                # cancellation path persists error+done and
+                                # frees the session for the next turn.
+                                if execution.task is not None and not execution.task.done():
+                                    execution.task.cancel()
+                                return
                     elif command.kind == "user_input":
                         from deeptutor.runtime.stream_bus import get_bus
 

--- a/tests/app/test_multiworker_turn_reply_after_queue_drop.py
+++ b/tests/app/test_multiworker_turn_reply_after_queue_drop.py
@@ -47,11 +47,20 @@ def _payload() -> dict:
     }
 
 
+@pytest.fixture(autouse=True)
+def _workspace_root(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Keep the runtime workspace binding local to the test process."""
+    root = tmp_path / "workspace"
+    root.mkdir()
+    monkeypatch.setenv("DEEPTUTOR_WORKSPACE_ROOT", str(root))
+    monkeypatch.delenv("DEEPTUTOR_WORKSPACE_ALLOWED_ROOTS", raising=False)
+
+
 @pytest.mark.asyncio
 async def test_reply_accepted_after_local_queue_dropped_is_never_delivered(
     monkeypatch, tmp_path, caplog
 ) -> None:
-    """A reply that outlives its turn's local waiter is ACKed but never delivered."""
+    """A reply that outlives its waiter terminalizes instead of locking the turn."""
     waiting = asyncio.Event()
 
     class Engine:
@@ -104,15 +113,25 @@ async def test_reply_accepted_after_local_queue_dropped_is_never_delivered(
 
     with caplog.at_level(logging.WARNING):
         accepted = await app_b.submit_user_reply(turn["id"], "yes", command_id="late-reply-from-b")
-        assert accepted is True  # the false-positive ACK
+        assert accepted is True  # ownership was proven before the waiter vanished.
 
-        # Give worker A's coordination loop a few polls to consume the command.
-        for _ in range(20):
-            await asyncio.sleep(0.05)
-
-    persisted = await store_b.get_turn(turn["id"])
+    # Worker A's coordination loop cancels the execution. Its cancellation
+    # path publishes the terminal pair and allows the session to start again.
+    for _ in range(100):
+        persisted = await store_b.get_turn(turn["id"])
+        if persisted["status"] in {"completed", "failed", "cancelled"}:
+            break
+        await asyncio.sleep(0.02)
     assert persisted is not None
-    assert persisted["status"] == "waiting_input"  # stuck forever, exactly as reported
+    assert persisted["status"] == "cancelled"
+
+    events = await store_b.get_turn_events(turn["id"])
+    event_types = [event["type"] for event in events]
+    assert "error" in event_types
+    assert event_types[-1] == "done"
+
+    _fresh_session, following = await app_b.start_turn(_payload())
+    assert following["id"] != turn["id"]
 
     warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
     assert any("late-reply-from-b" in r.getMessage() for r in warnings), (


### PR DESCRIPTION
## Summary

Closes #1359.

While #1361 (merged) reaps a zombie turn whose lease is gone, one coordination race remained: the owner lease is still live, but the in-memory `ask_user` reply queue has been removed. `TurnApplicationService.submit_user_reply` must accept the reply to route it to the owner, then the owner discovers there is no waiter and previously only logged a warning. The durable turn stayed `waiting_input` and kept the session locked.

This changes the owner coordination loop to cancel that execution after logging the undelivered command. The existing cancellation path then publishes a terminal `error` + `done` stream, persists the terminal transition, and lets the learner send the next turn immediately.

Thanks @KryptonGao for the focused diagnosis and implementation in #1363, and thanks @ZQR1101 for the complementary recovery work merged in #1361. This preserves the narrow boundary called out by reviewers in #1363 and does not reintroduce the broader local-queue ACK change.

## Testing

- `python -m pytest -q tests/app/test_multiworker_turn_application.py tests/app/test_multiworker_turn_reply_after_queue_drop.py tests/app/test_waiting_turn_recovery.py tests/app/test_turn_parked_on_ask_user_is_reclaimable.py tests/services/session/test_turn_runtime.py tests/services/session/test_turn_runtime_subscribe.py` — 87 passed.
- `ruff check .` — passed.
- `ruff format --check .` — passed.
- The queue-drop regression now asserts the terminal event pair and confirms a following turn can start.