### PR TITLE
fix(mastery): drop duplicate ask_user options (#1409)

### DIFF
--- a/deeptutor/tools/ask_user.py
+++ b/deeptutor/tools/ask_user.py
@@ -38,8 +38,7 @@ MAX_PLACEHOLDER_CHARS = 120
 
 # Labels the model sometimes adds as its own catch-all option. The card
 # already renders a free-form "Other" row whenever ``allow_free_text``
-# is on, so a model-supplied duplicate is dropped (exact match only —
-# being clever here risks eating legitimate options).
+# is on, so a model-supplied duplicate is dropped.
 _REDUNDANT_OTHER_LABELS = frozenset({"other", "其他", "其它"})
 
 
@@ -236,6 +235,11 @@ def _drop_half_written_options(raw: Any) -> Any:
     return {**raw, "options": kept}
 
 
+def _option_match_key(label: str) -> str:
+    """Compare labels like ``mastery_quiz`` compares option bodies."""
+    return "".join(label.split()).casefold()
+
+
 def _build_question(raw: Any, idx: int, used_ids: set[str]) -> AskUserQuestion | str:
     if not isinstance(raw, dict):
         return f"Question #{idx + 1} must be an object."
@@ -267,11 +271,15 @@ def _build_question(raw: Any, idx: int, used_ids: set[str]) -> AskUserQuestion |
                 continue
             # The card auto-renders an "Other" free-text row; drop a
             # model-supplied duplicate so the user never sees two.
-            if allow_free_text and normalised.label.lower() in _REDUNDANT_OTHER_LABELS:
+            match_key = _option_match_key(normalised.label)
+            if allow_free_text and match_key in _REDUNDANT_OTHER_LABELS:
                 continue
-            if normalised.label in seen_labels:
+            # Two labels that differ only by whitespace or case render as the
+            # same choice, so keep the first rather than shipping an
+            # unanswerable card (#1409).
+            if match_key in seen_labels:
                 continue
-            seen_labels.add(normalised.label)
+            seen_labels.add(match_key)
             cleaned.append(normalised)
             if len(cleaned) >= MAX_OPTIONS:
                 break

--- a/tests/tools/test_ask_user.py
+++ b/tests/tools/test_ask_user.py
@@ -7,6 +7,8 @@ single-question shorthand which auto-wraps into a one-element list.
 
 from __future__ import annotations
 
+import pytest
+
 from deeptutor.tools.ask_user import (
     MAX_HEADER_CHARS,
     MAX_OPTION_CHARS,
@@ -281,6 +283,44 @@ def test_v3_drops_model_supplied_other_option() -> None:
     )
     assert payload is not None
     assert _labels(payload.questions[0]) == ("A", "B")
+
+
+@pytest.mark.parametrize(
+    ("options", "expected"),
+    [
+        (["First answer", " first   ANSWER "], ("First answer",)),
+        (["Straße", "STRASSE"], ("Straße",)),
+        (
+            [
+                {"label": "First answer", "description": "keep"},
+                {"label": "  first\tanswer  ", "description": "drop"},
+            ],
+            ("First answer",),
+        ),
+    ],
+)
+def test_ask_user_drops_duplicate_labels_like_mastery_quiz(options, expected) -> None:
+    """A visible duplicate makes an interactive question unanswerable (#1409)."""
+    payload, err = build_ask_user_payload(
+        questions=[{"prompt": "Which answer?", "options": options}]
+    )
+    assert err is None
+    assert payload is not None
+    assert _labels(payload.questions[0]) == expected
+
+
+def test_ask_user_deduplicates_even_when_free_text_is_disabled() -> None:
+    payload, _ = build_ask_user_payload(
+        questions=[
+            {
+                "prompt": "Which answer?",
+                "options": ["Answer", " answer "],
+                "allow_free_text": False,
+            }
+        ]
+    )
+    assert payload is not None
+    assert _labels(payload.questions[0]) == ("Answer",)
 
 
 def test_v3_keeps_other_option_when_free_text_disabled() -> None:


### PR DESCRIPTION
## Summary

Fixes #1409.

Mastery Path can present an unanswerable choice card through the `ask_user` channel when the model sends labels that differ only in case or whitespace. This change normalises those labels with the same whitespace-collapsed, Unicode casefold comparison used by `mastery_quiz`, keeps the first occurrence in authoring order, and drops the duplicate before the learner sees the card.

- Applies to legacy string options and `{label, description}` options.
- Preserves model-authored option text for the retained choice.
- Continues to deduplicate when `allow_free_text` is disabled.
- Keeps normalised `Other` handling unchanged in behavior while reusing one comparison rule.

## Scope evidence

- Base: `origin/dev` at `0f8759f730da898cf99a081f0bec4230bb7ea44a`
- Merge base: `0f8759f730da898cf99a081f0bec4230bb7ea44a`
- Changed files:
  - `deeptutor/tools/ask_user.py`
  - `tests/tools/test_ask_user.py`

Preflight found no open PR referencing `#1409`; existing duplicate-body protection remains in `mastery_quiz`, and the active `#1412` PR covers a separate session-loop issue.

## Test plan

- [x] `python -m pytest tests/tools/test_ask_user.py -q` — 41 passed
- [x] `python -m pytest deeptutor/learning/tests/test_mastery_choices.py deeptutor/learning/tests/test_mastery_tools.py -q` — 112 passed, 2 warnings
- [x] `python -m pytest tests/tools deeptutor/learning/tests -q` — 716 passed, 2 skipped, 2 warnings
- [x] `ruff check deeptutor/tools/ask_user.py tests/tools/test_ask_user.py`
- [x] `ruff format --check deeptutor/tools/ask_user.py tests/tools/test_ask_user.py`

Not verified here: a live model authoring a malformed Mastery clarification card. The normalisation path is covered at the parser boundary where the learner-visible payload is built.
