### PR TITLE
fix(runtime): cancel the capability when a turn's consumer stops

### DIFF
--- a/deeptutor/runtime/orchestrator.py
+++ b/deeptutor/runtime/orchestrator.py
@@ -9,6 +9,7 @@ All consumers (CLI, WebSocket, SDK) call the orchestrator.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from typing import Any, AsyncIterator
 import uuid
@@ -168,11 +169,21 @@ class ChatOrchestrator:
 
         stream = bus.subscribe()
         task = asyncio.create_task(_run())
+        try:
+            async for event in stream:
+                yield event
+            await task
+        finally:
+            # The capability runs in its own task, so a consumer that stops
+            # reading — a cancelled turn, or a stream closed early — does not
+            # stop it. Left running, it keeps calling the model and tools for a
+            # turn already reported as stopped; left parked on ``ask_user``, it
+            # is collected mid-await and ``_run`` never unregisters the bus.
+            if not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
 
-        async for event in stream:
-            yield event
-
-        await task
         await self._publish_completion(context, cap_name)
 
     async def _publish_completion(self, context: UnifiedContext, cap_name: str) -> None:

--- a/tests/runtime/test_orchestrator.py
+++ b/tests/runtime/test_orchestrator.py
@@ -11,7 +11,7 @@ from deeptutor.core.capability_protocol import CapabilityManifest, TurnCapabilit
 from deeptutor.core.context import UnifiedContext
 from deeptutor.core.stream import StreamEvent, StreamEventType
 from deeptutor.runtime.orchestrator import ChatOrchestrator
-from deeptutor.runtime.stream_bus import StreamBus
+from deeptutor.runtime.stream_bus import StreamBus, get_bus
 
 
 @pytest.fixture(autouse=True)
@@ -51,6 +51,24 @@ class _FailingCapability(TurnCapability):
 
     async def run(self, context: UnifiedContext, stream: StreamBus) -> None:
         raise RuntimeError("intentional failure")
+
+
+class _ParkedCapability(TurnCapability):
+    """Capability that streams once, then waits until it is cancelled."""
+
+    manifest = CapabilityManifest(name="parked", description="Waits after its first event.")
+
+    def __init__(self) -> None:
+        self.cancelled = asyncio.Event()
+
+    async def run(self, context: UnifiedContext, stream: StreamBus) -> None:
+        await stream.content("thinking", source=self.name)
+        try:
+            # Stands in for a long model round or an ``ask_user`` pause.
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
 
 
 def _make_orchestrator(
@@ -198,6 +216,59 @@ class TestOrchestratorErrorHandling:
             "retryable": True,
             "partial_response": False,
         }
+
+
+# ---------------------------------------------------------------------------
+# Cancellation
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorCancellation:
+    @pytest.mark.asyncio
+    async def test_cancelling_the_consumer_cancels_the_capability(self) -> None:
+        """Stopping a turn must stop the capability, not only the event stream."""
+        parked = _ParkedCapability()
+        orch = _make_orchestrator({"parked": parked})
+        ctx = UnifiedContext(
+            user_message="hi",
+            active_capability="parked",
+            metadata={"turn_id": "turn-cancelled"},
+        )
+        first_content = asyncio.Event()
+
+        async def _consume() -> None:
+            async for event in orch.handle(ctx):
+                if event.type == StreamEventType.CONTENT:
+                    first_content.set()
+
+        consumer = asyncio.create_task(_consume())
+        await asyncio.wait_for(first_content.wait(), timeout=1)
+        consumer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await consumer
+
+        assert parked.cancelled.is_set()
+        assert get_bus("turn-cancelled") is None
+
+    @pytest.mark.asyncio
+    async def test_closing_the_stream_early_cancels_the_capability(self) -> None:
+        """A consumer that stops reading takes the capability down with it."""
+        parked = _ParkedCapability()
+        orch = _make_orchestrator({"parked": parked})
+        ctx = UnifiedContext(
+            user_message="hi",
+            active_capability="parked",
+            metadata={"turn_id": "turn-closed"},
+        )
+
+        stream = orch.handle(ctx)
+        async for event in stream:
+            if event.type == StreamEventType.CONTENT:
+                break
+        await stream.aclose()
+
+        assert parked.cancelled.is_set()
+        assert get_bus("turn-closed") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Description
`ChatOrchestrator.handle()` runs the capability in its own task (`asyncio.create_task(_run())`) and then only iterates the bus. Nothing connects the consumer's lifetime to that task, so when a consumer stops reading, the capability does not stop:

