### PR TITLE
test(app): stabilize multiworker reply subscription (#1432)

### DIFF
--- a/tests/app/test_multiworker_turn_application.py
+++ b/tests/app/test_multiworker_turn_application.py
@@ -133,6 +133,11 @@ async def test_remote_worker_reply_reaches_owner_waiter(monkeypatch, tmp_path) -
     runtime_b = TurnRuntimeManager(
         store_b, coordinator=coordinator, owner_id="worker-b", turn_engine=Engine()
     )
+
+    async def _noop_title(**_kwargs):
+        return None
+
+    monkeypatch.setattr(runtime_a, "_maybe_generate_session_title", _noop_title)
     app_a = _application(store_a, runtime_a, coordinator)
     app_b = _application(store_b, runtime_b, coordinator)
 
@@ -145,17 +150,30 @@ async def test_remote_worker_reply_reaches_owner_waiter(monkeypatch, tmp_path) -
         await asyncio.sleep(0.01)
     assert active is not None
     assert active["status"] == "waiting_input"
-    assert await app_b.submit_user_reply(turn["id"], "yes", command_id="reply-from-b") is True
-    events = [event async for event in app_b.subscribe_turn(turn["id"])]
 
-    assert any(event.get("content") == "reply:yes" for event in events)
+    received: list[dict] = []
+
+    async def collect() -> None:
+        async for event in app_b.subscribe_turn(turn["id"]):
+            received.append(event)
+
+    subscriber = asyncio.create_task(collect())
+    for _ in range(100):
+        if any(event["type"] == "wait_for_input" for event in received):
+            break
+        await asyncio.sleep(0.01)
+    assert any(event["type"] == "wait_for_input" for event in received)
+    assert await app_b.submit_user_reply(turn["id"], "yes", command_id="reply-from-b") is True
+    await asyncio.wait_for(subscriber, timeout=3)
+
+    assert any(event.get("content") == "reply:yes" for event in received)
     # DONE is not the last frame of a completed turn: the runtime publishes
     # post-turn metadata (the LLM-written session title) after it, and a
     # subscriber has to receive that too — dropping it is what left finished
     # conversations sitting on "New conversation". Assert the shape instead of
     # asserting DONE is last: everything after DONE must be post-turn metadata.
-    done_index = next(i for i, event in enumerate(events) if event["type"] == "done")
-    assert all(event["type"] == "session_meta" for event in events[done_index + 1 :])
-    assert [event["seq"] for event in events] == list(range(1, len(events) + 1))
+    done_index = next(i for i, event in enumerate(received) if event["type"] == "done")
+    assert all(event["type"] == "session_meta" for event in received[done_index + 1 :])
+    assert [event["seq"] for event in received] == list(range(1, len(received) + 1))
     await runtime_a.close()
     await runtime_b.close()


### PR DESCRIPTION
### Description

- Start the remote worker's turn subscription before submitting its reply.
- Wait until the subscription has observed `wait_for_input`, then submit the reply and consume the resulting live event stream.
- Replace session-title generation with a no-op in this test so its post-turn assertions do not invoke an LLM.
- Preserve the existing response, sequence, `done`, and post-`done` metadata assertions.

### Related Issues

- Closes #1432

### Module(s) Affected

- [ ] `agents`
- [ ] `api`
- [ ] `config`
- [ ] `core`
- [ ] `knowledge`
- [ ] `logging`
- [ ] `services`
- [ ] `tools`
- [ ] `utils`
- [ ] `web` (Frontend)
- [ ] `docs` (Documentation)
- [ ] `scripts`
- [x] `tests`
- [ ] Other: `...`

### Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/HKUDS/DeepTutor/blob/dev/CONTRIBUTING.md).
- [x] My code follows the project's coding standards.
- [ ] I have run `pre-commit run --all-files` and fixed any issues.
- [x] I have added relevant tests for my changes.
- [x] I have updated the documentation (if necessary).
- [x] My changes do not introduce any new security vulnerabilities.

### Additional Notes

Verification:

- `pytest tests/app/test_multiworker_turn_application.py -q` with an isolated workspace root: `2 passed`
- The focused reply test passed 10 consecutive runs (`10/10 passed`).
- `ruff check tests/app/test_multiworker_turn_application.py`: passed
- `ruff format --check tests/app/test_multiworker_turn_application.py`: passed
- `git diff --check`: passed
- `pre-commit run --all-files`: the hooks affecting this change passed; the all-file run is blocked by existing invalid JSON in `web/locales/zh/app.json`, `web/locales/en/app.json`, and `web/tsconfig.node-tests.json`. These files are outside this PR.

Scope audit:

- Base: `0f8759f730da898cf99a081f0bec4230bb7ea44a`
- Head: `4341ee9af1bd53a954554fb6a36593c8071c6d7f`
- Changed files: `tests/app/test_multiworker_turn_application.py` only
