### PR TITLE
fix(mastery): refuse a new-session handoff for the topic a turn is tutoring (#1412)

### DIFF
--- a/deeptutor/capabilities/mastery/loop.py
+++ b/deeptutor/capabilities/mastery/loop.py
@@ -203,6 +203,18 @@ class MasteryLoopCapability:
             updated = dict(kwargs)
             updated["source_index"] = context.metadata.get("mastery_topic_source_index") or {}
             return updated
+        if tool_name == "mastery_new_session":
+            # The nav tools are mounted chat-wide, so nothing tells them where
+            # this turn is tutoring. The new-session hand-off needs that one
+            # fact: a "start a conversation on this topic" card offered from
+            # inside a session already tutoring the same topic is the
+            # duplicate-session generator — the review entry opens a session,
+            # the model answers it with a card for the same thing, and every
+            # click of the card creates another session. The tool refuses
+            # that shape; different topics still hand off.
+            updated = dict(kwargs)
+            updated["_mastery_path_id"] = path_id
+            return updated
         if tool_name in MASTERY_TOOL_NAMES:
             updated = dict(kwargs)
             if tool_name == "mastery_quiz":

--- a/deeptutor/learning/tests/test_mastery_navigation.py
+++ b/deeptutor/learning/tests/test_mastery_navigation.py
@@ -26,6 +26,7 @@ from deeptutor.learning.service import LearningService
 from deeptutor.learning.storage import LearningStore
 from deeptutor.services.session.sqlite_store import SQLiteSessionStore
 from deeptutor.tools.mastery_nav import (
+    HANDOFF_META_KEY,
     MasteryNewSessionTool,
     MasteryOpenSessionTool,
     MasterySessionsTool,
@@ -327,3 +328,48 @@ async def test_an_invented_lesson_is_refused_with_the_real_outline(store):
     assert result.success is False
     assert "Descriptive statistics" in result.content
     assert "Sampling distributions" in result.content
+
+
+@pytest.mark.asyncio
+async def test_new_session_refuses_the_topic_the_turn_is_already_tutoring(store):
+    """A mastery turn bound to a topic must not hand the learner a card that
+    starts yet another conversation on that same topic.
+
+    The review entry already opens a session on the topic; a model that
+    answers it with a "start a session on this topic" card sends the learner
+    through the same click again — a new session every time, none of them the
+    one the tutor is speaking in (#1412's session bloat).
+    """
+    _create_topic()
+
+    result = await MasteryNewSessionTool().execute(
+        path_id="stats_101",
+        opening_message="Review the mean with me",
+        _mastery_path_id="stats_101",
+    )
+
+    assert result.success is False
+    assert not (result.metadata or {}).get(HANDOFF_META_KEY)
+    # The refusal tells the model what to do instead: this window IS the
+    # topic's session, so the tutoring happens here.
+    assert "already" in result.content
+    assert "stats_101" in result.content
+
+
+@pytest.mark.asyncio
+async def test_new_session_still_hands_off_other_topics_from_a_mastery_turn(store, session_store):
+    _create_topic()
+    _create_topic("algebra_101", "Algebra Basics")
+
+    payload = _payload(
+        await MasteryNewSessionTool().execute(
+            path_id="algebra_101",
+            opening_message="Start factoring with me",
+            _mastery_path_id="stats_101",
+        )
+    )
+
+    # A different topic is exactly what the hand-off is for: the learner is
+    # being pointed somewhere this conversation cannot tutor.
+    assert payload["kind"] == "new"
+    assert payload["path_id"] == "algebra_101"

--- a/deeptutor/tools/mastery_nav.py
+++ b/deeptutor/tools/mastery_nav.py
@@ -434,6 +434,21 @@ class MasteryNewSessionTool(_NavTool):
         topic, error = await _topic_or_error(kwargs.get("path_id", ""))
         if error is not None or topic is None:
             return error or _failure("path_id is required.")
+        tutoring = _text(kwargs.get("_mastery_path_id"))
+        if tutoring and tutoring == topic["path_id"]:
+            # Bound to the caller by the mastery loop on a mastery turn only
+            # (plain chats never carry it). The hand-off's own premise — "the
+            # mastery tutor picks up on the other side" — does not hold here:
+            # this window IS that topic's study session, so a card that starts
+            # another conversation on it just duplicates sessions (#1412).
+            return _failure(
+                "This conversation is already the study session for "
+                f"{topic['name']!r} ({topic['path_id']}). Tutor the learner "
+                "here instead of handing them a card that starts another "
+                "conversation on the same topic — that is how duplicate "
+                "sessions pile up. mastery_new_session is for sending the "
+                "learner to a different topic."
+            )
         module, module_error = _module_or_error(topic, kwargs.get("module", ""))
         if module_error is not None:
             return module_error

--- a/tests/capabilities/test_mastery_capability.py
+++ b/tests/capabilities/test_mastery_capability.py
@@ -271,6 +271,18 @@ def test_read_source_is_owned_and_reads_the_topic_index_on_demand():
     assert kwargs["source_index"] == {"bk-path-1-ch1": "chapter one text"}
 
 
+def test_new_session_handoff_learns_which_topic_the_turn_is_tutoring():
+    """The hand-off tool is mounted chat-wide and normally never learns where
+    the turn is tutoring. It needs exactly that one fact on a mastery turn: a
+    "start a new conversation on this topic" card offered from inside a
+    session already tutoring the same topic is the duplicate-session generator
+    behind #1412's review loop.
+    """
+    updated = MasteryLoopCapability().augment_kwargs("mastery_new_session", {}, _context())
+
+    assert updated["_mastery_path_id"] == "path-1"
+
+
 @pytest.mark.asyncio
 async def test_mastery_sync_carries_provenance_to_question_bank(tmp_path, monkeypatch) -> None:
     from deeptutor.capabilities.mastery.tools import (


### PR DESCRIPTION
## Summary

Fixes the duplicate-session loop of #1412 at its generator, and with it the "certain Mastery Path sessions" of #1411 whose turns answer in prose. Scope note up front: the topic-binding race on the opening turn is a frontend draft-gating problem already covered by #1403 (which closes #1392, the creation-flow twin of this); this PR is the tool-side half #1403 does not touch.

**The loop.** The atlas "Start review" banner opens `/mastery/{path}/sessions` — a draft route that starts a new conversation (by design). `mastery_new_session` is mounted inside mastery turns too, and its hand-off instruction tells the model *"do not start tutoring the topic here: the mastery tutor picks up on the other side."* Inside a mastery session that premise is false — this window IS the topic's study session — but the model cannot tell, so it answers the review opening with a "start a session on this topic" hand-off card. Clicking the card navigates to the draft route again: a brand-new session per click, the same review prompt card each time, sessions piling up under the topic (#1412 steps 2–4). A card whose `path_id` the model resolved differently lands on the wrong topic (#1412 step 5). The churned sessions — fresh, mode-less, on a scratch topic — are exactly the "certain sessions" of #1411 where the tutor has no study context and answers in prose without ever calling `mastery_quiz`.

**Fix.** `MasteryLoopCapability.augment_kwargs` now binds the turn's active `mastery_path_id` onto `mastery_new_session` calls (the one nav tool that needs it; plain chats never carry the key). `MasteryNewSessionTool` refuses a `kind:"new"` hand-off whose topic is the one the turn is already tutoring, with a corrective message that says what to do instead: tutor here; the tool is for sending the learner to a *different* topic. Hand-offs to other topics are unchanged, and the tool stays mounted chat-wide — a chat can still hand the learner into any topic.

## Validation

Covered by the automated suite (confirmed red on the pre-fix code, green after):

- [x] Same-topic new-session hand-off refused from a mastery turn, no card metadata, corrective content — `test_new_session_refuses_the_topic_the_turn_is_already_tutoring`
- [x] Hand-off to a different topic still produced from a mastery turn — `test_new_session_still_hands_off_other_topics_from_a_mastery_turn`
- [x] Plain-chat calls (no bound path) unchanged — existing `test_new_session_hands_off_without_touching_progress`
- [x] The mastery loop binds the path onto the hand-off call — `test_new_session_handoff_learns_which_topic_the_turn_is_tutoring`
- [x] Same-batch comparison against a pristine `dev` worktree (`tests/capabilities deeptutor/learning/tests tests/tools tests/agents/chat`): changed tree 1146 passed / 1 failed vs pristine 1142 / 2 — the failure sets are the known Windows concurrency flake plus an environment-dependent loop-registry probe, nothing new; `ruff check` / `ruff format --check` (0.16.0) clean

Not verified — needs a live model:

- [ ] End-to-end: clicking "Start review" and letting the tutor answer no longer produces the same-topic hand-off card (the guard is exercised through the scripted tool here)
