### PR TITLE
fix(users): derive learner preset from active policy

### DIFF
--- a/deeptutor/api/routers/auth.py
+++ b/deeptutor/api/routers/auth.py
@@ -517,6 +517,11 @@ async def auth_status(
             payload.user_id,
             is_admin=payload.role == "admin",
         )
+        # Guardians may attach a policy to a standard or custom account. That
+        # policy, not the stored label, is what the runtime must enforce and
+        # what clients need to render the scoped experience.
+        if learning_policy is not None and preset != "learner":
+            preset = "learner"
     return AuthStatusResponse(
         enabled=True,
         authenticated=payload is not None,

--- a/tests/multi_user/test_account_presets.py
+++ b/tests/multi_user/test_account_presets.py
@@ -196,6 +196,60 @@ def test_auth_status_returns_the_effective_learning_policy(preset_client):
     assert response.json()["learning_policy"]["default_capability"] == ("immersive_reading")
 
 
+@pytest.mark.parametrize("preset", ["standard", "custom"])
+def test_auth_status_derives_learner_from_an_active_policy(preset_client, preset):
+    from deeptutor.services.auth import TokenPayload
+
+    client, _admin, tokens = preset_client
+    username = f"policy-{preset}"
+    created = client.post(
+        "/api/auth/users",
+        headers={"Authorization": "Bearer admin-token"},
+        json={
+            "username": username,
+            "password": "reading-password-1",
+            "preset": preset,
+        },
+    ).json()
+    tokens["learner-token"] = TokenPayload(
+        username=username, role="user", user_id=created["user_id"]
+    )
+    response = client.put(
+        f"/api/multi-user/users/{created['user_id']}/grants",
+        headers={"Authorization": "Bearer admin-token"},
+        json={
+            "grant": {
+                "enabled_tools": [],
+                "mcp_tools": [],
+                "cli_apps": [],
+                "exec_enabled": False,
+                "learning_policy": {
+                    "age_band": "9-12",
+                    "locked_persona": "teacher",
+                    "allowed_capabilities": ["chat", "immersive_reading"],
+                    "default_capability": "immersive_reading",
+                    "allowed_surfaces": ["chat", "reading"],
+                    "reading": {
+                        "allow_upload": False,
+                        "material_ids": [],
+                        "extensions": [],
+                    },
+                },
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    status = client.get(
+        "/api/auth/status",
+        headers={"Authorization": "Bearer learner-token"},
+    )
+
+    assert status.status_code == 200
+    assert status.json()["preset"] == "learner"
+    assert status.json()["learning_policy"]["default_capability"] == "immersive_reading"
+
+
 def test_assigning_a_material_copies_the_admin_material_once(
     preset_client, as_user, seed_user, tmp_path
 ):


### PR DESCRIPTION
## Summary
- Treat an account as a learner in `/api/auth/status` when a server-enforced `learning_policy` is active, even if the stored account label is `standard` or `custom`.
- Keep the stored account preset unchanged; this only publishes the effective runtime identity to clients.
- Prevent admin-created standard/custom accounts with guardian-assigned policies from loading the unscoped shell and hitting mixed 403s.

This is a focused slice of #1222. It intentionally does not expand API surface permissions or close the broader tracking issue.

## Testing
- [x] `DEEPTUTOR_HOME=/Users/Shared/DeepTutor .venv/bin/pytest -q tests/multi_user/test_account_presets.py tests/multi_user/test_learning_policy.py tests/multi_user/test_learning_policy_http.py` — 22 passed
- [x] `DEEPTUTOR_HOME=/Users/Shared/DeepTutor .venv/bin/pytest -q tests/multi_user` — 189 passed
- [x] `ruff check` and `ruff format --check` on touched files
- [x] `git diff --check`
- [x] Diff audit: only `deeptutor/api/routers/auth.py` and `tests/multi_user/test_account_presets.py` changed