### PR TITLE
test(api): isolate partners router auth state (#1422)

### DIFF
--- a/tests/api/test_partners_router.py
+++ b/tests/api/test_partners_router.py
@@ -38,11 +38,15 @@ def isolated_root(tmp_path, monkeypatch) -> Path:
 
 @pytest.fixture
 def client(isolated_root, monkeypatch) -> TestClient:
+    from deeptutor.api.routers import auth as auth_module
     import deeptutor.api.routers.partners as partners_router_mod
     from deeptutor.multi_user.context import reset_current_user, set_current_user
     from deeptutor.multi_user.models import CurrentUser, UserScope
     from deeptutor.services.partners.manager import PartnerManager
 
+    # This fixture mounts the router into a fresh app with a synthetic owner.
+    # Explicitly disable auth so the deployment's global setting cannot leak in.
+    monkeypatch.setattr(auth_module, "AUTH_ENABLED", False)
     token = set_current_user(
         CurrentUser(
             id="test-admin",


### PR DESCRIPTION
## Summary

- Isolate `AUTH_ENABLED` in the fresh-app Partners router test fixture.
- Preserve the synthetic admin owner used by endpoint tests while preventing deployment-wide authentication settings from changing test outcomes.
- Match the explicit auth isolation already used by `tests/api/test_partner_groups_router.py`.
- No production route or authentication behavior changes.

Closes #1422.

## Scope audit

- Base: `origin/dev` at `0f8759f730da898cf99a081f0bec4230bb7ea44a`
- Merge base: `0f8759f730da898cf99a081f0bec4230bb7ea44a`
- Head: `5256305e00c6954175dacebfed3e6cd0b4c2a68f`
- Changed files:
  - `tests/api/test_partners_router.py` (+4)

## Reproduction

Before the change, on a clean `origin/dev` checkout:

- `python -m pytest -q tests/api/test_partners_router.py`: 36 passed
- `AUTH_ENABLED=true python -m pytest -q tests/api/test_partners_router.py`: 2 failed, 34 passed

The two soul-library tests received HTTP 401 because those routes retain `require_admin`, whose nested `require_auth` observed the globally enabled setting even though the fixture had installed a synthetic current user.

## Verification

- PASS: `python -m pytest -q tests/api/test_partners_router.py` (36 passed, 2 existing warnings)
- PASS: `AUTH_ENABLED=true python -m pytest -q tests/api/test_partners_router.py` (36 passed, 3 existing warnings)
- PASS: `python -m ruff check tests/api/test_partners_router.py`
- PASS: `python -m ruff format --check tests/api/test_partners_router.py`
- PASS: `git diff --check origin/dev...HEAD`