### PR TITLE
feat(reading): add provider-aware media ingestion

### DIFF
--- a/deeptutor/reading/ingestion.py
+++ b/deeptutor/reading/ingestion.py
@@ -794,47 +794,14 @@ def build_transcript_segments(cues: Sequence[TranscriptSegment]) -> list[Transcr
 async def _load_youtube_captions(
     url: str, languages: Sequence[str]
 ) -> tuple[str, str, list[TranscriptSegment]]:
-    video_id = youtube_video_id(url)
-    if not video_id:
-        raise ReadingError("invalid YouTube URL")
+    from deeptutor.video_learning.service import resolve_youtube_captions
 
-    def fetch_rows() -> list[Any]:
-        try:
-            from youtube_transcript_api import YouTubeTranscriptApi
-        except ImportError:
-            # Native playback is independent from transcript extraction.  A
-            # lean CLI/server install may omit this optional dependency; treat
-            # that exactly like a video with no public captions so the material
-            # still opens and the UI explains the grounding limitation.
-            return []
-        api = YouTubeTranscriptApi()
-        try:
-            if hasattr(api, "fetch"):
-                return list(api.fetch(video_id, languages=list(languages)))
-            return list(YouTubeTranscriptApi.get_transcript(video_id, languages=list(languages)))
-        except Exception:
-            # Captions can be disabled, unavailable in the preferred language,
-            # region-blocked, or temporarily rejected by YouTube. None of those
-            # should turn a valid native player into a failed reading source.
-            return []
-
-    rows = await asyncio.to_thread(fetch_rows)
-    segments = build_transcript_segments(normalize_transcript_segments(rows))
-
-    title = "YouTube video"
-    try:
-        import httpx
-
-        async with httpx.AsyncClient(timeout=8) as client:
-            response = await client.get(
-                "https://www.youtube.com/oembed",
-                params={"url": f"https://www.youtube.com/watch?v={video_id}", "format": "json"},
-            )
-            if response.is_success:
-                title = str(response.json().get("title") or title)
-    except Exception:
-        pass
-    cover = f"https://i.ytimg.com/vi/{video_id}/hqdefault.jpg"
+    resolution = await resolve_youtube_captions(url, list(languages))
+    metadata = resolution.metadata
+    video_id = parse_youtube_url(url).video_id
+    segments = build_transcript_segments(normalize_transcript_segments(resolution.cues))
+    title = str(metadata.get("title") or "YouTube video")
+    cover = str(metadata.get("thumbnail_url") or f"https://i.ytimg.com/vi/{video_id}/hqdefault.jpg")
     return title, cover, segments
 
 

--- a/deeptutor/video_learning/service.py
+++ b/deeptutor/video_learning/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -360,8 +361,14 @@ def material_id_for(video_id: str) -> str:
     return hashlib.sha256(f"youtube-resolve-{video_id}".encode()).hexdigest()[:32]
 
 
+def _language_preferences(language: str | Sequence[str]) -> list[str]:
+    if isinstance(language, str):
+        return [language] if language else ["zh-CN", "zh-Hans", "zh", "en"]
+    return [value for value in (str(row).strip() for row in language) if value]
+
+
 async def _youtube_transcript(
-    video_id: str, language: str
+    video_id: str, language: str | Sequence[str]
 ) -> tuple[list[dict[str, Any]], str, str]:
     settings = load_video_learning_settings()
     if settings["youtube"]["transcript_provider"] == "none":
@@ -372,14 +379,14 @@ async def _youtube_transcript(
         return [], "", "dependency_missing"
 
     def fetch() -> tuple[list[dict[str, Any]], str]:
-        languages = [language] if language else ["zh-CN", "zh-Hans", "zh", "en"]
+        languages = _language_preferences(language)
         api = YouTubeTranscriptApi()
         if hasattr(api, "fetch"):
             response = api.fetch(video_id, languages=languages)
             return normalize_cues(list(response)), str(getattr(response, "language_code", "") or "")
         return normalize_cues(
             YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
-        ), language
+        ), languages[0] if languages else ""
 
     try:
         cues, resolved_language = await asyncio.to_thread(fetch)
@@ -403,9 +410,9 @@ async def _youtube_metadata(request: YouTubeRequest) -> dict[str, Any]:
         return {}
 
 
-def _caption_choice(rows: Any, language: str) -> dict[str, Any] | None:
+def _caption_choice(rows: Any, language: str | Sequence[str]) -> dict[str, Any] | None:
     captions = [row for row in rows if isinstance(row, dict)] if isinstance(rows, list) else []
-    priorities = [language] if language else ["zh-CN", "zh-Hans", "zh", "en"]
+    priorities = _language_preferences(language)
     for preferred in priorities:
         found = next(
             (
@@ -423,7 +430,9 @@ def _caption_choice(rows: Any, language: str) -> dict[str, Any] | None:
     ) or (captions[0] if captions else None)
 
 
-async def _youtube_resolution(request: YouTubeRequest, language: str) -> ProviderResolution:
+async def _youtube_resolution(
+    request: YouTubeRequest, language: str | Sequence[str]
+) -> ProviderResolution:
     metadata = await _youtube_metadata(request)
     cues, transcript_language, transcript_source = await _youtube_transcript(
         request.video_id, language
@@ -451,7 +460,7 @@ async def _invidious_transcript(
     base: str,
     video_id: str,
     captions: Any,
-    language: str,
+    language: str | Sequence[str],
     *,
     raise_on_failure: bool = False,
 ) -> tuple[list[dict[str, Any]], str, str]:
@@ -460,8 +469,10 @@ async def _invidious_transcript(
         return [], "", "unavailable"
 
     label = str(caption.get("label") or "")
+    priorities = _language_preferences(language)
+    fallback_language = priorities[0] if priorities else ""
     transcript_language = str(
-        caption.get("languageCode") or caption.get("language_code") or language
+        caption.get("languageCode") or caption.get("language_code") or fallback_language
     )
     caption_response = await client.get(
         f"{base}/api/v1/captions/{video_id}",
@@ -482,7 +493,9 @@ async def _invidious_transcript(
     return cues, transcript_language, "invidious" if cues else "unavailable"
 
 
-async def _invidious_resolution(request: YouTubeRequest, language: str) -> ProviderResolution:
+async def _invidious_resolution(
+    request: YouTubeRequest, language: str | Sequence[str]
+) -> ProviderResolution:
     settings = load_video_learning_settings()
     base = settings["invidious"]["api_base_url"]
     if not base:
@@ -520,11 +533,30 @@ async def _invidious_resolution(request: YouTubeRequest, language: str) -> Provi
 
 PROVIDER_RESOLVERS: dict[
     ProviderName,
-    Callable[[YouTubeRequest, str], Awaitable[ProviderResolution]],
+    Callable[[YouTubeRequest, str | Sequence[str]], Awaitable[ProviderResolution]],
 ] = {
     "youtube": lambda request, language: _youtube_resolution(request, language),
     "invidious": lambda request, language: _invidious_resolution(request, language),
 }
+
+
+async def resolve_youtube_captions(
+    url: str,
+    language: str | Sequence[str] = ("zh-CN", "zh-Hans", "zh", "en"),
+) -> ProviderResolution:
+    """Resolve captions through the configured provider without requiring playback."""
+
+    request = parse_youtube_url(url)
+    settings = load_video_learning_settings()
+    if settings["default_provider"] == "invidious":
+        base = settings["invidious"]["api_base_url"]
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=False) as client:
+            metadata = await _invidious_metadata(client, base, request.video_id)
+            cues, transcript_language, transcript_source = await _invidious_transcript(
+                client, base, request.video_id, metadata.get("captions"), language
+            )
+        return ProviderResolution(metadata, cues, transcript_language, transcript_source, [])
+    return await _youtube_resolution(request, language)
 
 
 async def resolve_material(
@@ -760,6 +792,7 @@ __all__ = [
     "public_material",
     "refresh_invidious_transcript",
     "resolve_material",
+    "resolve_youtube_captions",
     "save_video_learning_settings",
     "test_invidious_connection",
 ]

--- a/tests/reading/test_ingestion.py
+++ b/tests/reading/test_ingestion.py
@@ -28,6 +28,7 @@ from deeptutor.reading.models import ReadingError
 from deeptutor.reading.store import ReadingStore
 from deeptutor.services.web_source.snapshot_assets import SnapshotAsset
 from deeptutor.tools.web_fetch import FetchOutcome, _extract_readable
+from deeptutor.video_learning import service as video_learning_service
 
 _ARTICLE_FIXTURE = Path(__file__).parents[1] / "fixtures" / "web" / "vector_article.html"
 
@@ -220,6 +221,113 @@ async def test_youtube_import_prefers_timed_captions(stores) -> None:
     assert reading.manifest(ready.material_id).unit == "segment"
     assert reading.manifest(ready.material_id).render_mode == "video"
     assert reading.unit_references(ready.material_id)[1].source_href == "#t=12"
+
+
+@pytest.mark.asyncio
+async def test_youtube_ingestion_default_uses_native_provider(
+    stores, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reading, catalog = stores
+    monkeypatch.setattr(
+        video_learning_service,
+        "load_video_learning_settings",
+        lambda: video_learning_service.DEFAULT_VIDEO_LEARNING_SETTINGS,
+    )
+
+    async def metadata(_request):
+        return {"title": "Native lecture", "thumbnail_url": "https://img/native.jpg"}
+
+    async def transcript(_video_id, _language):
+        return (
+            [{"start": 0, "end": 14, "text": "Native caption."}],
+            "en",
+            "youtube_transcript_api",
+        )
+
+    monkeypatch.setattr(video_learning_service, "_youtube_metadata", metadata)
+    monkeypatch.setattr(video_learning_service, "_youtube_transcript", transcript)
+
+    service = ReadingIngestionService(reading, catalog)
+    queued = service.queue_url("https://youtu.be/abc123xyz00")
+    ready = await service.process_url(queued.material_id)
+    manifest = reading.manifest(ready.material_id)
+
+    assert ready.status is IngestionStatus.READY
+    assert manifest.title == "Native lecture"
+    assert ready.cover_url == "https://img/native.jpg"
+    assert manifest.extractor == "youtube-captions"
+    assert reading.unit_text(ready.material_id, 1) == "Native caption."
+
+
+@pytest.mark.asyncio
+async def test_youtube_ingestion_uses_configured_invidious_captions(
+    stores, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reading, catalog = stores
+    monkeypatch.setattr(
+        video_learning_service,
+        "load_video_learning_settings",
+        lambda: {
+            "version": 1,
+            "default_provider": "invidious",
+            "youtube": {"transcript_provider": "youtube_transcript_api"},
+            "invidious": {"api_base_url": "http://localhost:3000", "public_base_url": ""},
+        },
+    )
+
+    async def metadata(_client, _base, _video_id):
+        return {
+            "title": "Mirrored lecture",
+            "thumbnail_url": "https://img/mirror.jpg",
+            "captions": [{"label": "English", "languageCode": "en"}],
+        }
+
+    async def transcript(_client, _base, _video_id, _captions, _language, **_kwargs):
+        assert _language == ["zh-CN", "zh", "en"]
+        return ([{"start": 0, "end": 14, "text": "Mirrored caption."}], "en", "invidious")
+
+    monkeypatch.setattr(video_learning_service, "_invidious_metadata", metadata)
+    monkeypatch.setattr(video_learning_service, "_invidious_transcript", transcript)
+
+    service = ReadingIngestionService(reading, catalog)
+    queued = service.queue_url("https://youtu.be/abc123xyz00")
+    ready = await service.process_url(queued.material_id)
+    manifest = reading.manifest(ready.material_id)
+
+    assert ready.status is IngestionStatus.READY
+    assert manifest.title == "Mirrored lecture"
+    assert ready.cover_url == "https://img/mirror.jpg"
+    assert manifest.extractor == "youtube-captions"
+    assert reading.unit_text(ready.material_id, 1) == "Mirrored caption."
+
+
+@pytest.mark.asyncio
+async def test_youtube_ingestion_reports_invidious_provider_failure(
+    stores, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _reading, catalog = stores
+    monkeypatch.setattr(
+        video_learning_service,
+        "load_video_learning_settings",
+        lambda: {
+            "version": 1,
+            "default_provider": "invidious",
+            "youtube": {"transcript_provider": "youtube_transcript_api"},
+            "invidious": {"api_base_url": "http://localhost:3000", "public_base_url": ""},
+        },
+    )
+
+    async def metadata(_client, _base, _video_id):
+        raise video_learning_service.TimedMediaError("Invidious request failed with HTTP 503.")
+
+    monkeypatch.setattr(video_learning_service, "_invidious_metadata", metadata)
+    service = ReadingIngestionService(_reading, catalog)
+    queued = service.queue_url("https://youtu.be/abc123xyz00")
+    failed = await service.process_url(queued.material_id)
+
+    assert failed.status is IngestionStatus.FAILED
+    assert failed.error_code == "youtube_transcript_failed"
+    assert "HTTP 503" in failed.error_detail
 
 
 @pytest.mark.parametrize(

--- a/tests/video_learning/test_service.py
+++ b/tests/video_learning/test_service.py
@@ -245,6 +245,37 @@ async def test_provider_switch_preserves_material_and_progress(monkeypatch, isol
 
 
 @pytest.mark.asyncio
+async def test_youtube_captions_resolution_allows_invidious_without_playback_stream(
+    monkeypatch, isolated: Path
+) -> None:
+    service.save_video_learning_settings(
+        {
+            "default_provider": "invidious",
+            "invidious": {"api_base_url": "http://localhost:3000"},
+        }
+    )
+
+    async def metadata(_client, _base, _video_id):
+        return {
+            "title": "Captions only",
+            "captions": [{"label": "English", "languageCode": "en"}],
+        }
+
+    async def transcript(_client, _base, _video_id, _captions, _language, **_kwargs):
+        return ([{"start": 0, "end": 12, "text": "Hello"}], "en", "invidious")
+
+    monkeypatch.setattr(service, "_invidious_metadata", metadata)
+    monkeypatch.setattr(service, "_invidious_transcript", transcript)
+
+    resolution = await service.resolve_youtube_captions("https://youtu.be/dQw4w9WgXcQ")
+
+    assert resolution.metadata["title"] == "Captions only"
+    assert resolution.transcript_source == "invidious"
+    assert resolution.cues == [{"start": 0, "end": 12, "text": "Hello"}]
+    assert resolution.formats == []
+
+
+@pytest.mark.asyncio
 async def test_missing_transcript_does_not_block_native_playback(
     monkeypatch, isolated: Path
 ) -> None:


### PR DESCRIPTION
## Summary

Part of #1378 (Step A only).

- Add a captions-only YouTube resolver in `video_learning` that follows the configured default provider.
- Route Reading default YouTube ingestion through that resolver so a configured Invidious instance can supply metadata and captions.
- Keep Invidious playback-stream availability out of Reading ingestion, preserving native YouTube playback when captions exist without a compatible MP4.
- Preserve explicit `youtube_loader` injection and leave Bilibili ingestion unchanged.

## Scope

- No Bilibili changes.
- No notes migration.
- No UI migration.
- No removal of the standalone Watching surface.
- No public discovery feed changes.

## Testing

- `.venv/bin/pytest -q tests/reading/test_ingestion.py tests/video_learning/test_service.py` — 63 passed.
- `.venv/bin/pytest -q tests/reading tests/video_learning` — 399 passed.
- `ruff check` and `ruff format --check` on touched files — passed.
- `./scripts/hooks/pre-commit` — passed.