### PR TITLE
fix(web): explicit retryable false takes precedence over HTTP status

### DIFF
--- a/web/shared/api/client.ts
+++ b/web/shared/api/client.ts
@@ -85,11 +85,13 @@ function normalizedHttpError(
       `http_${response.status}`,
     message: messageFromBody(body, response.statusText || "Request failed"),
     retryable:
-      (typeof value.retryable === "boolean" && value.retryable) ||
-      (typeof detail.retryable === "boolean" && detail.retryable) ||
-      response.status === 408 ||
-      response.status === 429 ||
-      response.status >= 500,
+      typeof value.retryable === "boolean"
+        ? value.retryable
+        : typeof detail.retryable === "boolean"
+          ? detail.retryable
+          : response.status === 408 ||
+            response.status === 429 ||
+            response.status >= 500,
     scope,
     correlationId:
       (typeof value.correlation_id === "string" && value.correlation_id) ||

--- a/web/tests/api-client.test.ts
+++ b/web/tests/api-client.test.ts
@@ -116,6 +116,74 @@ test("abort and network failures are distinguishable", async () => {
   }
 });
 
+test("explicit retryable false wins over HTTP status fallback", async () => {
+  const restore = withFetch(async () =>
+    Response.json(
+      { error_code: "permanent", message: "Not retryable", retryable: false },
+      { status: 503 },
+    ),
+  );
+  try {
+    const error = await expectApiError(() => requestJson("/turn"));
+    assert.equal(error.appError.retryable, false);
+  } finally {
+    restore();
+  }
+});
+
+test("nested detail.retryable false wins over HTTP status fallback", async () => {
+  const restore = withFetch(async () =>
+    Response.json(
+      {
+        error_code: "permanent_detail",
+        message: "Not retryable (detail)",
+        detail: { retryable: false },
+      },
+      { status: 500 },
+    ),
+  );
+  try {
+    const error = await expectApiError(() => requestJson("/turn"));
+    assert.equal(error.appError.retryable, false);
+  } finally {
+    restore();
+  }
+});
+
+test("missing retryable values fall back to HTTP status", async () => {
+  for (const status of [408, 429, 500]) {
+    const restore = withFetch(async () =>
+      Response.json({ error_code: "opaque" }, { status }),
+    );
+    try {
+      const error = await expectApiError(() => requestJson("/turn"));
+      assert.equal(error.appError.retryable, true);
+    } finally {
+      restore();
+    }
+  }
+});
+
+test("top-level retryable takes precedence over detail and status", async () => {
+  const restore = withFetch(async () =>
+    Response.json(
+      {
+        error_code: "conflict",
+        message: "Explicit false wins",
+        retryable: false,
+        detail: { retryable: true },
+      },
+      { status: 503 },
+    ),
+  );
+  try {
+    const error = await expectApiError(() => requestJson("/turn"));
+    assert.equal(error.appError.retryable, false);
+  } finally {
+    restore();
+  }
+});
+
 test("the shared boundary keeps the single apiFetch auth redirect gate", async () => {
   setRuntimeAuthEnabled(false);
   const restore = withFetch(async () =>


### PR DESCRIPTION
Resolves #1393.

The `normalizedHttpError` retryable resolver used an OR chain that allowed HTTP 408/429/5xx status to override an explicit `retryable: false` from the response body. This PR replaces the OR chain with a ternary precedence chain:

1. Top-level `retryable` (if boolean)
2. Nested `detail.retryable` (if boolean)
3. HTTP status heuristic (`408 || 429 || >= 500`) as fallback only when no explicit value exists

## Regression tests

- `explicit retryable false wins over HTTP status fallback` — 503 + `retryable: false` → `false`
- `nested detail.retryable false wins over HTTP status fallback` — 500 + `detail.retryable: false` → `false`
- `missing retryable values fall back to HTTP status` — 408/429/500 with no retryable key → `true`
- `top-level retryable takes precedence over detail and status` — 503 + top-level `false` + detail `true` → `false`

## Verification

- `npm run test:node` — 1135 tests, 0 fail (includes 4 new regression tests)
- `npm run lint` — 0 errors, 70 pre-existing warnings
- `npm run typecheck` — PASS