### PR TITLE
fix(api): preserve actual proxy peer identity (#1426)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -290,7 +290,7 @@ echo "[Backend]  🚀 Starting FastAPI backend on ${BACKEND_HOST}:${BACKEND_PORT
 # reaper so the client is the only side retiring idle connections.
 WS_MAX_SIZE=$(python -c "from deeptutor.services.config import get_ws_max_size; print(get_ws_max_size())" 2>/dev/null || echo 16777216)
 KEEP_ALIVE=$(python -c "from deeptutor.services.config import HTTP_KEEP_ALIVE_TIMEOUT; print(HTTP_KEEP_ALIVE_TIMEOUT)" 2>/dev/null || echo 300)
-exec python -m uvicorn deeptutor.api.main:app --host ${BACKEND_HOST} --port ${BACKEND_PORT} --workers ${BACKEND_WORKERS} --no-access-log --ws-max-size ${WS_MAX_SIZE} --timeout-keep-alive ${KEEP_ALIVE}
+exec python -m uvicorn deeptutor.api.main:app --host ${BACKEND_HOST} --port ${BACKEND_PORT} --workers ${BACKEND_WORKERS} --no-access-log --no-proxy-headers --ws-max-size ${WS_MAX_SIZE} --timeout-keep-alive ${KEEP_ALIVE}
 EOF
 
 RUN sed -i 's/\r$//' /app/start-backend.sh && chmod +x /app/start-backend.sh
@@ -519,7 +519,7 @@ RUN pip install --no-cache-dir \
 # the production stage is reused as-is.
 RUN cat > /etc/supervisor/conf.d/programs.conf <<'EOF'
 [program:backend]
-command=/bin/bash -c "exec python -m uvicorn deeptutor.api.main:app --host 0.0.0.0 --port ${BACKEND_PORT:-8001} --reload --no-access-log --ws-max-size $(python -c 'from deeptutor.services.config import get_ws_max_size; print(get_ws_max_size())' 2>/dev/null || echo 16777216) --timeout-keep-alive $(python -c 'from deeptutor.services.config import HTTP_KEEP_ALIVE_TIMEOUT; print(HTTP_KEEP_ALIVE_TIMEOUT)' 2>/dev/null || echo 300)"
+command=/bin/bash -c "exec python -m uvicorn deeptutor.api.main:app --host 0.0.0.0 --port ${BACKEND_PORT:-8001} --reload --no-access-log --no-proxy-headers --ws-max-size $(python -c 'from deeptutor.services.config import get_ws_max_size; print(get_ws_max_size())' 2>/dev/null || echo 16777216) --timeout-keep-alive $(python -c 'from deeptutor.services.config import HTTP_KEEP_ALIVE_TIMEOUT; print(HTTP_KEEP_ALIVE_TIMEOUT)' 2>/dev/null || echo 300)"
 directory=/app
 user=deeptutor
 autostart=true

--- a/deeptutor/api/run_server.py
+++ b/deeptutor/api/run_server.py
@@ -86,6 +86,9 @@ def main() -> None:
         reload_excludes=reload_excludes if dev_reload else None,
         log_level="info",
         access_log=False,
+        # XFF is client-controlled in this deployment. Keep request.client tied
+        # to the actual backend peer for the selective access log.
+        proxy_headers=False,
         ws_max_size=get_ws_max_size(),
         timeout_keep_alive=HTTP_KEEP_ALIVE_TIMEOUT,
     )

