### PR TITLE
fix(path-service): restore workspace chat output downloads

### DIFF
--- a/deeptutor/services/path_service.py
+++ b/deeptutor/services/path_service.py
@@ -166,6 +166,16 @@ class PathService:
         if parts[:3] == ("workspace", "co-writer", "audio"):
             return candidate
 
+        # Content-workspace runtimes write chat outputs beneath their selected
+        # workspace. Partner execution scopes therefore materialize the legacy
+        # chat shapes as ``workspace/outputs/chat/<session>/<turn>/<kind>/...``.
+        if (
+            len(parts) >= 6
+            and parts[:3] == ("workspace", "outputs", "chat")
+            and parts[5] in {"exec", "media", "cli"}
+        ):
+            return candidate
+
         if (
             len(parts) >= 5
             and parts[:3] == ("workspace", "chat", "deep_solve")

--- a/tests/api/test_output_files.py
+++ b/tests/api/test_output_files.py
@@ -123,7 +123,7 @@ def test_auth_disabled_reads_local_admin_output(output_app) -> None:
 
 
 def test_authenticated_user_downloads_visible_partner_output(output_app, monkeypatch) -> None:
-    relative_path = "workspace/chat/chat/session-1/code_runs/chart.png"
+    relative_path = "workspace/outputs/chat/session-1/turn-1/media/chart.png"
     alice = TokenPayload(username="alice", role="user", user_id="u_alice")
     client, admin_root, _users_root = output_app({"alice-token": alice})
 
@@ -144,6 +144,31 @@ def test_authenticated_user_downloads_visible_partner_output(output_app, monkeyp
     assert response.status_code == 200
     assert response.content.startswith(b"\x89PNG\r\n\x1a\n")
     assert response.headers["content-type"] == "image/png"
+
+
+@pytest.mark.parametrize("kind", ["exec", "media", "cli"])
+def test_workspace_output_chat_kinds_are_public(tmp_path: Path, kind: str) -> None:
+    workspace_root = tmp_path / "workspace"
+    service = PathService(workspace_root=workspace_root)
+    output = _write_output(
+        workspace_root,
+        f"workspace/outputs/chat/session-1/turn-1/{kind}/report.pdf",
+        b"generated output",
+    )
+
+    assert service.resolve_public_output_path(output) == output
+
+
+def test_arbitrary_workspace_output_file_is_not_public(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    service = PathService(workspace_root=workspace_root)
+    output = _write_output(
+        workspace_root,
+        "workspace/outputs/chat/session-1/turn-1/other/report.pdf",
+        b"private workspace file",
+    )
+
+    assert service.resolve_public_output_path(output) is None
 
 
 def test_private_suffix_is_rejected(output_app) -> None:


### PR DESCRIPTION
## Context

Follows up on #1269, as requested by @pancacake: keep only the missing `PathService.resolve_public_output_path` allowance from the superseded partner artifact download PR. This PR carries that allowance forward from #1269.

## Change

- Allow only generated content-workspace chat outputs under `workspace/outputs/chat/<session>/<turn>/{exec,media,cli}/...`.
- Preserve existing user-root containment, symlink rejection, and private-suffix checks.
- Cover the three allowed kinds, reject arbitrary chat output kinds, and exercise the new shape through `/files/outputs` for a visible partner.

## Scope audit

Base: `0f8759f730da898cf99a081f0bec4230bb7ea44a` (`origin/dev`)

Changed files:

- `deeptutor/services/path_service.py`
- `tests/api/test_output_files.py`

## Testing

- `python3 -m pytest tests/api/test_output_files.py -q` — 16 passed
- `ruff format --check deeptutor/services/path_service.py tests/api/test_output_files.py` — PASS
- `ruff check deeptutor/services/path_service.py tests/api/test_output_files.py` — PASS
- `git diff --check` — PASS