### PR TITLE
feat(settings): export value-free profiles

### DIFF
--- a/deeptutor/api/routers/settings.py
+++ b/deeptutor/api/routers/settings.py
@@ -49,6 +49,11 @@ from deeptutor.services.config.settings_draft import (
     merge_draft_secrets,
     redact_draft,
 )
+from deeptutor.services.config.settings_profile import (
+    SettingsProfileError,
+    export_settings_profile,
+    review_settings_profile_import,
+)
 from deeptutor.services.llm.config import clear_llm_config_cache
 from deeptutor.services.model_selection import list_llm_options
 from deeptutor.services.path_service import get_path_service
@@ -222,6 +227,13 @@ class SettingsDraftPayload(BaseModel):
     catalog: dict[str, Any] | None = None
     # Opaque per-page state, keyed by the string the page registers with.
     extensions: dict[str, Any] = Field(default_factory=dict)
+
+
+class SettingsProfileImportPayload(BaseModel):
+    """An exported value-free settings profile submitted for review only."""
+
+    schema_version: str
+    profile: dict[str, Any]
 
 
 class CodexReasoningEffortUpdate(BaseModel):
@@ -1133,6 +1145,25 @@ async def get_settings_readiness():
     from deeptutor.services.config.readiness import build_settings_readiness
 
     return await build_settings_readiness()
+
+
+@router.get("/profile")
+async def get_settings_profile():
+    """Export effective settings with credentials and deployment values removed."""
+
+    _require_settings_admin()
+    return export_settings_profile()
+
+
+@router.post("/profile/diff")
+async def diff_settings_profile(payload: SettingsProfileImportPayload):
+    """Review an imported profile without changing effective settings."""
+
+    _require_settings_admin()
+    try:
+        return review_settings_profile_import(payload.model_dump())
+    except SettingsProfileError as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from None
 
 
 @router.put("/document-parsing")

