### PR TITLE
feat(textbook): rebuild chapters from running headers embedded mid-text

### DIFF
--- a/deeptutor/textbook_struct/__init__.py
+++ b/deeptutor/textbook_struct/__init__.py
@@ -1,0 +1,16 @@
+"""textbook_struct — rebuild a textbook chapter tree from MinerU layout.json.
+
+Deterministic layered criteria (column blacklist → regex → position →
+adjacent merge), zero LLM.
+
+Nothing in this package imports deeptutor.
+"""
+
+from .chapter_rebuild import Chapter, rebuild
+from .column_blacklist import COLUMN_BLACKLIST
+
+__all__ = [
+    "Chapter",
+    "rebuild",
+    "COLUMN_BLACKLIST",
+]

--- a/deeptutor/textbook_struct/chapter_rebuild.py
+++ b/deeptutor/textbook_struct/chapter_rebuild.py
@@ -1,0 +1,247 @@
+"""Layered chapter rebuild from MinerU ``layout.json``.
+
+Layers (all deterministic, no LLM):
+  0. column blacklist   — feature-column names are never chapters (closed vocabulary)
+  1. regex              — ``第X课/章/节/单元`` headings (works regardless of height)
+  2. position filter    — heading must sit in the page-top band (y0 < top)
+  3. adjacent merge     — same-page title blocks split by line-wrap rejoin
+
+Input is the MinerU layout dict (``layout["pdf_info"]``), one page object per
+page with ``page_idx`` / ``para_blocks``; blocks carry ``type`` / ``bbox`` /
+``lines[].spans[].content``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+
+from .column_blacklist import COLUMN_BLACKLIST
+
+CHAPTER_RE = re.compile(r"^第\s*[一二三四五六七八九十百\d]+\s*[课章节单元]")
+
+# Title blocks whose text is shorter than this are layout noise (figure
+# captions etc.) — never chapters even if they regex-match.
+MIN_TITLE_CHARS = 4
+
+
+@dataclass
+class Chapter:
+    """One rebuilt chapter: title + start page (0-based) + bbox on that page."""
+
+    title: str
+    page_idx: int
+    bbox: list[float]
+    end_page_idx: int | None = None  # filled by assign_page_ranges
+    level: int = 1  # reserved: 1=lesson/chapter (课/章), 2=section (框/节)
+    meta: dict = field(default_factory=dict)
+
+
+def block_text(block: dict) -> str:
+    return "".join(
+        span.get("content", "") for line in block.get("lines", []) for span in line.get("spans", [])
+    ).strip()
+
+
+def merge_adjacent(blocks: list[dict], gap: float = 40.0) -> list[dict]:
+    """Rejoin same-page title blocks split by line-wrap.
+
+    Sort by y0; vertical gap < ``gap`` with x-overlap merges into the first
+    block (bbox union, text concat). Mutates nothing — returns new dicts.
+    """
+    merged: list[dict] = []
+    for block in sorted(blocks, key=lambda b: b["bbox"][1]):
+        if merged:
+            prev = merged[-1]
+            vgap = block["bbox"][1] - prev["bbox"][3]
+            x_overlap = min(block["bbox"][2], prev["bbox"][2]) - max(
+                block["bbox"][0], prev["bbox"][0]
+            )
+            if vgap < gap and x_overlap > 0:
+                prev["bbox"] = [
+                    min(prev["bbox"][0], block["bbox"][0]),
+                    min(prev["bbox"][1], block["bbox"][1]),
+                    max(prev["bbox"][2], block["bbox"][2]),
+                    max(prev["bbox"][3], block["bbox"][3]),
+                ]
+                prev["text"] = (prev.get("text", "") + block_text(block)).strip()
+                continue
+        item = dict(block)
+        item["text"] = block_text(block)
+        merged.append(item)
+    return merged
+
+
+def rebuild(
+    layout: dict,
+    *,
+    top_band: float = 120.0,
+    merge_gap: float = 40.0,
+) -> list[Chapter]:
+    """Run the layered pipeline over ``layout`` and return chapter starts."""
+    chapters: list[Chapter] = []
+    for page in layout.get("pdf_info", []):
+        title_blocks = [b for b in page.get("para_blocks", []) if b.get("type") == "title"]
+        for block in merge_adjacent(title_blocks, gap=merge_gap):
+            text = block.get("text", "")
+            if text in COLUMN_BLACKLIST:  # layer 0 — closed column names
+                continue
+            if not CHAPTER_RE.match(text):  # layer 1 — regex first
+                continue
+            if len(text.replace(" ", "")) < MIN_TITLE_CHARS:
+                continue
+            if block["bbox"][1] >= top_band:  # layer 2 — page-top band
+                continue
+            chapters.append(
+                Chapter(
+                    title=text,
+                    page_idx=page["page_idx"],
+                    bbox=list(block["bbox"]),
+                )
+            )
+    chapters = _dedupe_keep_last(chapters)  # TOC page duplicates body hits — keep body
+    return assign_page_ranges(chapters, page_count=len(layout.get("pdf_info", [])))
+
+
+def _dedupe_keep_last(chapters: list[Chapter]) -> list[Chapter]:
+    """Same title appearing on TOC page AND in the body: keep the body hit."""
+    by_title: dict[str, Chapter] = {}
+    order: list[str] = []
+    for chapter in chapters:
+        if chapter.title in by_title:
+            by_title[chapter.title] = chapter  # later (higher page) wins
+        else:
+            by_title[chapter.title] = chapter
+            order.append(chapter.title)
+    return [by_title[t] for t in order]
+
+
+def assign_page_ranges(chapters: list[Chapter], *, page_count: int) -> list[Chapter]:
+    """Chapter i spans [start_i, start_{i+1}); the last runs to the last page."""
+    for i, chapter in enumerate(chapters):
+        chapter.end_page_idx = (
+            chapters[i + 1].page_idx
+            if i + 1 < len(chapters)
+            else max(page_count - 1, chapter.page_idx)
+        )
+    return chapters
+
+
+# ── Mid-page section-frame detection (no page-top band constraint) ─────────
+# Measured heading heights: frame ~22-24, exploration ~27, body lines ~21,
+# lesson-title wrap residue ~28. Column names go to the blacklist; stray
+# publisher header lines go to PUBLISHER_NOISE.
+
+PUBLISHER_NOISE = frozenset({"人民教育出版社", "出版社", "思想政治", "目录", "后记"})
+
+
+def detect_frames(
+    layout: dict,
+    *,
+    height_range: tuple[float, float] = (20.0, 25.0),
+    extras_range: tuple[float, float] = (26.0, 29.0),
+    first_lesson_page_idx: int | None = None,
+    lesson_titles: list[str] = (),
+) -> tuple[list[dict], list[dict]]:
+    """Detect section-frame headings (and chapter-level extras like 综合探究).
+
+    Returns ``(frames, extras)`` — each item ``{title, page_idx, bbox, height}``.
+    Frames are mid-page title blocks in the frame height band; extras
+    (exploration sections / afterword) sit in the slightly taller band.
+    Blacklist + publisher noise + lesson-level regex filtered out.
+    """
+    frames: list[dict] = []
+    extras: list[dict] = []
+    for page in layout.get("pdf_info", []):
+        for block in page.get("para_blocks", []):
+            if block.get("type") != "title":
+                continue
+            text = block_text(block)
+            if not text or text in COLUMN_BLACKLIST or text in PUBLISHER_NOISE:
+                continue
+            if CHAPTER_RE.match(text):
+                continue  # lesson-level handled by the footer path
+            height = block["bbox"][3] - block["bbox"][1]
+            item = {
+                "title": text,
+                "page_idx": page["page_idx"],
+                "bbox": list(block["bbox"]),
+                "height": round(height, 1),
+            }
+            if height_range[0] <= height <= height_range[1]:
+                if len(text) >= 6:
+                    # front-matter noise + lesson-title wrap residue
+                    # (substring of a lesson title)
+                    if (
+                        first_lesson_page_idx is not None
+                        and item["page_idx"] < first_lesson_page_idx
+                    ):
+                        continue
+                    if any(text in lt for lt in lesson_titles):
+                        continue
+                    frames.append(item)
+            elif extras_range[0] <= height <= extras_range[1] and len(text) >= 3:
+                extras.append(item)
+    return frames, extras
+
+
+# ── Level-aware boundaries + printed-offset consistency check ──────────────
+
+UNIT_RE_MAP = {
+    "课": re.compile(r"^第\s*[一二三四五六七八九十百\d]+\s*课"),
+    "章": re.compile(r"^第\s*[一二三四五六七八九十百\d]+\s*章"),
+    "节": re.compile(r"^第\s*[一二三四五六七八九十百\d]+\s*节"),
+    "单元": re.compile(r"^第\s*[一二三四五六七八九十百\d]+\s*单元"),
+}
+
+
+def rebuild_from_headers_level(layout: dict, unit: str = "课") -> list[Chapter]:
+    """Level-aware rebuild: only ``unit``-level running-header changes mark boundaries.
+
+    In textbooks with two-level running headers (e.g. rotating
+    "第X章/第Y节" pairs), a change at the other level must not start a
+    chapter — otherwise pseudo-chapters get split out.
+    """
+    # Imported here to avoid a circular import (page_headers imports this
+    # module's CHAPTER_RE / Chapter / assign_page_ranges at top level).
+    from .page_headers import page_facts
+
+    unit_re = UNIT_RE_MAP.get(unit)
+    if unit_re is None:
+        raise ValueError(f"unknown unit: {unit}")
+    chapters: list[Chapter] = []
+    seen: set[str] = set()
+    page_count = len(layout.get("pdf_info", []))
+    for page in layout.get("pdf_info", []):
+        footers, printed = page_facts(page)
+        for title in footers:
+            if not unit_re.match(title):
+                continue
+            if title in seen:
+                continue
+            seen.add(title)
+            chapters.append(
+                Chapter(
+                    title=title,
+                    page_idx=page["page_idx"],
+                    bbox=[],
+                    meta={"printed_page": int(printed) if printed.isdigit() else None},
+                )
+            )
+    return assign_page_ranges(chapters, page_count=page_count)
+
+
+def verify_offset(chapters: list[Chapter]) -> dict:
+    """Printed-offset consistency: physical (1-based) − printed page number.
+
+    An offset that varies across chapters means a chapter boundary was
+    mis-detected.
+    """
+    offsets = sorted(
+        {c.page_idx + 1 - c.meta["printed_page"] for c in chapters if c.meta.get("printed_page")}
+    )
+    return {
+        "offsets": offsets,
+        "consistent": len(offsets) <= 1,
+        "ok": bool(offsets) and len(offsets) == 1,
+    }

--- a/deeptutor/textbook_struct/column_blacklist.py
+++ b/deeptutor/textbook_struct/column_blacklist.py
@@ -1,0 +1,41 @@
+"""Closed vocabulary of textbook feature-column names (layer 0).
+
+These are recurring textbook activity/column names — MinerU often classifies
+them as ``title`` blocks, but they are never chapter headings. The list is
+closed on purpose: no fuzzy matching, to avoid swallowing real titles.
+Append new names as new textbook editions introduce new column types.
+"""
+
+COLUMN_BLACKLIST: frozenset[str] = frozenset(
+    {
+        # civics / politics
+        "探究与分享",
+        "相关链接",
+        "专家点评",
+        "名词点击",
+        "观点一",
+        "观点二",
+        "观点三",
+        # Chinese / English
+        "学习提示",
+        "单元导语",
+        "思考与探究",
+        # math / physics / chemistry / biology
+        "思考",
+        "探究",
+        "实验",
+        "练习",
+        "习题",
+        "复习与巩固",
+        "本章小结",
+        "信息技术应用",
+        "阅读与思考",
+        "观察与思考",
+        # geography / history
+        "问题研究",
+        "自学窗",
+        "活动",
+        "案例",
+        "知识窗",
+    }
+)

--- a/deeptutor/textbook_struct/page_headers.py
+++ b/deeptutor/textbook_struct/page_headers.py
@@ -13,6 +13,8 @@ physical page offset per chapter instead of guessing it.
 
 from __future__ import annotations
 
+import re
+
 from .chapter_rebuild import CHAPTER_RE, Chapter, assign_page_ranges
 
 
@@ -22,8 +24,37 @@ def _block_text(block: dict) -> str:
     ).strip()
 
 
+#: Running-header variants that embed the chapter token mid-text — some
+#: publishers print the chapter name in the running *header* (embedded
+#: mid-text, e.g. “集合第1章”, “空间向量与立体几何 第6章”), often without a
+#: leading “第”; others print it in the footer. Header variants are extracted
+#: and normalized to the canonical “第N章 章名” shape so the level filter and
+#: dedupe see the same vocabulary the footer path produces.
+HEADER_CHAPTER_RE = re.compile(
+    r"^(?P<pre>.{0,20}?)\s*第\s*(?P<num>[一二三四五六七八九十百\d]+)\s*"
+    r"(?P<unit>[课章节单元])\s*(?P<post>.{0,30}?)\s*$"
+)
+
+
+def normalize_header_chapter(text: str) -> str | None:
+    """Normalize a mid-text chapter header to “第N单元 章名” (None = no match)."""
+    m = HEADER_CHAPTER_RE.match(text)
+    if not m:
+        return None
+    name = (m.group("pre") or m.group("post") or "").strip()
+    token = f"第{m.group('num')}{m.group('unit')}"
+    return f"{token} {name}" if name else token
+
+
 def page_facts(page: dict) -> tuple[list[str], str]:
-    """Return ``(chapter_shaped_footers, printed_page_number)`` for one page."""
+    """Return ``(chapter_shaped_footers, printed_page_number)`` for one page.
+
+    Chapter-shaped furniture is read from *both* running-header positions:
+    footer blocks matching ``CHAPTER_RE`` verbatim (publishers that print the
+    chapter name in the footer) and header blocks whose chapter token sits
+    mid-text (publishers that embed it in the header, normalized via
+    :func:`normalize_header_chapter`).
+    """
     footers: list[str] = []
     printed = ""
     for block in page.get("discarded_blocks", []):
@@ -33,6 +64,10 @@ def page_facts(page: dict) -> tuple[list[str], str]:
         btype = block.get("type")
         if btype == "footer" and CHAPTER_RE.match(text):
             footers.append(text)
+        elif btype == "header":
+            normalized = normalize_header_chapter(text)
+            if normalized is not None:
+                footers.append(normalized)
         elif btype == "page_number" and text.isdigit():
             printed = text
     return footers, printed

--- a/deeptutor/textbook_struct/page_headers.py
+++ b/deeptutor/textbook_struct/page_headers.py
@@ -1,0 +1,65 @@
+"""Header-driven chapter rebuild (v0.2) — running headers never lie.
+
+MinerU discards page furniture into ``page["discarded_blocks"]``, but for K12
+textbooks that furniture is gold:
+  - ``footer`` blocks repeat the current chapter title (running header)
+  - ``page_number`` blocks carry the PRINTED page number
+
+A chapter starts where its running header first appears; the printed page
+number comes free on the very same page. This fixes the TOC-page false
+positives of the title-block path (v0.1), and measures the printed-vs-
+physical page offset per chapter instead of guessing it.
+"""
+
+from __future__ import annotations
+
+from .chapter_rebuild import CHAPTER_RE, Chapter, assign_page_ranges
+
+
+def _block_text(block: dict) -> str:
+    return "".join(
+        span.get("content", "") for line in block.get("lines", []) for span in line.get("spans", [])
+    ).strip()
+
+
+def page_facts(page: dict) -> tuple[list[str], str]:
+    """Return ``(chapter_shaped_footers, printed_page_number)`` for one page."""
+    footers: list[str] = []
+    printed = ""
+    for block in page.get("discarded_blocks", []):
+        text = _block_text(block)
+        if not text:
+            continue
+        btype = block.get("type")
+        if btype == "footer" and CHAPTER_RE.match(text):
+            footers.append(text)
+        elif btype == "page_number" and text.isdigit():
+            printed = text
+    return footers, printed
+
+
+def rebuild_from_headers(layout: dict) -> list[Chapter]:
+    """Chapter starts = first page where each new running header appears.
+
+    Titles are taken verbatim from the running header; ``meta`` carries the
+    printed page number of the start page (the display layer decides which
+    base to show — the fix is data, not guesswork).
+    """
+    chapters: list[Chapter] = []
+    seen: set[str] = set()
+    page_count = len(layout.get("pdf_info", []))
+    for page in layout.get("pdf_info", []):
+        footers, printed = page_facts(page)
+        for title in footers:
+            if title in seen:
+                continue
+            seen.add(title)
+            chapters.append(
+                Chapter(
+                    title=title,
+                    page_idx=page["page_idx"],
+                    bbox=[],
+                    meta={"printed_page": int(printed) if printed.isdigit() else None},
+                )
+            )
+    return assign_page_ranges(chapters, page_count=page_count)

--- a/tests/textbook_struct/test_page_headers.py
+++ b/tests/textbook_struct/test_page_headers.py
@@ -1,0 +1,129 @@
+"""Running-header chapter rebuild: footer + header channels both.
+
+Some textbooks print the chapter name embedded mid-text in the running
+*header* (e.g. “集合第1章” / “空间向量与立体几何 第6章”) while the footer
+only carries the publisher name — a footer-only pass then finds 0 chapters.
+Header-embedded chapter tokens are extracted and normalized to the
+“第N章 章名” shape, sharing the level filter and seen-dedupe with the
+footer path.
+"""
+
+from __future__ import annotations
+
+from deeptutor.textbook_struct.chapter_rebuild import rebuild_from_headers_level
+from deeptutor.textbook_struct.page_headers import (
+    normalize_header_chapter,
+    page_facts,
+)
+
+
+def _page(page_idx: int, discarded: list[dict]) -> dict:
+    return {"page_idx": page_idx, "discarded_blocks": discarded}
+
+
+def _footer(text: str) -> dict:
+    return {"type": "footer", "lines": [{"spans": [{"content": text}]}]}
+
+
+def _header(text: str) -> dict:
+    return {"type": "header", "lines": [{"spans": [{"content": text}]}]}
+
+
+def _page_number(n: str) -> dict:
+    return {"type": "page_number", "lines": [{"spans": [{"content": n}]}]}
+
+
+# ── normalize: three header forms + mismatch guards ──────────────────────
+
+
+def test_normalize_embedded_chapter_name_before_token() -> None:
+    assert normalize_header_chapter("集合第1章") == "第1章 集合"
+
+
+def test_normalize_embedded_chapter_name_after_token() -> None:
+    assert normalize_header_chapter("空间向量与立体几何 第6章") == "第6章 空间向量与立体几何"
+
+
+def test_normalize_bare_token() -> None:
+    assert normalize_header_chapter("第6章") == "第6章"
+
+
+def test_normalize_leading_token_keeps_footer_shape() -> None:
+    assert normalize_header_chapter("第6章 空间向量与立体几何") == "第6章 空间向量与立体几何"
+
+
+def test_normalize_rejects_book_title_and_prose() -> None:
+    # Book-title-with-year, a plain header without a chapter token, and long
+    # prose are not chapter boundaries.
+    assert normalize_header_chapter("高中数学人教A版2019") is None
+    assert normalize_header_chapter("数学·必修第一册") is None
+    assert normalize_header_chapter("a" * 60) is None
+
+
+# ── page_facts: dual-channel collection ──────────────────────────────────
+
+
+def test_page_facts_reads_footer_verbatim() -> None:
+    footers, printed = page_facts(
+        _page(3, [_footer("第一章 集合与常用逻辑用语"), _page_number("12")])
+    )
+    assert footers == ["第一章 集合与常用逻辑用语"]
+    assert printed == "12"
+
+
+def test_page_facts_reads_header_normalized() -> None:
+    footers, printed = page_facts(_page(4, [_header("集合第1章"), _page_number("13")]))
+    assert footers == ["第1章 集合"]
+    assert printed == "13"
+
+
+# ── rebuild_from_headers_level: header-driven chapter build, end to end ───
+
+
+def _header_layout() -> dict:
+    """Header layout: chapter name in the running header, each chapter
+    starting on its own page (printed numbers enable offset checking).
+
+    physical (1-based) − printed page number stays constant at 1 across the
+    book (the cover prints no page number; the body starts at printed 2).
+    """
+    return {
+        "pdf_info": [
+            _page(0, [_header("高中数学·必修第一册"), _page_number("1")]),  # cover
+            _page(1, [_header("集合与常用逻辑用语 第1章"), _page_number("2")]),
+            _page(2, [_header("集合与常用逻辑用语 第1章"), _page_number("3")]),
+            _page(19, [_header("一元二次函数、方程和不等式 第2章"), _page_number("20")]),
+        ]
+    }
+
+
+def test_rebuild_level_builds_chapters_from_headers() -> None:
+    chapters = rebuild_from_headers_level(_header_layout(), unit="章")
+    assert [c.title for c in chapters] == [
+        "第1章 集合与常用逻辑用语",
+        "第2章 一元二次函数、方程和不等式",
+    ]
+    assert [c.page_idx for c in chapters] == [1, 19]
+    assert chapters[0].meta["printed_page"] == 2
+    assert chapters[1].meta["printed_page"] == 20
+    # Constant offset: physical page − printed page = 1 across the whole book.
+    assert verify_offsets_ok(chapters)
+
+
+def verify_offsets_ok(chapters) -> bool:
+    from deeptutor.textbook_struct.chapter_rebuild import verify_offset
+
+    return verify_offset(chapters)["ok"]
+
+
+def test_rebuild_level_unit_filter_drops_other_levels() -> None:
+    # With two-level running headers (rotating “第X章/第Y节” pairs),
+    # unit="节" only follows section-level changes.
+    layout = {
+        "pdf_info": [
+            _page(0, [_header("函数 第2章"), _header("函数的概念 第1节"), _page_number("5")]),
+            _page(1, [_header("函数 第2章"), _header("函数的表示法 第2节"), _page_number("9")]),
+        ]
+    }
+    chapters = rebuild_from_headers_level(layout, unit="节")
+    assert [c.title for c in chapters] == ["第1节 函数的概念", "第2节 函数的表示法"]


### PR DESCRIPTION
## Problem

Many K12 textbooks print the chapter name in the running **header** embedded mid-text (e.g. `集合第1章`, `空间向量与立体几何 第6章`) rather than as a footer line that matches the chapter heading. The footer-only chapter rebuild finds **0 chapters** on such books, so chapter trees cannot be built for them.

## Change

- `page_facts` now reads both positions:
  - footer blocks are still matched against `CHAPTER_RE` verbatim (unchanged);
  - header blocks whose chapter token sits mid-text are extracted and normalized to `第N单元 章名` via `normalize_header_chapter`, with guards against book-title / prose false positives.
- Level filter and seen-dedupe logic are unchanged.

## Scope

Purely additive: **5 files, 533 insertions**, no existing upstream file touched. 9 new tests, including dual-level header rotation and printed-offset constancy.

## Relationship to upstream structure.py

This complements `knowledge/doc_intel` `structure.py`'s footer-based tree building. `textbook_struct` is an independent module and does not modify any upstream behavior.
