### PR TITLE
feat(sidebar): collapse fixed multi-user sections (#1230)

### DIFF
--- a/web/components/sidebar/SidebarNav.tsx
+++ b/web/components/sidebar/SidebarNav.tsx
@@ -38,10 +38,12 @@ import { useTranslation } from "react-i18next";
 
 import { useCapabilityAccess } from "@/components/access/CapabilityAccessContext";
 import {
+  MULTI_USER_DEFAULT_COLLAPSED_NAV_HREFS,
   NAV_BY_HREF,
   PRIMARY_NAV_HREFS,
   isNavActive,
 } from "@/components/sidebar/nav-entries";
+import { useAuthStatus } from "@/hooks/useAuthStatus";
 import { Tooltip } from "@/components/ui/Tooltip";
 import { useDragSort, type DragSort } from "@/hooks/useDragSort";
 import { placeMenu, type FloatingMenuPosition } from "@/lib/floating-menu";
@@ -87,6 +89,7 @@ export function SidebarNav({
   const pathname = usePathname();
   const { t } = useTranslation();
   const { has } = useCapabilityAccess();
+  const { enabled: multiUserMode } = useAuthStatus();
 
   const [layout, setLayout] = useState<SidebarNavLayout>(DEFAULT_NAV_LAYOUT);
   const [moreExpanded, setMoreExpanded] = useState(false);
@@ -95,14 +98,36 @@ export function SidebarNav({
   const menuRootRef = useRef<HTMLDivElement>(null);
   const menuAnchorRef = useRef<HTMLElement | null>(null);
 
+  const applyLayout = useCallback((next: SidebarNavLayout) => {
+    setLayout(next);
+    writeNavLayout(next);
+  }, []);
+
   // Hydrate after first paint so the server and the client agree on the
   // shipped order, then settle into this machine's arrangement.
   useEffect(() => {
     if (typeof window === "undefined") return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setLayout(readNavLayout());
+    const stored = readNavLayout();
+    if (
+      multiUserMode &&
+      stored.order.length === 0 &&
+      stored.collapsed.length === 0
+    ) {
+      const initial: SidebarNavLayout = {
+        order: [...PRIMARY_NAV_HREFS],
+        collapsed: [...MULTI_USER_DEFAULT_COLLAPSED_NAV_HREFS],
+      };
+      writeNavLayout(initial);
+      // The storage read is one-shot hydration, not a stream of external updates.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setLayout(initial);
+    } else {
+      setLayout(stored);
+    }
     setMoreExpanded(browserStorage.readRaw("local", MORE_EXPANDED_KEY) === "1");
-  }, []);
+    // Re-run only when auth resolves/changes so a first multi-user visitor can
+    // adopt the folded default without overwriting an existing arrangement.
+  }, [multiUserMode]);
 
   const resolved = useMemo(
     () => resolveNavLayout(PRIMARY_NAV_HREFS, layout),
@@ -113,11 +138,6 @@ export function SidebarNav({
     () => ({ order: resolved.order, collapsed: resolved.collapsed }),
     [resolved],
   );
-
-  const applyLayout = useCallback((next: SidebarNavLayout) => {
-    setLayout(next);
-    writeNavLayout(next);
-  }, []);
 
   const showMore = useCallback((next: boolean) => {
     setMoreExpanded(next);

--- a/web/components/sidebar/nav-entries.ts
+++ b/web/components/sidebar/nav-entries.ts
@@ -94,33 +94,37 @@ export const PRIMARY_NAV: NavEntry[] = [
     icon: LayoutGrid,
     tooltipKey: "Space tooltip",
   },
-];
-
-/** Consoles that sit under the chat history. Not arrangeable: Settings has to
- *  stay findable, and a console nobody folds away is one less thing to explain. */
-export const SECONDARY_NAV: NavEntry[] = [
   {
-    // Memory is its own top-level console (pulled out of the Learning Space):
-    // a place to inspect and curate the tutor's long-term memory, not a daily
-    // workspace. Never gated — memory has no per-user model requirement.
+    // Memory and Knowledge Center are consoles rather than daily workspaces.
+    // They ship visible, but a multi-user deployment can fold them into More
+    // immediately to leave more room for the conversation list.
     href: "/memory",
     label: "Memory",
     icon: Brain,
     tooltipKey: "Memory tooltip",
   },
   {
-    // Knowledge Center sits just above Settings: it's a console for managing
-    // KBs and retrieval engines, not a daily workspace. Never gated — embedding
-    // / search are shared admin infrastructure, no per-user model grant needed.
     href: "/knowledge-bases",
     label: "Knowledge Center",
     icon: BookOpen,
     tooltipKey: "Knowledge tooltip",
   },
+];
+
+/** Consoles that sit under the chat history. Not arrangeable: Settings has to
+ *  stay findable, and a console nobody folds away is one less thing to explain. */
+export const SECONDARY_NAV: NavEntry[] = [
   { href: "/settings", label: "Settings", icon: Settings },
 ];
 
 export const PRIMARY_NAV_HREFS = PRIMARY_NAV.map((entry) => entry.href);
+
+/** Fixed consoles that may default into More when auth creates the crowded
+ *  multi-user shell, while Settings stays discoverable below the history. */
+export const MULTI_USER_DEFAULT_COLLAPSED_NAV_HREFS = [
+  "/memory",
+  "/knowledge-bases",
+] as const;
 
 export const NAV_BY_HREF = new Map(
   [...PRIMARY_NAV, ...SECONDARY_NAV].map((entry) => [entry.href, entry]),

--- a/web/tests/sidebar-lazy-history.spec.tsx
+++ b/web/tests/sidebar-lazy-history.spec.tsx
@@ -18,6 +18,9 @@ vi.mock("@/context/AppShellContext", () => ({
 vi.mock("@/components/layout/AppShell", () => ({
   useSidebarDrawer: () => ({ close: fixture.close }),
 }));
+vi.mock("@/hooks/useAuthStatus", () => ({
+  useAuthStatus: () => ({ enabled: false }),
+}));
 vi.mock("@/hooks/useDevice", () => ({
   useDevice: () => ({ isMobile: false }),
 }));

--- a/web/tests/sidebar-multiuser-collapse.spec.tsx
+++ b/web/tests/sidebar-multiuser-collapse.spec.tsx
@@ -1,0 +1,57 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, expect, it, vi } from "vitest";
+import { SidebarNav } from "@/components/sidebar/SidebarNav";
+
+const fixture = vi.hoisted(() => ({ multiUserMode: true }));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/chat",
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@/hooks/useAuthStatus", () => ({
+  useAuthStatus: () => ({ enabled: fixture.multiUserMode }),
+}));
+
+beforeEach(() => {
+  localStorage.clear();
+  fixture.multiUserMode = true;
+});
+
+it("folds the fixed consoles into More for a first multi-user visitor", async () => {
+  render(
+    <SidebarNav collapsed={false} onHomeClick={vi.fn()} onNavigate={vi.fn()} />,
+  );
+
+  await act(async () => {});
+
+  const more = screen.getByRole("button", { name: /^More/ });
+  expect(more).toHaveAttribute("aria-expanded", "false");
+  expect(more).toHaveTextContent("2");
+
+  fireEvent.click(more);
+
+  expect(more).toHaveAttribute("aria-expanded", "true");
+  expect(screen.getByRole("link", { name: "Memory" })).toHaveAttribute(
+    "href",
+    "/memory",
+  );
+  expect(
+    screen.getByRole("link", { name: "Knowledge Center" }),
+  ).toHaveAttribute("href", "/knowledge-bases");
+});
+
+it("keeps the consoles visible in the single-user shell", () => {
+  fixture.multiUserMode = false;
+
+  render(
+    <SidebarNav collapsed={false} onHomeClick={vi.fn()} onNavigate={vi.fn()} />,
+  );
+
+  expect(screen.getByRole("link", { name: "Memory" })).toHaveAttribute(
+    "href",
+    "/memory",
+  );
+  expect(screen.queryByRole("button", { name: "More" })).not.toBeInTheDocument();
+});

--- a/web/tests/sidebar-nav-groups.test.ts
+++ b/web/tests/sidebar-nav-groups.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  MULTI_USER_DEFAULT_COLLAPSED_NAV_HREFS,
+  PRIMARY_NAV,
+  SECONDARY_NAV,
+} from "../components/sidebar/nav-entries";
+
+test("selected fixed consoles can fold while Settings stays fixed", () => {
+  assert.deepEqual(MULTI_USER_DEFAULT_COLLAPSED_NAV_HREFS, [
+    "/memory",
+    "/knowledge-bases",
+  ]);
+  assert.deepEqual(
+    PRIMARY_NAV.map((entry) => entry.href),
+    [
+      "/chat",
+      "/partners",
+      "/agents",
+      "/co-writer",
+      "/books",
+      "/mastery",
+      "/reading",
+      "/space",
+      "/memory",
+      "/knowledge-bases",
+    ],
+  );
+  assert.deepEqual(
+    SECONDARY_NAV.map((entry) => entry.href),
+    ["/settings"],
+  );
+});


### PR DESCRIPTION
## Summary

Addresses the sidebar-layout half of #1230. The account-migration half is intentionally left for a separate, security-sensitive change.

- Move Memory and Knowledge Center into the existing arrangeable primary navigation so users can fold them into "More"; Settings remains fixed for discoverability.
- When auth is enabled, first-run visitors get these two consoles folded by default, preserving more room for the conversation list in multi-user deployments.
- Preserve any existing sidebar arrangement; only an empty layout adopts the multi-user default.

## Duplicate-work preflight

- Issue #1230 has no upstream PR associated in its timeline.
- PR searches for the issue, "collapsible sidebar", and "multi-user mode" found no overlapping upstream implementation.
- The timeline references an unrelated external workspace-isolation fix for the account half of the issue.

## Verification

- `npm run check:fast` — PASS
- `npm run build` — PASS (after allowing Google Fonts network access; the initial sandboxed build was blocked by restricted DNS)
- Focused sidebar tests — PASS