--- a/deeptutor/services/config/settings_profile.py
+++ b/deeptutor/services/config/settings_profile.py
@@ -1,0 +1,370 @@
+"""Value-free Settings profile export and review-only import diff.
+
+Profiles carry selections, model anchors, and non-secret configuration
+knobs.  Deployment endpoints, local paths, and credentials never enter the
+profile; an imported profile can therefore be reviewed without exposing any
+of those values.  This module deliberately has no write path.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any
+
+from .model_catalog import get_model_catalog_service
+from .runtime_settings import RuntimeSettingsService, get_runtime_settings_service
+
+PROFILE_SCHEMA_VERSION = "deeptutor.settings-profile/v1"
+
+_SECRET_FIELD_HINTS = (
+    "api_key",
+    "apikey",
+    "api_token",
+    "extra_headers",
+    "password",
+    "secret",
+)
+_DEPLOYMENT_FIELD_HINTS = (
+    "url",
+    "endpoint",
+    "path",
+    "host",
+    "origin",
+    "port",
+    "dir",
+)
+_DEPLOYMENT_FIELD_PREFIXES = ("cors_",)
+_SYSTEM_FIELDS = (
+    "version_check_enabled",
+    "backend_workers",
+    "disable_ssl_verify",
+    "sandbox_allow_subprocess",
+    "capability_routing_enabled",
+    "web_search_source_filtering",
+    "chat_attachment_max_file_mb",
+    "chat_attachment_max_total_mb",
+    "chat_attachment_max_chars_per_doc",
+    "chat_attachment_max_chars_total",
+)
+_AUTH_FIELDS = ("enabled", "token_expire_hours", "cookie_secure")
+_COORDINATION_FIELDS = (
+    "backend",
+    "key_prefix",
+    "lease_ttl_seconds",
+    "renew_interval_seconds",
+    "recovery_interval_seconds",
+    "stream_retention_seconds",
+)
+_CATALOG_EXCLUDED_FIELDS = {"base_url"}
+
+
+class SettingsProfileError(ValueError):
+    """The submitted profile is not an export produced by this schema."""
+
+
+def _is_secret_field(name: str) -> bool:
+    normalized = name.lower()
+    return any(hint in normalized for hint in _SECRET_FIELD_HINTS)
+
+
+def _is_deployment_field(name: str) -> bool:
+    normalized = name.lower()
+    return normalized.startswith(_DEPLOYMENT_FIELD_PREFIXES) or any(
+        normalized == hint or normalized.endswith(f"_{hint}") for hint in _DEPLOYMENT_FIELD_HINTS
+    )
+
+
+def _public_value(value: Any) -> Any:
+    """Redact credentials and deployment values from untrusted diff output."""
+
+    if isinstance(value, dict):
+        public: dict[str, Any] = {}
+        for key, item in value.items():
+            if _is_secret_field(str(key)):
+                public[key] = {"present": bool(item)}
+            elif _is_deployment_field(str(key)):
+                public[key] = None
+            else:
+                public[key] = _public_value(item)
+        return public
+    if isinstance(value, list):
+        return [_public_value(item) for item in value]
+    return value
+
+
+def _value_presence(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value)
+    if isinstance(value, (dict, list, tuple, set)):
+        return bool(value)
+    return True
+
+
+def _selected_fields(settings: dict[str, Any], fields: tuple[str, ...]) -> dict[str, Any]:
+    return {field: deepcopy(settings[field]) for field in fields if field in settings}
+
+
+def _catalog_profile(profile: dict[str, Any]) -> dict[str, Any]:
+    public: dict[str, Any] = {}
+    for key, value in profile.items():
+        if key in _CATALOG_EXCLUDED_FIELDS:
+            continue
+        if key == "extra_headers":
+            headers = value if isinstance(value, dict) else {}
+            public[key] = {
+                header: {"present": _value_presence(item)} for header, item in headers.items()
+            }
+        elif _is_secret_field(key):
+            public[key] = {"present": _value_presence(value)}
+        else:
+            public[key] = _public_value(value)
+    return public
+
+
+def _catalog_profile_settings(catalog: dict[str, Any]) -> dict[str, Any]:
+    services = catalog.get("services")
+    services = services if isinstance(services, dict) else {}
+    public_services: dict[str, Any] = {}
+    for name, service in services.items():
+        if not isinstance(service, dict):
+            continue
+        profiles = service.get("profiles")
+        profiles = profiles if isinstance(profiles, list) else []
+        public_services[name] = {
+            "active_profile_id": deepcopy(service.get("active_profile_id")),
+            "active_model_id": deepcopy(service.get("active_model_id")),
+            "profiles": [
+                _catalog_profile(profile) for profile in profiles if isinstance(profile, dict)
+            ],
+        }
+    return {"services": public_services}
+
+
+def _document_parsing_profile(settings: dict[str, Any]) -> dict[str, Any]:
+    engines = settings.get("engines")
+    engines = engines if isinstance(engines, dict) else {}
+    public_engines: dict[str, Any] = {}
+    for name, engine in engines.items():
+        if not isinstance(engine, dict):
+            continue
+        if name == "tika":
+            public_engines[name] = {"server_url_present": _value_presence(engine.get("server_url"))}
+            continue
+        public = {
+            key: deepcopy(value)
+            for key, value in engine.items()
+            if not _is_secret_field(key) and not _is_deployment_field(key)
+        }
+        public_engines[name] = public
+    return {
+        "engine": deepcopy(settings.get("engine")),
+        "engines": public_engines,
+    }
+
+
+def _integrations_profile(settings: dict[str, Any]) -> dict[str, Any]:
+    coordination = settings.get("turn_coordination")
+    coordination = coordination if isinstance(coordination, dict) else {}
+    return {
+        "turn_coordination": _selected_fields(coordination, _COORDINATION_FIELDS),
+    }
+
+
+def _effective_profile(
+    service: RuntimeSettingsService,
+    *,
+    catalog: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "settings": {
+            "system": _selected_fields(
+                service.load_system(include_process_overrides=True), _SYSTEM_FIELDS
+            ),
+            "auth": _selected_fields(
+                service.load_auth(include_process_overrides=True), _AUTH_FIELDS
+            ),
+            "integrations": _integrations_profile(
+                service.load_integrations(include_process_overrides=True)
+            ),
+            "document_parsing": _document_parsing_profile(
+                service.load_document_parsing(include_process_overrides=True)
+            ),
+            "llamaindex": deepcopy(service.load_llamaindex(include_process_overrides=True)),
+            "graphrag": deepcopy(service.load_graphrag()),
+            "lightrag": deepcopy(service.load_lightrag()),
+            "catalog": _catalog_profile_settings(catalog),
+        }
+    }
+
+
+def export_settings_profile(
+    *,
+    service: RuntimeSettingsService | None = None,
+    catalog: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return the effective, value-free profile for API export."""
+
+    runtime_service = service or get_runtime_settings_service()
+    catalog_service = catalog or get_model_catalog_service().load()
+    return {
+        "schema_version": PROFILE_SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "profile": _effective_profile(runtime_service, catalog=catalog_service),
+    }
+
+
+def _join_path(parent: str, key: Any) -> str:
+    if not parent:
+        return str(key)
+    return f"{parent}.{key}"
+
+
+def _path_kind(key: str) -> str | None:
+    if _is_secret_field(key):
+        return "secret_not_exported"
+    if _is_deployment_field(key):
+        return "deployment_value_not_exported"
+    return None
+
+
+def _is_presence_anchor(value: Any) -> bool:
+    return (
+        isinstance(value, dict) and set(value) == {"present"} and isinstance(value["present"], bool)
+    )
+
+
+def _is_secret_anchor(value: Any) -> bool:
+    if _is_presence_anchor(value):
+        return True
+    return (
+        bool(value)
+        and isinstance(value, dict)
+        and all(_is_presence_anchor(item) for item in value.values())
+    )
+
+
+def _diff_settings(
+    proposed: Any,
+    current: Any,
+    *,
+    path: str,
+    changes: list[dict[str, Any]],
+    unsupported: list[dict[str, Any]],
+) -> None:
+    if isinstance(proposed, dict):
+        if not isinstance(current, dict):
+            unsupported.append({"path": path, "reason": "type_mismatch"})
+            return
+        for key, child in proposed.items():
+            child_path = _join_path(path, key)
+            reason = _path_kind(str(key))
+            if (
+                reason == "secret_not_exported"
+                and _is_secret_anchor(child)
+                and _is_secret_anchor(current.get(key))
+            ):
+                reason = None
+            if reason is not None:
+                unsupported.append({"path": child_path, "reason": reason})
+                continue
+            if key not in current:
+                unsupported.append({"path": child_path, "reason": "unknown_field"})
+                continue
+            _diff_settings(
+                child,
+                current[key],
+                path=child_path,
+                changes=changes,
+                unsupported=unsupported,
+            )
+        return
+
+    if (
+        isinstance(proposed, list)
+        and isinstance(current, list)
+        and len(proposed) == len(current)
+        and all(
+            isinstance(item, dict) and isinstance(current[index], dict)
+            for index, item in enumerate(proposed)
+        )
+    ):
+        for index, child in enumerate(proposed):
+            _diff_settings(
+                child,
+                current[index],
+                path=_join_path(path, index),
+                changes=changes,
+                unsupported=unsupported,
+            )
+        return
+
+    if isinstance(proposed, list) and isinstance(current, list) and len(proposed) != len(current):
+        unsupported.append({"path": path, "reason": "list_length_changed"})
+        return
+
+    if proposed != current:
+        changes.append(
+            {
+                "path": path,
+                "kind": "changed",
+                "current": _public_value(current),
+                "proposed": _public_value(proposed),
+            }
+        )
+
+
+def review_settings_profile_import(
+    payload: dict[str, Any],
+    *,
+    service: RuntimeSettingsService | None = None,
+    catalog: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Validate an exported profile and compare it with effective settings."""
+
+    if not isinstance(payload, dict):
+        raise SettingsProfileError("profile payload must be an object")
+    if payload.get("schema_version") != PROFILE_SCHEMA_VERSION:
+        raise SettingsProfileError(f"unsupported schema_version: expected {PROFILE_SCHEMA_VERSION}")
+    profile = payload.get("profile")
+    if not isinstance(profile, dict) or not isinstance(profile.get("settings"), dict):
+        raise SettingsProfileError("profile.settings must be an object")
+    unknown_profile_fields = set(profile) - {"settings"}
+    if unknown_profile_fields:
+        raise SettingsProfileError(
+            f"unknown profile fields: {', '.join(sorted(unknown_profile_fields))}"
+        )
+
+    runtime_service = service or get_runtime_settings_service()
+    catalog_value = catalog or get_model_catalog_service().load()
+    current = _effective_profile(runtime_service, catalog=catalog_value)
+    proposed = deepcopy(profile)
+    changes: list[dict[str, Any]] = []
+    unsupported: list[dict[str, Any]] = []
+    _diff_settings(
+        proposed["settings"],
+        current["settings"],
+        path="settings",
+        changes=changes,
+        unsupported=unsupported,
+    )
+    return {
+        "schema_version": PROFILE_SCHEMA_VERSION,
+        "changes": sorted(changes, key=lambda item: item["path"]),
+        "unsupported": sorted(unsupported, key=lambda item: item["path"]),
+        "summary": {
+            "changed": len(changes),
+            "unsupported": len(unsupported),
+            "compatible": not unsupported,
+        },
+    }
+
+
+__all__ = [
+    "PROFILE_SCHEMA_VERSION",
+    "SettingsProfileError",
+    "export_settings_profile",
+    "review_settings_profile_import",
+]

--- a/tests/services/config/test_settings_profile.py
+++ b/tests/services/config/test_settings_profile.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+
+import pytest
+
+from deeptutor.api.routers import settings as settings_router
+from deeptutor.services.config.runtime_settings import RuntimeSettingsService
+from deeptutor.services.config.settings_profile import (
+    PROFILE_SCHEMA_VERSION,
+    SettingsProfileError,
+    export_settings_profile,
+    review_settings_profile_import,
+)
+
+
+def _runtime_service(tmp_path) -> RuntimeSettingsService:
+    return RuntimeSettingsService(tmp_path / "settings", process_env={})
+
+
+def _catalog() -> dict:
+    return {
+        "version": 1,
+        "services": {
+            "llm": {
+                "active_profile_id": "llm-profile",
+                "active_model_id": "model-id",
+                "profiles": [
+                    {
+                        "id": "llm-profile",
+                        "binding": "openai",
+                        "base_url": "https://provider.example.test/v1",
+                        "api_key": "secret-api-key",
+                        "extra_headers": {"Authorization": "Bearer secret-header"},
+                        "models": [{"id": "model-id", "model": "model-name", "dimension": "1536"}],
+                    }
+                ],
+            }
+        },
+    }
+
+
+def _configured_service(tmp_path) -> RuntimeSettingsService:
+    service = _runtime_service(tmp_path)
+    service.save_system(
+        {
+            "backend_port": 9101,
+            "backend_workers": 3,
+            "next_public_api_base_external": "https://deep.example.test",
+            "cors_origins": ["https://ui.example.test"],
+            "chat_attachment_max_file_mb": 40,
+        }
+    )
+    service.save_auth({"enabled": True, "cookie_secure": True})
+    service.save_integrations(
+        {
+            "pocketbase_admin_password": "secret-password",
+            "turn_coordination": {
+                "backend": "redis",
+                "redis_url": "redis://redis.example.test:6379",
+                "key_prefix": "university",
+            },
+        }
+    )
+    service.save_document_parsing(
+        {
+            "engine": "tika",
+            "engines": {
+                "mineru": {
+                    "mode": "cloud",
+                    "api_base_url": "https://mineru.example.test",
+                    "api_token": "secret-token",
+                    "local_cli_path": "/private/mineru",
+                    "model_version": "vlm",
+                },
+                "tika": {"server_url": "http://tika.example.test:9998"},
+            },
+        }
+    )
+    return service
+
+
+def _export(service: RuntimeSettingsService) -> dict:
+    return export_settings_profile(service=service, catalog=_catalog())
+
+
+def test_export_is_value_free_and_preserves_safe_configuration(tmp_path) -> None:
+    service = _configured_service(tmp_path)
+    exported = _export(service)
+    profile = exported["profile"]
+    serialized = json.dumps(profile)
+
+    assert exported["schema_version"] == PROFILE_SCHEMA_VERSION
+    assert profile["settings"]["system"]["backend_workers"] == 3
+    assert profile["settings"]["system"]["chat_attachment_max_file_mb"] == 40
+    assert profile["settings"]["auth"] == {
+        "enabled": True,
+        "token_expire_hours": 24,
+        "cookie_secure": True,
+    }
+    assert profile["settings"]["integrations"]["turn_coordination"] == {
+        "backend": "redis",
+        "key_prefix": "university",
+        "lease_ttl_seconds": 30,
+        "renew_interval_seconds": 10,
+        "recovery_interval_seconds": 10,
+        "stream_retention_seconds": 86_400,
+    }
+    assert profile["settings"]["document_parsing"]["engine"] == "tika"
+    assert profile["settings"]["document_parsing"]["engines"]["mineru"] == {
+        "mode": "cloud",
+        "model_download_source": "huggingface",
+        "model_version": "vlm",
+        "language": "auto",
+        "enable_formula": True,
+        "enable_table": True,
+        "is_ocr": False,
+        "allow_local_model_download": False,
+    }
+    assert profile["settings"]["document_parsing"]["engines"]["tika"] == {
+        "server_url_present": True
+    }
+    llm = profile["settings"]["catalog"]["services"]["llm"]["profiles"][0]
+    assert llm["id"] == "llm-profile"
+    assert llm["binding"] == "openai"
+    assert llm["api_key"] == {"present": True}
+    assert llm["extra_headers"] == {"Authorization": {"present": True}}
+
+    for secret in (
+        "secret-api-key",
+        "secret-header",
+        "secret-password",
+        "secret-token",
+        "provider.example.test",
+        "deep.example.test",
+        "ui.example.test",
+        "redis.example.test",
+        "mineru.example.test",
+        "tika.example.test",
+        "/private/mineru",
+    ):
+        assert secret not in serialized
+
+    # Deployment-specific values stay outside the portable profile.
+    assert "backend_port" not in profile["settings"]["system"]
+    assert "cors_origins" not in profile["settings"]["system"]
+    assert "redis_url" not in profile["settings"]["integrations"]["turn_coordination"]
+
+
+def test_profile_shape_is_stable_across_export_calls(tmp_path) -> None:
+    service = _configured_service(tmp_path)
+
+    assert _export(service)["profile"] == _export(service)["profile"]
+
+
+def test_review_diff_reports_effective_changes_without_mutation(tmp_path) -> None:
+    service = _configured_service(tmp_path)
+    exported = _export(service)
+    before = service.load_system()
+    exported["profile"]["settings"]["system"]["backend_workers"] = 8
+
+    review = review_settings_profile_import(
+        exported,
+        service=service,
+        catalog=_catalog(),
+    )
+
+    assert review["changes"] == [
+        {
+            "path": "settings.system.backend_workers",
+            "kind": "changed",
+            "current": 3,
+            "proposed": 8,
+        }
+    ]
+    assert review["summary"] == {"changed": 1, "unsupported": 0, "compatible": True}
+    assert service.load_system() == before
+
+
+def test_review_marks_unknown_secret_and_deployment_fields_unsupported(tmp_path) -> None:
+    service = _configured_service(tmp_path)
+    exported = _export(service)
+    exported["profile"]["settings"]["unknown_section"] = {}
+    exported["profile"]["settings"]["system"]["backend_port"] = 9000
+    exported["profile"]["settings"]["catalog"]["services"]["llm"]["profiles"][0]["api_key"] = {
+        "present": "raw-secret"
+    }
+    exported["profile"]["settings"]["catalog"]["services"]["llm"]["profiles"][0][
+        "extra_headers"
+    ] = {"Authorization": "raw-secret-header"}
+
+    review = review_settings_profile_import(
+        exported,
+        service=service,
+        catalog=_catalog(),
+    )
+
+    assert review["unsupported"] == [
+        {
+            "path": "settings.catalog.services.llm.profiles.0.api_key",
+            "reason": "secret_not_exported",
+        },
+        {
+            "path": "settings.catalog.services.llm.profiles.0.extra_headers",
+            "reason": "secret_not_exported",
+        },
+        {"path": "settings.system.backend_port", "reason": "deployment_value_not_exported"},
+        {"path": "settings.unknown_section", "reason": "unknown_field"},
+    ]
+    assert review["summary"]["compatible"] is False
+
+
+def test_review_rejects_unknown_profile_level_fields(tmp_path) -> None:
+    service = _runtime_service(tmp_path)
+    payload = {
+        "schema_version": PROFILE_SCHEMA_VERSION,
+        "profile": {"settings": {}, "runtime_values": {}},
+    }
+
+    with pytest.raises(SettingsProfileError, match="unknown profile fields: runtime_values"):
+        review_settings_profile_import(payload, service=service, catalog=_catalog())
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({}, "unsupported schema_version"),
+        ({"schema_version": PROFILE_SCHEMA_VERSION}, "profile.settings"),
+    ],
+)
+def test_review_rejects_invalid_profile_schema(
+    tmp_path,
+    payload: dict,
+    message: str,
+) -> None:
+    service = _runtime_service(tmp_path)
+
+    with pytest.raises(SettingsProfileError, match=message):
+        review_settings_profile_import(payload, service=service, catalog=_catalog())
+
+
+@pytest.mark.asyncio
+async def test_profile_endpoints_are_admin_guarded_and_review_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    guarded = 0
+    service = _configured_service(tmp_path)
+    exported = _export(service)
+
+    def require_admin() -> None:
+        nonlocal guarded
+        guarded += 1
+
+    def export_profile() -> dict:
+        return exported
+
+    def review(payload: dict) -> dict:
+        return review_settings_profile_import(payload, service=service, catalog=_catalog())
+
+    monkeypatch.setattr(settings_router, "_require_settings_admin", require_admin)
+    monkeypatch.setattr(settings_router, "export_settings_profile", export_profile)
+    monkeypatch.setattr(settings_router, "review_settings_profile_import", review)
+
+    profile = await settings_router.get_settings_profile()
+    diff = await settings_router.diff_settings_profile(
+        settings_router.SettingsProfileImportPayload(**exported)
+    )
+
+    assert profile is exported
+    assert diff["summary"]["changed"] == 0
+    assert guarded == 2

--- a/web/contracts/generated/api.ts
+++ b/web/contracts/generated/api.ts
@@ -7039,6 +7039,46 @@ export interface paths {
     readonly patch?: never;
     readonly trace?: never;
   };
+  readonly "/api/settings/profile": {
+    readonly parameters: {
+      readonly query?: never;
+      readonly header?: never;
+      readonly path?: never;
+      readonly cookie?: never;
+    };
+    /**
+     * Get Settings Profile
+     * @description Export effective settings with credentials and deployment values removed.
+     */
+    readonly get: operations["get_settings_profile_api_settings_profile_get"];
+    readonly put?: never;
+    readonly post?: never;
+    readonly delete?: never;
+    readonly options?: never;
+    readonly head?: never;
+    readonly patch?: never;
+    readonly trace?: never;
+  };
+  readonly "/api/settings/profile/diff": {
+    readonly parameters: {
+      readonly query?: never;
+      readonly header?: never;
+      readonly path?: never;
+      readonly cookie?: never;
+    };
+    readonly get?: never;
+    readonly put?: never;
+    /**
+     * Diff Settings Profile
+     * @description Review an imported profile without changing effective settings.
+     */
+    readonly post: operations["diff_settings_profile_api_settings_profile_diff_post"];
+    readonly delete?: never;
+    readonly options?: never;
+    readonly head?: never;
+    readonly patch?: never;
+    readonly trace?: never;
+  };
   readonly "/api/settings/providers/codebuddy/auth/cancel": {
     readonly parameters: {
       readonly query?: never;
@@ -12352,6 +12392,18 @@ export interface components {
         readonly [key: string]: unknown;
       };
     };
+    /**
+     * SettingsProfileImportPayload
+     * @description An exported value-free settings profile submitted for review only.
+     */
+    readonly SettingsProfileImportPayload: {
+      /** Profile */
+      readonly profile: {
+        readonly [key: string]: unknown;
+      };
+      /** Schema Version */
+      readonly schema_version: string;
+    };
     /** SidebarDescriptionUpdate */
     readonly SidebarDescriptionUpdate: {
       /** Description */
@@ -13898,6 +13950,8 @@ export type SchemaSetSyllabusRequest =
   components["schemas"]["SetSyllabusRequest"];
 export type SchemaSettingsDraftPayload =
   components["schemas"]["SettingsDraftPayload"];
+export type SchemaSettingsProfileImportPayload =
+  components["schemas"]["SettingsProfileImportPayload"];
 export type SchemaSidebarDescriptionUpdate =
   components["schemas"]["SidebarDescriptionUpdate"];
 export type SchemaSidebarNavOrder = components["schemas"]["SidebarNavOrder"];
@@ -29955,6 +30009,76 @@ export interface operations {
     readonly requestBody: {
       readonly content: {
         readonly "application/json": components["schemas"]["NetworkSettingsUpdate"];
+      };
+    };
+    readonly responses: {
+      /** @description Successful Response */
+      readonly 200: {
+        headers: {
+          readonly [name: string]: unknown;
+        };
+        content: {
+          readonly "application/json": unknown;
+        };
+      };
+      /** @description Validation Error */
+      readonly 422: {
+        headers: {
+          readonly [name: string]: unknown;
+        };
+        content: {
+          readonly "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  readonly get_settings_profile_api_settings_profile_get: {
+    readonly parameters: {
+      readonly query?: never;
+      readonly header?: {
+        readonly Authorization?: string | null;
+      };
+      readonly path?: never;
+      readonly cookie?: {
+        readonly dt_token?: string | null;
+      };
+    };
+    readonly requestBody?: never;
+    readonly responses: {
+      /** @description Successful Response */
+      readonly 200: {
+        headers: {
+          readonly [name: string]: unknown;
+        };
+        content: {
+          readonly "application/json": unknown;
+        };
+      };
+      /** @description Validation Error */
+      readonly 422: {
+        headers: {
+          readonly [name: string]: unknown;
+        };
+        content: {
+          readonly "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  readonly diff_settings_profile_api_settings_profile_diff_post: {
+    readonly parameters: {
+      readonly query?: never;
+      readonly header?: {
+        readonly Authorization?: string | null;
+      };
+      readonly path?: never;
+      readonly cookie?: {
+        readonly dt_token?: string | null;
+      };
+    };
+    readonly requestBody: {
+      readonly content: {
+        readonly "application/json": components["schemas"]["SettingsProfileImportPayload"];
       };
     };
     readonly responses: {

--- a/web/contracts/schema/openapi.json
+++ b/web/contracts/schema/openapi.json
@@ -7165,6 +7165,26 @@
         "title": "SettingsDraftPayload",
         "type": "object"
       },
+      "SettingsProfileImportPayload": {
+        "description": "An exported value-free settings profile submitted for review only.",
+        "properties": {
+          "profile": {
+            "additionalProperties": true,
+            "title": "Profile",
+            "type": "object"
+          },
+          "schema_version": {
+            "title": "Schema Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema_version",
+          "profile"
+        ],
+        "title": "SettingsProfileImportPayload",
+        "type": "object"
+      },
       "SidebarDescriptionUpdate": {
         "properties": {
           "description": {
@@ -43361,6 +43381,144 @@
         ]
       }
     },
+    "/api/settings/profile": {
+      "get": {
+        "description": "Export effective settings with credentials and deployment values removed.",
+        "operationId": "get_settings_profile_api_settings_profile_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "dt_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Dt Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Settings Profile",
+        "tags": [
+          "settings"
+        ]
+      }
+    },
+    "/api/settings/profile/diff": {
+      "post": {
+        "description": "Review an imported profile without changing effective settings.",
+        "operationId": "diff_settings_profile_api_settings_profile_diff_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "dt_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Dt Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SettingsProfileImportPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Diff Settings Profile",
+        "tags": [
+          "settings"
+        ]
+      }
+    },
     "/api/settings/providers/codebuddy/auth/cancel": {
       "post": {
         "operationId": "cancel_codebuddy_auth_api_settings_providers_codebuddy_auth_cancel_post",
@@ -49642,7 +49800,9 @@
           }
         },
         "summary": "Browse Invidious",
-        "tags": ["video-learning"]
+        "tags": [
+          "video-learning"
+        ]
       }
     },
     "/api/video-learning/materials/resolve": {


### PR DESCRIPTION
Part of #1209.

## Summary

- Add a settings-admin profile export that preserves safe selections and anchors while removing credentials, endpoints, local paths, and other deployment-specific values.
- Add a review-only profile diff endpoint that validates an exported profile against effective settings without mutating configuration.
- Report unknown fields, raw credential fields, deployment-only fields, and incompatible list shapes as unsupported instead of applying or echoing them.
- Export focused backend contracts and tests.

## Scope boundary

This slice does not add named presets, silent bulk import, or mutation/apply behavior. Readiness overview remains the existing #1209 implementation.

## Validation

- `pytest -q tests/services/config/test_settings_profile.py tests/services/config/test_readiness.py tests/api/test_settings_router.py` — 78 passed
- `ruff check` / `ruff format` on touched Python files
- `npm run contracts:check`
- `npm run typecheck`
- `npm run test:node` — 1131 passed
- `python scripts/check_architecture.py`
- `python scripts/check_repo_hygiene.py`
- `git diff --check`