- **Stop on a running turn** — `TurnLifecycle.cancel_turn` cancels the executor task, which persists the turn as `cancelled` and publishes the terminal `error` + `done`. The capability task is never cancelled, so it keeps calling the model and running tools until it finishes on its own. Its output is discarded, but the tokens are spent and tool side effects land after the user was told the turn stopped.
- **Stop on a turn parked on `ask_user`** — the capability waits on the turn's reply queue, which nothing wakes on cancellation. Once the turn drops its references, the task is destroyed mid-await (`Task was destroyed but it is pending!`), the capability sees `GeneratorExit` instead of `CancelledError`, and `_run`'s `finally` fails at `bus.emit` (`RuntimeError: no running event loop`) before it reaches `unregister_bus`. The turn's `StreamBus`, with its full event history, stays in `_bus_registry` for the life of the process.

This PR wraps the consumption loop in `try`/`finally` and, if the capability task is still running when the consumer leaves, cancels and awaits it. It is the same shape `services/llm/factory.py::stream()` already uses for its runner task. Both exits are covered: a cancelled consumer (`CancelledError`, e.g. the Stop button) and a stream closed early (`GeneratorExit`, e.g. `aclose()` or the async-generator finalizer after the executor was cancelled outside the generator). A normal turn is unaffected: the capability task has finished by the time the loop ends, so the `finally` is a no-op.

Behaviour note for SDK users of `get_turn_engine().execute()`: closing the event stream before it ends now cancels the turn's capability instead of leaving it running unobserved. No in-tree consumer stops early (session executor, cron and partners all read to the end).

### Related Issues
- Related to #1373 — that PR ends a turn parked on `ask_user` by cancelling its execution task, which is exactly the path that currently leaks the bus; with this change the capability is cancelled along with it.
- Context: #1297, #1359 (turns left stuck around `ask_user` pauses). This PR does not change how their persisted status is handled; it only makes sure the capability itself stops.

### Module(s) Affected
- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [x] Other: `runtime` (`deeptutor/runtime/orchestrator.py`)

### Checklist
- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [x] I have run `pre-commit run --all-files` and fixed any issues. (Run on the touched files; see notes.)
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes
Two tests were added to `tests/runtime/test_orchestrator.py` (`TestOrchestratorCancellation`), one per exit path. Each parks a capability after its first event, stops the consumer, and asserts the capability received `CancelledError` and the turn's bus was unregistered:

- `test_cancelling_the_consumer_cancels_the_capability`
- `test_closing_the_stream_early_cancels_the_capability`

Both fail on `dev` at `assert parked.cancelled.is_set()` and pass with this change.

I also checked the real path end-to-end with a probe capability behind `TurnRuntimeManager.cancel_turn` (real executor, turn engine and orchestrator; only context/LLM/workspace services stubbed):

| Scenario | Before | After |
| --- | --- | --- |
| Stop while the capability works | persisted `cancelled`, yet the capability ran all 37 of its remaining steps | capability cancelled immediately |
| Stop while parked on `ask_user` | bus left registered, `Task was destroyed but it is pending!` | capability cancelled, bus unregistered |
| Client terminal events | `error` + `done` (`cancelled`) | unchanged |

Regression check on `tests/runtime`, `tests/core`, `tests/services/session`, `tests/app`, `tests/services/partners`, `tests/services/cron`: 1228 passed with the change vs 1226 without; the only difference is the two new tests. The remaining failures are identical on both sides and environment-specific to this Windows machine (missing `telegram`/`slack_sdk`, sandboxed exec, macOS launcher). `ruff check`, `ruff format --check` (0.16.0), `lint-imports` (3 kept, 0 broken) and `scripts/check_architecture.py` pass; all pre-commit hooks pass on the touched files (the local `deeptutor-repo-hygiene` hook cannot launch on Windows because it calls `python3`, but `python scripts/check_repo_hygiene.py` passes).
