### PR TITLE
fix(reading): keep material loading during hydration

### DIFF
--- a/web/components/reading/workspace/useReadingWorkspace.ts
+++ b/web/components/reading/workspace/useReadingWorkspace.ts
@@ -10,7 +10,6 @@ import { courseSessionConfiguration } from "@/lib/course-session-scope";
 import {
   addBookmark,
   deleteBookmark,
-  getMaterial,
   getReadingTranscript,
   listBookmarks,
   type ReadingBookmark,
@@ -137,21 +136,12 @@ export function useReadingWorkspace(
       closeMaterial();
       return;
     }
-    let cancelled = false;
-    void getMaterial(active.material_id)
-      .then((detail) => {
-        if (!cancelled) return openMaterial(detail);
-      })
-      .catch((caught) => {
-        if (!cancelled)
-          setError(
-            caught instanceof Error ? caught.message : t("Open failed."),
-          );
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [activeTab?.material, closeMaterial, openMaterial, t]);
+    // Let ReadingContext own the request from its first tick. Prefetching the
+    // detail here left `loading` false until that fetch completed, so the
+    // reader briefly rendered its unavailable state between workspace and
+    // material hydration (most visibly in Safari).
+    void openMaterial(active.material_id);
+  }, [activeTab?.material, closeMaterial, openMaterial]);
 
   // Poll while anything is still being processed, backing off as the wait
   // grows. A flat 2.5s forever means a source wedged in "processing" quietly

--- a/web/tests/reading-v2-surface.test.ts
+++ b/web/tests/reading-v2-surface.test.ts
@@ -220,6 +220,17 @@ test("naming the first turn's conversation does not remount the reader", () => {
   assert.doesNotMatch(page, /params\.sessionId/);
 });
 
+test("material hydration owns its loading state from the first request tick", () => {
+  const hook = source(`${WORKSPACE_DIR}/useReadingWorkspace.ts`);
+
+  // ReadingContext sets `loading` before it fetches a material. Fetching the
+  // detail in the workspace first creates a paintable gap after the collection
+  // finishes loading: no material, but no material-loading state either. The
+  // reader then flashes its unavailable recovery UI before the document opens.
+  assert.match(hook, /void openMaterial\(active\.material_id\);/);
+  assert.doesNotMatch(hook, /getMaterial\(active\.material_id\)/);
+});
+
 test("a material reopens where the reader left off", () => {
   const pane = source("components/reading/ReaderPane.tsx");
 


### PR DESCRIPTION
## Summary

- let `ReadingContext` own material hydration from the first request tick
- keep the document loading shell visible while the active material is fetched
- add a regression contract preventing workspace-level material prefetch from reintroducing the unavailable-state flash

## Problem

After the reading workspace finished loading, `useReadingWorkspace()` fetched the active material before calling `openMaterial()`. During that request, the workspace loading state was already false while `ReadingContext` still had neither a material nor a loading state. Safari could briefly render “This document could not be opened” before opening the document normally.

## Fix

Call `openMaterial(active.material_id)` directly. `ReadingContext` now sets its loading state before fetching the material and annotations, while retaining its existing stale-request token protection.

## Testing

- `node --test tests/reading-v2-surface.test.ts` — 16 passed
- `npm run typecheck`
- `npx eslint components/reading/workspace/useReadingWorkspace.ts tests/reading-v2-surface.test.ts`
- `git diff --check`

Closes #1439