### PR TITLE
fix(graphrag): recover stale pandas Arrow extension registrations

### DIFF
--- a/deeptutor/services/rag/pipelines/graphrag/engine.py
+++ b/deeptutor/services/rag/pipelines/graphrag/engine.py
@@ -34,6 +34,7 @@ from .errors import (
     classify_embedding_error,
     classify_model_error,
 )
+from .pandas_compat import prepare_pandas_arrow_extensions
 from .provider import (
     COMPLETION_TYPE,
     resolve_completion_call_args,
@@ -102,6 +103,7 @@ async def _run_isolated(work: Callable[[], Awaitable[_T]]) -> _T:
     """
 
     def _runner() -> _T:
+        prepare_pandas_arrow_extensions()
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         try:

--- a/deeptutor/services/rag/pipelines/graphrag/pandas_compat.py
+++ b/deeptutor/services/rag/pipelines/graphrag/pandas_compat.py
@@ -1,0 +1,68 @@
+"""Scoped compatibility for stale Pandas/Arrow extension registrations."""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from typing import Any
+
+_PANDAS_ARROW_EXTENSION_MODULE = "pandas.core.arrays.arrow.extension_types"
+_PANDAS_ARROW_EXTENSION_NAMES = ("pandas.period", "pandas.interval")
+_extension_registration_lock = threading.Lock()
+
+
+def _is_duplicate_registration_error(error: BaseException) -> bool:
+    message = str(error)
+    return (
+        "A type extension with name" in message
+        and "already defined" in message
+        and any(name in message for name in _PANDAS_ARROW_EXTENSION_NAMES)
+    )
+
+
+def _unregister_stale_extension_types(
+    pyarrow: Any,
+    arrow_key_error: type[BaseException],
+) -> None:
+    for name in _PANDAS_ARROW_EXTENSION_NAMES:
+        try:
+            pyarrow.unregister_extension_type(name)
+        except arrow_key_error:
+            # The extension may not have been registered yet.
+            continue
+
+
+def prepare_pandas_arrow_extensions() -> None:
+    """Import Pandas Arrow extensions, repairing stale registry entries.
+
+    Pandas registers ``pandas.period`` and ``pandas.interval`` as a module import
+    side effect. If a test runner, plugin, or reload hook removes that module from
+    ``sys.modules`` without unregistering the pyarrow types, importing it again
+    raises ``pyarrow.lib.ArrowKeyError``. GraphRAG runs in isolated worker threads,
+    so this repair is performed immediately inside each worker before GraphRAG
+    imports its pandas users.
+
+    The helper is a no-op when pyarrow is not installed. Other import or registry
+    errors are allowed to propagate so a real dependency failure is not hidden.
+    """
+    try:
+        import pyarrow
+        from pyarrow.lib import ArrowKeyError
+    except ImportError:
+        return
+
+    with _extension_registration_lock:
+        try:
+            importlib.import_module(_PANDAS_ARROW_EXTENSION_MODULE)
+        except ModuleNotFoundError as error:
+            if error.name == "pandas":
+                return
+            raise
+        except ArrowKeyError as error:
+            if not _is_duplicate_registration_error(error):
+                raise
+            _unregister_stale_extension_types(pyarrow, ArrowKeyError)
+            importlib.import_module(_PANDAS_ARROW_EXTENSION_MODULE)
+
+
+__all__ = ["prepare_pandas_arrow_extensions"]

--- a/tests/services/rag/test_graphrag_pandas_compat.py
+++ b/tests/services/rag/test_graphrag_pandas_compat.py
@@ -1,0 +1,69 @@
+"""Regression tests for Pandas/Arrow extension registration in GraphRAG."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+def test_prepare_pandas_arrow_extensions_repairs_stale_registration() -> None:
+    """A re-import after module removal must not hit ArrowKeyError."""
+    pytest.importorskip("pandas", reason="pandas is required for this regression test")
+    pytest.importorskip("pyarrow", reason="pyarrow is required for this regression test")
+    root = Path(__file__).parents[3]
+    script = """
+import importlib
+import sys
+
+import pandas.core.arrays.arrow.extension_types
+
+module_name = "pandas.core.arrays.arrow.extension_types"
+del sys.modules[module_name]
+
+from deeptutor.services.rag.pipelines.graphrag.pandas_compat import (
+    prepare_pandas_arrow_extensions,
+)
+
+prepare_pandas_arrow_extensions()
+importlib.import_module(module_name)
+print("ok")
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(root), env.get("PYTHONPATH", "")) if part
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith("ok")
+
+
+def test_prepare_pandas_arrow_extensions_does_not_hide_unrelated_arrow_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the known duplicate-registration error is recovered."""
+    pytest.importorskip("pyarrow", reason="pyarrow is required for this regression test")
+
+    from pyarrow.lib import ArrowKeyError
+
+    from deeptutor.services.rag.pipelines.graphrag import pandas_compat
+
+    def raise_unrelated_error(_name: str) -> None:
+        raise ArrowKeyError("unrelated Arrow registry failure")
+
+    monkeypatch.setattr(importlib, "import_module", raise_unrelated_error)
+
+    with pytest.raises(ArrowKeyError, match="unrelated Arrow registry failure"):
+        pandas_compat.prepare_pandas_arrow_extensions()

--- a/tests/services/rag/test_graphrag_pipeline.py
+++ b/tests/services/rag/test_graphrag_pipeline.py
@@ -382,6 +382,23 @@ def test_engine_entry_points_run_on_a_private_loop() -> None:
     assert seen["current"] is seen["running"]
 
 
+def test_engine_isolated_runtime_prepares_pandas_arrow_extensions(monkeypatch) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        engine,
+        "prepare_pandas_arrow_extensions",
+        lambda: calls.append("prepared"),
+    )
+
+    async def work() -> str:
+        calls.append("work")
+        return "done"
+
+    assert asyncio.run(engine._run_isolated(work)) == "done"
+    assert calls == ["prepared", "work"]
+
+
 def test_compatibility_probe_resolves_candidate_without_mutating_active_model(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
### Description

Fix GraphRAG failures caused by stale Pandas Arrow extension registrations during isolated worker startup.

Pandas registers `pandas.period` and `pandas.interval` as a side effect of importing `pandas.core.arrays.arrow.extension_types`. If a test runner, plugin, or reload hook removes that module from `sys.modules` without clearing pyarrow's process-local registry, importing it again raises `pyarrow.lib.ArrowKeyError: A type extension with name pandas.period already defined`.

This PR prepares the extension module at the beginning of every isolated GraphRAG worker. If the import raises the exact known duplicate-registration error, it unregisters only the two Pandas extension names and retries the import. Unrelated Arrow errors are still raised. The previous warning-filter and BLAS-thread-limit approach from closed PR #1338 is intentionally not used because the failure is an exception during registration, not a warning or numeric thread race.

### Related Issues

- Supersedes the closed approach in #1338.

### Module(s) Affected

- [x] `services`
- [x] `tests`

### Checklist

- [x] I have read and followed the contribution guidelines.
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues. The changed-file hooks pass; the full run is blocked by pre-existing repository hygiene, JSON, and Windows-only mypy failures documented below.
- [x] I have added relevant regression tests.
- [x] I have updated the documentation (not necessary for this internal compatibility fix).
- [x] My changes do not introduce any new security vulnerabilities.

### Verification

- Targeted GraphRAG tests: `87 passed, 2 skipped`.
- Subprocess regression passed with `pandas 3.0.0 / pyarrow 25.0.1`.
- Subprocess regression passed with the GraphRAG 3.0.6 dependency combination `pandas 2.3.3 / pyarrow 22.0.0`.
- Ruff, Ruff format, Bandit, detect-secrets, compilation, and whitespace checks passed for the changed files.
- GitNexus reports no uncommitted changes after commit and a low-risk change scope.

### Additional Notes

The full `pre-commit run --all-files` command still reports unrelated baseline failures: the repository hygiene hook exits with Windows code 9009, three existing JSON files contain duplicate/invalid JSON, and mypy reports existing Unix-only attributes such as `fcntl.flock` and `os.sysconf` on Windows.

The full `tests/services/rag` run reached `505 passed, 15 skipped`; four failures were unrelated existing environment/fixture issues: Windows symlink privilege failures and one pre-existing MinerU golden hash mismatch. A complete GraphRAG indexing run against external model services was not performed.
