### PR TITLE
fix(ask-user): drop an option whose visible text duplicates another (#1409)

### DIFF
--- a/deeptutor/tools/ask_user.py
+++ b/deeptutor/tools/ask_user.py
@@ -261,6 +261,7 @@ def _build_question(raw: Any, idx: int, used_ids: set[str]) -> AskUserQuestion |
             return f"Question #{idx + 1}: `options` must be an array."
         cleaned: list[AskUserOption] = []
         seen_labels: set[str] = set()
+        seen_bodies: set[str] = set()
         for opt in options_raw:
             normalised = _build_option(opt)
             if normalised is None:
@@ -272,6 +273,17 @@ def _build_question(raw: Any, idx: int, used_ids: set[str]) -> AskUserQuestion |
             if normalised.label in seen_labels:
                 continue
             seen_labels.add(normalised.label)
+            # Two options whose visible text matches once whitespace and case
+            # are folded leave the learner nothing to pick between — the same
+            # duplicate-body rule the mastery quiz contract enforces at
+            # registration (#1409). An option with no body *is* its label, so
+            # label-only cards are governed by label uniqueness alone.
+            body = (normalised.description or "").strip()
+            if body:
+                body_key = " ".join(body.split()).casefold()
+                if body_key in seen_bodies:
+                    continue
+                seen_bodies.add(body_key)
             cleaned.append(normalised)
             if len(cleaned) >= MAX_OPTIONS:
                 break

--- a/tests/tools/test_ask_user.py
+++ b/tests/tools/test_ask_user.py
@@ -292,6 +292,69 @@ def test_v3_keeps_other_option_when_free_text_disabled() -> None:
     assert _labels(payload.questions[0]) == ("A", "Other")
 
 
+def test_v3_drops_an_option_whose_body_duplicates_another() -> None:
+    """Two options with the same visible text leave the learner nothing to
+    pick between (#1409: a duplicated choice makes the question unanswerable).
+
+    The mastery quiz contract already refuses duplicate bodies at
+    registration; the clarification-card channel gets the same rule here.
+    """
+    payload, _ = build_ask_user_payload(
+        questions=[
+            {
+                "prompt": "x",
+                "options": [
+                    {"label": "B", "description": "8"},
+                    {"label": "C", "description": "8"},
+                    {"label": "D", "description": "-2"},
+                ],
+            }
+        ]
+    )
+    assert payload is not None
+    assert _labels(payload.questions[0]) == ("B", "D")
+
+
+def test_v3_duplicate_body_comparison_ignores_case_and_spacing() -> None:
+    """Near-duplicates that differ only by case or spacing read as the same
+    choice to a learner, so the same rule applies to them."""
+    payload, _ = build_ask_user_payload(
+        questions=[
+            {
+                "prompt": "x",
+                "options": [
+                    {"label": "A", "description": "Rerank  the query."},
+                    {"label": "B", "description": "  rerank the query.  "},
+                    {"label": "C", "description": "Rewrite the query."},
+                ],
+            }
+        ]
+    )
+    assert payload is not None
+    assert _labels(payload.questions[0]) == ("A", "C")
+
+
+def test_v3_label_only_options_are_never_body_deduped() -> None:
+    """An option with no body is its label; distinct labels are distinct
+    choices even though every description is empty."""
+    payload, _ = build_ask_user_payload(questions=[{"prompt": "x", "options": ["A", "B", "C"]}])
+    assert payload is not None
+    assert _labels(payload.questions[0]) == ("A", "B", "C")
+
+
+def test_v3_duplicate_body_check_is_per_question() -> None:
+    """Two different questions may offer the same answer text."""
+    payload, _ = build_ask_user_payload(
+        questions=[
+            {"prompt": "x", "options": [{"label": "A", "description": "same"}]},
+            {"prompt": "y", "options": [{"label": "A", "description": "same"}]},
+        ]
+    )
+    assert payload is not None
+    assert _labels(payload.questions[0]) == ("A",)
+    assert _labels(payload.questions[1]) == ("A",)
+
+
 # ------------------------- frontend contract shape ------------------------
 
 


### PR DESCRIPTION
## Summary

Fixes the server-side half of #1409 — duplicate choice options reaching the learner on an `ask_user` card.

The mastery quiz contract already refuses duplicate option bodies at registration (exact match, and again after whitespace/case folding), and the learner-facing quiz card is rebuilt from the persisted question — so a registered mastery question cannot show two identical choices. What can still produce them is the `ask_user` card the model writes itself (the playbook allows ordinary clarification cards mid-session): its option loop dropped duplicate *labels* and the model-supplied "Other" catch-all, but two options whose visible *description* was identical — or identical up to case and spacing — both rendered, and a choice question with two indistinguishable options is unanswerable.

The option parser now also drops an option whose description duplicates an already-kept option's, compared after whitespace collapsing and case folding — the same normalisation the quiz gate uses, so the two surfaces agree on what "duplicate" means. An option with no body *is* its label, so label-only cards stay governed by label uniqueness alone. The comparison is per question, and the first occurrence is always kept.

## Validation

Covered by the automated suite (`tests/tools/test_ask_user.py`, confirmed red on the pre-fix code and green after):

- [x] An option whose body duplicates another is dropped, first kept — `test_v3_drops_an_option_whose_body_duplicates_another`
- [x] Case/spacing-only differences count as duplicates — `test_v3_duplicate_body_comparison_ignores_case_and_spacing`
- [x] Label-only options (no descriptions) are never body-deduped — `test_v3_label_only_options_are_never_body_deduped`
- [x] The check is per question — `test_v3_duplicate_body_check_is_per_question`
- [x] Same-batch comparison against a pristine `dev` worktree (`tests/tools tests/capabilities tests/agents/chat`): identical failure set (the known Windows concurrency flake and an environment-dependent loop-registry probe), 648 passed vs 644 pristine (+4 new); `ruff check` / `ruff format --check` (0.16.0) clean

Not verified — needs a live model:

- [ ] End-to-end: a tutor session that styles a question as a clarification card no longer renders two indistinguishable choices (exercised here through the payload builder only)
