### PR TITLE
fix(web): package standalone runtime assets (#1424)

### DIFF
--- a/web/scripts/build.mjs
+++ b/web/scripts/build.mjs
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  cpSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -53,6 +59,25 @@ function prepareBuildTsconfig(snapshots, distDir) {
   return buildTsconfigPath;
 }
 
+function completeStandaloneBundle(distDir) {
+  const distRoot = path.resolve(webRoot, distDir);
+  const standaloneRoot = path.join(distRoot, "standalone");
+
+  mkdirSync(path.join(standaloneRoot, distDir), { recursive: true });
+  cpSync(
+    path.join(distRoot, "static"),
+    path.join(standaloneRoot, distDir, "static"),
+    {
+      recursive: true,
+      force: true,
+    },
+  );
+  cpSync(path.join(webRoot, "public"), path.join(standaloneRoot, "public"), {
+    recursive: true,
+    force: true,
+  });
+}
+
 const snapshots = generatedPaths
   .filter((path) => process.env.DEEPTUTOR_BUILD_SKIP_MISSING !== "1")
   .map((path) => [path, snapshot(path)]);
@@ -93,5 +118,7 @@ if (isEntry) {
     console.error(result.error);
     process.exit(1);
   }
-  process.exit(result.status ?? 1);
+  const status = result.status ?? 1;
+  if (status === 0) completeStandaloneBundle(distDir);
+  process.exit(status);
 }

--- a/web/tests/build-wrapper.test.ts
+++ b/web/tests/build-wrapper.test.ts
@@ -96,6 +96,19 @@ test("the build wrapper restores every generated checked-in input", () => {
   );
 });
 
+test("the build wrapper makes standalone output self-contained", () => {
+  const source = read("scripts", "build.mjs");
+  assert.match(source, /cpSync\(\s*path\.join\(distRoot, "static"\)/);
+  assert.match(source, /mkdirSync\(path\.join\(standaloneRoot, distDir\)/);
+  assert.match(source, /path\.join\(standaloneRoot, distDir, "static"\)/);
+  assert.match(source, /cpSync\(\s*path\.join\(webRoot, "public"\)/);
+  assert.match(source, /path\.join\(standaloneRoot, "public"\)/);
+  assert.match(
+    source,
+    /if \(status === 0\) completeStandaloneBundle\(distDir\)/,
+  );
+});
+
 test("the standalone bundle is rooted where the Python launcher expects it", () => {
   const source = read("next.config.js");
   assert.match(source, /output:\s*"standalone"/);


### PR DESCRIPTION
### Description

Next.js standalone output omits generated client chunks and `web/public`. After a successful Webpack build, the existing build wrapper now copies:

- `<distDir>/static` to `<distDir>/standalone/<distDir>/static`, preserving the active Next.js `distDir`;
- `web/public` to `<distDir>/standalone/public`.

The copy runs only after `next build --webpack` exits successfully, so failed builds do not produce a misleadingly complete bundle. A source contract test in the existing build-wrapper suite locks the runtime paths and success-only behavior.

### Related Issues

- Closes #1424

### Module(s) Affected

- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [x] `web` (Frontend)
- [ ] `docs` (Documentation)
- [x] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues. *(Run completed with four pre-existing JSON decode failures in `web/locales/en/app.json`, `web/locales/zh/app.json`, and `web/tsconfig.node-tests.json`; these files are outside this PR boundary. Every other reported hook passed.)*
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary). *(No public interface or user workflow changed.)*
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

Verified on `dev` base `0f8759f730da898cf99a081f0bec4230bb7ea44a`:

- Baseline custom-dist build emitted 379 files under `<distDir>/static` and 68 under `web/public`, but neither tree existed inside `standalone`.
- With the fix, a custom build copied all 379 static files and all 68 public files into the standalone directory.
- A default `npm run build` likewise copied 379/379 static files and 68/68 public files into `.next/standalone`.
- Runtime smoke test against the custom standalone server: `/` and `/pdfjs/wasm/openjpeg.wasm` returned 200, and every real `/_next/static/*` JS, CSS, and font URL referenced by the rendered homepage returned 200.
- `npm run test:node`: PASS, 1132/1132.
- `npm run typecheck`: PASS.
- `npm run lint`: PASS with 0 errors; 70 warnings are pre-existing in untouched files.
- `node --check scripts/build.mjs`: PASS.
- `git diff --check`: PASS.
