### PR TITLE
fix(mastery): bind draft before sending opening turn

### DIFF
--- a/web/components/space/learning/MasteryStudy.tsx
+++ b/web/components/space/learning/MasteryStudy.tsx
@@ -31,6 +31,7 @@ import {
   useChatStateAdapter,
 } from "@/features/chat/ChatStateAdapter";
 import { useChatAutoScroll } from "@/hooks/useChatAutoScroll";
+import { useMasteryOpening } from "@/hooks/useMasteryOpening";
 import { useMasteryStudySession } from "@/hooks/useMasteryStudySession";
 import { useMeasuredHeight } from "@/hooks/useMeasuredHeight";
 import { useResearchOutlineContinuation } from "@/hooks/useResearchOutlineContinuation";
@@ -45,8 +46,6 @@ import { consumePendingPrompt } from "@/lib/pending-prompt";
 import { buildChatOutline, scrollToChatTurn } from "@/lib/chat-outline";
 import { buildConversationNotebookSave } from "@/lib/conversation-notebook-save";
 import {
-  MASTERY_OPENING_SCOPE,
-  masteryOpeningMessage,
   masterySessionRoute,
   type MasteryMode,
 } from "@/lib/mastery-mode";
@@ -471,42 +470,16 @@ export function MasteryStudy({
     [state.activeCapability, submit],
   );
 
-  // A conversation that opens with nothing to say says the thing it was
-  // opened to say.
-  //
-  // Derived from the mode rather than handed across the navigation. The
-  // hand-off channel that used to carry it reads *destructively*, so a send
-  // refused for any reason (a turn still settling, a session still resolving)
-  // consumed the message and left the screen insisting work was under way
-  // forever — the same dead end twice, in two different places. There is no
-  // channel to lose now: an empty outline conversation always knows what it
-  // is for. The hand-off is still read, but only to *enrich* the opening (the
-  // review card names what is due), never to supply it.
-  const openingSentRef = useRef("");
-  useEffect(() => {
-    if (!topic || hasMessages || sessionLoading || sessionError) return;
-    if (state.isStreaming || openingSentRef.current === pathId) return;
-    const opening =
-      consumePendingPrompt(MASTERY_OPENING_SCOPE).trim() ||
-      masteryOpeningMessage(sessionMode, t as Translate);
-    // A study conversation opens with nothing on purpose: "start learning"
-    // does not say what to start with, so the screen offers ways in instead.
-    if (!opening) return;
-    // Latch on the send, never before it: ``submit`` refuses silently while a
-    // turn is live or the session is still resolving, and the next render
-    // tries again.
-    if (submit(opening)) openingSentRef.current = pathId;
-  }, [
-    hasMessages,
+  useMasteryOpening({
     pathId,
-    sessionError,
+    topicReady: Boolean(topic),
+    hasMessages,
     sessionLoading,
+    sessionError,
     sessionMode,
-    state.isStreaming,
+    isStreaming: state.isStreaming,
     submit,
-    t,
-    topic,
-  ]);
+  });
 
   // The learner pressing one of the three modes above the transcript. The same
   // move the tutor makes with ``mastery_mode``, through the same admission

--- a/web/features/chat/ChatStateAdapter.tsx
+++ b/web/features/chat/ChatStateAdapter.tsx
@@ -132,6 +132,8 @@ export interface SendMessageOptions {
 }
 
 export interface ChatState {
+  /** Local identity, available before the backend assigns a session ID. */
+  sessionKey: string;
   sessionId: string | null;
   sessionTitle: string;
   enabledTools: string[];
@@ -252,7 +254,7 @@ export interface MessageItem {
   parentMessageId?: number | null;
 }
 
-interface SessionEntry extends ChatState {
+interface SessionEntry extends Omit<ChatState, "sessionKey"> {
   key: string;
   status: SessionRuntimeStatus;
   activeTurnId: string | null;
@@ -913,6 +915,10 @@ function reducer(state: ProviderState, action: Action): ProviderState {
               action.masteryPathId !== undefined
                 ? action.masteryPathId
                 : existing.masteryPathId,
+            masterySessionMode:
+              action.masterySessionMode !== undefined
+                ? action.masterySessionMode
+                : existing.masterySessionMode,
             courseId:
               action.courseId !== undefined
                 ? action.courseId
@@ -1215,7 +1221,7 @@ interface ChatContextValue {
   /** Switch which sibling is currently visible at a branch point. */
   switchBranch: (parentMessageId: number | null, childId: number) => void;
   renameSessionTitle: (title: string) => Promise<void>;
-  newSession: (configuration?: SessionConfiguration) => void;
+  newSession: (configuration?: SessionConfiguration) => string;
   /** Apply route-owned preferences to an explicit loaded session (or the
    * selected draft). Dispatching by key keeps this safe immediately after
    * LOAD_SESSION, before React has committed a new context render. */
@@ -1948,6 +1954,7 @@ export function ChatStateAdapterProvider({
       options?: { signal?: AbortSignal; revalidate?: boolean },
     ) => {
       const session = await getSession(sessionId, options?.signal);
+      if (options?.signal?.aborted) return;
       const key = session.session_id || session.id;
       const activeTurn = Array.isArray(session.active_turns)
         ? session.active_turns[0]
@@ -2376,6 +2383,7 @@ export function ChatStateAdapterProvider({
         bookReferences: effectiveBookReferences,
         readingReferences: effectiveReadingReferences,
         masteryPathId: effectiveMasteryPathId || null,
+        masterySessionMode: effectiveMasterySessionMode || null,
         masteryAnswer: options?.masteryAnswer ?? null,
         masterySkip: options?.masterySkip ?? null,
         // Immersive reading. Gated on the stable workspace mode as well as on
@@ -2507,6 +2515,7 @@ export function ChatStateAdapterProvider({
   const derivedState = useMemo<ChatState>(() => {
     const current = ensureSelectedSession(state);
     return {
+      sessionKey: current.key,
       sessionId: current.sessionId,
       sessionTitle: current.sessionTitle,
       enabledTools: current.enabledTools,
@@ -2600,7 +2609,9 @@ export function ChatStateAdapterProvider({
 
   const newSession = useCallback(
     (configuration?: SessionConfiguration) => {
-      dispatch({ type: "NEW_SESSION", key: makeDraftKey(), configuration });
+      const key = makeDraftKey();
+      dispatch({ type: "NEW_SESSION", key, configuration });
+      return key;
     },
     [makeDraftKey],
   );

--- a/web/hooks/useMasteryOpening.ts
+++ b/web/hooks/useMasteryOpening.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { consumePendingPrompt } from "@/lib/pending-prompt";
+import {
+  MASTERY_OPENING_SCOPE,
+  masteryOpeningMessage,
+  type MasteryMode,
+} from "@/lib/mastery-mode";
+
+/** Keep the opening pending until the route's session can accept a turn. */
+export function useMasteryOpening({
+  pathId,
+  topicReady,
+  hasMessages,
+  sessionLoading,
+  sessionError,
+  sessionMode,
+  isStreaming,
+  submit,
+}: {
+  pathId: string;
+  topicReady: boolean;
+  hasMessages: boolean;
+  sessionLoading: boolean;
+  sessionError: string | null;
+  sessionMode: MasteryMode;
+  isStreaming: boolean;
+  submit: (content: string) => boolean;
+}) {
+  const { t } = useTranslation();
+  const openingSentRef = useRef("");
+  useEffect(() => {
+    if (!topicReady || hasMessages || sessionLoading || sessionError) return;
+    if (isStreaming || openingSentRef.current === pathId) return;
+    const opening =
+      consumePendingPrompt(MASTERY_OPENING_SCOPE).trim() ||
+      masteryOpeningMessage(sessionMode, t);
+    // Study mode has no automatic opening. Latch only after submitting.
+    if (opening && submit(opening)) openingSentRef.current = pathId;
+  }, [
+    hasMessages,
+    pathId,
+    sessionError,
+    sessionLoading,
+    sessionMode,
+    isStreaming,
+    submit,
+    t,
+    topicReady,
+  ]);
+}

--- a/web/hooks/useMasteryStudySession.ts
+++ b/web/hooks/useMasteryStudySession.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/learning-api";
 import {
   isMasteryDraftSessionReady,
+  isMasteryDraftSendReady,
   type MasteryDraftRouteGuard,
 } from "@/lib/mastery-study-route";
 import { courseSessionConfiguration } from "@/lib/course-session-scope";
@@ -60,6 +61,11 @@ export function useMasteryStudySession(
   const [sessionResolution, setSessionResolution] = useState<{
     routeKey: string;
     error: string | null;
+  } | null>(null);
+  const [draftBinding, setDraftBinding] = useState<{
+    routeKey: string;
+    draftKey: string;
+    previousSessionId: string | null;
   } | null>(null);
   const initializedRouteRef = useRef("");
   const draftRouteGuardRef = useRef<MasteryDraftRouteGuard | null>(null);
@@ -116,7 +122,7 @@ export function useMasteryStudySession(
   );
 
   useEffect(() => {
-    if (!topic) return;
+    if (topic?.path_id !== pathId) return;
     const routeKey = currentRouteKey;
     if (initializedRouteRef.current === routeKey) return;
     initializedRouteRef.current = routeKey;
@@ -126,14 +132,24 @@ export function useMasteryStudySession(
         routeKey,
         previousSessionId: state.sessionId,
       };
-      newSession(courseSessionConfiguration(sessionConfiguration, courseId));
+      const draftKey = newSession(
+        courseSessionConfiguration(sessionConfiguration, courseId),
+      );
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- record the draft created for this route.
+      setDraftBinding({
+        routeKey,
+        draftKey,
+        previousSessionId: state.sessionId,
+      });
       return;
     }
 
     draftRouteGuardRef.current = null;
+    const controller = new AbortController();
 
     void fetchMasteryTopicSessions(pathId, { cache: "no-store" })
       .then((topicSessions) => {
+        if (controller.signal.aborted) return;
         if (
           !topicSessions.some(
             (candidate) => candidate.session_id === routeSessionId,
@@ -152,12 +168,13 @@ export function useMasteryStudySession(
             routeSessionId,
           );
         }
-        return loadSession(
-          routeSessionId,
-          cached ? { revalidate: true } : undefined,
-        );
+        return loadSession(routeSessionId, {
+          signal: controller.signal,
+          revalidate: Boolean(cached),
+        });
       })
       .then(() => {
+        if (controller.signal.aborted) return;
         configureSession(
           courseSessionConfiguration(sessionConfiguration, courseId),
           routeSessionId,
@@ -165,6 +182,7 @@ export function useMasteryStudySession(
         setSessionResolution({ routeKey, error: null });
       })
       .catch((reason: unknown) => {
+        if (controller.signal.aborted) return;
         setSessionResolution({
           routeKey,
           error:
@@ -173,6 +191,10 @@ export function useMasteryStudySession(
               : t("This learning session could not be opened"),
         });
       });
+    return () => {
+      controller.abort();
+      initializedRouteRef.current = "";
+    };
   }, [
     courseId,
     configureSession,
@@ -225,16 +247,39 @@ export function useMasteryStudySession(
     sessionResolution?.routeKey === currentRouteKey
       ? sessionResolution.error
       : null;
-  const sessionLoading = Boolean(
-    routeSessionId && sessionResolution?.routeKey !== currentRouteKey,
-  );
+  const bindingMatches =
+    topic?.path_id === pathId &&
+    state.workspaceMode === MASTERY_WORKSPACE_MODE &&
+    state.masteryPathId === pathId;
+  const sessionLoading = routeSessionId
+    ? sessionResolution?.routeKey !== currentRouteKey ||
+      (!sessionError && (!bindingMatches || state.sessionId !== routeSessionId))
+    : !bindingMatches ||
+      !(
+        isMasteryDraftSendReady({
+          binding: draftBinding,
+          routeKey: currentRouteKey,
+          sessionKey: state.sessionKey,
+          workspaceMode: state.workspaceMode,
+          masteryPathId: state.masteryPathId,
+          pathId,
+          masterySessionMode: state.masterySessionMode,
+          requestedMode,
+        }) ||
+        isMasteryDraftSessionReady({
+          guard: draftBinding,
+          routeKey: currentRouteKey,
+          sessionId: state.sessionId,
+          masteryPathId: state.masteryPathId,
+          pathId,
+        })
+      );
 
   // The kind actually in force: what the server remembers for an existing
   // conversation, and what this route asked for while a new one is still
   // being created.
   const sessionMode: MasteryMode =
-    (state.masterySessionMode as MasteryMode | null) ||
-    requestedMode;
+    (state.masterySessionMode as MasteryMode | null) || requestedMode;
 
   return {
     topic,

--- a/web/lib/mastery-study-route.ts
+++ b/web/lib/mastery-study-route.ts
@@ -29,3 +29,24 @@ export function isMasteryDraftSessionReady({
     masteryPathId === pathId,
   );
 }
+
+/** Sending the first turn requires a committed local draft, not a server ID. */
+export function isMasteryDraftSendReady(input: {
+  binding: { routeKey: string; draftKey: string } | null;
+  routeKey: string;
+  sessionKey: string;
+  workspaceMode: string | null;
+  masteryPathId: string | null;
+  pathId: string;
+  masterySessionMode: string | null;
+  requestedMode: string;
+}): boolean {
+  return Boolean(
+    input.binding &&
+    input.binding.routeKey === input.routeKey &&
+    input.binding.draftKey === input.sessionKey &&
+    input.workspaceMode === "mastery_path" &&
+    input.masteryPathId === input.pathId &&
+    input.masterySessionMode === input.requestedMode,
+  );
+}

--- a/web/tests/mastery-opening.spec.tsx
+++ b/web/tests/mastery-opening.spec.tsx
@@ -1,0 +1,279 @@
+import { StrictMode, useCallback } from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ChatStateAdapterProvider,
+  useChatStateAdapter,
+} from "@/features/chat/ChatStateAdapter";
+import { useMasteryStudySession } from "@/hooks/useMasteryStudySession";
+import { useMasteryOpening } from "@/hooks/useMasteryOpening";
+import { isMasteryDraftSendReady } from "@/lib/mastery-study-route";
+import { setPendingPrompt } from "@/lib/pending-prompt";
+import { MASTERY_OPENING_SCOPE } from "@/lib/mastery-mode";
+import { initI18n } from "@/i18n/init";
+
+initI18n("en");
+const mocks = vi.hoisted(() => ({
+  topic: vi.fn(),
+  sessions: vi.fn(),
+  getSession: vi.fn(),
+  replace: vi.fn(),
+  requests: [] as Record<string, unknown>[],
+  emit: undefined as undefined | ((event: Record<string, unknown>) => void),
+}));
+vi.mock("next/navigation", () => ({ useRouter: () => router }));
+const router = { replace: mocks.replace };
+vi.mock("@/lib/learning-api", () => ({
+  fetchMasteryTopic: mocks.topic,
+  fetchMasteryTopicSessions: mocks.sessions,
+}));
+vi.mock("@/lib/session-api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/session-api")>()),
+  getSession: mocks.getSession,
+}));
+vi.mock("@/hooks/useMasteryPathActivity", () => ({
+  useMasteryPathActivity: () => ({ revision: 0 }),
+}));
+vi.mock("@/features/chat/transport/UnifiedTurnClient", () => ({
+  UnifiedTurnClient: class {
+    connected = true;
+    constructor(emit: typeof mocks.emit) {
+      mocks.emit = emit;
+    }
+    connect() {}
+    disconnect() {}
+    setResumeState() {}
+    send(message: Record<string, unknown>) {
+      mocks.requests.push(message);
+    }
+    sendAwaitingAck(message: Record<string, unknown>) {
+      mocks.requests.push(message);
+      return Promise.resolve(true);
+    }
+  },
+}));
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+const topic = (pathId: string) => ({
+  path_id: pathId,
+  sources: [],
+  map: { modules: [], counts: { mastered: 0, learning: 0, new: 0, total: 0 } },
+});
+function Harness({
+  pathId,
+  sessionId,
+}: {
+  pathId: string;
+  sessionId?: string;
+}) {
+  const { state, sendMessage } = useChatStateAdapter();
+  const session = useMasteryStudySession(pathId, sessionId, "", "outline");
+  const submit = useCallback(
+    (content: string) => {
+      if (session.sessionLoading || session.sessionError || state.isStreaming)
+        return false;
+      sendMessage(content);
+      return true;
+    },
+    [
+      sendMessage,
+      session.sessionLoading,
+      session.sessionError,
+      state.isStreaming,
+    ],
+  );
+  useMasteryOpening({
+    pathId,
+    topicReady: Boolean(session.topic),
+    hasMessages: state.messages.length > 0,
+    sessionLoading: session.sessionLoading,
+    sessionError: session.sessionError,
+    sessionMode: session.sessionMode,
+    isStreaming: state.isStreaming,
+    submit,
+  });
+  return (
+    <>
+      <span data-testid="loading">{String(session.sessionLoading)}</span>
+      <span data-testid="error">{session.sessionError}</span>
+      <span data-testid="server-id">{state.sessionId ?? "none"}</span>
+    </>
+  );
+}
+const view = (pathId: string, sessionId?: string) => (
+  <StrictMode>
+    <ChatStateAdapterProvider>
+      <Harness pathId={pathId} sessionId={sessionId} />
+    </ChatStateAdapterProvider>
+  </StrictMode>
+);
+const starts = () => mocks.requests.filter((r) => r.type === "start_turn");
+beforeEach(() => {
+  mocks.requests.length = 0;
+  mocks.emit = undefined;
+  mocks.topic.mockReset();
+  mocks.sessions.mockReset();
+  mocks.getSession.mockReset();
+  mocks.replace.mockClear();
+});
+
+describe("mastery opening binding", () => {
+  it("waits for an empty topic's draft and sends exactly once with its path", async () => {
+    const pending = deferred<ReturnType<typeof topic>>();
+    mocks.topic.mockReturnValue(pending.promise);
+    setPendingPrompt("Design my outline", MASTERY_OPENING_SCOPE);
+    render(view("topic_created"));
+    expect(starts()).toHaveLength(0);
+    expect(screen.getByTestId("loading")).toHaveTextContent("true");
+    await act(async () => pending.resolve(topic("topic_created")));
+    await waitFor(() => expect(starts()).toHaveLength(1));
+    expect(starts()[0]).toMatchObject({
+      workspace_mode: "mastery_path",
+      mastery_path_id: "topic_created",
+      mastery_session_mode: "outline",
+      content: "Design my outline",
+    });
+    expect(screen.getByTestId("server-id")).toHaveTextContent("none");
+    await act(async () =>
+      mocks.emit?.({
+        type: "session",
+        metadata: { session_id: "unified_bound" },
+      }),
+    );
+    await waitFor(() =>
+      expect(mocks.replace).toHaveBeenCalledWith(
+        "/mastery/topic_created/sessions/unified_bound",
+        {
+          scroll: false,
+        },
+      ),
+    );
+    expect(starts()).toHaveLength(1);
+  });
+
+  it("ignores a delayed topic after switching paths", async () => {
+    const old = deferred<ReturnType<typeof topic>>();
+    const next = deferred<ReturnType<typeof topic>>();
+    mocks.topic.mockImplementation((id: string) =>
+      id === "topic_old" ? old.promise : next.promise,
+    );
+    const rendered = render(view("topic_old"));
+    rendered.rerender(view("topic_next"));
+    await act(async () => old.resolve(topic("topic_old")));
+    expect(starts()).toHaveLength(0);
+    await act(async () => next.resolve(topic("topic_next")));
+    await waitFor(() => expect(starts()).toHaveLength(1));
+    expect(starts()[0]).toMatchObject({ mastery_path_id: "topic_next" });
+  });
+
+  it("does not send when existing-session membership fails", async () => {
+    mocks.topic.mockResolvedValue(topic("topic_created"));
+    mocks.sessions.mockResolvedValue([]);
+    render(view("topic_created", "other_session"));
+    await waitFor(() =>
+      expect(screen.getByTestId("error").textContent).toContain(
+        "different topic",
+      ),
+    );
+    expect(starts()).toHaveLength(0);
+  });
+
+  it("blocks opening while an existing session loads and after failure", async () => {
+    const pending = deferred<never>();
+    mocks.topic.mockResolvedValue(topic("topic_created"));
+    mocks.sessions.mockResolvedValue([{ session_id: "session_saved" }]);
+    mocks.getSession.mockReturnValue(pending.promise);
+    render(view("topic_created", "session_saved"));
+    await waitFor(() => expect(mocks.getSession).toHaveBeenCalled());
+    expect(starts()).toHaveLength(0);
+    await act(async () => pending.reject(new Error("Session unavailable")));
+    await waitFor(() =>
+      expect(screen.getByTestId("error")).toHaveTextContent(
+        "Session unavailable",
+      ),
+    );
+    expect(starts()).toHaveLength(0);
+  });
+
+  it("preserves an existing session's stored study mode", async () => {
+    mocks.topic.mockResolvedValue(topic("topic_created"));
+    mocks.sessions.mockResolvedValue([{ session_id: "session_saved" }]);
+    mocks.getSession.mockResolvedValue({
+      session_id: "session_saved",
+      messages: [],
+      preferences: {
+        workspace_mode: "mastery_path",
+        mastery_path_id: "topic_created",
+        mastery_session_mode: "study",
+      },
+    });
+    render(view("topic_created", "session_saved"));
+    await waitFor(() =>
+      expect(screen.getByTestId("loading")).toHaveTextContent("false"),
+    );
+    expect(screen.getByTestId("server-id")).toHaveTextContent("session_saved");
+    expect(starts()).toHaveLength(0);
+  });
+
+  it("discards an in-flight session snapshot after switching paths", async () => {
+    const pending = deferred<Record<string, unknown>>();
+    mocks.topic.mockImplementation((id: string) => Promise.resolve(topic(id)));
+    mocks.sessions.mockResolvedValue([{ session_id: "session_old" }]);
+    mocks.getSession.mockReturnValue(pending.promise);
+    const rendered = render(view("topic_old", "session_old"));
+    await waitFor(() => expect(mocks.getSession).toHaveBeenCalled());
+    const signal = mocks.getSession.mock.calls[0][1] as AbortSignal;
+    rendered.rerender(view("topic_next"));
+    await waitFor(() => expect(starts()).toHaveLength(1));
+    expect(signal.aborted).toBe(true);
+    await act(async () =>
+      pending.resolve({ session_id: "session_old", messages: [] }),
+    );
+    expect(screen.getByTestId("server-id")).toHaveTextContent("none");
+    expect(starts()).toHaveLength(1);
+  });
+
+  it("ignores an old membership response after navigating to a new draft", async () => {
+    const membership = deferred<unknown[]>();
+    mocks.topic.mockImplementation((id: string) => Promise.resolve(topic(id)));
+    mocks.sessions.mockReturnValue(membership.promise);
+    const rendered = render(view("topic_old", "old_session"));
+    await waitFor(() => expect(mocks.sessions).toHaveBeenCalled());
+    rendered.rerender(view("topic_next"));
+    await waitFor(() => expect(starts()).toHaveLength(1));
+    await act(async () => membership.resolve([{ session_id: "old_session" }]));
+    expect(starts()).toHaveLength(1);
+    expect(screen.getByTestId("error")).toBeEmptyDOMElement();
+  });
+});
+
+it("only admits the exact committed draft and configuration", () => {
+  const ready = {
+    binding: { routeKey: "topic:new", draftKey: "draft-new" },
+    routeKey: "topic:new",
+    sessionKey: "draft-new",
+    workspaceMode: "mastery_path",
+    masteryPathId: "topic",
+    pathId: "topic",
+    masterySessionMode: "outline",
+    requestedMode: "outline",
+  };
+  expect(isMasteryDraftSendReady(ready)).toBe(true);
+  for (const override of [
+    { binding: null },
+    { sessionKey: "old-session" },
+    { sessionKey: "draft-old" },
+    { routeKey: "other:new" },
+    { workspaceMode: "chat" },
+    { masteryPathId: "other" },
+    { masterySessionMode: "study" },
+  ])
+    expect(isMasteryDraftSendReady({ ...ready, ...override })).toBe(false);
+});


### PR DESCRIPTION
### Description
Creating a Mastery Path could auto-submit its outline opening before React committed the new draft configuration. The first turn then omitted the intended Path ID, allowing the backend to write the outline to a separate, panel-invisible session-owned path.

Wait for the exact local draft key, workspace, Path ID, and session mode before allowing the opening or manual submissions. Keep server-session URL promotion separate so the first turn does not wait for the ID it creates. Ignore stale topic/session responses after navigation, and preserve the Mastery session mode when loading sessions and building turn requests.

Automatic openings and creation without materials remain supported. Historical orphan paths and backend fallback behavior are unchanged.

### Related Issues
Closes #1392

### Module(s) Affected
- [x] `web` (Frontend)
- [x] `tests`

### Validation
Rebased onto the latest `HKUDS/DeepTutor:dev` before validation.
- 25 rendered tests passed across 7 files, including 8 new regression cases using the real chat provider, session hook, and extracted opening hook with mocked API/transport.
- 88 targeted Node tests passed: Mastery, start-turn input, session loading, route selection, turn lifecycle/transport, and Watching session routing.
- Frontend typecheck, affected-file ESLint, repository hygiene, and `git diff --check` passed.
- Regression control: disabling the draft gate makes the first request lose its Path ID, workspace, and session mode; restoring it passes.

Coverage includes empty materials/modules, one opening under StrictMode, navigation races, failed and cancelled session loads, stored session modes, and URL promotion after the server binds the session. No live-backend end-to-end run was performed.

### Checklist
- [x] I have read and followed the contribution guidelines.
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] Documentation changes are not necessary.

Validation follows the repository's risk-based policy; the full pre-commit and regression suites were not run locally.