--- a/deeptutor/runtime/launcher.py
+++ b/deeptutor/runtime/launcher.py
@@ -1368,6 +1368,8 @@ def start(
         # 200 polling (/settings, /tools, /knowledge-bases, ...) stays out of the
         # logs — matching run_server.py's access_log=False.
         "--no-access-log",
+        # Do not replace the backend peer with client-controlled XFF values.
+        "--no-proxy-headers",
         # Chat attachments ride the unified WS as base64 in one JSON message;
         # uvicorn's default 16MB frame cap would sever the socket on uploads
         # allowed by the configured policy. Derived from system.json — raising

--- a/deeptutor_cli/main.py
+++ b/deeptutor_cli/main.py
@@ -207,6 +207,9 @@ def serve(
         reload=reload,
         workers=backend_workers,
         reload_excludes=["web/*", "data/*"] if reload else None,
+        # Keep request.client tied to the actual peer; XFF is client-controlled
+        # unless the deployment explicitly provides a trusted proxy.
+        proxy_headers=False,
         ws_max_size=get_ws_max_size(),
         timeout_keep_alive=HTTP_KEEP_ALIVE_TIMEOUT,
     )

--- a/tests/runtime/test_run_server_memory_mode.py
+++ b/tests/runtime/test_run_server_memory_mode.py
@@ -37,6 +37,15 @@ def test_run_server_disables_reload_by_default(
     assert uvicorn_kwargs["reload_excludes"] is None
 
 
+def test_run_server_preserves_actual_proxy_peer(
+    uvicorn_kwargs: dict[str, Any],
+) -> None:
+    """Do not replace the backend peer with client-controlled XFF values."""
+    run_server.main()
+
+    assert uvicorn_kwargs["proxy_headers"] is False
+
+
 def test_run_server_reload_remains_available_for_development(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/runtime/test_uvicorn_launch_flags.py
+++ b/tests/runtime/test_uvicorn_launch_flags.py
@@ -23,8 +23,8 @@ import pytest
 _REPO = Path(__file__).resolve().parents[2]
 
 # (path, marker anchoring the uvicorn invocation, flag spellings for this style)
-_PYTHON_FLAGS = ("ws_max_size", "timeout_keep_alive")
-_CLI_FLAGS = ("--ws-max-size", "--timeout-keep-alive")
+_PYTHON_FLAGS = ("proxy_headers", "ws_max_size", "timeout_keep_alive")
+_CLI_FLAGS = ("--no-proxy-headers", "--ws-max-size", "--timeout-keep-alive")
 _LAUNCH_POINTS = [
     ("deeptutor/runtime/launcher.py", '"uvicorn",', _CLI_FLAGS),
     ("deeptutor/api/run_server.py", "uvicorn.run(", _PYTHON_FLAGS),


### PR DESCRIPTION
## Summary

- Closes #1426.
- Disables Uvicorn generic proxy-header rewriting at all five backend launch points.
- Keeps ASGI `request.client` tied to the actual backend peer so non-200 selective access logs cannot be populated with client-controlled `X-Forwarded-For` values.

## Change Boundary

- Merge base: `0f8759f730da898cf99a081f0bec4230bb7ea44a` (`origin/dev`)
- Head: `dad11eef6f3d8e9042beea17f08f9ad9efced0e8`
- Changed files:
  - `Dockerfile`
  - `deeptutor/api/run_server.py`
  - `deeptutor/runtime/launcher.py`
  - `deeptutor_cli/main.py`
  - `tests/runtime/test_run_server_memory_mode.py`
  - `tests/runtime/test_uvicorn_launch_flags.py`

## Verification

- `PASS`: minimal FastAPI/Uvicorn request sent from `127.0.0.1` with forged `X-Forwarded-For: 203.0.113.9`
  - `proxy_headers=True`: peer `203.0.113.9`
  - `proxy_headers=False`: peer `127.0.0.1`
- `PASS`: `/Users/Shared/DeepTutor/.venv/bin/python -m pytest tests/runtime/test_run_server_memory_mode.py tests/runtime/test_uvicorn_launch_flags.py tests/api/test_selective_access_log.py`
  - 11 passed
- `PASS`: `/Users/Shared/DeepTutor/.venv/bin/ruff check deeptutor/api/run_server.py deeptutor/runtime/launcher.py deeptutor_cli/main.py tests/runtime/test_run_server_memory_mode.py tests/runtime/test_uvicorn_launch_flags.py`
- `PASS`: `git diff --check`
- `PASS`: upstream issue and open-PR searches found no duplicate proxy peer identity fix.

## Compatibility

Generic `X-Forwarded-For` rewriting is disabled by default. Applications that need a deployment-specific forwarded identity should consume that information through an explicitly trusted proxy contract rather than allowing arbitrary browser input to replace the backend socket peer.
