### PR TITLE
fix(agents): ignore leading think blocks when extracting JSON

### DIFF
--- a/deeptutor/agents/_shared/json_output.py
+++ b/deeptutor/agents/_shared/json_output.py
@@ -13,6 +13,20 @@ def extract_json_object(text: str) -> dict[str, Any]:
     if not raw:
         return {}
 
+    # Only strip complete leading reasoning blocks; tags inside JSON strings
+    # are payload data. Never fall back to JSON drafts from stripped reasoning.
+    while match := re.match(r"<think\b[^>]*>.*?</think>\s*", raw, re.DOTALL | re.IGNORECASE):
+        raw = raw[match.end() :]
+
+    # Preserve a complete object before looking for fenced examples in its
+    # string values, including after a reasoning prelude has been removed.
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict):
+            return parsed
+    except json.JSONDecodeError:
+        pass
+
     fenced = re.findall(r"```(?:json)?\s*([\s\S]*?)\s*```", raw)
     for candidate in [*fenced, raw]:
         try:

--- a/tests/agents/test_shared_json_output.py
+++ b/tests/agents/test_shared_json_output.py
@@ -24,3 +24,63 @@ def test_extract_json_object(text: str, expected: dict[str, int]) -> None:
 def test_extract_json_object_rejects_output_without_an_object() -> None:
     with pytest.raises(json.JSONDecodeError, match="No JSON object found"):
         extract_json_object("No structured output")
+
+
+@pytest.mark.parametrize(
+    "reasoning",
+    [
+        "<think>Deriving \\frac{1}{2} and PE_{pos, 2i}.\n</think>",
+        '<think>Consider {"draft": true} first.</think>',
+        '<think>Draft:\n```json\n{"draft": true}\n```\n</think>',
+        '<THINK>Formula {2i/d_model}</THINK>\n<think>{"draft": true}</think>\n',
+    ],
+    ids=["latex", "draft-object", "fenced-draft", "multiple-mixed-case-blocks"],
+)
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"value": 42}',
+        '```json\n{"value": 42}\n```',
+        '{"value": 42}\nTrailing explanation',
+    ],
+    ids=["bare", "fenced", "trailing-prose"],
+)
+def test_extract_json_object_ignores_leading_reasoning(reasoning: str, payload: str) -> None:
+    assert extract_json_object(f" \n{reasoning}{payload}") == {"value": 42}
+
+
+@pytest.mark.parametrize(
+    "wrapper",
+    [
+        "{payload}",
+        "```json\n{payload}\n```",
+        "<think>Prepare the answer.</think>{payload}",
+        "<think>Prepare the answer.</think>```json\n{payload}\n```",
+    ],
+    ids=["bare", "fenced", "after-reasoning", "fenced-after-reasoning"],
+)
+def test_extract_json_object_preserves_literal_think_tags(wrapper: str) -> None:
+    expected = {"text": "a <think>b</think> c"}
+    raw = wrapper.format(payload=json.dumps(expected))
+
+    assert extract_json_object(raw) == expected
+
+
+def test_extract_json_object_preserves_fenced_example_inside_valid_json() -> None:
+    expected = {"example": "```json {} ```", "text": "<think>literal</think>"}
+
+    assert extract_json_object(json.dumps(expected)) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        '<think>{"draft": true}</think>',
+        '<think>```json\n{"draft": true}\n```</think>Not a JSON answer',
+        '<think>{"draft": true}</think>{"value": broken}',
+    ],
+    ids=["reasoning-only", "non-json-answer", "invalid-json-answer"],
+)
+def test_extract_json_object_does_not_fall_back_to_reasoning(text: str) -> None:
+    with pytest.raises(json.JSONDecodeError, match="No JSON object found"):
+        extract_json_object(text)


### PR DESCRIPTION
### Description

`math_animator` concept analysis fails with `No JSON object found` when a reasoning prelude contains LaTeX braces before a valid JSON answer, for example:

```text
<think>Deriving \frac{1}{2} and PE_{pos, 2i}.</think>{"value": 42}
```

JSON objects or fenced drafts inside the reasoning can also be returned instead of the final answer.

Strip complete leading `<think>...</think>` blocks before extracting JSON, including consecutive blocks and case-insensitive tags. Parse the complete remaining object before inspecting Markdown fences, preserving literal tags and fenced examples inside JSON string values. Do not fall back to the stripped reasoning when the answer is absent or invalid. Empty input keeps its existing `{}` behavior. Recovery from unclosed reasoning tags is outside this change.

### Related Issues

Related to #673 and #675: that fix covers `utils/json_parser.py`; this PR covers the separate shared agent extractor. #1219 addresses empty-response validation/retries and does not strip reasoning blocks.

### Module(s) Affected

- [x] `agents`
- [x] `tests`

### Validation

- `pytest tests/agents/test_shared_json_output.py tests/agents/math_animator/test_utils.py -q`: **30 passed** on Python 3.13.
- Before the implementation change, the expanded shared-extractor suite produced **13 failures and 13 passes**, demonstrating the regression cases.
- `pre-commit run --files deeptutor/agents/_shared/json_output.py tests/agents/test_shared_json_output.py`: **passed**.
- `pre-commit run --all-files`: all hooks passed except `check-json`, which reports duplicate `Retry` keys in `web/locales/en/app.json` and `web/locales/zh/app.json`, plus a parse error in `web/tsconfig.node-tests.json`. These three files are byte-for-byte unchanged from base `0f8759f7` and are not included in this PR.
- No live-model or end-to-end Manim run was performed.

### Checklist

- [x] Read and followed the contribution guidelines; targets `dev`.
- [x] Added regression and compatibility tests.
- [x] Changed files pass formatting and applicable pre-commit checks.
- [ ] Full-repository pre-commit checks are green (existing `check-json` failures described above).

